### PR TITLE
feat: add span processor

### DIFF
--- a/packages/opentelemetry-basic-tracer/src/SpanProcessor.ts
+++ b/packages/opentelemetry-basic-tracer/src/SpanProcessor.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Span } from '@opentelemetry/types';
+
+/**
+ * SpanProcessor is the interface Tracer SDK uses to allow synchronous hooks
+ * for when a {@link Span} is started or when a {@link Span} is ended.
+ */
+export interface SpanProcessor {
+  /**
+   * Called when a {@link Span} is started, if the `span.isRecordingEvents()`
+   * returns true.
+   * @param span the Span that just started.
+   */
+  onStart(span: Span): void;
+
+  /**
+   * Called when a {@link Span} is ended, if the `span.isRecordingEvents()`
+   * returns true.
+   * @param span the Span that just ended.
+   */
+  onEnd(span: Span): void;
+
+  /**
+   * Shuts down the processor. Called when SDK is shut down. This is an
+   * opportunity for processor to do any cleanup required.
+   */
+  shutdown(): void;
+}

--- a/packages/opentelemetry-basic-tracer/src/index.ts
+++ b/packages/opentelemetry-basic-tracer/src/index.ts
@@ -20,3 +20,4 @@ export * from './export/SpanExporter';
 export * from './types';
 export * from './BasicTracer';
 export * from './Span';
+export * from './SpanProcessor';


### PR DESCRIPTION
Idea: The `SpanProcessor` interface allows users to build frameworks like exporter/z-pages/etc. The `SpanProcessor` interface should allow intercepting `Span`s immediately after start and immediately after end.

OpenCensus contains the same kind of interface: 
https://github.com/census-instrumentation/opencensus-node/blob/056523d83d21449e3bd888fec624d33c129951cc/packages/opencensus-core/src/trace/model/types.ts#L261-L266

This exist in [java](https://github.com/open-telemetry/opentelemetry-java/blob/cd06daa70eca1223c1c78a1ed7daee620d311dc5/sdk/src/main/java/io/opentelemetry/sdk/trace/SpanProcessor.java) but aren't yet included in the [spec](https://github.com/open-telemetry/opentelemetry-specification/issues/54).
