### PR TITLE
feat(plugin): add supportedVersions property

### DIFF
--- a/packages/opentelemetry-core/src/trace/instrumentation/BasePlugin.ts
+++ b/packages/opentelemetry-core/src/trace/instrumentation/BasePlugin.ts
@@ -21,6 +21,7 @@ export abstract class BasePlugin<T> implements Plugin<T> {
   protected _moduleExports!: T;
   protected _tracer!: Tracer;
   protected _logger!: Logger;
+  supportedVersions?: string[];
 
   enable(
     moduleExports: T,

--- a/packages/opentelemetry-node-tracer/src/instrumentation/PluginLoader.ts
+++ b/packages/opentelemetry-node-tracer/src/instrumentation/PluginLoader.ts
@@ -90,8 +90,6 @@ export class PluginLoader {
           `PluginLoader#load: trying loading ${name}.${version}`
         );
 
-        // @todo (issues/132): Check if version and supportedVersions are
-        // satisfied
         if (!version) return exports;
 
         this.logger.debug(
@@ -101,6 +99,11 @@ export class PluginLoader {
         // Expecting a plugin from module;
         try {
           const plugin: Plugin = require(moduleName).plugin;
+
+          if (!utils.isSupportedVersion(version, plugin.supportedVersions)) {
+            return exports;
+          }
+
           this._plugins.push(plugin);
           // Enable each supported plugin.
           return plugin.enable(exports, this.tracer, this.logger);

--- a/packages/opentelemetry-node-tracer/src/instrumentation/utils.ts
+++ b/packages/opentelemetry-node-tracer/src/instrumentation/utils.ts
@@ -60,11 +60,16 @@ export function getPackageVersion(
   }
 }
 
+/**
+ * Determines if a version is supported
+ * @param moduleVersion a version in [semver](https://semver.org/spec/v2.0.0.html) format.
+ * @param [supportedVersions] a list of supported versions ([semver](https://semver.org/spec/v2.0.0.html) format).
+ */
 export function isSupportedVersion(
   moduleVersion: string,
   supportedVersions?: string[]
 ) {
-  if (!Array.isArray(supportedVersions)) {
+  if (!Array.isArray(supportedVersions) || supportedVersions.length === 0) {
     return true;
   }
 

--- a/packages/opentelemetry-node-tracer/src/instrumentation/utils.ts
+++ b/packages/opentelemetry-node-tracer/src/instrumentation/utils.ts
@@ -60,6 +60,19 @@ export function getPackageVersion(
   }
 }
 
+export function isSupportedVersion(
+  moduleVersion: string,
+  supportedVersions?: string[]
+) {
+  if (!Array.isArray(supportedVersions)) {
+    return true;
+  }
+
+  return supportedVersions.some(supportedVersion =>
+    semver.satisfies(moduleVersion, supportedVersion)
+  );
+}
+
 /**
  * Adds a search path for plugin modules. Intended for testing purposes only.
  * @param searchPath The path to add.

--- a/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/@opentelemetry/plugin-notsupported-module/index.js
+++ b/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/@opentelemetry/plugin-notsupported-module/index.js
@@ -1,0 +1,5 @@
+function __export(m) {
+  for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(require("./simple-module"));

--- a/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/@opentelemetry/plugin-notsupported-module/package.json
+++ b/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/@opentelemetry/plugin-notsupported-module/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@opentelemetry/plugin-notsupported-module",
+  "version": "1.0.0"
+}

--- a/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/@opentelemetry/plugin-notsupported-module/simple-module.js
+++ b/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/@opentelemetry/plugin-notsupported-module/simple-module.js
@@ -1,0 +1,24 @@
+Object.defineProperty(exports, "__esModule", { value: true });
+const core_1 = require("@opentelemetry/core");
+const shimmer = require("shimmer");
+
+class SimpleModulePlugin extends core_1.BasePlugin {
+    constructor() {
+        super();
+    }
+
+    patch() {
+        shimmer.wrap(this._moduleExports, 'name', orig => () => 'patched-' + orig.apply());
+        shimmer.wrap(this._moduleExports, 'value', orig => () => orig.apply() + 1);
+        return this._moduleExports;
+    }
+
+    unpatch() {
+        shimmer.unwrap(this._moduleExports, 'name');
+        shimmer.unwrap(this._moduleExports, 'value');
+    }
+}
+exports.SimpleModulePlugin = SimpleModulePlugin;
+const plugin = new SimpleModulePlugin();
+plugin.supportedVersions = ['1.0.0'];
+exports.plugin = plugin;

--- a/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/@opentelemetry/plugin-supported-module/index.js
+++ b/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/@opentelemetry/plugin-supported-module/index.js
@@ -1,0 +1,5 @@
+function __export(m) {
+  for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+__export(require("./simple-module"));

--- a/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/@opentelemetry/plugin-supported-module/package.json
+++ b/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/@opentelemetry/plugin-supported-module/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@opentelemetry/plugin-supported-module",
+  "version": "0.0.1"
+}

--- a/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/@opentelemetry/plugin-supported-module/simple-module.js
+++ b/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/@opentelemetry/plugin-supported-module/simple-module.js
@@ -1,0 +1,24 @@
+Object.defineProperty(exports, "__esModule", { value: true });
+const core_1 = require("@opentelemetry/core");
+const shimmer = require("shimmer");
+
+class SimpleModulePlugin extends core_1.BasePlugin {
+    constructor() {
+        super();
+    }
+
+    patch() {
+        shimmer.wrap(this._moduleExports, 'name', orig => () => 'patched-' + orig.apply());
+        shimmer.wrap(this._moduleExports, 'value', orig => () => orig.apply() + 1);
+        return this._moduleExports;
+    }
+
+    unpatch() {
+        shimmer.unwrap(this._moduleExports, 'name');
+        shimmer.unwrap(this._moduleExports, 'value');
+    }
+}
+exports.SimpleModulePlugin = SimpleModulePlugin;
+const plugin = new SimpleModulePlugin();
+plugin.supportedVersions = ['^0.0.1'];
+exports.plugin = plugin;

--- a/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/notsupported-module/index.js
+++ b/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/notsupported-module/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+    name: () => 'notsupported-module',
+    value: () => 0,
+};

--- a/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/notsupported-module/package.json
+++ b/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/notsupported-module/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "notsupported-module",
+  "version": "0.0.1"
+}

--- a/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/supported-module/index.js
+++ b/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/supported-module/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+    name: () => 'supported-module',
+    value: () => 0,
+};

--- a/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/supported-module/package.json
+++ b/packages/opentelemetry-node-tracer/test/instrumentation/node_modules/supported-module/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "supported-module",
+  "version": "0.0.1"
+}

--- a/packages/opentelemetry-node-tracer/test/instrumentation/utils.test.ts
+++ b/packages/opentelemetry-node-tracer/test/instrumentation/utils.test.ts
@@ -84,6 +84,7 @@ describe('Instrumentation#utils', () => {
       ['~1.0.0', '^0.1.0'],
       ['*'],
       ['>1.0.0'],
+      [],
     ].forEach(supportedVersion => {
       it(`should return true when version is equal to ${version} and supportedVersions is equal to ${supportedVersion}`, () => {
         assert.strictEqual(
@@ -105,9 +106,8 @@ describe('Instrumentation#utils', () => {
     );
 
     it(`should return false when version is equal to null and supportedVersions is equal to '*'`, () => {
-      /* tslint:disable:no-any */
+      // tslint:disable-next-line:no-any
       assert.strictEqual(utils.isSupportedVersion(null as any, ['*']), false);
-      /* tslint:enable:no-any */
     });
   });
 });

