### PR TITLE
Tslint rules for license headers and file names matching exports (case sensitive)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "devDependencies": {
+    "gts": "^1.0.0",
     "lerna": "^3.13.4",
     "typescript": "^3.4.5"
   }

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -46,6 +46,7 @@
     "mocha": "^6.1.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.0.0",
+    "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "^3.4.5"
   },
   "dependencies": {}

--- a/packages/opentelemetry-context-async-hooks/src/index.ts
+++ b/packages/opentelemetry-context-async-hooks/src/index.ts
@@ -1,11 +1,11 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/opentelemetry-context-async-hooks/tslint.json
+++ b/packages/opentelemetry-context-async-hooks/tslint.json
@@ -1,0 +1,4 @@
+{
+  "rulesDirectory": ["node_modules/tslint-microsoft-contrib"],
+  "extends": "../../tslint.base.js"
+}

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -76,6 +76,7 @@
     "ts-loader": "^6.0.4",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.0.0",
+    "tslint-microsoft-contrib": "^6.2.0",
     "webpack": "^4.35.2",
     "typescript": "^3.4.5"
   },

--- a/packages/opentelemetry-core/src/common/NoopLogger.ts
+++ b/packages/opentelemetry-core/src/common/NoopLogger.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/src/context/propagation/BinaryTraceContext.ts
+++ b/packages/opentelemetry-core/src/context/propagation/BinaryTraceContext.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/src/context/propagation/HttpTraceContext.ts
+++ b/packages/opentelemetry-core/src/context/propagation/HttpTraceContext.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/src/index.ts
+++ b/packages/opentelemetry-core/src/index.ts
@@ -1,11 +1,11 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/opentelemetry-core/src/internal/validators.ts
+++ b/packages/opentelemetry-core/src/internal/validators.ts
@@ -1,11 +1,11 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/opentelemetry-core/src/platform/browser/id.ts
+++ b/packages/opentelemetry-core/src/platform/browser/id.ts
@@ -1,11 +1,11 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/opentelemetry-core/src/platform/browser/index.ts
+++ b/packages/opentelemetry-core/src/platform/browser/index.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/src/platform/index.ts
+++ b/packages/opentelemetry-core/src/platform/index.ts
@@ -1,11 +1,11 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/opentelemetry-core/src/platform/node/id.ts
+++ b/packages/opentelemetry-core/src/platform/node/id.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/src/platform/node/index.ts
+++ b/packages/opentelemetry-core/src/platform/node/index.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/src/resources/Resource.ts
+++ b/packages/opentelemetry-core/src/resources/Resource.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/src/trace/NoopSpan.ts
+++ b/packages/opentelemetry-core/src/trace/NoopSpan.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/src/trace/TraceState.ts
+++ b/packages/opentelemetry-core/src/trace/TraceState.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/src/trace/sampler/ProbabilitySampler.ts
+++ b/packages/opentelemetry-core/src/trace/sampler/ProbabilitySampler.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/src/trace/spancontext-utils.ts
+++ b/packages/opentelemetry-core/src/trace/spancontext-utils.ts
@@ -1,6 +1,4 @@
-import { SpanContext } from '@opentelemetry/types';
-
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +13,8 @@ import { SpanContext } from '@opentelemetry/types';
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { SpanContext } from '@opentelemetry/types';
 
 export const INVALID_SPANID = '0';
 export const INVALID_TRACEID = '0';

--- a/packages/opentelemetry-core/test/context/BinaryTraceContext.test.ts
+++ b/packages/opentelemetry-core/test/context/BinaryTraceContext.test.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/test/context/HttpTraceContext.test.ts
+++ b/packages/opentelemetry-core/test/context/HttpTraceContext.test.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/test/index-webpack.ts
+++ b/packages/opentelemetry-core/test/index-webpack.ts
@@ -1,11 +1,11 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/opentelemetry-core/test/internal/validators.test.ts
+++ b/packages/opentelemetry-core/test/internal/validators.test.ts
@@ -1,11 +1,11 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/opentelemetry-core/test/platform/id.test.ts
+++ b/packages/opentelemetry-core/test/platform/id.test.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/test/resources/resource.test.ts
+++ b/packages/opentelemetry-core/test/resources/resource.test.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/test/trace/NoopSpan.test.ts
+++ b/packages/opentelemetry-core/test/trace/NoopSpan.test.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/test/trace/ProbabilitySampler.test.ts
+++ b/packages/opentelemetry-core/test/trace/ProbabilitySampler.test.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/test/trace/tracestate.test.ts
+++ b/packages/opentelemetry-core/test/trace/tracestate.test.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-core/tslint.json
+++ b/packages/opentelemetry-core/tslint.json
@@ -1,0 +1,4 @@
+{
+  "rulesDirectory": ["node_modules/tslint-microsoft-contrib"],
+  "extends": "../../tslint.base.js"
+}

--- a/packages/opentelemetry-scope-base/package.json
+++ b/packages/opentelemetry-scope-base/package.json
@@ -47,6 +47,7 @@
     "mocha": "^6.1.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.0.0",
+    "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "^3.4.5"
   },
   "dependencies": {}

--- a/packages/opentelemetry-scope-base/src/NoopScopeManager.ts
+++ b/packages/opentelemetry-scope-base/src/NoopScopeManager.ts
@@ -1,11 +1,11 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/opentelemetry-scope-base/src/index.ts
+++ b/packages/opentelemetry-scope-base/src/index.ts
@@ -1,11 +1,11 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/opentelemetry-scope-base/src/types.ts
+++ b/packages/opentelemetry-scope-base/src/types.ts
@@ -1,11 +1,11 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/opentelemetry-scope-base/test/noop/NoopScopeManager.test.ts
+++ b/packages/opentelemetry-scope-base/test/noop/NoopScopeManager.test.ts
@@ -1,11 +1,11 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/opentelemetry-scope-base/tslint.json
+++ b/packages/opentelemetry-scope-base/tslint.json
@@ -1,0 +1,4 @@
+{
+  "rulesDirectory": ["node_modules/tslint-microsoft-contrib"],
+  "extends": "../../tslint.base.js"
+}

