### PR TITLE
Codecov: Fix file path prefixes

### DIFF
--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -15,7 +15,7 @@
     "tdd": "yarn tdd:node",
     "tdd:node": "yarn test -- --watch-extensions ts --watch",
     "tdd:browser": "karma start",
-    "codecov": "c8 report --reporter=json && codecov -f coverage/*.json",
+    "codecov": "c8 report --reporter=json && codecov -f coverage/*.json -p ../../",
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",

--- a/packages/opentelemetry-scope-base/package.json
+++ b/packages/opentelemetry-scope-base/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "c8 ts-mocha -p tsconfig.json test/**/*.ts",
     "tdd": "yarn test -- --watch-extensions ts --watch",
-    "codecov": "c8 report --reporter=json && codecov -f coverage/*.json",
+    "codecov": "c8 report --reporter=json",
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",


### PR DESCRIPTION
Fixes #97 

[Sample Generated Report](https://codecov.io/gh/markwolff/opentelemetry-js/tree/a8a1a3d1ad73f66c78dd179de0cd8871a9324e20) - only core has a non-empty report for now

5e7b244 removes the publishing of the report of `opentelemetry-scope-base` because it was an empty report. Codecov seems to error out every report if any are empty, so this should be added back in (with `-p ../../`) when there is code to be coverage checked.

Opting to use method proposed [here](https://github.com/open-telemetry/opentelemetry-js/issues/97#issuecomment-510788353) so that all script logic is located in each `package.json`, instead of scanning for (non-empty) coverage reports in circleCI yaml.

It might also be a good idea to separate generation and publishing of reports as in [https://github.com/vmarchaud/openprofiling-node/blob/master/packages/openprofiling-core/package.json#L12](OpenProfiling), since local dev box will never need to publish coverage reports.