### PR TITLE
TraceState: Add validators

### DIFF
--- a/packages/opentelemetry-core/src/internal/validators.ts
+++ b/packages/opentelemetry-core/src/internal/validators.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-const KEY_MAX_SIZE = 256;
 const VALUE_MAX_SIZE = 256;
+const VALID_KEY_REGEX = /^[a-z][_0-9a-z-*/]{0,255}$/;
 
 /**
  * Key is opaque string up to 256 characters printable. It MUST begin with a
@@ -23,23 +23,7 @@ const VALUE_MAX_SIZE = 256;
  * underscores _, dashes -, asterisks *, and forward slashes /.
  */
 export function validateKey(key: string): boolean {
-  if (key.length > KEY_MAX_SIZE || key.charAt(0) < 'a' || key.charAt(0) > 'z') {
-    return false;
-  }
-  for (let i = 1; i < key.length; i++) {
-    const c = key.charAt(i);
-    if (
-      !(c >= 'a' && c <= 'z') &&
-      !(c >= '0' && c <= '9') &&
-      c !== '_' &&
-      c !== '-' &&
-      c !== '*' &&
-      c !== '/'
-    ) {
-      return false;
-    }
-  }
-  return true;
+  return VALID_KEY_REGEX.test(key);
 }
 
 /**

--- a/packages/opentelemetry-core/src/internal/validators.ts
+++ b/packages/opentelemetry-core/src/internal/validators.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const KEY_MAX_SIZE = 256;
+const VALUE_MAX_SIZE = 256;
+
+/**
+ * Key is opaque string up to 256 characters printable. It MUST begin with a
+ * lowercase letter, and can only contain lowercase letters a-z, digits 0-9,
+ * underscores _, dashes -, asterisks *, and forward slashes /.
+ */
+export function validateKey(key: string): boolean {
+  if (key.length > KEY_MAX_SIZE || key.charAt(0) < 'a' || key.charAt(0) > 'z') {
+    return false;
+  }
+  for (let i = 1; i < key.length; i++) {
+    const c = key.charAt(i);
+    if (
+      !(c >= 'a' && c <= 'z') &&
+      !(c >= '0' && c <= '9') &&
+      c !== '_' &&
+      c !== '-' &&
+      c !== '*' &&
+      c !== '/'
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Value is opaque string up to 256 characters printable ASCII RFC0020
+ * characters (i.e., the range 0x20 to 0x7E) except comma , and =.
+ */
+export function validateValue(value: string): boolean {
+  if (value.length > VALUE_MAX_SIZE || value.charAt(value.length - 1) === ' ') {
+    return false;
+  }
+  for (let i = 0; i < value.length; i++) {
+    const c = value.charAt(i);
+    if (c === ',' || c === '=' || c < ' ' || c > '~') {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/opentelemetry-core/src/internal/validators.ts
+++ b/packages/opentelemetry-core/src/internal/validators.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-const VALUE_MAX_SIZE = 256;
 const VALID_KEY_REGEX = /^[a-z][_0-9a-z-*/]{0,255}$/;
+const VALID_VALUE_REGEX = /^[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e]$/;
 
 /**
  * Key is opaque string up to 256 characters printable. It MUST begin with a
@@ -31,14 +31,5 @@ export function validateKey(key: string): boolean {
  * characters (i.e., the range 0x20 to 0x7E) except comma , and =.
  */
 export function validateValue(value: string): boolean {
-  if (value.length > VALUE_MAX_SIZE || value.charAt(value.length - 1) === ' ') {
-    return false;
-  }
-  for (let i = 0; i < value.length; i++) {
-    const c = value.charAt(i);
-    if (c === ',' || c === '=' || c < ' ' || c > '~') {
-      return false;
-    }
-  }
-  return true;
+  return VALID_VALUE_REGEX.test(value);
 }

--- a/packages/opentelemetry-core/src/internal/validators.ts
+++ b/packages/opentelemetry-core/src/internal/validators.ts
@@ -15,7 +15,8 @@
  */
 
 const VALID_KEY_REGEX = /^[a-z][_0-9a-z-*/]{0,255}$/;
-const VALID_VALUE_REGEX = /^[\x20-\x2b\x2d-\x3c\x3e-\x7e]{0,255}[\x21-\x2b\x2d-\x3c\x3e-\x7e]$/;
+const VALID_VALUE_BASE_REGEX = /^[ -~]{0,255}[!-~]$/;
+const INVALID_VALUE_COMMA_EQUAL_REGEX = /,|=/;
 
 /**
  * Key is opaque string up to 256 characters printable. It MUST begin with a
@@ -31,5 +32,8 @@ export function validateKey(key: string): boolean {
  * characters (i.e., the range 0x20 to 0x7E) except comma , and =.
  */
 export function validateValue(value: string): boolean {
-  return VALID_VALUE_REGEX.test(value);
+  return (
+    VALID_VALUE_BASE_REGEX.test(value) &&
+    !INVALID_VALUE_COMMA_EQUAL_REGEX.test(value)
+  );
 }

--- a/packages/opentelemetry-core/src/trace/TraceState.ts
+++ b/packages/opentelemetry-core/src/trace/TraceState.ts
@@ -15,6 +15,7 @@
  */
 
 import * as types from '@opentelemetry/types';
+import { validateKey, validateValue } from '../internal/validators';
 
 // TODO validate maximum number of items
 // const MAX_TRACE_STATE_ITEMS = 32;
@@ -72,8 +73,13 @@ export class TraceState implements types.TraceState {
       .reduce((agg: Map<string, string>, part: string) => {
         const i = part.indexOf(LIST_MEMBER_KEY_VALUE_SPLITTER);
         if (i !== -1) {
-          // TODO validate key/value constraints defined in the spec
-          agg.set(part.slice(0, i), part.slice(i + 1, part.length));
+          const key = part.slice(0, i);
+          const value = part.slice(i + 1, part.length);
+          if (validateKey(key) && validateValue(value)) {
+            agg.set(key, value);
+          } else {
+            // TODO: Consider to add warning log
+          }
         }
         return agg;
       }, new Map());

--- a/packages/opentelemetry-core/test/internal/validators.test.ts
+++ b/packages/opentelemetry-core/test/internal/validators.test.ts
@@ -42,7 +42,7 @@ describe('validators', () => {
       assert.ok(!validateValue('my_vakue=5'));
     });
 
-    it('returns false when value contain equal', () => {
+    it('returns false when value contain comma', () => {
       assert.ok(!validateValue('first,second'));
     });
 
@@ -52,10 +52,6 @@ describe('validators', () => {
 
     it('returns false when invalid value size', () => {
       assert.ok(!validateValue('k'.repeat(257)));
-    });
-
-    it('returns true when value is empty', () => {
-      assert.ok(validateValue(''));
     });
   });
 });

--- a/packages/opentelemetry-core/test/internal/validators.test.ts
+++ b/packages/opentelemetry-core/test/internal/validators.test.ts
@@ -19,39 +19,71 @@ import { validateKey, validateValue } from '../../src/internal/validators';
 
 describe('validators', () => {
   describe('validateKey', () => {
-    it('returns true when key contain all allowed characters', () => {
-      const allowedKeys = 'abcdefghijklmnopqrstuvwxyz0123456789-_*/';
-      assert.ok(validateKey(allowedKeys));
-    });
+    const validKeysTestCases = [
+      'abcdefghijklmnopqrstuvwxyz0123456789-_*/',
+      'baz-',
+      'baz_',
+      'baz*',
+      'baz*bar',
+      'baz/',
+      'tracestate',
+    ];
+    validKeysTestCases.forEach(testCase =>
+      it(`returns true when key contains valid chars ${testCase}`, () => {
+        assert.ok(validateKey(testCase));
+      })
+    );
 
-    it('returns false when invalid first key character', () => {
-      assert.ok(!validateKey('1_key'));
-    });
-
-    it('returns false when invalid key characters', () => {
-      assert.ok(!validateKey('kEy_1'));
-    });
-
-    it('returns false when invalid key size', () => {
-      assert.ok(!validateKey('k'.repeat(257)));
-    });
+    const invalidKeysTestCases = [
+      '1_key',
+      'kEy_1',
+      'k'.repeat(257),
+      'key,',
+      'TrAcEsTaTE',
+      'TRACESTATE',
+      '',
+    ];
+    invalidKeysTestCases.forEach(testCase =>
+      it(`returns true when key contains invalid chars ${testCase}`, () => {
+        assert.ok(!validateKey(testCase));
+      })
+    );
   });
 
   describe('validateValue', () => {
-    it('returns false when value contain equal', () => {
-      assert.ok(!validateValue('my_vakue=5'));
-    });
+    const validValuesTestCases = [
+      'first second',
+      'baz*',
+      'baz$',
+      'baz@',
+      'first-second',
+      'baz~bar',
+      'test-v1:120',
+      '-second',
+      'first.second',
+      'TrAcEsTaTE',
+      'TRACESTATE',
+    ];
+    validValuesTestCases.forEach(testCase =>
+      it(`returns true when value contains valid chars ${testCase}`, () => {
+        assert.ok(validateValue(testCase));
+      })
+    );
 
-    it('returns false when value contain comma', () => {
-      assert.ok(!validateValue('first,second'));
-    });
-
-    it('returns false when value contain trailing spaces', () => {
-      assert.ok(!validateValue('first '));
-    });
-
-    it('returns false when invalid value size', () => {
-      assert.ok(!validateValue('k'.repeat(257)));
-    });
+    const invalidValuesTestCases = [
+      'my_value=5',
+      'first,second',
+      'first ',
+      'k'.repeat(257),
+      ',baz',
+      'baz,',
+      'baz=',
+      '',
+    ];
+    invalidValuesTestCases.forEach(testCase =>
+      it(`returns true when value contains invalid chars ${testCase}`, () => {
+        assert.ok(!validateValue(testCase));
+      })
+    );
   });
 });

--- a/packages/opentelemetry-core/test/internal/validators.test.ts
+++ b/packages/opentelemetry-core/test/internal/validators.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { validateKey, validateValue } from '../../src/internal/validators';
+
+describe('validators', () => {
+  describe('validateKey', () => {
+    it('returns true when key contain all allowed characters', () => {
+      const allowedKeys = 'abcdefghijklmnopqrstuvwxyz0123456789-_*/';
+      assert.ok(validateKey(allowedKeys));
+    });
+
+    it('returns false when invalid first key character', () => {
+      assert.ok(!validateKey('1_key'));
+    });
+
+    it('returns false when invalid key characters', () => {
+      assert.ok(!validateKey('kEy_1'));
+    });
+
+    it('returns false when invalid key size', () => {
+      assert.ok(!validateKey('k'.repeat(257)));
+    });
+  });
+
+  describe('validateValue', () => {
+    it('returns false when value contain equal', () => {
+      assert.ok(!validateValue('my_vakue=5'));
+    });
+
+    it('returns false when value contain equal', () => {
+      assert.ok(!validateValue('first,second'));
+    });
+
+    it('returns false when value contain trailing spaces', () => {
+      assert.ok(!validateValue('first '));
+    });
+
+    it('returns false when invalid value size', () => {
+      assert.ok(!validateValue('k'.repeat(257)));
+    });
+
+    it('returns true when value is empty', () => {
+      assert.ok(validateValue(''));
+    });
+  });
+});

--- a/packages/opentelemetry-core/test/trace/tracestate.test.ts
+++ b/packages/opentelemetry-core/test/trace/tracestate.test.ts
@@ -83,5 +83,19 @@ describe('TraceState', () => {
       const state = new TraceState('a=1=');
       assert.deepStrictEqual(state.get('a'), undefined);
     });
+
+    it('must successfully parse valid state keys', () => {
+      const state = new TraceState('a-b=1,c/d=2,p*q=3,x_y=4');
+      assert.deepStrictEqual(state.get('a-b'), '1');
+      assert.deepStrictEqual(state.get('c/d'), '2');
+      assert.deepStrictEqual(state.get('p*q'), '3');
+      assert.deepStrictEqual(state.get('x_y'), '4');
+    });
+
+    it('must successfully parse valid state value with spaces in between', () => {
+      const state = new TraceState('a=1,foo=bar baz');
+      assert.deepStrictEqual(state.get('foo'), 'bar baz');
+      assert.deepStrictEqual(state.serialize(), 'a=1,foo=bar baz');
+    });
   });
 });

--- a/packages/opentelemetry-core/test/trace/tracestate.test.ts
+++ b/packages/opentelemetry-core/test/trace/tracestate.test.ts
@@ -79,9 +79,9 @@ describe('TraceState', () => {
       assert.deepStrictEqual(state.serialize(), 'a=1,c=3');
     });
 
-    it('must parse states that only have a single value with an equal sign', () => {
+    it('must skip states that only have a single value with an equal sign', () => {
       const state = new TraceState('a=1=');
-      assert.deepStrictEqual(state.get('a'), '1=');
+      assert.deepStrictEqual(state.get('a'), undefined);
     });
   });
 });


### PR DESCRIPTION
Based on https://w3c.github.io/trace-context/#tracestate-field

limits:
**Key** is opaque string up to 256 characters printable. It MUST begin with a lowercase letter, and can only contain lowercase letters `a-z`, digits `0-9`, underscores `_`, dashes `-`, asterisks `*`, and forward slashes `/`.

**Value** is opaque string up to 256 characters printable ASCII RFC0020 characters (i.e., the range 0x20 to 0x7E) except comma `,` and `=`.