### PR TITLE
fix(plugin-http): improve formatting for url attribute

### DIFF
--- a/packages/opentelemetry-plugin-http/src/http.ts
+++ b/packages/opentelemetry-plugin-http/src/http.ts
@@ -179,13 +179,17 @@ export class HttpPlugin extends BasePlugin<Http> {
               response.req && response.req.method
                 ? response.req.method.toUpperCase()
                 : 'GET';
-            const headers = options.headers;
-            const userAgent = headers ? headers['user-agent'] : null;
+            const headers = options.headers || {};
+            const userAgent = headers['user-agent'];
 
             const host = options.hostname || options.host || 'localhost';
 
             const attributes: Attributes = {
-              [AttributeNames.HTTP_URL]: `${options.protocol}//${options.hostname}${options.path}`,
+              [AttributeNames.HTTP_URL]: Utils.getAbsoluteUrl(
+                options,
+                headers,
+                `${HttpPlugin.component}:`
+              ),
               [AttributeNames.HTTP_HOSTNAME]: host,
               [AttributeNames.HTTP_METHOD]: method,
               [AttributeNames.HTTP_PATH]: options.path || '/',
@@ -286,9 +290,10 @@ export class HttpPlugin extends BasePlugin<Http> {
           const userAgent = headers['user-agent'];
 
           const attributes: Attributes = {
-            [AttributeNames.HTTP_URL]: Utils.getUrlFromIncomingRequest(
+            [AttributeNames.HTTP_URL]: Utils.getAbsoluteUrl(
               requestUrl,
-              headers
+              headers,
+              `${HttpPlugin.component}:`
             ),
             [AttributeNames.HTTP_HOSTNAME]: hostname,
             [AttributeNames.HTTP_METHOD]: method,

--- a/packages/opentelemetry-plugin-http/test/functionals/utils.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/utils.test.ts
@@ -165,20 +165,27 @@ describe('Utils', () => {
     });
   });
 
-  describe('getUrlFromIncomingRequest()', () => {
+  describe('getAbsoluteUrl()', () => {
     it('should return absolute url with localhost', () => {
       const path = '/test/1';
-      const result = Utils.getUrlFromIncomingRequest(url.parse(path), {});
+      const result = Utils.getAbsoluteUrl(url.parse(path), {});
       assert.strictEqual(result, `http://localhost${path}`);
     });
     it('should return absolute url', () => {
       const absUrl = 'http://www.google/test/1?query=1';
-      const result = Utils.getUrlFromIncomingRequest(url.parse(absUrl), {});
+      const result = Utils.getAbsoluteUrl(url.parse(absUrl), {});
       assert.strictEqual(result, absUrl);
     });
     it('should return default url', () => {
-      const result = Utils.getUrlFromIncomingRequest(null, {});
+      const result = Utils.getAbsoluteUrl(null, {});
       assert.strictEqual(result, 'http://localhost/');
+    });
+    it("{ path: '/helloworld', port: 8080 } should return http://localhost:8080/helloworld", () => {
+      const result = Utils.getAbsoluteUrl(
+        { path: '/helloworld', port: 8080 },
+        {}
+      );
+      assert.strictEqual(result, 'http://localhost:8080/helloworld');
     });
   });
   describe('setSpanOnError()', () => {


### PR DESCRIPTION
## Which problem is this PR solving?
- closes #316

## Short description of the changes
- rename getUrlFromIncomingRequest to getAbsoluteUrl (since we use it for outgoing and incoming requests)
- improve formatting
- add test
