### PR TITLE
feat(Node-Tracer): initialize plugin loader

### DIFF
--- a/packages/opentelemetry-node-tracer/src/NodeTracer.ts
+++ b/packages/opentelemetry-node-tracer/src/NodeTracer.ts
@@ -14,24 +14,17 @@
  * limitations under the License.
  */
 
-import { BasicTracer, BasicTracerConfig } from '@opentelemetry/basic-tracer';
+import { BasicTracer } from '@opentelemetry/basic-tracer';
 import { AsyncHooksScopeManager } from '@opentelemetry/scope-async-hooks';
-import { Plugins } from './instrumentation/PluginLoader';
-
-/**
- * NodeTracerConfig provides an interface for configuring a Node Tracer.
- */
-export interface NodeTracerConfig extends BasicTracerConfig {
-  /**
-   * Plugins options.
-   */
-  plugins?: Plugins;
-}
+import { PluginLoader } from './instrumentation/PluginLoader';
+import { NodeTracerConfig, DEFAULT_INSTRUMENTATION_PLUGINS } from './config';
 
 /**
  * This class represents a node tracer with `async_hooks` module.
  */
 export class NodeTracer extends BasicTracer {
+  private readonly _pluginLoader: PluginLoader;
+
   /**
    * Constructs a new Tracer instance.
    */
@@ -42,6 +35,11 @@ export class NodeTracer extends BasicTracer {
     }
     super(Object.assign({}, { scopeManager: config.scopeManager }, config));
 
-    // @todo: Integrate Plugin Loader (pull/126).
+    this._pluginLoader = new PluginLoader(this, this.logger);
+    this._pluginLoader.load(config.plugins || DEFAULT_INSTRUMENTATION_PLUGINS);
+  }
+
+  stop() {
+    this._pluginLoader.unload();
   }
 }

--- a/packages/opentelemetry-node-tracer/src/config.ts
+++ b/packages/opentelemetry-node-tracer/src/config.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Plugins } from './instrumentation/PluginLoader';
+import { BasicTracerConfig } from '@opentelemetry/basic-tracer';
+
+
+/**
+ * NodeTracerConfig provides an interface for configuring a Node Tracer.
+ */
+export interface NodeTracerConfig extends BasicTracerConfig {
+  /**
+   * Plugins options.
+   */
+  plugins?: Plugins;
+}
+
+/** List of all default supported plugins */
+export const DEFAULT_INSTRUMENTATION_PLUGINS: Plugins = {
+  http: {
+    enabled: true,
+    path: '@opentelemetry/plugin-http',
+    ignoreMethods: [],
+    ignoreUrls: [],
+  },
+};

--- a/packages/opentelemetry-node-tracer/src/config.ts
+++ b/packages/opentelemetry-node-tracer/src/config.ts
@@ -17,14 +17,11 @@
 import { Plugins } from './instrumentation/PluginLoader';
 import { BasicTracerConfig } from '@opentelemetry/basic-tracer';
 
-
 /**
  * NodeTracerConfig provides an interface for configuring a Node Tracer.
  */
 export interface NodeTracerConfig extends BasicTracerConfig {
-  /**
-   * Plugins options.
-   */
+  /** Plugins options. */
   plugins?: Plugins;
 }
 
@@ -33,7 +30,9 @@ export const DEFAULT_INSTRUMENTATION_PLUGINS: Plugins = {
   http: {
     enabled: true,
     path: '@opentelemetry/plugin-http',
-    ignoreMethods: [],
-    ignoreUrls: [],
+  },
+  grpc: {
+    enabled: true,
+    path: '@opentelemetry/plugin-grpc',
   },
 };

