### PR TITLE
Export NoopLogger and BinaryTraceContext

### DIFF
--- a/packages/opentelemetry-core/src/index.ts
+++ b/packages/opentelemetry-core/src/index.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+export * from './common/NoopLogger';
+export * from './context/propagation/BinaryTraceContext';
 export * from './context/propagation/HttpTraceContext';
 export * from './resources/Resource';
 export * from './trace/NoopSpan';


### PR DESCRIPTION
This is required in `basic-tracer` and `node-tracer` package.