--- a/packages/opentelemetry-node-tracer/test/instrumentation/utils.test.ts
+++ b/packages/opentelemetry-node-tracer/test/instrumentation/utils.test.ts
@@ -69,4 +69,45 @@ describe('Instrumentation#utils', () => {
       });
     });
   });
+  describe('isSupportedVersion', () => {
+    const version = '1.0.1';
+
+    it('should return true when supportedVersions is not defined', () => {
+      assert.strictEqual(utils.isSupportedVersion('1.0.0', undefined), true);
+    });
+
+    [
+      ['1.X'],
+      [version],
+      ['1.X.X', '3.X.X'],
+      ['^1.0.0'],
+      ['~1.0.0', '^0.1.0'],
+      ['*'],
+      ['>1.0.0'],
+    ].forEach(supportedVersion => {
+      it(`should return true when version is equal to ${version} and supportedVersions is equal to ${supportedVersion}`, () => {
+        assert.strictEqual(
+          utils.isSupportedVersion(version, supportedVersion),
+          true
+        );
+      });
+    });
+
+    [['0.X'], ['0.0.1'], ['0.X.X'], ['^0.1.0'], ['1.0.0'], ['<1.0.0']].forEach(
+      supportedVersion => {
+        it(`should return false when version is equal to ${version} and supportedVersions is equal to ${supportedVersion}`, () => {
+          assert.strictEqual(
+            utils.isSupportedVersion(version, supportedVersion),
+            false
+          );
+        });
+      }
+    );
+
+    it(`should return false when version is equal to null and supportedVersions is equal to '*'`, () => {
+      /* tslint:disable:no-any */
+      assert.strictEqual(utils.isSupportedVersion(null as any, ['*']), false);
+      /* tslint:enable:no-any */
+    });
+  });
 });

--- a/packages/opentelemetry-types/src/trace/instrumentation/Plugin.ts
+++ b/packages/opentelemetry-types/src/trace/instrumentation/Plugin.ts
@@ -22,9 +22,9 @@ import { Logger } from '../../common/Logger';
 export interface Plugin<T = any> {
   /**
    * Contains all supported versions.
-   * all versions must be compatible with [semver](https://semver.org/spec/v2.0.0.html) format.
+   * All versions must be compatible with [semver](https://semver.org/spec/v2.0.0.html) format.
    * If the version is not supported, we won't apply instrumentation patch (see `enable` method).
-   * If not defined, we will apply instrumentation for every version.
+   * If omitted, all versions of the module will be patched.
    */
   supportedVersions?: string[];
 

--- a/packages/opentelemetry-types/src/trace/instrumentation/Plugin.ts
+++ b/packages/opentelemetry-types/src/trace/instrumentation/Plugin.ts
@@ -21,6 +21,14 @@ import { Logger } from '../../common/Logger';
 // tslint:disable-next-line:no-any
 export interface Plugin<T = any> {
   /**
+   * Contains all supported versions.
+   * all versions must be compatible with [semver](https://semver.org/spec/v2.0.0.html) format.
+   * If the version is not supported, we won't apply instrumentation patch (see `enable` method).
+   * If not defined, we will apply instrumentation for every version.
+   */
+  supportedVersions?: string[];
+
+  /**
    * Method that enables the instrumentation patch.
    * @param moduleExports The value of the `module.exports` property that would
    *     normally be exposed by the required module. ex: `http`, `https` etc.


### PR DESCRIPTION
## Which problem is this PR solving?
It's backward compatible. supportedVersion is optional in plugins. If not defined, all versions are supported. See related tests.

Closes #132


Signed-off-by: Olivier Albertini <olivier.albertini@montreal.ca>
