### PR TITLE
chore: add 'private: true' for non ready packages

### DIFF
--- a/packages/opentelemetry-plugin-http2/package.json
+++ b/packages/opentelemetry-plugin-http2/package.json
@@ -2,6 +2,7 @@
   "name": "@opentelemetry/plugin-http2",
   "version": "0.0.1",
   "description": "OpenTelemetry http2 automatic instrumentation package.",
+  "private": true,
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js",

--- a/packages/opentelemetry-plugin-https/package.json
+++ b/packages/opentelemetry-plugin-https/package.json
@@ -2,6 +2,7 @@
   "name": "@opentelemetry/plugin-https",
   "version": "0.0.1",
   "description": "OpenTelemetry https automatic instrumentation package.",
+  "private": true,
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js",

--- a/packages/opentelemetry-plugin-mongodb/package.json
+++ b/packages/opentelemetry-plugin-mongodb/package.json
@@ -2,6 +2,7 @@
   "name": "@opentelemetry/plugin-mongodb",
   "version": "0.0.1",
   "description": "OpenTelemetry mongodb automatic instrumentation package.",
+  "private": true,
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js",

--- a/packages/opentelemetry-plugin-redis/package.json
+++ b/packages/opentelemetry-plugin-redis/package.json
@@ -2,6 +2,7 @@
   "name": "@opentelemetry/plugin-redis",
   "version": "0.0.1",
   "description": "OpenTelemetry redis automatic instrumentation package.",
+  "private": true,
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js",


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- This is to avoid publishing non-ready (work-in-progress) packages (`https`, `http2`, `redis`, `mongodb`).

- Once packages/instrumentations are ready will remove this flag.