### PR TITLE
Add LocalContext interface

### DIFF
--- a/packages/opentelemetry-types/src/trace/event.ts
+++ b/packages/opentelemetry-types/src/trace/event.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-export * from './trace/span';
-export * from './trace/span_context';
-export * from './trace/local_context';
-export * from './trace/span_kind';
-export * from './trace/status';
-export * from './trace/link';
-export * from './trace/attributes';
-export * from './trace/trace_options';
-export * from './trace/trace_state';
-export * from './trace/event';
+import { Attributes } from './attributes';
+
+/** A text annotation with a set of attributes. */
+export interface Event {
+  /** The name of the event. */
+  name: string;
+  /** The attributes of the event. */
+  attributes?: Attributes;
+}

--- a/packages/opentelemetry-types/src/trace/local_context.ts
+++ b/packages/opentelemetry-types/src/trace/local_context.ts
@@ -14,13 +14,24 @@
  * limitations under the License.
  */
 
-export * from './trace/span';
-export * from './trace/span_context';
-export * from './trace/local_context';
-export * from './trace/span_kind';
-export * from './trace/status';
-export * from './trace/link';
-export * from './trace/attributes';
-export * from './trace/trace_options';
-export * from './trace/trace_state';
-export * from './trace/event';
+import { SpanKind } from './span_kind';
+import { Status } from './status';
+import { Link } from './link';
+import { Attributes } from './attributes';
+import { Event } from './event';
+
+/** LocalContext allows to attach arbitrary data on the span. */
+export interface LocalContext {
+  name?: string;
+  kind?: SpanKind;
+  spanId: string;
+  traceId: string;
+  parentSpanId?: string;
+  startTime?: number;
+  endTime?: number;
+  status?: Status;
+  links?: Link[];
+  events?: Event[];
+  attributes?: Attributes;
+  isRecordingEvents?: boolean;
+}


### PR DESCRIPTION
As per the specs, `SpanContext` must be immutable and should contain only propagating (and serializable) information. This PR contains `LocalContext` interface, based on our discussion in SIGs meeting (6/26). This will be used to hold span related metadata.

~Also, added `Event` interface.~