### PR TITLE
fix(example): add flushInterval to report spans to Jaeger exporter

### DIFF
--- a/examples/grpc/client.js
+++ b/examples/grpc/client.js
@@ -42,6 +42,12 @@ function main() {
       console.log('Greeting:', response.getMessage());
     });
   });
+
+  // The process must live for at least the interval past any traces that
+  // must be exported, or some risk being lost if they are recorded after the
+  // last export.
+  console.log('Sleeping 5 seconds before shutdown to ensure all records are flushed.')
+  setTimeout(() => { console.log('Completed.'); }, 5000);
 }
 
 main();


### PR DESCRIPTION
- Same as HTTP example.
