### PR TITLE
feat(ah-scope): add scope propagation for event emitters

### DIFF
--- a/packages/opentelemetry-scope-async-hooks/src/AsyncHooksScopeManager.ts
+++ b/packages/opentelemetry-scope-async-hooks/src/AsyncHooksScopeManager.ts
@@ -16,6 +16,26 @@
 
 import { ScopeManager } from '@opentelemetry/scope-base';
 import * as asyncHooks from 'async_hooks';
+import { EventEmitter } from 'events';
+
+type Func<T> = (...args: unknown[]) => T;
+
+type PatchedEventEmitter = {
+  /**
+   * Store a map for each event of all original listener and their "patched"
+   * version so when the listener is removed by the user, we remove the
+   * correspoding "patched" function.
+   */
+  __ot_listeners?: { [name: string]: WeakMap<Func<void>, Func<void>> };
+} & EventEmitter;
+
+const ADD_LISTENER_METHODS = [
+  'addListener' as 'addListener',
+  'on' as 'on',
+  'once' as 'once',
+  'prependListener' as 'prependListener',
+  'prependOnceListener' as 'prependOnceListener',
+];
 
 export class AsyncHooksScopeManager implements ScopeManager {
   private _asyncHook: asyncHooks.AsyncHook;
@@ -58,7 +78,9 @@ export class AsyncHooksScopeManager implements ScopeManager {
     if (scope === undefined) {
       scope = this.active();
     }
-    if (typeof target === 'function') {
+    if (target instanceof EventEmitter) {
+      return this._bindEventEmitter(target, scope);
+    } else if (typeof target === 'function') {
       return this._bindFunction(target, scope);
     }
     return target;
@@ -92,6 +114,112 @@ export class AsyncHooksScopeManager implements ScopeManager {
      */
     // tslint:disable-next-line:no-any
     return contextWrapper as any;
+  }
+
+  /**
+   * By default, EventEmitter call their callback with their scope, which we do
+   * not want, instead we will bind a specific scope to all callbacks that
+   * go through it.
+   * @param target EventEmitter a instance of EventEmitter to patch
+   * @param scope the scope we want to bind
+   */
+  private _bindEventEmitter<T extends EventEmitter>(
+    target: T,
+    scope?: unknown
+  ): T {
+    const ee = (target as unknown) as PatchedEventEmitter;
+    if (ee.__ot_listeners !== undefined) return target;
+    ee.__ot_listeners = {};
+
+    // patch methods that add a listener to propagate scope
+    ADD_LISTENER_METHODS.forEach(methodName => {
+      if (ee[methodName] === undefined) return;
+      ee[methodName] = this._patchAddListener(ee, ee[methodName], scope);
+    });
+    // patch methods that remove a listener
+    if (typeof ee.removeListener === 'function') {
+      ee.removeListener = this._patchRemoveListener(ee, ee.removeListener);
+    }
+    if (typeof ee.off === 'function') {
+      ee.off = this._patchRemoveListener(ee, ee.off);
+    }
+    // patch method that remove all listeners
+    if (typeof ee.removeAllListeners === 'function') {
+      ee.removeAllListeners = this._patchRemoveAllListeners(
+        ee,
+        ee.removeAllListeners
+      );
+    }
+    return target;
+  }
+
+  /**
+   * Patch methods that remove a given listener so that we match the "patched"
+   * version of that listener (the one that propagate context).
+   * @param ee EventEmitter instance
+   * @param original reference to the patched method
+   */
+  private _patchRemoveListener(ee: PatchedEventEmitter, original: Function) {
+    return function(this: {}, event: string, listener: Func<void>) {
+      if (
+        ee.__ot_listeners === undefined ||
+        ee.__ot_listeners[event] === undefined
+      ) {
+        return original.call(this, event, listener);
+      }
+      const events = ee.__ot_listeners[event];
+      const patchedListener = events.get(listener);
+      return original.call(this, event, patchedListener || listener);
+    };
+  }
+
+  /**
+   * Patch methods that remove all listeners so we remove our
+   * internal references for a given event.
+   * @param ee EventEmitter instance
+   * @param original reference to the patched method
+   */
+  private _patchRemoveAllListeners(
+    ee: PatchedEventEmitter,
+    original: Function
+  ) {
+    return function(this: {}, event: string) {
+      if (
+        ee.__ot_listeners === undefined ||
+        ee.__ot_listeners[event] === undefined
+      ) {
+        return original.call(this, event);
+      }
+      delete ee.__ot_listeners[event];
+      return original.call(this, event);
+    };
+  }
+
+  /**
+   * Patch methods on an event emitter instance that can add listeners so we
+   * can force them to propagate a given context.
+   * @param ee EventEmitter instance
+   * @param original reference to the patched method
+   * @param [scope] scope to propagate when calling listeners
+   */
+  private _patchAddListener(
+    ee: PatchedEventEmitter,
+    original: Function,
+    scope?: unknown
+  ) {
+    const scopeManager = this;
+    return function(this: {}, event: string, listener: Func<void>) {
+      if (ee.__ot_listeners === undefined) ee.__ot_listeners = {};
+      let listeners = ee.__ot_listeners[event];
+      if (listeners === undefined) {
+        listeners = new WeakMap();
+        ee.__ot_listeners[event] = listeners;
+      }
+      const patchedListener = scopeManager.bind(listener, scope);
+      // store a weak reference of the user listener to ours
+      listeners.set(listener, patchedListener);
+      return original.call(this, event, patchedListener);
+    };
   }
 
   /**


### PR DESCRIPTION
Making a new PR for event emitters support with async hooks.
Link to initial PR issue with the current implementation: https://github.com/open-telemetry/opentelemetry-js/pull/103#discussion_r303908136

I was saying that i would expect this behavior:
```
let ee = new EventEmitter()
ee = scopeManager.bind(ee, { test: 1 })
ee.on('test', () => {
// i would expect that scopeManager.active() would be { test: 1 } here.
})
```

@rochdev is the implementation using the scope at the `.on` moment would have the same behavior ? I'm not sure.