### PR TITLE
Add TraceState

### DIFF
--- a/packages/opentelemetry-core/src/trace/TraceState.ts
+++ b/packages/opentelemetry-core/src/trace/TraceState.ts
@@ -39,16 +39,19 @@ export class TraceState implements types.TraceState {
     if (rawTraceState) this._parse(rawTraceState);
   }
 
-  set(name: string, value: string): void {
-    // TODO: Benchmark the different approaches and use the faster one.
-    if (this._internalState.has(name)) {
-      this._internalState.delete(name);
-    }
-    this._internalState.set(name, value);
+  set(key: string, value: string): void {
+    // TODO: Benchmark the different approaches(map vs list) and
+    // use the faster one.
+    if (this._internalState.has(key)) this._internalState.delete(key);
+    this._internalState.set(key, value);
   }
 
-  get(name: string): string | undefined {
-    return this._internalState.get(name);
+  unset(key: string): void {
+    this._internalState.delete(key);
+  }
+
+  get(key: string): string | undefined {
+    return this._internalState.get(key);
   }
 
   serialize(): string {

--- a/packages/opentelemetry-core/src/trace/TraceState.ts
+++ b/packages/opentelemetry-core/src/trace/TraceState.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as types from '@opentelemetry/types';
+
+// TODO validate maximum number of items
+// const maximumTraceStateItems = 32;
+
+const maximumTraceStateLength = 512;
+export interface InternalTraceState {
+  [key: string]: string;
+}
+
+export class TraceState implements types.TraceState {
+  private internalState: InternalTraceState = {};
+
+  constructor(internalState?: InternalTraceState) {
+    if (internalState) this.internalState = internalState;
+  }
+
+  get(name: string): string | undefined {
+    return this.internalState[name];
+  }
+
+  keys(): string[] {
+    return Object.keys(this.internalState);
+  }
+
+  set(name: string, value: string): void {
+    this.internalState = {
+      // ensure that the new key ends up in the beginning of the list
+      [name]: value,
+      ...this.internalState,
+      // ensure that updates work
+      [name]: value,
+    };
+  }
+}
+
+export function serialize(state: TraceState): string {
+  return state
+    .keys()
+    .reduce((agg: string[], key) => {
+      agg.push(`${key}=${state.get(key)}`);
+      return agg;
+    }, [])
+    .join(',');
+}
+
+export function parse(s: string | null): TraceState | null {
+  if (s == null || s.length > maximumTraceStateLength) return null;
+
+  // TODO validate maximum number of items
+  const states = s
+    .split(',')
+    .reduce((agg: InternalTraceState, part: string) => {
+      const i = part.indexOf('=');
+      if (i !== -1) {
+        // TODO validate key/value constraints defined in the spec
+        agg[part.slice(0, i)] = part.slice(i + 1, part.length);
+      }
+      return agg;
+    }, {});
+
+  return new TraceState(states);
+}

--- a/packages/opentelemetry-core/src/trace/TraceState.ts
+++ b/packages/opentelemetry-core/src/trace/TraceState.ts
@@ -24,18 +24,18 @@ const LIST_MEMBERS_SEPARATOR = ',';
 const LIST_MEMBER_KEY_VALUE_SPLITTER = '=';
 
 export class TraceState implements types.TraceState {
-  private internalState: Map<string, string> = new Map();
+  private _internalState: Map<string, string> = new Map();
 
-  constructor(s?: string) {
-    if (s) this.parse(s);
+  constructor(rawTraceState?: string) {
+    if (rawTraceState) this._parse(rawTraceState);
   }
 
   set(name: string, value: string): void {
     // TODO: Benchmark the different approaches and use the faster one.
-    if (this.internalState.has(name)) {
-      this.internalState.delete(name);
+    if (this._internalState.has(name)) {
+      this._internalState.delete(name);
     }
-    this.internalState.set(name, value);
+    this._internalState.set(name, value);
   }
 
   serialize(): string {
@@ -47,10 +47,10 @@ export class TraceState implements types.TraceState {
       .join(LIST_MEMBERS_SEPARATOR);
   }
 
-  private parse(s: string) {
-    if (s.length > MAX_TRACE_STATE_LEN) return;
+  private _parse(rawTraceState: string) {
+    if (rawTraceState.length > MAX_TRACE_STATE_LEN) return;
     // TODO validate maximum number of items
-    this.internalState = s
+    this._internalState = rawTraceState
       .split(LIST_MEMBERS_SEPARATOR)
       .reverse()
       .reduce((agg: Map<string, string>, part: string) => {
@@ -65,11 +65,11 @@ export class TraceState implements types.TraceState {
 
   // TEST_ONLY
   keys(): string[] {
-    return Array.from(this.internalState.keys()).reverse();
+    return Array.from(this._internalState.keys()).reverse();
   }
 
   // TEST_ONLY
   get(name: string): string | undefined {
-    return this.internalState.get(name);
+    return this._internalState.get(name);
   }
 }

--- a/packages/opentelemetry-core/src/trace/TraceState.ts
+++ b/packages/opentelemetry-core/src/trace/TraceState.ts
@@ -38,8 +38,12 @@ export class TraceState implements types.TraceState {
     this._internalState.set(name, value);
   }
 
+  get(name: string): string | undefined {
+    return this._internalState.get(name);
+  }
+
   serialize(): string {
-    return this.keys()
+    return this._keys()
       .reduce((agg: string[], key) => {
         agg.push(key + LIST_MEMBER_KEY_VALUE_SPLITTER + this.get(key));
         return agg;
@@ -63,13 +67,7 @@ export class TraceState implements types.TraceState {
       }, new Map());
   }
 
-  // TEST_ONLY
-  keys(): string[] {
+  private _keys(): string[] {
     return Array.from(this._internalState.keys()).reverse();
-  }
-
-  // TEST_ONLY
-  get(name: string): string | undefined {
-    return this._internalState.get(name);
   }
 }

--- a/packages/opentelemetry-core/src/trace/TraceState.ts
+++ b/packages/opentelemetry-core/src/trace/TraceState.ts
@@ -23,6 +23,15 @@ const MAX_TRACE_STATE_LEN = 512;
 const LIST_MEMBERS_SEPARATOR = ',';
 const LIST_MEMBER_KEY_VALUE_SPLITTER = '=';
 
+/**
+ * TraceState must be a class and not a simple object type because of the spec
+ * requirement (https://www.w3.org/TR/trace-context/#tracestate-field).
+ *
+ * Here is the list of allowed mutations:
+ * - New key-value pair should be added into the beginning of the list
+ * - The value of any key can be updated. Modified keys MUST be moved to the
+ * beginning of the list.
+ */
 export class TraceState implements types.TraceState {
   private _internalState: Map<string, string> = new Map();
 

--- a/packages/opentelemetry-core/test/tracestate.test.ts
+++ b/packages/opentelemetry-core/test/tracestate.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { TraceState, parse, serialize } from '../src/trace/TraceState';
+
+describe('TraceState', () => {
+  describe('serialize', () => {
+    it('returns serialize string', () => {
+      const state = new TraceState({ a: '1', b: '2' });
+      assert.deepStrictEqual(state.keys(), ['a', 'b']);
+      assert.deepStrictEqual(serialize(state), 'a=1,b=2');
+    });
+
+    it('must add new keys', () => {
+      const state = new TraceState({ a: '1', b: '2' });
+      assert.deepStrictEqual(state.keys(), ['a', 'b']);
+
+      state.set('c', '3');
+      assert.deepStrictEqual(state.keys(), ['c', 'a', 'b']);
+      assert.deepStrictEqual(serialize(state), 'c=3,a=1,b=2');
+    });
+
+    it('must replace keys and move them to the front', () => {
+      const state = new TraceState({ a: '1', b: '2' });
+      state.set('b', '3');
+      assert.deepStrictEqual(state.keys(), ['b', 'a']);
+      assert.deepStrictEqual(serialize(state), 'b=3,a=1');
+    });
+
+    it('must add new keys to the front', () => {
+      const state = new TraceState();
+      state.set('vendorname1', 'opaqueValue1');
+      assert.deepStrictEqual(serialize(state), 'vendorname1=opaqueValue1');
+
+      state.set('vendorname2', 'opaqueValue2');
+      assert.deepStrictEqual(
+        serialize(state),
+        'vendorname2=opaqueValue2,vendorname1=opaqueValue1'
+      );
+    });
+  });
+
+  describe('parse', () => {
+    it('must successfully parse valid state value', () => {
+      const state = parse('vendorname2=opaqueValue2,vendorname1=opaqueValue1');
+      assert.ok(state);
+      if (state != null) {
+        assert.deepStrictEqual(state!.get('vendorname1'), 'opaqueValue1');
+        assert.deepStrictEqual(state!.get('vendorname2'), 'opaqueValue2');
+        assert.deepStrictEqual(
+          serialize(state),
+          'vendorname2=opaqueValue2,vendorname1=opaqueValue1'
+        );
+      }
+    });
+
+    it('should handle null string', () => {
+      const state = parse(null);
+      assert.deepStrictEqual(state, null);
+    });
+
+    it('must fail when the items are too long', () => {
+      const state = parse('a=' + 'b'.repeat(512));
+      assert.deepStrictEqual(state, null);
+    });
+
+    it('must drop states which cannot be parsed', () => {
+      const state = parse('a=1,b,c=3');
+      assert.ok(state);
+      if (state != null) {
+        assert.deepStrictEqual(state.get('a'), '1');
+        assert.deepStrictEqual(state.get('b'), undefined);
+        assert.deepStrictEqual(state.get('c'), '3');
+        assert.deepStrictEqual(serialize(state), 'a=1,c=3');
+      }
+    });
+
+    it('must parse states that only have a single value with an equal sign', () => {
+      const state = parse('a=1=');
+      assert.ok(state);
+      if (state != null) {
+        assert.deepStrictEqual(state.get('a'), '1=');
+      }
+    });
+  });
+});

--- a/packages/opentelemetry-core/test/tracestate.test.ts
+++ b/packages/opentelemetry-core/test/tracestate.test.ts
@@ -21,14 +21,12 @@ describe('TraceState', () => {
   describe('serialize', () => {
     it('returns serialize string', () => {
       const state = new TraceState('a=1,b=2');
-      assert.deepStrictEqual(state.keys(), ['a', 'b']);
       assert.deepStrictEqual(state.serialize(), 'a=1,b=2');
     });
 
     it('must replace keys and move them to the front', () => {
       const state = new TraceState('a=1,b=2');
       state.set('b', '3');
-      assert.deepStrictEqual(state.keys(), ['b', 'a']);
       assert.deepStrictEqual(state.serialize(), 'b=3,a=1');
     });
 
@@ -50,39 +48,31 @@ describe('TraceState', () => {
       const state = new TraceState(
         'vendorname2=opaqueValue2,vendorname1=opaqueValue1'
       );
-      assert.ok(state);
-      if (state != null) {
-        assert.deepStrictEqual(state.get('vendorname1'), 'opaqueValue1');
-        assert.deepStrictEqual(state.get('vendorname2'), 'opaqueValue2');
-        assert.deepStrictEqual(
-          state.serialize(),
-          'vendorname2=opaqueValue2,vendorname1=opaqueValue1'
-        );
-      }
+      assert.deepStrictEqual(state.get('vendorname1'), 'opaqueValue1');
+      assert.deepStrictEqual(state.get('vendorname2'), 'opaqueValue2');
+      assert.deepStrictEqual(
+        state.serialize(),
+        'vendorname2=opaqueValue2,vendorname1=opaqueValue1'
+      );
     });
 
     it('must drop states when the items are too long', () => {
       const state = new TraceState('a=' + 'b'.repeat(512));
-      assert.deepStrictEqual(state.keys(), []);
+      assert.deepStrictEqual(state.get('a'), undefined);
+      assert.deepStrictEqual(state.serialize(), '');
     });
 
     it('must drop states which cannot be parsed', () => {
       const state = new TraceState('a=1,b,c=3');
-      assert.ok(state);
-      if (state != null) {
-        assert.deepStrictEqual(state.get('a'), '1');
-        assert.deepStrictEqual(state.get('b'), undefined);
-        assert.deepStrictEqual(state.get('c'), '3');
-        assert.deepStrictEqual(state.serialize(), 'a=1,c=3');
-      }
+      assert.deepStrictEqual(state.get('a'), '1');
+      assert.deepStrictEqual(state.get('b'), undefined);
+      assert.deepStrictEqual(state.get('c'), '3');
+      assert.deepStrictEqual(state.serialize(), 'a=1,c=3');
     });
 
     it('must parse states that only have a single value with an equal sign', () => {
       const state = new TraceState('a=1=');
-      assert.ok(state);
-      if (state != null) {
-        assert.deepStrictEqual(state.get('a'), '1=');
-      }
+      assert.deepStrictEqual(state.get('a'), '1=');
     });
   });
 });

--- a/packages/opentelemetry-core/test/tracestate.test.ts
+++ b/packages/opentelemetry-core/test/tracestate.test.ts
@@ -41,6 +41,15 @@ describe('TraceState', () => {
         'vendorname2=opaqueValue2,vendorname1=opaqueValue1'
       );
     });
+
+    it('must unset the entries', () => {
+      const state = new TraceState('c=4,b=3,a=1');
+      state.unset('b');
+      assert.deepStrictEqual(state.serialize(), 'c=4,a=1');
+      state.unset('c');
+      state.unset('A');
+      assert.deepStrictEqual(state.serialize(), 'a=1');
+    });
   });
 
   describe('parse', () => {

--- a/packages/opentelemetry-types/src/trace/trace_state.ts
+++ b/packages/opentelemetry-types/src/trace/trace_state.ts
@@ -14,6 +14,25 @@
  * limitations under the License.
  */
 
+/**
+ * Tracestate carries system-specific configuration data, represented as a list
+ * of key-value pairs. TraceState allows multiple tracing systems to
+ * participate in the same trace.
+ */
 export interface TraceState {
-  // TODO
+  /**
+   * Adds or updates the TraceState that has the given `key` if it is
+   * present. The new State will always be added in the front of the
+   * list of states.
+   */
+  set(name: string, value: string): void;
+
+  /**
+   * Returns the value to which the specified key is mapped, or `undefined` if
+   * this map contains no mapping for the key.
+   */
+  get(name: string): string | undefined;
+
+  /** Returns a list of key string contained in this TraceState. */
+  keys(): string[];
 }

--- a/packages/opentelemetry-types/src/trace/trace_state.ts
+++ b/packages/opentelemetry-types/src/trace/trace_state.ts
@@ -25,10 +25,20 @@ export interface TraceState {
    * present. The new State will always be added in the front of the
    * list of states.
    *
-   * @param name key of the TraceState entry.
+   * @param key key of the TraceState entry.
    * @param value value of the TraceState entry.
    */
-  set(name: string, value: string): void;
+  set(key: string, value: string): void;
+
+  /**
+   * Returns the value to which the specified key is mapped, or `undefined` if
+   * this map contains no mapping for the key.
+   *
+   * @param key with which the specified value is to be associated.
+   * @returns the value to which the specified key is mapped, or `undefined` if
+   *     this map contains no mapping for the key.
+   */
+  get(key: string): string | undefined;
 
   // TODO: Consider to add support for merging an object as well by also
   // accepting a single internalTraceState argument similar to the constructor.

--- a/packages/opentelemetry-types/src/trace/trace_state.ts
+++ b/packages/opentelemetry-types/src/trace/trace_state.ts
@@ -31,6 +31,13 @@ export interface TraceState {
   set(key: string, value: string): void;
 
   /**
+   * Removes the TraceState Entry that has the given `key` if it is present.
+   *
+   * @param key the key for the TraceState Entry to be removed.
+   */
+  unset(key: string): void;
+
+  /**
    * Returns the value to which the specified key is mapped, or `undefined` if
    * this map contains no mapping for the key.
    *

--- a/packages/opentelemetry-types/src/trace/trace_state.ts
+++ b/packages/opentelemetry-types/src/trace/trace_state.ts
@@ -24,15 +24,30 @@ export interface TraceState {
    * Adds or updates the TraceState that has the given `key` if it is
    * present. The new State will always be added in the front of the
    * list of states.
+   *
+   * @param name key of the TraceState entry.
+   * @param value value of the TraceState entry.
    */
   set(name: string, value: string): void;
 
-  /**
-   * Returns the value to which the specified key is mapped, or `undefined` if
-   * this map contains no mapping for the key.
-   */
-  get(name: string): string | undefined;
+  // TODO: Consider to add support for merging an object as well by also
+  // accepting a single internalTraceState argument similar to the constructor.
 
-  /** Returns a list of key string contained in this TraceState. */
-  keys(): string[];
+  /**
+   * Serializes the TraceState to a `list` as defined below. The `list` is a
+   * series of `list-members` separated by commas `,`, and a list-member is a
+   * key/value pair separated by an equals sign `=`. Spaces and horizontal tabs
+   * surrounding `list-members` are ignored. There can be a maximum of 32
+   * `list-members` in a `list`.
+   *
+   * @returns the serialized string.
+   */
+  serialize(): string;
+
+  /**
+   * Parses the input string and generates a TraceState.
+   *
+   * @param s the string to parse.
+   */
+  parse(s: string): void;
 }

--- a/packages/opentelemetry-types/src/trace/trace_state.ts
+++ b/packages/opentelemetry-types/src/trace/trace_state.ts
@@ -43,11 +43,4 @@ export interface TraceState {
    * @returns the serialized string.
    */
   serialize(): string;
-
-  /**
-   * Parses the input string and generates a TraceState.
-   *
-   * @param s the string to parse.
-   */
-  parse(s: string): void;
 }


### PR DESCRIPTION
Specs: https://w3c.github.io/trace-context/#tracestate-field

Originates from https://github.com/open-telemetry/opentelemetry-js/pull/31#discussion_r294313856
> This would be easier to interact with by using an actual object than can then be serialized to a string by some formatter/encoder. Of course this could be done with a getter and a corresponding _traceState private property to hold the object, but then every vendor will have to replicate this logic.