### PR TITLE
fix(basic-tracer): add timestamp for event

### DIFF
--- a/packages/opentelemetry-basic-tracer/src/Span.ts
+++ b/packages/opentelemetry-basic-tracer/src/Span.ts
@@ -79,7 +79,7 @@ export class Span implements types.Span, ReadableSpan {
 
   addEvent(name: string, attributes?: types.Attributes): this {
     if (this._isSpanEnded()) return this;
-    this.events.push({ name, attributes, time: Date.now() });
+    this.events.push({ name, attributes, time: performance.now() });
     return this;
   }
 

--- a/packages/opentelemetry-basic-tracer/src/Span.ts
+++ b/packages/opentelemetry-basic-tracer/src/Span.ts
@@ -30,7 +30,7 @@ export class Span implements types.Span, ReadableSpan {
   readonly parentSpanId?: string;
   readonly attributes: types.Attributes = {};
   readonly links: types.Link[] = [];
-  readonly events: types.Event[] = [];
+  readonly events: types.TimedEvent[] = [];
   readonly startTime: number;
   name: string;
   status: types.Status = {
@@ -79,7 +79,7 @@ export class Span implements types.Span, ReadableSpan {
 
   addEvent(name: string, attributes?: types.Attributes): this {
     if (this._isSpanEnded()) return this;
-    this.events.push({ name, attributes });
+    this.events.push({ name, attributes, time: Date.now() });
     return this;
   }
 

--- a/packages/opentelemetry-basic-tracer/src/export/ReadableSpan.ts
+++ b/packages/opentelemetry-basic-tracer/src/export/ReadableSpan.ts
@@ -19,8 +19,8 @@ import {
   Status,
   Attributes,
   Link,
-  Event,
   SpanContext,
+  TimedEvent,
 } from '@opentelemetry/types';
 
 export interface ReadableSpan {
@@ -33,5 +33,5 @@ export interface ReadableSpan {
   readonly status: Status;
   readonly attributes: Attributes;
   readonly links: Link[];
-  readonly events: Event[];
+  readonly events: TimedEvent[];
 }

--- a/packages/opentelemetry-basic-tracer/test/Span.test.ts
+++ b/packages/opentelemetry-basic-tracer/test/Span.test.ts
@@ -176,30 +176,25 @@ describe('Span', () => {
     span.addEvent('sent');
     let readableSpan = span.toReadableSpan();
     assert.strictEqual(readableSpan.events.length, 1);
-    assert.deepStrictEqual(readableSpan.events, [
-      {
-        attributes: undefined,
-        name: 'sent',
-      },
-    ]);
+    const [event] = readableSpan.events;
+    assert.deepStrictEqual(event.name, 'sent');
+    assert.ok(!event.attributes);
+    assert.ok(event.time > 0);
 
     span.addEvent('rev', { attr1: 'value', attr2: 123, attr3: true });
     readableSpan = span.toReadableSpan();
     assert.strictEqual(readableSpan.events.length, 2);
-    assert.deepStrictEqual(readableSpan.events, [
-      {
-        attributes: undefined,
-        name: 'sent',
-      },
-      {
-        attributes: {
-          attr1: 'value',
-          attr2: 123,
-          attr3: true,
-        },
-        name: 'rev',
-      },
-    ]);
+    const [event1, event2] = readableSpan.events;
+    assert.deepStrictEqual(event1.name, 'sent');
+    assert.ok(!event1.attributes);
+    assert.ok(event1.time > 0);
+    assert.deepStrictEqual(event2.name, 'rev');
+    assert.deepStrictEqual(event2.attributes, {
+      attr1: 'value',
+      attr2: 123,
+      attr3: true,
+    });
+    assert.ok(event2.time > 0);
 
     span.end();
     // shouldn't add new event

--- a/packages/opentelemetry-types/src/index.ts
+++ b/packages/opentelemetry-types/src/index.ts
@@ -30,7 +30,7 @@ export * from './trace/SpanOptions';
 export * from './trace/span_context';
 export * from './trace/span_kind';
 export * from './trace/status';
+export * from './trace/TimedEvent';
 export * from './trace/tracer';
 export * from './trace/trace_options';
 export * from './trace/trace_state';
-export * from './trace/tracer';


### PR DESCRIPTION
Closes https://github.com/open-telemetry/opentelemetry-js/issues/191

originates from https://github.com/open-telemetry/opentelemetry-js/pull/192/files#diff-08ba7b60ae6ed103fba2d7664cff8c92R88