### PR TITLE
feat(exporter-jaeger): flush data before shutdown

### DIFF
--- a/packages/opentelemetry-exporter-jaeger/src/jaeger.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/jaeger.ts
@@ -55,7 +55,15 @@ export class JaegerExporter implements SpanExporter {
 
   /** Shutdown exporter. */
   shutdown(): void {
-    this._sender.close();
+    this._sender.flush((numSpans: number, err?: string) => {
+      if (err) {
+        this._logger.error(`failed to flush span: ${err}`);
+      }
+    });
+    // Sleeping 2 seconds before closing the sender's connection to ensure all spans are flushed.
+    setTimeout(() => {
+      this._sender.close();
+    }, 2000);
   }
 
   /** Transform spans and sends to Jaeger service. */


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Added an optimistic flush before shutting down the Jaeger exporter to ensure all the spans are flushed properly. I faced this issue when running the [node basic tracer](https://github.com/open-telemetry/opentelemetry-js/blob/master/examples/node-basic/index.js) example with Jaeger exporter.
