### PR TITLE
Adds the SpanData type

### DIFF
--- a/packages/opentelemetry-types/src/trace/span.ts
+++ b/packages/opentelemetry-types/src/trace/span.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Attributes } from './attributes';
 import { SpanContext } from './span_context';
 import { Status } from './status';
+import { Attributes } from './attributes';
 
 /**
  * An interface that represents a span. A span represents a single operation
@@ -27,7 +27,7 @@ import { Status } from './status';
  */
 export interface Span {
   /**
-   * Returns the {@link SpanContext} object associated with this Span.
+   * Returns the SpanContext object associated with this Span.
    *
    * @returns the SpanContext object associated with this Span.
    */
@@ -62,7 +62,7 @@ export interface Span {
    * @param [attributes] the attributes that will be added; these are
    *     associated with this event.
    */
-  addEvent(name: string, attributes?: Attributes): this;
+  addEvent(name: string, attributes?: { [key: string]: unknown }): this;
 
   /**
    * Adds a link to the Span.
@@ -71,11 +71,14 @@ export interface Span {
    * @param [attributes] the attributes that will be added; these are
    *     associated with this link.
    */
-  addLink(spanContext: SpanContext, attributes?: Attributes): this;
+  addLink(
+    spanContext: SpanContext,
+    attributes?: { [key: string]: unknown }
+  ): this;
 
   /**
    * Sets a status to the span. If used, this will override the default Span
-   * status. Default is {@link CanonicalCode.OK}.
+   * status. Default is 'OK'.
    *
    * @param status the Status to set.
    */

--- a/packages/opentelemetry-types/src/trace/span_data.ts
+++ b/packages/opentelemetry-types/src/trace/span_data.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SpanContext } from "./span_context";
+import { Resource } from "../resources/Resource";
+import { SpanKind } from "./span_kind";
+import { Attributes } from "./attributes";
+import { Link } from "./link";
+import { Status } from "./status";
+
+/**
+ * SpanData an object that is used to report out-of-band completed spans.
+ * The object and its members have to be treated as immutable.
+ */
+export interface SpanData {
+  /**
+   * Returns the name of this SpanData.
+   */
+  getName(): string;
+
+  /**
+   * Returns the SpanKind of this SpanData.
+   */
+  getKind(): SpanKind;
+
+  /**
+   * Returns the start timestamp of this SpanData.
+   */
+  getStartTimestamp(): number;
+
+  /**
+   * Returns the end timestamp of this SpanData.
+   */
+  getEndTimestamp: number;
+
+  /**
+   * Returns the SpanContext associated with this SpanData.
+   */
+  getContext(): SpanContext;
+
+  /**
+   * Returns the SpanId of the parent of this SpanData.
+   */
+  getParentSpanId(): string;
+
+  /**
+   * Returns the Resource associated with this SpanData.
+   * When null is returned the assumption is that Resource
+   * will be taken from the Tracer that is used to record this SpanData.
+   */
+  getResource(): Resource;
+
+  /**
+   * Returns the Attributes collection associated with this SpanData.
+   * The order of attributes in this collection is not significant.
+   * This collection MUST be immutable.
+   */
+  getAttributes(): Attributes[];
+
+  /**
+   * Return the collection of Events with the timestamps associated with this SpanData.
+   * The order of events in collection is not guaranteed.
+   * This collection MUST be immutable.
+   *
+   * @todo: Add Event type
+   */
+  getTimedEvents(): any[];
+
+  /**
+   * Returns the Links collection associated with this SpanData.
+   * The order of links in this collection is not significant.
+   * This collection MUST be immutable.
+   */
+  getLinks(): Link[];
+
+  /**
+   * Returns the Status of this SpanData.
+   */
+  getStatus(): Status;
+}


### PR DESCRIPTION
This adds the [SpanData type](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/tracing-api.md#spandata) that is also needed to implement `Tracer`.
Todo: Add an event type.