### PR TITLE
refactor: cal duration once instead of each get duration call

### DIFF
--- a/packages/opentelemetry-tracing/src/Span.ts
+++ b/packages/opentelemetry-tracing/src/Span.ts
@@ -141,6 +141,16 @@ export class Span implements types.Span, ReadableSpan {
     }
     this._ended = true;
     this.endTime = timeInputToHrTime(endTime);
+
+    this._duration = hrTimeDuration(this.startTime, this.endTime);
+    if (this._duration[0] < 0) {
+      this._logger.warn(
+        'Inconsistent start and end time, startTime > endTime',
+        this.startTime,
+        this.endTime
+      );
+    }
+
     this._spanProcessor.onEnd(this);
   }
 
@@ -153,20 +163,6 @@ export class Span implements types.Span, ReadableSpan {
   }
 
   get duration(): types.HrTime {
-    if (this._duration[0] !== -1) {
-      return this._duration;
-    }
-
-    this._duration = hrTimeDuration(this.startTime, this.endTime);
-
-    if (this._duration[0] < 0) {
-      this._logger.warn(
-        'Inconsistent start and end time, startTime > endTime',
-        this.startTime,
-        this.endTime
-      );
-    }
-
     return this._duration;
   }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Calculate `span`'s duration ONLY at the end of the span instead of each `get duration()` call.

- This will also set `_duration` immediately. See below snap, `_duration` is still pointing to invalid value even after a `span` is ended.

![Screen Shot 2019-10-07 at 12 53 46 PM](https://user-images.githubusercontent.com/6525361/66350483-494c5a80-e910-11e9-8bec-2c058ba836f1.png)
