### PR TITLE
feat(sdk): add ReadableSpan

### DIFF
--- a/packages/opentelemetry-basic-tracer/src/Span.ts
+++ b/packages/opentelemetry-basic-tracer/src/Span.ts
@@ -17,6 +17,7 @@
 import * as types from '@opentelemetry/types';
 import { performance } from 'perf_hooks';
 import { SpanKind, SpanContext } from '@opentelemetry/types';
+import { ReadableSpan } from './export/ReadableSpan';
 
 /**
  * This class represents a span.
@@ -108,6 +109,22 @@ export class Span implements types.Span {
 
   isRecordingEvents(): boolean {
     return true;
+  }
+
+  toReadableSpan(): ReadableSpan {
+    return {
+      name: this._name,
+      traceId: this._spanContext.traceId,
+      spanId: this._spanContext.spanId,
+      parentSpanId: this._parentId,
+      kind: this._kind,
+      startTime: this._startTime,
+      endTime: this._endTime,
+      status: this._status,
+      attributes: this._attributes,
+      links: this._links,
+      events: this._events,
+    };
   }
 
   toString() {

--- a/packages/opentelemetry-basic-tracer/src/Span.ts
+++ b/packages/opentelemetry-basic-tracer/src/Span.ts
@@ -128,16 +128,7 @@ export class Span implements types.Span {
   }
 
   toString() {
-    const json = JSON.stringify({
-      traceId: this._spanContext.traceId,
-      spanId: this._spanContext.spanId,
-      parentId: this._parentId,
-      name: this._name,
-      kind: this._kind,
-      status: this._status,
-      startTime: this._startTime,
-      endTime: this._endTime,
-    });
+    const json = JSON.stringify(this.toReadableSpan());
     return `Span${json}`;
   }
 

--- a/packages/opentelemetry-basic-tracer/src/Span.ts
+++ b/packages/opentelemetry-basic-tracer/src/Span.ts
@@ -23,6 +23,8 @@ import { ReadableSpan } from './export/ReadableSpan';
  */
 export class Span implements types.Span, ReadableSpan {
   private readonly _tracer: types.Tracer;
+  // Below properties are included to implement ReadableSpan for export
+  // purposes but are not intended to be written-to directly.
   readonly spanContext: types.SpanContext;
   readonly kind: types.SpanKind;
   readonly parentSpanId?: string;

--- a/packages/opentelemetry-basic-tracer/src/export/ReadableSpan.ts
+++ b/packages/opentelemetry-basic-tracer/src/export/ReadableSpan.ts
@@ -14,9 +14,24 @@
  * limitations under the License.
  */
 
-export * from './export/ExportResult';
-export * from './export/ReadableSpan';
-export * from './export/SpanExporter';
-export * from './types';
-export * from './BasicTracer';
-export * from './Span';
+import {
+  SpanKind,
+  Status,
+  Attributes,
+  Link,
+  Event,
+} from '@opentelemetry/types';
+
+export interface ReadableSpan {
+  readonly name: string;
+  readonly kind: SpanKind;
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly parentSpanId?: string;
+  readonly startTime: number;
+  readonly endTime: number;
+  readonly status: Status;
+  readonly attributes: Attributes;
+  readonly links: Link[];
+  readonly events: Event[];
+}

--- a/packages/opentelemetry-basic-tracer/src/export/ReadableSpan.ts
+++ b/packages/opentelemetry-basic-tracer/src/export/ReadableSpan.ts
@@ -20,13 +20,13 @@ import {
   Attributes,
   Link,
   Event,
+  SpanContext,
 } from '@opentelemetry/types';
 
 export interface ReadableSpan {
   readonly name: string;
   readonly kind: SpanKind;
-  readonly traceId: string;
-  readonly spanId: string;
+  readonly spanContext: SpanContext;
   readonly parentSpanId?: string;
   readonly startTime: number;
   readonly endTime: number;

--- a/packages/opentelemetry-basic-tracer/test/Span.test.ts
+++ b/packages/opentelemetry-basic-tracer/test/Span.test.ts
@@ -106,7 +106,7 @@ describe('Span', () => {
   });
 
   it('should return ReadableSpan', () => {
-    const span = new Span(tracer, 'my-span', { parent: spanContext });
+    const span = new Span(tracer, 'my-span', spanContext, SpanKind.CLIENT);
 
     const readableSpan = span.toReadableSpan();
     assert.strictEqual(readableSpan.name, 'my-span');
@@ -122,7 +122,7 @@ describe('Span', () => {
   });
 
   it('should return ReadableSpan with attributes', () => {
-    const span = new Span(tracer, 'my-span', { parent: spanContext });
+    const span = new Span(tracer, 'my-span', spanContext, SpanKind.CLIENT);
     span.setAttribute('attr1', 'value1');
     let readableSpan = span.toReadableSpan();
     assert.deepStrictEqual(readableSpan.attributes, { attr1: 'value1' });
@@ -145,7 +145,7 @@ describe('Span', () => {
   });
 
   it('should return ReadableSpan with links', () => {
-    const span = new Span(tracer, 'my-span', { parent: spanContext });
+    const span = new Span(tracer, 'my-span', spanContext, SpanKind.CLIENT);
     span.addLink(spanContext);
     let readableSpan = span.toReadableSpan();
     assert.strictEqual(readableSpan.links.length, 1);
@@ -182,7 +182,7 @@ describe('Span', () => {
   });
 
   it('should return ReadableSpan with events', () => {
-    const span = new Span(tracer, 'my-span', { parent: spanContext });
+    const span = new Span(tracer, 'my-span', spanContext, SpanKind.CLIENT);
     span.addEvent('sent');
     let readableSpan = span.toReadableSpan();
     assert.strictEqual(readableSpan.events.length, 1);
@@ -220,7 +220,7 @@ describe('Span', () => {
   });
 
   it('should return ReadableSpan with new status', () => {
-    const span = new Span(tracer, name, {});
+    const span = new Span(tracer, name, spanContext, SpanKind.CLIENT);
     span.setStatus({
       code: CanonicalCode.PERMISSION_DENIED,
       message: 'This is an error',

--- a/packages/opentelemetry-basic-tracer/test/Span.test.ts
+++ b/packages/opentelemetry-basic-tracer/test/Span.test.ts
@@ -104,4 +104,132 @@ describe('Span', () => {
       `Span{"traceId":"${context.traceId}","spanId":"${context.spanId}","parentId":"${parentId}","name":"${name}","kind":1,"status":{"code":0},"startTime":100,"endTime":0}`
     );
   });
+
+  it('should return ReadableSpan', () => {
+    const span = new Span(tracer, 'my-span', { parent: spanContext });
+
+    const readableSpan = span.toReadableSpan();
+    assert.strictEqual(readableSpan.name, 'my-span');
+    assert.strictEqual(readableSpan.kind, SpanKind.INTERNAL);
+    assert.strictEqual(readableSpan.parentSpanId, spanContext.spanId);
+    assert.strictEqual(readableSpan.traceId, spanContext.traceId);
+    assert.deepStrictEqual(readableSpan.status, {
+      code: CanonicalCode.OK,
+    });
+    assert.deepStrictEqual(readableSpan.attributes, {});
+    assert.deepStrictEqual(readableSpan.links, []);
+    assert.deepStrictEqual(readableSpan.events, []);
+  });
+
+  it('should return ReadableSpan with attributes', () => {
+    const span = new Span(tracer, 'my-span', { parent: spanContext });
+    span.setAttribute('attr1', 'value1');
+    let readableSpan = span.toReadableSpan();
+    assert.deepStrictEqual(readableSpan.attributes, { attr1: 'value1' });
+
+    span.setAttributes({ attr2: 123, attr1: false });
+    readableSpan = span.toReadableSpan();
+    assert.deepStrictEqual(readableSpan.attributes, {
+      attr1: false,
+      attr2: 123,
+    });
+
+    span.end();
+    // shouldn't add new attribute
+    span.setAttribute('attr3', 'value3');
+    readableSpan = span.toReadableSpan();
+    assert.deepStrictEqual(readableSpan.attributes, {
+      attr1: false,
+      attr2: 123,
+    });
+  });
+
+  it('should return ReadableSpan with links', () => {
+    const span = new Span(tracer, 'my-span', { parent: spanContext });
+    span.addLink(spanContext);
+    let readableSpan = span.toReadableSpan();
+    assert.strictEqual(readableSpan.links.length, 1);
+    assert.deepStrictEqual(readableSpan.links, [
+      {
+        attributes: undefined,
+        spanContext: {
+          spanId: '6e0c63257de34c92',
+          traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+          traceOptions: 1,
+        },
+      },
+    ]);
+
+    span.addLink(spanContext, { attr1: 'value', attr2: 123, attr3: true });
+    readableSpan = span.toReadableSpan();
+    assert.strictEqual(readableSpan.links.length, 2);
+    assert.deepStrictEqual(readableSpan.links, [
+      {
+        attributes: undefined,
+        spanContext,
+      },
+      {
+        attributes: { attr1: 'value', attr2: 123, attr3: true },
+        spanContext,
+      },
+    ]);
+
+    span.end();
+    // shouldn't add new link
+    span.addLink(spanContext);
+    readableSpan = span.toReadableSpan();
+    assert.strictEqual(readableSpan.links.length, 2);
+  });
+
+  it('should return ReadableSpan with events', () => {
+    const span = new Span(tracer, 'my-span', { parent: spanContext });
+    span.addEvent('sent');
+    let readableSpan = span.toReadableSpan();
+    assert.strictEqual(readableSpan.events.length, 1);
+    assert.deepStrictEqual(readableSpan.events, [
+      {
+        attributes: undefined,
+        name: 'sent',
+      },
+    ]);
+
+    span.addEvent('rev', { attr1: 'value', attr2: 123, attr3: true });
+    readableSpan = span.toReadableSpan();
+    assert.strictEqual(readableSpan.events.length, 2);
+    assert.deepStrictEqual(readableSpan.events, [
+      {
+        attributes: undefined,
+        name: 'sent',
+      },
+      {
+        attributes: {
+          attr1: 'value',
+          attr2: 123,
+          attr3: true,
+        },
+        name: 'rev',
+      },
+    ]);
+
+    span.end();
+    // shouldn't add new event
+    span.addEvent('sent');
+    assert.strictEqual(readableSpan.events.length, 2);
+    readableSpan = span.toReadableSpan();
+    assert.strictEqual(readableSpan.events.length, 2);
+  });
+
+  it('should return ReadableSpan with new status', () => {
+    const span = new Span(tracer, name, {});
+    span.setStatus({
+      code: CanonicalCode.PERMISSION_DENIED,
+      message: 'This is an error',
+    });
+    const readableSpan = span.toReadableSpan();
+    assert.strictEqual(
+      readableSpan.status.code,
+      CanonicalCode.PERMISSION_DENIED
+    );
+    assert.strictEqual(readableSpan.status.message, 'This is an error');
+  });
 });

--- a/packages/opentelemetry-basic-tracer/test/Span.test.ts
+++ b/packages/opentelemetry-basic-tracer/test/Span.test.ts
@@ -88,23 +88,6 @@ describe('Span', () => {
     });
   });
 
-  it('should return toString', () => {
-    const parentId = '5c1c63257de34c67';
-    const span = new Span(
-      tracer,
-      name,
-      spanContext,
-      SpanKind.SERVER,
-      parentId,
-      100
-    );
-    const context = span.context();
-    assert.strictEqual(
-      span.toString(),
-      `Span{"name":"${name}","traceId":"${context.traceId}","spanId":"${context.spanId}","parentSpanId":"${parentId}","kind":1,"startTime":100,"endTime":0,"status":{"code":0},"attributes":{},"links":[],"events":[]}`
-    );
-  });
-
   it('should return ReadableSpan', () => {
     const parentId = '5c1c63257de34c67';
     const span = new Span(
@@ -119,7 +102,7 @@ describe('Span', () => {
     assert.strictEqual(readableSpan.name, 'my-span');
     assert.strictEqual(readableSpan.kind, SpanKind.INTERNAL);
     assert.strictEqual(readableSpan.parentSpanId, parentId);
-    assert.strictEqual(readableSpan.traceId, spanContext.traceId);
+    assert.strictEqual(readableSpan.spanContext.traceId, spanContext.traceId);
     assert.deepStrictEqual(readableSpan.status, {
       code: CanonicalCode.OK,
     });

--- a/packages/opentelemetry-basic-tracer/test/Span.test.ts
+++ b/packages/opentelemetry-basic-tracer/test/Span.test.ts
@@ -101,17 +101,24 @@ describe('Span', () => {
     const context = span.context();
     assert.strictEqual(
       span.toString(),
-      `Span{"traceId":"${context.traceId}","spanId":"${context.spanId}","parentId":"${parentId}","name":"${name}","kind":1,"status":{"code":0},"startTime":100,"endTime":0}`
+      `Span{"name":"${name}","traceId":"${context.traceId}","spanId":"${context.spanId}","parentSpanId":"${parentId}","kind":1,"startTime":100,"endTime":0,"status":{"code":0},"attributes":{},"links":[],"events":[]}`
     );
   });
 
   it('should return ReadableSpan', () => {
-    const span = new Span(tracer, 'my-span', spanContext, SpanKind.CLIENT);
+    const parentId = '5c1c63257de34c67';
+    const span = new Span(
+      tracer,
+      'my-span',
+      spanContext,
+      SpanKind.INTERNAL,
+      parentId
+    );
 
     const readableSpan = span.toReadableSpan();
     assert.strictEqual(readableSpan.name, 'my-span');
     assert.strictEqual(readableSpan.kind, SpanKind.INTERNAL);
-    assert.strictEqual(readableSpan.parentSpanId, spanContext.spanId);
+    assert.strictEqual(readableSpan.parentSpanId, parentId);
     assert.strictEqual(readableSpan.traceId, spanContext.traceId);
     assert.deepStrictEqual(readableSpan.status, {
       code: CanonicalCode.OK,


### PR DESCRIPTION
Split from https://github.com/open-telemetry/opentelemetry-js/pull/149 with tests.

In SIG meeting, we have decided not to use `object.freeze` on `ReadableSpan` when constructing from `Span` object. 