--- a/packages/opentelemetry-node-tracer/test/NodeTracer.test.ts
+++ b/packages/opentelemetry-node-tracer/test/NodeTracer.test.ts
@@ -40,6 +40,7 @@ const INSTALLED_PLUGINS_PATH = path.join(
 );
 
 describe('NodeTracer', () => {
+  let tracer: NodeTracer;
   before(() => {
     module.paths.push(INSTALLED_PLUGINS_PATH);
   });
@@ -47,49 +48,45 @@ describe('NodeTracer', () => {
   afterEach(() => {
     // clear require cache
     Object.keys(require.cache).forEach(key => delete require.cache[key]);
+    tracer.stop();
   });
 
   describe('constructor', () => {
     it('should construct an instance with required only options', () => {
-      const tracer = new NodeTracer({});
+      tracer = new NodeTracer({});
       assert.ok(tracer instanceof NodeTracer);
-      tracer.stop();
     });
 
     it('should construct an instance with binary format', () => {
-      const tracer = new NodeTracer({
+      tracer = new NodeTracer({
         binaryFormat: new BinaryTraceContext(),
       });
       assert.ok(tracer instanceof NodeTracer);
-      tracer.stop();
     });
 
     it('should construct an instance with http text format', () => {
-      const tracer = new NodeTracer({
+      tracer = new NodeTracer({
         httpTextFormat: new HttpTraceContext(),
       });
       assert.ok(tracer instanceof NodeTracer);
-      tracer.stop();
     });
 
     it('should construct an instance with logger', () => {
-      const tracer = new NodeTracer({
+      tracer = new NodeTracer({
         logger: new NoopLogger(),
       });
       assert.ok(tracer instanceof NodeTracer);
-      tracer.stop();
     });
 
     it('should construct an instance with sampler', () => {
-      const tracer = new NodeTracer({
+      tracer = new NodeTracer({
         sampler: ALWAYS_SAMPLER,
       });
       assert.ok(tracer instanceof NodeTracer);
-      tracer.stop();
     });
 
     it('should load user configured plugins', () => {
-      const tracer = new NodeTracer({
+      tracer = new NodeTracer({
         logger: new NoopLogger(),
         plugins: {
           'simple-module': {
@@ -111,42 +108,38 @@ describe('NodeTracer', () => {
       assert.strictEqual(pluginLoader['_plugins'].length, 1);
       require('supported-module');
       assert.strictEqual(pluginLoader['_plugins'].length, 2);
-      tracer.stop();
     });
 
     it('should construct an instance with default attributes', () => {
-      const tracer = new NodeTracer({
+      tracer = new NodeTracer({
         defaultAttributes: {
           region: 'eu-west',
           asg: 'my-asg',
         },
       });
       assert.ok(tracer instanceof NodeTracer);
-      tracer.stop();
     });
   });
 
   describe('.startSpan()', () => {
     it('should start a span with name only', () => {
-      const tracer = new NodeTracer({
+      tracer = new NodeTracer({
         logger: new NoopLogger(),
       });
       const span = tracer.startSpan('my-span');
       assert.ok(span);
-      tracer.stop();
     });
 
     it('should start a span with name and options', () => {
-      const tracer = new NodeTracer({
+      tracer = new NodeTracer({
         logger: new NoopLogger(),
       });
       const span = tracer.startSpan('my-span', {});
       assert.ok(span);
-      tracer.stop();
     });
 
     it('should return a default span with no sampling', () => {
-      const tracer = new NodeTracer({
+      tracer = new NodeTracer({
         sampler: NEVER_SAMPLER,
         logger: new NoopLogger(),
       });
@@ -154,7 +147,6 @@ describe('NodeTracer', () => {
       assert.ok(span instanceof NoRecordingSpan);
       assert.strictEqual(span.context().traceFlags, TraceFlags.UNSAMPLED);
       assert.strictEqual(span.isRecordingEvents(), false);
-      tracer.stop();
     });
 
     // @todo: implement
@@ -164,39 +156,36 @@ describe('NodeTracer', () => {
       const defaultAttributes = {
         foo: 'bar',
       };
-      const tracer = new NodeTracer({
+      tracer = new NodeTracer({
         defaultAttributes,
       });
 
       const span = tracer.startSpan('my-span') as Span;
       assert.ok(span instanceof Span);
       assert.deepStrictEqual(span.attributes, defaultAttributes);
-      tracer.stop();
     });
   });
 
   describe('.getCurrentSpan()', () => {
     it('should return null with AsyncHooksScopeManager when no span started', () => {
-      const tracer = new NodeTracer({});
+      tracer = new NodeTracer({});
       assert.deepStrictEqual(tracer.getCurrentSpan(), null);
-      tracer.stop();
     });
   });
 
   describe('.withSpan()', () => {
     it('should run scope with AsyncHooksScopeManager scope manager', done => {
-      const tracer = new NodeTracer({});
+      tracer = new NodeTracer({});
       const span = tracer.startSpan('my-span');
       tracer.withSpan(span, () => {
         assert.deepStrictEqual(tracer.getCurrentSpan(), span);
         return done();
       });
       assert.deepStrictEqual(tracer.getCurrentSpan(), null);
-      tracer.stop();
     });
 
     it('should run scope with AsyncHooksScopeManager scope manager with multiple spans', done => {
-      const tracer = new NodeTracer({});
+      tracer = new NodeTracer({});
       const span = tracer.startSpan('my-span');
       tracer.withSpan(span, () => {
         assert.deepStrictEqual(tracer.getCurrentSpan(), span);
@@ -217,7 +206,7 @@ describe('NodeTracer', () => {
     });
 
     it('should find correct scope with promises', done => {
-      const tracer = new NodeTracer({});
+      tracer = new NodeTracer({});
       const span = tracer.startSpan('my-span');
       tracer.withSpan(span, async () => {
         for (let i = 0; i < 3; i++) {
@@ -251,17 +240,15 @@ describe('NodeTracer', () => {
 
   describe('.getBinaryFormat()', () => {
     it('should get default binary formatter', () => {
-      const tracer = new NodeTracer({});
+      tracer = new NodeTracer({});
       assert.ok(tracer.getBinaryFormat() instanceof BinaryTraceContext);
-      tracer.stop();
     });
   });
 
   describe('.getHttpTextFormat()', () => {
     it('should get default HTTP text formatter', () => {
-      const tracer = new NodeTracer({});
+      tracer = new NodeTracer({});
       assert.ok(tracer.getHttpTextFormat() instanceof HttpTraceContext);
-      tracer.stop();
     });
   });
 });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Closes #199 

## Short description of the changes

- With `Node-Tracer` will load all the default supported plugins. 
