### PR TITLE
feat(logger): pass logger to plugin packages

### DIFF
--- a/packages/opentelemetry-core/src/trace/instrumentation/BasePlugin.ts
+++ b/packages/opentelemetry-core/src/trace/instrumentation/BasePlugin.ts
@@ -14,20 +14,23 @@
  * limitations under the License.
  */
 
-import { Tracer, Plugin } from '@opentelemetry/types';
+import { Tracer, Plugin, Logger } from '@opentelemetry/types';
 
 /** This class represent the base to patch plugin. */
 export abstract class BasePlugin<T> implements Plugin<T> {
   protected _moduleExports!: T;
   protected _tracer!: Tracer;
+  protected _logger!: Logger;
 
   enable(
     moduleExports: T,
     tracer: Tracer,
+    logger: Logger,
     config?: { [key: string]: unknown }
   ): T {
     this._moduleExports = moduleExports;
     this._tracer = tracer;
+    this._logger = logger;
     return this.patch();
   }
 

--- a/packages/opentelemetry-node-tracer/src/instrumentation/PluginLoader.ts
+++ b/packages/opentelemetry-node-tracer/src/instrumentation/PluginLoader.ts
@@ -103,7 +103,7 @@ export class PluginLoader {
           const plugin: Plugin = require(moduleName).plugin;
           this._plugins.push(plugin);
           // Enable each supported plugin.
-          return plugin.enable(exports, this.tracer);
+          return plugin.enable(exports, this.tracer, this.logger);
         } catch (e) {
           this.logger.error(
             `PluginLoader#load: could not load plugin ${moduleName} of module ${name}. Error: ${e.message}`

--- a/packages/opentelemetry-types/src/trace/instrumentation/Plugin.ts
+++ b/packages/opentelemetry-types/src/trace/instrumentation/Plugin.ts
@@ -15,6 +15,7 @@
  */
 
 import { Tracer } from '../tracer';
+import { Logger } from '../../common/Logger';
 
 /** Interface Plugin to apply patch. */
 // tslint:disable-next-line:no-any
@@ -24,11 +25,13 @@ export interface Plugin<T = any> {
    * @param moduleExports The value of the `module.exports` property that would
    *     normally be exposed by the required module. ex: `http`, `https` etc.
    * @param tracer a tracer instance.
+   * @param logger a logger instance.
    * @param [config] an object to configure the plugin.
    */
   enable(
     moduleExports: T,
     tracer: Tracer,
+    logger: Logger,
     config?: { [key: string]: unknown }
   ): T;
 


### PR DESCRIPTION


Signed-off-by: Olivier Albertini <olivier.albertini@montreal.ca>

## Which problem is this PR solving?
Closes #193

## Short description of the changes
The logger is passed from PluginLoader to plugin like http, grpc, etc.
Each plugin class won't need to have a property _logger since it's added in `BasicPlugin`.