--- a/packages/opentelemetry-types/package.json
+++ b/packages/opentelemetry-types/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "gts": "^1.0.0",
     "typedoc": "^0.14.2",
+    "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "^3.4.5"
   }
 }

--- a/packages/opentelemetry-types/src/common/Logger.ts
+++ b/packages/opentelemetry-types/src/common/Logger.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/context/propagation/BinaryFormat.ts
+++ b/packages/opentelemetry-types/src/context/propagation/BinaryFormat.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/context/propagation/HttpTextFormat.ts
+++ b/packages/opentelemetry-types/src/context/propagation/HttpTextFormat.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/distributed_context/DistributedContext.ts
+++ b/packages/opentelemetry-types/src/distributed_context/DistributedContext.ts
@@ -1,11 +1,11 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/opentelemetry-types/src/distributed_context/EntryValue.ts
+++ b/packages/opentelemetry-types/src/distributed_context/EntryValue.ts
@@ -1,11 +1,11 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/packages/opentelemetry-types/src/index.ts
+++ b/packages/opentelemetry-types/src/index.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/resources/Resource.ts
+++ b/packages/opentelemetry-types/src/resources/Resource.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/trace/Event.ts
+++ b/packages/opentelemetry-types/src/trace/Event.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/trace/Sampler.ts
+++ b/packages/opentelemetry-types/src/trace/Sampler.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/trace/SpanOptions.ts
+++ b/packages/opentelemetry-types/src/trace/SpanOptions.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/trace/TimedEvent.ts
+++ b/packages/opentelemetry-types/src/trace/TimedEvent.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/trace/attributes.ts
+++ b/packages/opentelemetry-types/src/trace/attributes.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/trace/link.ts
+++ b/packages/opentelemetry-types/src/trace/link.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/trace/span.ts
+++ b/packages/opentelemetry-types/src/trace/span.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/trace/span_context.ts
+++ b/packages/opentelemetry-types/src/trace/span_context.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/trace/span_kind.ts
+++ b/packages/opentelemetry-types/src/trace/span_kind.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/trace/status.ts
+++ b/packages/opentelemetry-types/src/trace/status.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/trace/trace_options.ts
+++ b/packages/opentelemetry-types/src/trace/trace_options.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/trace/trace_state.ts
+++ b/packages/opentelemetry-types/src/trace/trace_state.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/src/trace/tracer.ts
+++ b/packages/opentelemetry-types/src/trace/tracer.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/opentelemetry-types/tslint.json
+++ b/packages/opentelemetry-types/tslint.json
@@ -1,0 +1,4 @@
+{
+  "rulesDirectory": ["node_modules/tslint-microsoft-contrib"],
+  "extends": "../../tslint.base.js"
+}

--- a/tslint.base.js
+++ b/tslint.base.js
@@ -1,0 +1,70 @@
+/* !
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Note the `file-header` TS lint rule implicitly adds comments around this, and
+// makes the first comment line begin with /*!
+// See:
+// https://github.com/palantir/tslint/blob/b2972495e05710fa55600c233bf46a8a5c02e3cd/src/rules/fileHeaderRule.ts#L224
+const fileHeaderTemplate = `Copyright YEAR_PLACEHOLDER, OpenTelemetry Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.`;
+
+const fileHeaderRegexStr =
+    fileHeaderTemplate
+        .replace(/[\\\/^$.*+?()[\]{}|]/g, '\\$&')  // Escape regex
+        .replace(/\n/g, '\n \\* ?')  // Per line space+asterisk, optional space
+        .replace('YEAR_PLACEHOLDER', '2\\d{3}');
+
+const fileHeaderDefault =
+    fileHeaderTemplate.replace('YEAR_PLACEHOLDER', new Date().getFullYear());
+
+const rules = {
+  'file-header': [
+    true,
+    {
+      'allow-single-line-comments': false,
+      'match': fileHeaderRegexStr,
+      'default': fileHeaderDefault,
+    },
+  ],
+
+  // Require file name to match export name for files wtih a single export.
+  'export-name': [
+    true,
+    {
+      allow: [
+        // These export a capitalized singleton constant but not the class
+        // name, but allow them to be named based on the class name.
+        'NOOP_BINARY_FORMAT',
+        'NOOP_HTTP_TEXT_FORMAT',
+      ],
+    },
+  ],
+};
+
+module.exports = {
+  rules,
+};


### PR DESCRIPTION
This adds a TSLint rule for the license file in its current multi-line state. I made small tweaks to existing license files to match what TSLint offers (it requires a prefix of `/*!` rather than `/**`). If we can confirm with CNCF that a single line license prefix is OK, we can update all files and the TSLint rule at once.

I also added the `'export-name'` rule from [tslint-microsoft-contrib](https://github.com/microsoft/tslint-microsoft-contrib) that enforces that files that have a single export be named to match the export. It's supposed to be case sensitive but when I tested it it didn't seem to correctly catch case mismatches. So we may have to enforce the case manually.

I noticed also that TSLint itself is [being deprecated in favor of ESLint's TypeScript support](https://github.com/palantir/tslint/issues/4534). Eventually we should migrate to that, perhaps once the `gts` package does that (see [their tracking issue for it](https://github.com/google/gts/issues/302)).