### PR TITLE
fix: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ packages/**/package-lock.json
 
 # docs files
 docs
+
+.nyc_output


### PR DESCRIPTION
Updates .gitignore to ignore .nyc_output