### PR TITLE
Add Logger interface

### DIFF
--- a/packages/opentelemetry-core/src/common/NoopLogger.ts
+++ b/packages/opentelemetry-core/src/common/NoopLogger.ts
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-export * from './common/Logger';
-export * from './context/propagation/Propagator';
-export * from './distributed_context/DistributedContext';
-export * from './distributed_context/EntryValue';
-export * from './resources/Resource';
-export * from './trace/attributes';
-export * from './trace/Event';
-export * from './trace/link';
-export * from './trace/Sampler';
-export * from './trace/span';
-export * from './trace/span_context';
-export * from './trace/span_kind';
-export * from './trace/status';
-export * from './trace/trace_options';
-export * from './trace/trace_state';
+import { Logger } from '@opentelemetry/types';
+
+/** No-op implementation of Logger */
+export class NoopLogger implements Logger {
+  // By default does nothing
+  debug(message: string, ...args: unknown[]) {}
+
+  // By default does nothing
+  error(message: string, ...args: unknown[]) {}
+
+  // By default does nothing
+  warn(message: string, ...args: unknown[]) {}
+
+  // By default does nothing
+  info(message: string, ...args: unknown[]) {}
+}

--- a/packages/opentelemetry-types/src/common/Logger.ts
+++ b/packages/opentelemetry-types/src/common/Logger.ts
@@ -14,18 +14,12 @@
  * limitations under the License.
  */
 
-export * from './common/Logger';
-export * from './context/propagation/Propagator';
-export * from './distributed_context/DistributedContext';
-export * from './distributed_context/EntryValue';
-export * from './resources/Resource';
-export * from './trace/attributes';
-export * from './trace/Event';
-export * from './trace/link';
-export * from './trace/Sampler';
-export * from './trace/span';
-export * from './trace/span_context';
-export * from './trace/span_kind';
-export * from './trace/status';
-export * from './trace/trace_options';
-export * from './trace/trace_state';
+export type LogFunction = (message: string, ...args: unknown[]) => void;
+
+/** Defines a logger interface. */
+export interface Logger {
+  error: LogFunction;
+  warn: LogFunction;
+  info: LogFunction;
+  debug: LogFunction;
+}


### PR DESCRIPTION
This PR contains `Logger` interface and `NoopLogger`  implementation. 

I think we can extend this base interface to add `ConsoleLogger` (or somthing else) with config options like logLevel, strictMode(https://github.com/open-telemetry/opentelemetry-js/issues/92) etc.