### PR TITLE
Add no-op implementations of Tracer API

### DIFF
--- a/packages/opentelemetry-core/src/context/propagation/NoopBinaryFormat.ts
+++ b/packages/opentelemetry-core/src/context/propagation/NoopBinaryFormat.ts
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import { SpanContext } from '@opentelemetry/types';
+import { SpanContext, BinaryFormat } from '@opentelemetry/types';
 
 /**
  * No-op implementations of {@link BinaryFormat}.
- *
- * @todo: Implement BinaryFormat based on https://github.com/open-telemetry/opentelemetry-js/pull/74
  */
-class NoopBinaryFormat {
+class NoopBinaryFormat implements BinaryFormat {
   private readonly _buff = new ArrayBuffer(0);
   // By default does nothing
   toBytes(spanContext: SpanContext): ArrayBuffer {

--- a/packages/opentelemetry-core/src/context/propagation/NoopBinaryFormat.ts
+++ b/packages/opentelemetry-core/src/context/propagation/NoopBinaryFormat.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SpanContext } from '@opentelemetry/types';
+
+/**
+ * No-op implementations of {@link BinaryFormat}.
+ *
+ * @todo: Implement BinaryFormat based on https://github.com/open-telemetry/opentelemetry-js/pull/74
+ */
+class NoopBinaryFormat {
+  private readonly _buff = new ArrayBuffer(0);
+  // By default does nothing
+  toBytes(spanContext: SpanContext): ArrayBuffer {
+    return this._buff;
+  }
+
+  // By default does nothing
+  fromBytes(buf: ArrayBuffer): SpanContext | null {
+    return null;
+  }
+}
+
+export const NOOP_BINARY_FORMAT = new NoopBinaryFormat();

--- a/packages/opentelemetry-core/src/context/propagation/NoopHttpTextFormat.ts
+++ b/packages/opentelemetry-core/src/context/propagation/NoopHttpTextFormat.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Propagator, SpanContext } from '@opentelemetry/types';
+
+/**
+ * No-op implementations of {@link Propagator}.
+ *
+ * @todo: Change Propagator to HttpTextFormat based on https://github.com/open-telemetry/opentelemetry-js/pull/70
+ */
+class NoopHttpTextFormat implements Propagator {
+  // By default does nothing
+  inject(spanContext: SpanContext, format: string, carrier: unknown): void {}
+  // By default does nothing
+  extract(format: string, carrier: unknown): SpanContext | null {
+    return null;
+  }
+}
+
+export const NOOP_HTTP_TEXT_FORMAT = new NoopHttpTextFormat();

--- a/packages/opentelemetry-core/src/context/propagation/NoopHttpTextFormat.ts
+++ b/packages/opentelemetry-core/src/context/propagation/NoopHttpTextFormat.ts
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import { Propagator, SpanContext } from '@opentelemetry/types';
+import { HttpTextFormat, SpanContext } from '@opentelemetry/types';
 
 /**
- * No-op implementations of {@link Propagator}.
- *
- * @todo: Change Propagator to HttpTextFormat based on https://github.com/open-telemetry/opentelemetry-js/pull/70
+ * No-op implementations of {@link HttpTextFormat}.
  */
-class NoopHttpTextFormat implements Propagator {
+class NoopHttpTextFormat implements HttpTextFormat {
   // By default does nothing
   inject(spanContext: SpanContext, format: string, carrier: unknown): void {}
   // By default does nothing

--- a/packages/opentelemetry-core/src/index.ts
+++ b/packages/opentelemetry-core/src/index.ts
@@ -17,3 +17,4 @@
 export * from './context/propagation/HttpTraceContext';
 export * from './resources/Resource';
 export * from './trace/NoopSpan';
+export * from './trace/NoopTracer';

--- a/packages/opentelemetry-core/src/trace/NoopTracer.ts
+++ b/packages/opentelemetry-core/src/trace/NoopTracer.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { Tracer, SpanOptions, Span, Propagator } from '@opentelemetry/types';
+import {
+  Tracer,
+  SpanOptions,
+  Span,
+  Propagator,
+  BinaryFormat,
+} from '@opentelemetry/types';
 import { NOOP_HTTP_TEXT_FORMAT } from '../context/propagation/NoopHttpTextFormat';
 import { NOOP_BINARY_FORMAT } from '../context/propagation/NoopBinaryFormat';
 import { NoopSpan } from './NoopSpan';
@@ -34,7 +40,7 @@ export class NoopTracer implements Tracer {
     return NOOP_SPAN;
   }
 
-  // @todo
+  // @todo: dependency on https://github.com/open-telemetry/opentelemetry-js/pull/100, Use new return type.
   withSpan<T extends (...args: unknown[]) => unknown>(
     span: Span,
     fn: T
@@ -45,10 +51,13 @@ export class NoopTracer implements Tracer {
   // By default does nothing
   recordSpanData(span: Span): void {}
 
-  getBinaryFormat(): unknown {
+  // By default does nothing
+  getBinaryFormat(): BinaryFormat {
     return NOOP_BINARY_FORMAT;
   }
 
+  // @todo: Use new interface https://github.com/open-telemetry/opentelemetry-js/pull/70
+  // By default does nothing
   getHttpTextFormat(): Propagator {
     return NOOP_HTTP_TEXT_FORMAT;
   }

--- a/packages/opentelemetry-core/src/trace/NoopTracer.ts
+++ b/packages/opentelemetry-core/src/trace/NoopTracer.ts
@@ -24,8 +24,9 @@ import {
 import { NOOP_HTTP_TEXT_FORMAT } from '../context/propagation/NoopHttpTextFormat';
 import { NOOP_BINARY_FORMAT } from '../context/propagation/NoopBinaryFormat';
 import { NoopSpan } from './NoopSpan';
+import { INVALID_SPAN_CONTEXT } from './spancontext-utils';
 
-export const NOOP_SPAN = new NoopSpan({ traceId: '', spanId: '' });
+export const NOOP_SPAN = new NoopSpan(INVALID_SPAN_CONTEXT);
 
 /**
  * No-op implementations of {@link Tracer}.

--- a/packages/opentelemetry-core/src/trace/NoopTracer.ts
+++ b/packages/opentelemetry-core/src/trace/NoopTracer.ts
@@ -18,7 +18,7 @@ import {
   Tracer,
   SpanOptions,
   Span,
-  Propagator,
+  HttpTextFormat,
   BinaryFormat,
 } from '@opentelemetry/types';
 import { NOOP_HTTP_TEXT_FORMAT } from '../context/propagation/NoopHttpTextFormat';
@@ -57,9 +57,8 @@ export class NoopTracer implements Tracer {
     return NOOP_BINARY_FORMAT;
   }
 
-  // @todo: Use new interface https://github.com/open-telemetry/opentelemetry-js/pull/70
   // By default does nothing
-  getHttpTextFormat(): Propagator {
+  getHttpTextFormat(): HttpTextFormat {
     return NOOP_HTTP_TEXT_FORMAT;
   }
 }

--- a/packages/opentelemetry-core/src/trace/NoopTracer.ts
+++ b/packages/opentelemetry-core/src/trace/NoopTracer.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Tracer, SpanOptions, Span, Propagator } from '@opentelemetry/types';
+import { NOOP_HTTP_TEXT_FORMAT } from '../context/propagation/NoopHttpTextFormat';
+import { NOOP_BINARY_FORMAT } from '../context/propagation/NoopBinaryFormat';
+import { NoopSpan } from './NoopSpan';
+
+export const NOOP_SPAN = new NoopSpan({ traceId: '', spanId: '' });
+
+/**
+ * No-op implementations of {@link Tracer}.
+ */
+export class NoopTracer implements Tracer {
+  getCurrentSpan(): Span {
+    return NOOP_SPAN;
+  }
+
+  // startSpan starts a noop span.
+  startSpan(name: string, options?: SpanOptions): Span {
+    return NOOP_SPAN;
+  }
+
+  // @todo
+  withSpan<T extends (...args: unknown[]) => unknown>(
+    span: Span,
+    fn: T
+  ): ReturnType<T> {
+    throw new Error('Method not implemented.');
+  }
+
+  // By default does nothing
+  recordSpanData(span: Span): void {}
+
+  getBinaryFormat(): unknown {
+    return NOOP_BINARY_FORMAT;
+  }
+
+  getHttpTextFormat(): Propagator {
+    return NOOP_HTTP_TEXT_FORMAT;
+  }
+}

--- a/packages/opentelemetry-core/src/trace/spancontext-utils.ts
+++ b/packages/opentelemetry-core/src/trace/spancontext-utils.ts
@@ -1,0 +1,35 @@
+import { SpanContext } from '@opentelemetry/types';
+
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const INVALID_SPANID = '0';
+export const INVALID_TRACEID = '0';
+export const INVALID_SPAN_CONTEXT: SpanContext = {
+  traceId: INVALID_TRACEID,
+  spanId: INVALID_SPANID,
+};
+
+/**
+ * Returns true if this {@link SpanContext} is valid.
+ * @return true if this {@link SpanContext} is valid.
+ */
+export function isValid(spanContext: SpanContext): boolean {
+  return (
+    spanContext.traceId !== INVALID_TRACEID &&
+    spanContext.spanId !== INVALID_SPANID
+  );
+}

--- a/packages/opentelemetry-core/test/trace/NoopTracer.test.ts
+++ b/packages/opentelemetry-core/test/trace/NoopTracer.test.ts
@@ -19,7 +19,8 @@ import { NoopTracer, NOOP_SPAN } from '../../src/trace/NoopTracer';
 import { SpanKind } from '@opentelemetry/types';
 
 describe('NoopTracer', () => {
-  it('do not crash', () => {
+  it('does not crash', () => {
+    const spanContext = { traceId: '', spanId: '' };
     const tracer = new NoopTracer();
 
     assert.deepStrictEqual(tracer.startSpan('span-name'), NOOP_SPAN);
@@ -40,7 +41,16 @@ describe('NoopTracer', () => {
     assert.deepStrictEqual(tracer.getCurrentSpan(), NOOP_SPAN);
     const httpTextFormat = tracer.getHttpTextFormat();
     assert.ok(httpTextFormat);
-    httpTextFormat.inject({ traceId: '', spanId: '' }, 'HttpTextFormat', {});
-    httpTextFormat.extract('HttpTextFormat', {});
+    httpTextFormat.inject(spanContext, 'HttpTextFormat', {});
+    assert.deepStrictEqual(httpTextFormat.extract('HttpTextFormat', {}), null);
+
+    const binaryFormat = tracer.getBinaryFormat();
+    assert.ok(binaryFormat);
+    assert.ok(binaryFormat.toBytes(spanContext), typeof ArrayBuffer);
+    assert.deepStrictEqual(binaryFormat.fromBytes(new ArrayBuffer(0)), null);
+
+    assert.throws(() => {
+      tracer.withSpan(NOOP_SPAN, () => {});
+    });
   });
 });

--- a/packages/opentelemetry-core/test/trace/NoopTracer.test.ts
+++ b/packages/opentelemetry-core/test/trace/NoopTracer.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { NoopTracer, NOOP_SPAN } from '../../src/trace/NoopTracer';
+import { SpanKind } from '@opentelemetry/types';
+
+describe('NoopTracer', () => {
+  it('do not crash', () => {
+    const tracer = new NoopTracer();
+
+    assert.deepStrictEqual(tracer.startSpan('span-name'), NOOP_SPAN);
+    assert.deepStrictEqual(
+      tracer.startSpan('span-name1', { kind: SpanKind.CLIENT }),
+      NOOP_SPAN
+    );
+    assert.deepStrictEqual(
+      tracer.startSpan('span-name2', {
+        kind: SpanKind.CLIENT,
+        isRecordingEvents: true,
+      }),
+      NOOP_SPAN
+    );
+
+    tracer.recordSpanData(NOOP_SPAN);
+
+    assert.deepStrictEqual(tracer.getCurrentSpan(), NOOP_SPAN);
+    const httpTextFormat = tracer.getHttpTextFormat();
+    assert.ok(httpTextFormat);
+    httpTextFormat.inject({ traceId: '', spanId: '' }, 'HttpTextFormat', {});
+    httpTextFormat.extract('HttpTextFormat', {});
+  });
+});

--- a/packages/opentelemetry-types/src/index.ts
+++ b/packages/opentelemetry-types/src/index.ts
@@ -29,5 +29,6 @@ export * from './trace/SpanOptions';
 export * from './trace/span_context';
 export * from './trace/span_kind';
 export * from './trace/status';
+export * from './trace/tracer';
 export * from './trace/trace_options';
 export * from './trace/trace_state';


### PR DESCRIPTION
Closes #86 

~This is still work in progress as some dependencies are not yet merged (especially ~`BinaryFormat` (merged now)~ and ~`HttpTraceContext`(merged now)~ PRs) but it should provide a starting point and avoid blocking other work. Comments are welcome.~