### PR TITLE
fix: minor fix

### DIFF
--- a/packages/opentelemetry-core/src/trace/TracerDelegate.ts
+++ b/packages/opentelemetry-core/src/trace/TracerDelegate.ts
@@ -29,20 +29,20 @@ export class TracerDelegate implements types.Tracer {
   // Wrap a tracer with a TracerDelegate. Provided tracer becomes the default
   // fallback tracer for when a global tracer has not been initialized
   constructor(
-    private readonly tracer: types.Tracer | null = null,
-    private readonly fallbackTracer: types.Tracer = new NoopTracer()
+    private readonly _tracer: types.Tracer | null = null,
+    private readonly _fallbackTracer: types.Tracer = new NoopTracer()
   ) {
-    this._currentTracer = tracer || fallbackTracer; // equivalent to this.start()
+    this._currentTracer = _tracer || _fallbackTracer; // equivalent to this.start()
   }
 
   // Begin using the user provided tracer. Stop always falling back to fallback tracer
   start(): void {
-    this._currentTracer = this.tracer || this.fallbackTracer;
+    this._currentTracer = this._tracer || this._fallbackTracer;
   }
 
   // Stop the delegate from using the provided tracer. Begin to use the fallback tracer
   stop(): void {
-    this._currentTracer = this.fallbackTracer;
+    this._currentTracer = this._fallbackTracer;
   }
 
   // -- Tracer interface implementation below -- //
@@ -55,7 +55,7 @@ export class TracerDelegate implements types.Tracer {
     );
   }
 
-  startSpan(name: string, options?: types.SpanOptions | undefined): types.Span {
+  startSpan(name: string, options?: types.SpanOptions): types.Span {
     return this._currentTracer.startSpan.apply(
       this._currentTracer,
       // tslint:disable-next-line:no-any

--- a/packages/opentelemetry-core/src/trace/TracerDelegate.ts
+++ b/packages/opentelemetry-core/src/trace/TracerDelegate.ts
@@ -29,20 +29,20 @@ export class TracerDelegate implements types.Tracer {
   // Wrap a tracer with a TracerDelegate. Provided tracer becomes the default
   // fallback tracer for when a global tracer has not been initialized
   constructor(
-    private readonly _tracer: types.Tracer | null = null,
-    private readonly _fallbackTracer: types.Tracer = new NoopTracer()
+    private readonly tracer: types.Tracer | null = null,
+    private readonly fallbackTracer: types.Tracer = new NoopTracer()
   ) {
-    this._currentTracer = _tracer || _fallbackTracer; // equivalent to this.start()
+    this._currentTracer = tracer || fallbackTracer; // equivalent to this.start()
   }
 
   // Begin using the user provided tracer. Stop always falling back to fallback tracer
   start(): void {
-    this._currentTracer = this._tracer || this._fallbackTracer;
+    this._currentTracer = this.tracer || this.fallbackTracer;
   }
 
   // Stop the delegate from using the provided tracer. Begin to use the fallback tracer
   stop(): void {
-    this._currentTracer = this._fallbackTracer;
+    this._currentTracer = this.fallbackTracer;
   }
 
   // -- Tracer interface implementation below -- //

--- a/packages/opentelemetry-core/test/trace/TracerDelegate.test.ts
+++ b/packages/opentelemetry-core/test/trace/TracerDelegate.test.ts
@@ -35,7 +35,7 @@ describe('TracerDelegate', () => {
     traceOptions: TraceOptions.UNSAMPLED,
   };
 
-  describe('#constructor(...)', () => {
+  describe('constructor', () => {
     it('should not crash with default constructor', () => {
       functions.forEach(fn => {
         const tracer = new TracerDelegate();
@@ -66,7 +66,7 @@ describe('TracerDelegate', () => {
       assert.deepStrictEqual(dummyTracer.spyCounter, 1);
     });
 
-    describe('#start/stop()', () => {
+    describe('.start/stop()', () => {
       it('should use the fallback tracer when stop is called', () => {
         const dummyTracerUser = new DummyTracer();
         const dummyTracerFallback = new DummyTracer();


### PR DESCRIPTION
One of the leftovers from https://github.com/open-telemetry/opentelemetry-js/pull/118#discussion_r308255830 (Private properties should always start with an underscore).