### PR TITLE
fix(grpc): patch loadPackageDefinition

### DIFF
--- a/packages/opentelemetry-plugin-grpc/package.json
+++ b/packages/opentelemetry-plugin-grpc/package.json
@@ -38,6 +38,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@grpc/proto-loader": "^0.4.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.6.9",
     "@types/shimmer": "^1.0.1",

--- a/packages/opentelemetry-plugin-grpc/src/grpc.ts
+++ b/packages/opentelemetry-plugin-grpc/src/grpc.ts
@@ -538,12 +538,15 @@ export class GrpcPlugin extends BasePlugin<grpc> {
         ((call as unknown) as events.EventEmitter).on(
           'status',
           (status: Status) => {
-            span.setStatus({ code: CanonicalCode.OK });
-            span.setAttribute(
-              AttributeNames.GRPC_STATUS_CODE,
-              status.code.toString()
-            );
-            endSpan();
+            // if an error was emitted, the span will be ended there
+            if (status.code === 0) {
+              span.setStatus({ code: CanonicalCode.OK });
+              span.setAttribute(
+                AttributeNames.GRPC_STATUS_CODE,
+                status.code.toString()
+              );
+              endSpan();
+            }
           }
         );
       }

--- a/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
+++ b/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
@@ -32,7 +32,12 @@ import * as grpc from 'grpc';
 import * as sinon from 'sinon';
 
 const PROTO_PATH = __dirname + '/fixtures/grpc-test.proto';
-const PROTO_OPTIONS = { keepCae: true, enums: String, defaults: true, oneofs: true };
+const PROTO_OPTIONS = {
+  keepCae: true,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+};
 const memoryExporter = new InMemorySpanExporter();
 
 type GrpcModule = typeof grpc;

--- a/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
+++ b/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
@@ -32,6 +32,7 @@ import * as grpc from 'grpc';
 import * as sinon from 'sinon';
 
 const PROTO_PATH = __dirname + '/fixtures/grpc-test.proto';
+const PROTO_OPTIONS = { keepCae: true, enums: String, defaults: true, oneofs: true };
 const memoryExporter = new InMemorySpanExporter();
 
 type GrpcModule = typeof grpc;
@@ -299,7 +300,7 @@ describe('GrpcPlugin', () => {
 
     it('should patch client constructor makeClientConstructor() and makeGenericClientConstructor()', () => {
       plugin.enable(grpc, new NoopTracer(), new NoopLogger());
-      (plugin['_moduleExports'] as any).makeGenericClientConstructor({});
+      (grpc as any).makeGenericClientConstructor({});
       assert.strictEqual(clientPatchStub.callCount, 1);
     });
   });
@@ -536,8 +537,9 @@ describe('GrpcPlugin', () => {
         // TODO: add plugin options here once supported
       };
       plugin.enable(grpc, tracer, logger, config);
-
-      const proto = grpc.load(PROTO_PATH).pkg_test;
+      const protoLoader = require('@grpc/proto-loader');
+      const definition = protoLoader.loadSync(PROTO_PATH, PROTO_OPTIONS);
+      const proto = grpc.loadPackageDefinition(definition).pkg_test;
       server = startServer(grpc, proto);
       client = createClient(grpc, proto);
     });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes #384 

## Short description of the changes

The internal files loader is not correctly patching the internal generic catch all `client.makeClientConstructor`, so the 2 main ways of creating clients are patched instead. `loadObject` is not patched. I've disabled the generic patch until #285 solves the internal patches not propagating to the module's usage of them.
