### PR TITLE
fix: increase timeout for BatchSpanProcessor test

### DIFF
--- a/packages/opentelemetry-basic-tracer/test/export/BatchSpanProcessor.test.ts
+++ b/packages/opentelemetry-basic-tracer/test/export/BatchSpanProcessor.test.ts
@@ -120,7 +120,7 @@ describe('BatchSpanProcessor', () => {
       setTimeout(() => {
         assert.strictEqual(exporter.spansDataList.length, 5);
         done();
-      }, defaultBufferConfig.bufferTimeout + 100);
+      }, defaultBufferConfig.bufferTimeout + 1000);
     }).timeout(defaultBufferConfig.bufferTimeout * 2);
   });
 });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Resolves #350.

 - Increasing timeout number, this should give enough time to report spans collected by `BatchSpanProcessor`.