### PR TITLE
fix(http-plugin): move node-sdk to dev deps

### DIFF
--- a/packages/opentelemetry-plugin-http/package.json
+++ b/packages/opentelemetry-plugin-http/package.json
@@ -48,6 +48,7 @@
     "@types/sinon": "^7.0.13",
     "@types/superagent": "^4.1.3",
     "@opentelemetry/basic-tracer": "^0.0.1",
+    "@opentelemetry/node-sdk": "^0.0.1",
     "@opentelemetry/scope-base": "^0.0.1",
     "axios": "^0.19.0",
     "got": "^9.6.0",
@@ -69,7 +70,6 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^0.0.1",
-    "@opentelemetry/node-sdk": "^0.0.1",
     "@opentelemetry/types": "^0.0.1",
     "semver": "^6.3.0",
     "shimmer": "^1.2.1"


### PR DESCRIPTION
## Which problem is this PR solving?
`node-sdk` is only used in tests and should be in `devDependencies`
/cc @OlivierAlbertini 