### PR TITLE
feat: add TraceParams config

### DIFF
--- a/packages/opentelemetry-basic-tracer/package.json
+++ b/packages/opentelemetry-basic-tracer/package.json
@@ -38,6 +38,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@types/extend": "^3.0.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.6.8",
     "codecov": "^3.1.0",
@@ -51,6 +52,7 @@
   "dependencies": {
     "@opentelemetry/core": "^0.0.1",
     "@opentelemetry/scope-base": "^0.0.1",
-    "@opentelemetry/types": "^0.0.1"
+    "@opentelemetry/types": "^0.0.1",
+    "extend": "^3.0.2"
   }
 }

--- a/packages/opentelemetry-basic-tracer/package.json
+++ b/packages/opentelemetry-basic-tracer/package.json
@@ -38,7 +38,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@types/extend": "^3.0.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.6.8",
     "codecov": "^3.1.0",
@@ -52,7 +51,6 @@
   "dependencies": {
     "@opentelemetry/core": "^0.0.1",
     "@opentelemetry/scope-base": "^0.0.1",
-    "@opentelemetry/types": "^0.0.1",
-    "extend": "^3.0.2"
+    "@opentelemetry/types": "^0.0.1"
   }
 }

--- a/packages/opentelemetry-basic-tracer/src/BasicTracer.ts
+++ b/packages/opentelemetry-basic-tracer/src/BasicTracer.ts
@@ -31,8 +31,7 @@ import {
 import { BasicTracerConfig, TraceParams } from '../src/types';
 import { ScopeManager } from '@opentelemetry/scope-base';
 import { Span } from './Span';
-import { defaultConfig } from './config';
-import * as extend from 'extend';
+import { mergeConfig } from './utility';
 
 /**
  * This class represents a basic tracer.
@@ -50,14 +49,14 @@ export class BasicTracer implements types.Tracer {
    * Constructs a new Tracer instance.
    */
   constructor(config: BasicTracerConfig) {
-    const localConfig = extend(true, {}, defaultConfig, config);
+    const localConfig = mergeConfig(config);
     this._binaryFormat = localConfig.binaryFormat;
     this._defaultAttributes = localConfig.defaultAttributes;
     this._httpTextFormat = localConfig.httpTextFormat;
     this._sampler = localConfig.sampler;
     this._scopeManager = localConfig.scopeManager;
     this._traceParams = localConfig.traceParams;
-    this.logger = localConfig.logger || new ConsoleLogger(localConfig.logLevel);
+    this.logger = config.logger || new ConsoleLogger(config.logLevel);
   }
 
   /**

--- a/packages/opentelemetry-basic-tracer/src/BasicTracer.ts
+++ b/packages/opentelemetry-basic-tracer/src/BasicTracer.ts
@@ -16,9 +16,6 @@
 
 import * as types from '@opentelemetry/types';
 import {
-  ALWAYS_SAMPLER,
-  BinaryTraceContext,
-  HttpTraceContext,
   randomTraceId,
   isValid,
   randomSpanId,
@@ -31,9 +28,11 @@ import {
   TraceOptions,
   Logger,
 } from '@opentelemetry/types';
-import { BasicTracerConfig } from '../src/types';
+import { BasicTracerConfig, TraceParams } from '../src/types';
 import { ScopeManager } from '@opentelemetry/scope-base';
 import { Span } from './Span';
+import { defaultConfig } from './config';
+import * as extend from 'extend';
 
 /**
  * This class represents a basic tracer.
@@ -44,18 +43,21 @@ export class BasicTracer implements types.Tracer {
   private readonly _httpTextFormat: types.HttpTextFormat;
   private readonly _sampler: types.Sampler;
   private readonly _scopeManager: ScopeManager;
+  private readonly _traceParams: TraceParams;
   readonly logger: Logger;
 
   /**
    * Constructs a new Tracer instance.
    */
   constructor(config: BasicTracerConfig) {
-    this._binaryFormat = config.binaryFormat || new BinaryTraceContext();
-    this._defaultAttributes = config.defaultAttributes || {};
-    this._httpTextFormat = config.httpTextFormat || new HttpTraceContext();
-    this._sampler = config.sampler || ALWAYS_SAMPLER;
-    this._scopeManager = config.scopeManager;
-    this.logger = config.logger || new ConsoleLogger(config.logLevel);
+    const localConfig = extend(true, {}, defaultConfig, config);
+    this._binaryFormat = localConfig.binaryFormat;
+    this._defaultAttributes = localConfig.defaultAttributes;
+    this._httpTextFormat = localConfig.httpTextFormat;
+    this._sampler = localConfig.sampler;
+    this._scopeManager = localConfig.scopeManager;
+    this._traceParams = localConfig.traceParams;
+    this.logger = localConfig.logger || new ConsoleLogger(localConfig.logLevel);
   }
 
   /**
@@ -153,6 +155,11 @@ export class BasicTracer implements types.Tracer {
    */
   getHttpTextFormat(): HttpTextFormat {
     return this._httpTextFormat;
+  }
+
+  /** Returns the active {@link TraceParams}. */
+  getActiveTraceParams(): TraceParams {
+    return this._traceParams;
   }
 
   private _getParentSpanContext(

--- a/packages/opentelemetry-basic-tracer/src/config.ts
+++ b/packages/opentelemetry-basic-tracer/src/config.ts
@@ -23,11 +23,11 @@ import {
 import { NoopScopeManager } from '@opentelemetry/scope-base';
 
 /** Default limit for Message events per span */
-const DEFAULT_MAX_EVENTS_PER_SPAN = 128;
+export const DEFAULT_MAX_EVENTS_PER_SPAN = 128;
 /** Default limit for Attributes per span */
-const DEFAULT_MAX_ATTRIBUTES_PER_SPAN = 32;
+export const DEFAULT_MAX_ATTRIBUTES_PER_SPAN = 32;
 /** Default limit for Links per span */
-const DEFAULT_MAX_LINKS_PER_SPAN = 32;
+export const DEFAULT_MAX_LINKS_PER_SPAN = 32;
 
 /**
  * Default configuration. For fields with primitive values, any user-provided

--- a/packages/opentelemetry-basic-tracer/src/config.ts
+++ b/packages/opentelemetry-basic-tracer/src/config.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ALWAYS_SAMPLER,
+  BinaryTraceContext,
+  HttpTraceContext,
+  LogLevel,
+} from '@opentelemetry/core';
+import { NoopScopeManager } from '@opentelemetry/scope-base';
+
+/** Default limit for Message events per span */
+const DEFAULT_MAX_EVENTS_PER_SPAN = 128;
+/** Default limit for Attributes per span */
+const DEFAULT_MAX_ATTRIBUTES_PER_SPAN = 32;
+/** Default limit for Links per span */
+const DEFAULT_MAX_LINKS_PER_SPAN = 32;
+
+/**
+ * Default configuration. For fields with primitive values, any user-provided
+ * value will override the corresponding default value. For fields with
+ * non-primitive values (like `traceParams`), the user-provided value will be
+ * used to extend the default value.
+ */
+export const defaultConfig = {
+  defaultAttributes: {},
+  binaryFormat: new BinaryTraceContext(),
+  httpTextFormat: new HttpTraceContext(),
+  logLevel: LogLevel.DEBUG,
+  sampler: ALWAYS_SAMPLER,
+  scopeManager: new NoopScopeManager(),
+  traceParams: {
+    numberOfAttributesPerSpan: DEFAULT_MAX_ATTRIBUTES_PER_SPAN,
+    numberOfLinksPerSpan: DEFAULT_MAX_LINKS_PER_SPAN,
+    numberOfEventsPerSpan: DEFAULT_MAX_EVENTS_PER_SPAN,
+  },
+  // @todo add support for plugins
+  // plugins: {},
+};

--- a/packages/opentelemetry-basic-tracer/src/types.ts
+++ b/packages/opentelemetry-basic-tracer/src/types.ts
@@ -61,4 +61,17 @@ export interface BasicTracerConfig {
    * Scope manager keeps context across in-process operations.
    */
   scopeManager: ScopeManager;
+
+  /** Trace Parameters */
+  traceParams?: TraceParams;
+}
+
+/** Global configuration of trace service */
+export interface TraceParams {
+  /** numberOfAttributesPerSpan is number of attributes per span */
+  numberOfAttributesPerSpan?: number;
+  /** numberOfLinksPerSpan is number of links per span */
+  numberOfLinksPerSpan?: number;
+  /** numberOfEventsPerSpan is number of message events per span */
+  numberOfEventsPerSpan?: number;
 }

--- a/packages/opentelemetry-basic-tracer/src/utility.ts
+++ b/packages/opentelemetry-basic-tracer/src/utility.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BasicTracerConfig } from './types';
+import {
+  DEFAULT_MAX_ATTRIBUTES_PER_SPAN,
+  DEFAULT_MAX_EVENTS_PER_SPAN,
+  DEFAULT_MAX_LINKS_PER_SPAN,
+} from './config';
+import { defaultConfig } from './config';
+
+/**
+ * Function to merge Default configuration (as specified in './config') with
+ * user provided configurations.
+ */
+export function mergeConfig(userConfig: BasicTracerConfig) {
+  const traceParams = userConfig.traceParams;
+  const target = Object.assign({}, defaultConfig, userConfig);
+
+  // the user-provided value will be used to extend the default value.
+  if (traceParams) {
+    target.traceParams.numberOfAttributesPerSpan =
+      traceParams.numberOfAttributesPerSpan || DEFAULT_MAX_ATTRIBUTES_PER_SPAN;
+    target.traceParams.numberOfEventsPerSpan =
+      traceParams.numberOfEventsPerSpan || DEFAULT_MAX_EVENTS_PER_SPAN;
+    target.traceParams.numberOfLinksPerSpan =
+      traceParams.numberOfLinksPerSpan || DEFAULT_MAX_LINKS_PER_SPAN;
+  }
+  return target;
+}

--- a/packages/opentelemetry-basic-tracer/test/BasicTracer.test.ts
+++ b/packages/opentelemetry-basic-tracer/test/BasicTracer.test.ts
@@ -70,6 +70,59 @@ describe('BasicTracer', () => {
       assert.ok(tracer instanceof BasicTracer);
     });
 
+    it('should construct an instance with default trace params', () => {
+      const tracer = new BasicTracer({
+        scopeManager: new NoopScopeManager(),
+      });
+      assert.deepStrictEqual(tracer.getActiveTraceParams(), {
+        numberOfAttributesPerSpan: 32,
+        numberOfEventsPerSpan: 128,
+        numberOfLinksPerSpan: 32,
+      });
+    });
+
+    it('should construct an instance with customized numberOfAttributesPerSpan trace params', () => {
+      const tracer = new BasicTracer({
+        scopeManager: new NoopScopeManager(),
+        traceParams: {
+          numberOfAttributesPerSpan: 100,
+        },
+      });
+      assert.deepStrictEqual(tracer.getActiveTraceParams(), {
+        numberOfAttributesPerSpan: 100,
+        numberOfEventsPerSpan: 128,
+        numberOfLinksPerSpan: 32,
+      });
+    });
+
+    it('should construct an instance with customized numberOfEventsPerSpan trace params', () => {
+      const tracer = new BasicTracer({
+        scopeManager: new NoopScopeManager(),
+        traceParams: {
+          numberOfEventsPerSpan: 300,
+        },
+      });
+      assert.deepStrictEqual(tracer.getActiveTraceParams(), {
+        numberOfAttributesPerSpan: 32,
+        numberOfEventsPerSpan: 300,
+        numberOfLinksPerSpan: 32,
+      });
+    });
+
+    it('should construct an instance with customized numberOfLinksPerSpan trace params', () => {
+      const tracer = new BasicTracer({
+        scopeManager: new NoopScopeManager(),
+        traceParams: {
+          numberOfLinksPerSpan: 10,
+        },
+      });
+      assert.deepStrictEqual(tracer.getActiveTraceParams(), {
+        numberOfAttributesPerSpan: 32,
+        numberOfEventsPerSpan: 128,
+        numberOfLinksPerSpan: 10,
+      });
+    });
+
     it('should construct an instance with default attributes', () => {
       const tracer = new BasicTracer({
         defaultAttributes: {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Add functionality to hold global trace parameters (like `Attributes`, `Link`s, `Event`s etc.). Limits will be enforced on each span in order to prevent an unbounded memory increase for long-running spans.

## Short description of the changes

- Limits are taken from OpenCensus specs: https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/TraceConfig.md#limits

- These are the default values (**recommended by the SDK**), users/vendors are allowed to override the globals per-span values.

- I planned to enforce these limits on per-span in next PR.