### PR TITLE
chore: add HTTPS to default instrumented plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ OpenTelemetry can collect tracing data automatically using plugins. Vendors/User
 
 - [@opentelemetry/plugin-http](https://github.com/open-telemetry/opentelemetry-js/tree/master/packages/opentelemetry-plugin-http)
 - [@opentelemetry/plugin-grpc](https://github.com/open-telemetry/opentelemetry-js/tree/master/packages/opentelemetry-plugin-grpc)
+- [@opentelemetry/plugin-https](https://github.com/open-telemetry/opentelemetry-js/tree/master/packages/opentelemetry-plugin-https)
 
 To request automatic tracing support for a module not on this list, please [file an issue](https://github.com/open-telemetry/opentelemetry-js/issues). Alternatively, you can [write a plugin yourself](https://github.com/open-telemetry/opentelemetry-js/blob/master/doc/plugin-guide.md).
 

--- a/packages/opentelemetry-node-sdk/README.md
+++ b/packages/opentelemetry-node-sdk/README.md
@@ -44,6 +44,7 @@ npm install --save @opentelemetry/node-sdk
 # Install instrumentation plugins
 npm install --save @opentelemetry/plugin-http
 npm install --save @opentelemetry/plugin-grpc
+npm install --save @opentelemetry/plugin-https
 ```
 
 ## Usage

--- a/packages/opentelemetry-node-sdk/src/config.ts
+++ b/packages/opentelemetry-node-sdk/src/config.ts
@@ -35,4 +35,8 @@ export const DEFAULT_INSTRUMENTATION_PLUGINS: Plugins = {
     enabled: true,
     path: '@opentelemetry/plugin-grpc',
   },
+  https: {
+    enabled: true,
+    path: '@opentelemetry/plugin-https',
+  },
 };


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- With this, `HTTPS` plugin will be loaded automatically when you use `node-sdk`.