### PR TITLE
tests: use node-tracer scope manager instead of creating one #226

### DIFF
--- a/packages/opentelemetry-node-tracer/test/NodeTracer.test.ts
+++ b/packages/opentelemetry-node-tracer/test/NodeTracer.test.ts
@@ -23,7 +23,6 @@ import {
   NoopLogger,
   NoRecordingSpan,
 } from '@opentelemetry/core';
-import { AsyncHooksScopeManager } from '@opentelemetry/scope-async-hooks';
 import { NodeTracer } from '../src/NodeTracer';
 import { TraceFlags } from '@opentelemetry/types';
 import { Span } from '@opentelemetry/basic-tracer';
@@ -50,7 +49,6 @@ describe('NodeTracer', () => {
     it('should construct an instance with http text format', () => {
       const tracer = new NodeTracer({
         httpTextFormat: new HttpTraceContext(),
-        scopeManager: new AsyncHooksScopeManager(),
       });
       assert.ok(tracer instanceof NodeTracer);
     });
@@ -116,7 +114,6 @@ describe('NodeTracer', () => {
         foo: 'bar',
       };
       const tracer = new NodeTracer({
-        scopeManager: new AsyncHooksScopeManager(),
         defaultAttributes,
       });
 

--- a/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
+++ b/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import { AsyncHooksScopeManager } from '@opentelemetry/scope-async-hooks';
 import { NoopLogger } from '@opentelemetry/core';
 import {
-  BasicTracer,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/basic-tracer';
 import { SpanKind, Tracer } from '@opentelemetry/types';
+import { NodeTracer } from '@opentelemetry/node-tracer';
 
 import { assertSpan, assertPropagation } from './utils/assertionUtils';
 import { GrpcPlugin, plugin } from '../src';
@@ -507,9 +506,8 @@ describe('GrpcPlugin', () => {
   };
 
   describe('enable()', () => {
-    const scopeManager = new AsyncHooksScopeManager();
     const logger = new NoopLogger();
-    const tracer = new BasicTracer({ scopeManager, logger });
+    const tracer = new NodeTracer({ logger });
     tracer.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     beforeEach(() => {
       memoryExporter.reset();
@@ -554,9 +552,8 @@ describe('GrpcPlugin', () => {
   });
 
   describe('disable()', () => {
-    const scopeManager = new AsyncHooksScopeManager();
     const logger = new NoopLogger();
-    const tracer = new BasicTracer({ scopeManager, logger });
+    const tracer = new NodeTracer({ logger });
     tracer.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     beforeEach(() => {
       memoryExporter.reset();

--- a/packages/opentelemetry-plugin-http/package.json
+++ b/packages/opentelemetry-plugin-http/package.json
@@ -46,7 +46,6 @@
     "@types/shimmer": "^1.0.1",
     "@types/sinon": "^7.0.13",
     "@types/superagent": "^4.1.3",
-    "@opentelemetry/scope-async-hooks": "^0.0.1",
     "@opentelemetry/scope-base": "^0.0.1",
     "@opentelemetry/basic-tracer": "^0.0.1",
     "axios": "^0.19.0",

--- a/packages/opentelemetry-plugin-http/test/functionals/http-disable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-disable.test.ts
@@ -20,7 +20,6 @@ import * as nock from 'nock';
 import * as sinon from 'sinon';
 
 import { plugin } from '../../src/http';
-import { AsyncHooksScopeManager } from '@opentelemetry/scope-async-hooks';
 import { NodeTracer } from '@opentelemetry/node-tracer';
 import { NoopLogger } from '@opentelemetry/core';
 import { AddressInfo } from 'net';
@@ -32,11 +31,9 @@ describe('HttpPlugin', () => {
   let serverPort = 0;
 
   describe('disable()', () => {
-    const scopeManager = new AsyncHooksScopeManager();
     const httpTextFormat = new DummyPropagation();
     const logger = new NoopLogger();
     const tracer = new NodeTracer({
-      scopeManager,
       logger,
       httpTextFormat,
     });

--- a/packages/opentelemetry-plugin-http/test/functionals/http-package.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-package.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { NoopLogger } from '@opentelemetry/core';
-import { AsyncHooksScopeManager } from '@opentelemetry/scope-async-hooks';
 import { SpanKind, Span } from '@opentelemetry/types';
 import * as assert from 'assert';
 import * as http from 'http';
@@ -43,12 +42,10 @@ export const customAttributeFunction = (span: Span): void => {
 
 describe('Packages', () => {
   describe('get', () => {
-    const scopeManager = new AsyncHooksScopeManager();
     const httpTextFormat = new DummyPropagation();
     const logger = new NoopLogger();
 
     const tracer = new NodeTracer({
-      scopeManager,
       logger,
       httpTextFormat,
     });

--- a/packages/opentelemetry-plugin-http/test/integrations/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/integrations/http-enable.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { NoopLogger } from '@opentelemetry/core';
-import { AsyncHooksScopeManager } from '@opentelemetry/scope-async-hooks';
 import { SpanKind, Span } from '@opentelemetry/types';
 import * as assert from 'assert';
 import * as http from 'http';
@@ -57,11 +56,9 @@ describe('HttpPlugin Integration tests', () => {
       });
     });
 
-    const scopeManager = new AsyncHooksScopeManager();
     const httpTextFormat = new DummyPropagation();
     const logger = new NoopLogger();
     const tracer = new NodeTracer({
-      scopeManager,
       logger,
       httpTextFormat,
     });


### PR DESCRIPTION
It was still failling simply because the scopeManager wasn't still enabled in the test code, so i switched to use the one created by the `NodeTracer` which is automatically enabled. Note that we shouldn't create async hooks scope manager to test default behavior.


close #226 