### PR TITLE
chore: remove all references to SpanData

### DIFF
--- a/packages/opentelemetry-basic-tracer/src/BasicTracer.ts
+++ b/packages/opentelemetry-basic-tracer/src/BasicTracer.ts
@@ -143,14 +143,6 @@ export class BasicTracer implements types.Tracer {
   }
 
   /**
-   * Records a SpanData.
-   */
-  /* c8 ignore next 3 */
-  recordSpanData(span: types.Span): void {
-    // TODO: notify exporter
-  }
-
-  /**
    * Returns the binary format interface which can serialize/deserialize Spans.
    */
   getBinaryFormat(): BinaryFormat {

--- a/packages/opentelemetry-basic-tracer/test/BasicTracer.test.ts
+++ b/packages/opentelemetry-basic-tracer/test/BasicTracer.test.ts
@@ -350,11 +350,6 @@ describe('BasicTracer', () => {
     });
   });
 
-  describe('.recordSpanData()', () => {
-    // @todo: implement
-    it('should call exporters with span data');
-  });
-
   describe('.getBinaryFormat()', () => {
     it('should get default binary formatter', () => {
       const tracer = new BasicTracer();

--- a/packages/opentelemetry-core/src/trace/NoopTracer.ts
+++ b/packages/opentelemetry-core/src/trace/NoopTracer.ts
@@ -50,9 +50,6 @@ export class NoopTracer implements Tracer {
   }
 
   // By default does nothing
-  recordSpanData(span: Span): void {}
-
-  // By default does nothing
   getBinaryFormat(): BinaryFormat {
     return NOOP_BINARY_FORMAT;
   }

--- a/packages/opentelemetry-core/src/trace/TracerDelegate.ts
+++ b/packages/opentelemetry-core/src/trace/TracerDelegate.ts
@@ -82,14 +82,6 @@ export class TracerDelegate implements types.Tracer {
     );
   }
 
-  recordSpanData(span: types.Span): void {
-    return this._currentTracer.recordSpanData.apply(
-      this._currentTracer,
-      // tslint:disable-next-line:no-any
-      arguments as any
-    );
-  }
-
   getBinaryFormat(): types.BinaryFormat {
     return this._currentTracer.getBinaryFormat.apply(
       this._currentTracer,

--- a/packages/opentelemetry-core/test/trace/NoopTracer.test.ts
+++ b/packages/opentelemetry-core/test/trace/NoopTracer.test.ts
@@ -37,7 +37,6 @@ describe('NoopTracer', () => {
       NOOP_SPAN
     );
 
-
     assert.deepStrictEqual(tracer.getCurrentSpan(), NOOP_SPAN);
     const httpTextFormat = tracer.getHttpTextFormat();
     assert.ok(httpTextFormat);

--- a/packages/opentelemetry-core/test/trace/NoopTracer.test.ts
+++ b/packages/opentelemetry-core/test/trace/NoopTracer.test.ts
@@ -37,7 +37,6 @@ describe('NoopTracer', () => {
       NOOP_SPAN
     );
 
-    tracer.recordSpanData(NOOP_SPAN);
 
     assert.deepStrictEqual(tracer.getCurrentSpan(), NOOP_SPAN);
     const httpTextFormat = tracer.getHttpTextFormat();

--- a/packages/opentelemetry-core/test/trace/TracerDelegate.test.ts
+++ b/packages/opentelemetry-core/test/trace/TracerDelegate.test.ts
@@ -26,7 +26,6 @@ describe('TracerDelegate', () => {
     'startSpan',
     'withSpan',
     'bind',
-    'recordSpanData',
     'getBinaryFormat',
     'getHttpTextFormat',
   ];

--- a/packages/opentelemetry-core/test/trace/globaltracer-utils.test.ts
+++ b/packages/opentelemetry-core/test/trace/globaltracer-utils.test.ts
@@ -28,7 +28,6 @@ describe('globaltracer-utils', () => {
     'getCurrentSpan',
     'startSpan',
     'withSpan',
-    'recordSpanData',
     'getBinaryFormat',
     'getHttpTextFormat',
   ];

--- a/packages/opentelemetry-node-sdk/test/NodeTracer.test.ts
+++ b/packages/opentelemetry-node-sdk/test/NodeTracer.test.ts
@@ -233,11 +233,6 @@ describe('NodeTracer', () => {
     });
   });
 
-  describe('.recordSpanData()', () => {
-    // @todo: implement
-    it('should call exporters with span data');
-  });
-
   describe('.getBinaryFormat()', () => {
     it('should get default binary formatter', () => {
       tracer = new NodeTracer({});

--- a/packages/opentelemetry-plugin-http/test/functionals/http-disable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-disable.test.ts
@@ -55,7 +55,6 @@ describe('HttpPlugin', () => {
     beforeEach(() => {
       tracer.startSpan = sinon.spy();
       tracer.withSpan = sinon.spy();
-      tracer.recordSpanData = sinon.spy();
     });
 
     afterEach(() => {
@@ -78,10 +77,6 @@ describe('HttpPlugin', () => {
             false
           );
           assert.strictEqual((tracer.withSpan as sinon.SinonSpy).called, false);
-          assert.strictEqual(
-            (tracer.recordSpanData as sinon.SinonSpy).called,
-            false
-          );
         });
       });
     });

--- a/packages/opentelemetry-types/src/trace/tracer.ts
+++ b/packages/opentelemetry-types/src/trace/tracer.ts
@@ -66,17 +66,6 @@ export interface Tracer {
   bind<T>(target: T, span?: Span): T;
 
   /**
-   * Send a pre-populated span object to the exporter.
-   * Sampling and recording decisions as well as other collection optimizations
-   * are the responsibility of a caller.
-   *
-   * @todo: Pending API discussion. Revisit if Span or SpanData should be passed
-   *        in here once this is sorted out.
-   * @param span Span Data to be reported to all exporters.
-   */
-  recordSpanData(span: Span): void;
-
-  /**
    * Returns the {@link BinaryFormat} interface which can serialize/deserialize
    * Spans.
    *


### PR DESCRIPTION
Remove all references to SpanDat per the specification update in https://github.com/open-telemetry/opentelemetry-specification/pull/215

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-telemetry/opentelemetry-js/286)
<!-- Reviewable:end -->
