### PR TITLE
feat: implement metrics sdk

### DIFF
--- a/packages/opentelemetry-metrics/src/Handle.ts
+++ b/packages/opentelemetry-metrics/src/Handle.ts
@@ -28,14 +28,15 @@ export class CounterHandle implements types.CounterHandle {
   constructor(
     private readonly _disabled: boolean,
     private readonly _monotonic: boolean,
-    private readonly _labelValues: string[]
+    private readonly _labelValues: string[],
+    private readonly _logger: types.Logger
   ) {}
 
   add(value: number): void {
     if (this._disabled) return;
 
     if (this._monotonic && value < 0) {
-      // log: Monotonic counter cannot descend.
+      this._logger.error('Monotonic counter cannot descend.');
       return;
     }
     this._data = this._data + value;
@@ -65,14 +66,15 @@ export class GaugeHandle implements types.GaugeHandle {
   constructor(
     private readonly _disabled: boolean,
     private readonly _monotonic: boolean,
-    private readonly _labelValues: string[]
+    private readonly _labelValues: string[],
+    private readonly _logger: types.Logger
   ) {}
 
   set(value: number): void {
     if (this._disabled) return;
 
     if (this._monotonic && value < this._data) {
-      // log: Monotonic gauge cannot descend.
+      this._logger.error('Monotonic gauge cannot descend.');
       return;
     }
     this._data = value;

--- a/packages/opentelemetry-metrics/src/Handle.ts
+++ b/packages/opentelemetry-metrics/src/Handle.ts
@@ -16,67 +16,62 @@
 
 import * as types from '@opentelemetry/types';
 
-export class BaseHandle {
-  protected _data = 0;
-  protected _disabled: boolean;
-  protected _monotonic: boolean;
-
-  constructor(disabled: boolean, monotonic: boolean) {
-    this._disabled = disabled;
-    this._monotonic = monotonic;
-  }
-
-  protected validateUpdate() {
-    if (this._disabled) return false;
-    return true;
-  }
-}
-
 /**
  * CounterHandle is an implementation of the {@link CounterHandle} interface.
  */
-export class CounterHandle extends BaseHandle implements types.CounterHandle {
-  constructor(disabled: boolean, monotonic: boolean) {
-    super(disabled, monotonic);
-  }
+export class CounterHandle implements types.CounterHandle {
+  // @todo: remove below line once data is exported as a part of Metric.
+  /* tslint:disable-next-line:no-unused-variable */
+  private _data = 0;
+  constructor(
+    private readonly _disabled: boolean,
+    private readonly _monotonic: boolean
+  ) {}
 
   add(value: number): void {
-    if (!this.validateUpdate()) return;
+    if (this._disabled) return;
 
     if (this._monotonic && value < 0) {
       // log: Monotonic counter cannot descend.
       return;
     }
-    this._data += value;
+    this._data = this._data + value;
   }
 }
 
 /**
  * GaugeHandle is an implementation of the {@link GaugeHandle} interface.
  */
-export class GaugeHandle extends BaseHandle implements types.GaugeHandle {
-  constructor(disabled: boolean, monotonic: boolean) {
-    super(disabled, monotonic);
-  }
+export class GaugeHandle implements types.GaugeHandle {
+  // @todo: remove below line once data is exported as a part of Metric.
+  /* tslint:disable-next-line:no-unused-variable */
+  private _data = 0;
+  constructor(
+    private readonly _disabled: boolean,
+    private readonly _monotonic: boolean
+  ) {}
 
   set(value: number): void {
-    return;
+    if (this._disabled) return;
+
+    if (this._monotonic && value < this._data) {
+      // log: Monotonic gauge cannot descend.
+      return;
+    }
+    this._data = value;
   }
 }
 
 /**
  * MeasureHandle is an implementation of the {@link MeasureHandle} interface.
  */
-export class MeasureHandle extends BaseHandle implements types.MeasureHandle {
-  constructor(disabled: boolean, monotonic: boolean) {
-    super(disabled, monotonic);
-  }
-
+export class MeasureHandle implements types.MeasureHandle {
   record(
     value: number,
     distContext?: types.DistributedContext,
     spanContext?: types.SpanContext
   ): void {
-    throw new Error('not implemented yet');
+    // @todo: implement this method.
+    return;
   }
 }

--- a/packages/opentelemetry-metrics/src/Handle.ts
+++ b/packages/opentelemetry-metrics/src/Handle.ts
@@ -1,0 +1,82 @@
+/*!
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as types from '@opentelemetry/types';
+
+export class BaseHandle {
+  protected _data = 0;
+  protected _disabled: boolean;
+  protected _monotonic: boolean;
+
+  constructor(disabled: boolean, monotonic: boolean) {
+    this._disabled = disabled;
+    this._monotonic = monotonic;
+  }
+
+  protected validateUpdate() {
+    if (this._disabled) return false;
+    return true;
+  }
+}
+
+/**
+ * CounterHandle is an implementation of the {@link CounterHandle} interface.
+ */
+export class CounterHandle extends BaseHandle implements types.CounterHandle {
+  constructor(disabled: boolean, monotonic: boolean) {
+    super(disabled, monotonic);
+  }
+
+  add(value: number): void {
+    if (!this.validateUpdate()) return;
+
+    if (this._monotonic && value < 0) {
+      // log: Monotonic counter cannot descend.
+      return;
+    }
+    this._data += value;
+  }
+}
+
+/**
+ * GaugeHandle is an implementation of the {@link GaugeHandle} interface.
+ */
+export class GaugeHandle extends BaseHandle implements types.GaugeHandle {
+  constructor(disabled: boolean, monotonic: boolean) {
+    super(disabled, monotonic);
+  }
+
+  set(value: number): void {
+    return;
+  }
+}
+
+/**
+ * MeasureHandle is an implementation of the {@link MeasureHandle} interface.
+ */
+export class MeasureHandle extends BaseHandle implements types.MeasureHandle {
+  constructor(disabled: boolean, monotonic: boolean) {
+    super(disabled, monotonic);
+  }
+
+  record(
+    value: number,
+    distContext?: types.DistributedContext,
+    spanContext?: types.SpanContext
+  ): void {
+    throw new Error('not implemented yet');
+  }
+}

--- a/packages/opentelemetry-metrics/src/Handle.ts
+++ b/packages/opentelemetry-metrics/src/Handle.ts
@@ -17,7 +17,9 @@
 import * as types from '@opentelemetry/types';
 
 /**
- * CounterHandle is an implementation of the {@link CounterHandle} interface.
+ * CounterHandle allows the SDK to observe/record a single metric event. The
+ * value of single handle in the `Counter` associated with specified label
+ * values.
  */
 export class CounterHandle implements types.CounterHandle {
   // @todo: remove below line once data is exported as a part of Metric.
@@ -40,7 +42,8 @@ export class CounterHandle implements types.CounterHandle {
 }
 
 /**
- * GaugeHandle is an implementation of the {@link GaugeHandle} interface.
+ * GaugeHandle allows the SDK to observe/record a single metric event. The
+ * value of single handle in the `Gauge` associated with specified label values.
  */
 export class GaugeHandle implements types.GaugeHandle {
   // @todo: remove below line once data is exported as a part of Metric.

--- a/packages/opentelemetry-metrics/src/Handle.ts
+++ b/packages/opentelemetry-metrics/src/Handle.ts
@@ -15,6 +15,7 @@
  */
 
 import * as types from '@opentelemetry/types';
+import { TimeSeries } from './export/types';
 
 /**
  * CounterHandle allows the SDK to observe/record a single metric event. The
@@ -22,12 +23,12 @@ import * as types from '@opentelemetry/types';
  * values.
  */
 export class CounterHandle implements types.CounterHandle {
-  // @todo: remove below line once data is exported as a part of Metric.
-  /* tslint:disable-next-line:no-unused-variable */
   private _data = 0;
+
   constructor(
     private readonly _disabled: boolean,
-    private readonly _monotonic: boolean
+    private readonly _monotonic: boolean,
+    private readonly _labelValues: string[]
   ) {}
 
   add(value: number): void {
@@ -39,6 +40,19 @@ export class CounterHandle implements types.CounterHandle {
     }
     this._data = this._data + value;
   }
+
+  /**
+   * Returns the TimeSeries with one or more Point.
+   *
+   * @param timestamp The time at which the counter is recorded.
+   * @returns The TimeSeries.
+   */
+  getTimeSeries(timestamp: types.HrTime): TimeSeries {
+    return {
+      labelValues: this._labelValues.map(value => ({ value })),
+      points: [{ value: this._data, timestamp }],
+    };
+  }
 }
 
 /**
@@ -46,12 +60,12 @@ export class CounterHandle implements types.CounterHandle {
  * value of single handle in the `Gauge` associated with specified label values.
  */
 export class GaugeHandle implements types.GaugeHandle {
-  // @todo: remove below line once data is exported as a part of Metric.
-  /* tslint:disable-next-line:no-unused-variable */
   private _data = 0;
+
   constructor(
     private readonly _disabled: boolean,
-    private readonly _monotonic: boolean
+    private readonly _monotonic: boolean,
+    private readonly _labelValues: string[]
   ) {}
 
   set(value: number): void {
@@ -62,6 +76,19 @@ export class GaugeHandle implements types.GaugeHandle {
       return;
     }
     this._data = value;
+  }
+
+  /**
+   * Returns the TimeSeries with one or more Point.
+   *
+   * @param timestamp The time at which the gauge is recorded.
+   * @returns The TimeSeries.
+   */
+  getTimeSeries(timestamp: types.HrTime): TimeSeries {
+    return {
+      labelValues: this._labelValues.map(value => ({ value })),
+      points: [{ value: this._data, timestamp }],
+    };
   }
 }
 

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -1,0 +1,62 @@
+/*!
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as types from '@opentelemetry/types';
+import { CounterHandle, GaugeHandle, MeasureHandle } from './Handle';
+import { Metric } from './Metric';
+
+/**
+ * Meter is an implementation of the {@link Meter} interface.
+ */
+export class Meter implements types.Meter {
+  /**
+   * Creates and returns a new {@link Measure}.
+   * @param name the name of the metric.
+   * @param [options] the metric options.
+   */
+  createMeasure(
+    name: string,
+    options?: types.MetricOptions
+  ): Metric<MeasureHandle> {
+    throw new Error('not implemented yet');
+  }
+
+  /**
+   * Creates a new counter metric.
+   * @param name the name of the metric.
+   * @param [options] the metric options.
+   */
+  createCounter(
+    name: string,
+    options?: types.MetricOptions
+  ): Metric<CounterHandle> {
+    const opt = Object.assign({ monotonic: false, disabled: false }, options);
+    const counter = new Metric<CounterHandle>(name, opt);
+    return counter;
+  }
+
+  /**
+   * Creates a new gauge metric.
+   * @param name the name of the metric.
+   * @param [options] the metric options.
+   */
+  createGauge(
+    name: string,
+    options?: types.MetricOptions
+  ): Metric<GaugeHandle> {
+    throw new Error('not implemented yet');
+  }
+}

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -16,7 +16,8 @@
 
 import * as types from '@opentelemetry/types';
 import { CounterHandle, GaugeHandle, MeasureHandle } from './Handle';
-import { Metric } from './Metric';
+import { Metric, CounterMetric, GaugeMetric } from './Metric';
+import { MetricOptions, DEFAULT_METRIC_OPTIONS } from './types';
 
 /**
  * Meter is an implementation of the {@link Meter} interface.
@@ -31,6 +32,7 @@ export class Meter implements types.Meter {
     name: string,
     options?: types.MetricOptions
   ): Metric<MeasureHandle> {
+    // @todo: implement this method
     throw new Error('not implemented yet');
   }
 
@@ -43,9 +45,12 @@ export class Meter implements types.Meter {
     name: string,
     options?: types.MetricOptions
   ): Metric<CounterHandle> {
-    const opt = Object.assign({ monotonic: false, disabled: false }, options);
-    const counter = new Metric<CounterHandle>(name, opt);
-    return counter;
+    const opt: MetricOptions = {
+      monotonic: true,
+      ...DEFAULT_METRIC_OPTIONS,
+      ...options,
+    };
+    return new CounterMetric(name, opt);
   }
 
   /**
@@ -57,6 +62,11 @@ export class Meter implements types.Meter {
     name: string,
     options?: types.MetricOptions
   ): Metric<GaugeHandle> {
-    throw new Error('not implemented yet');
+    const opt: MetricOptions = {
+      monotonic: false,
+      ...DEFAULT_METRIC_OPTIONS,
+      ...options,
+    };
+    return new GaugeMetric(name, opt);
   }
 }

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -37,7 +37,9 @@ export class Meter implements types.Meter {
   }
 
   /**
-   * Creates a new counter metric.
+   * Creates a new counter metric. Generally, this kind of metric when the
+   * value is a quantity, the sum is of primary interest, and the event count
+   * and value distribution are not of primary interest.
    * @param name the name of the metric.
    * @param [options] the metric options.
    */
@@ -46,6 +48,7 @@ export class Meter implements types.Meter {
     options?: types.MetricOptions
   ): Metric<CounterHandle> {
     const opt: MetricOptions = {
+      // Counters are defined as monotonic by default
       monotonic: true,
       ...DEFAULT_METRIC_OPTIONS,
       ...options,
@@ -54,7 +57,10 @@ export class Meter implements types.Meter {
   }
 
   /**
-   * Creates a new gauge metric.
+   * Creates a new gauge metric. Generally, this kind of metric should be used
+   * when the metric cannot be expressed as a sum or because the measurement
+   * interval is arbitrary. Use this kind of metric when the measurement is not
+   * a quantity, and the sum and event count are not of interest.
    * @param name the name of the metric.
    * @param [options] the metric options.
    */
@@ -63,6 +69,7 @@ export class Meter implements types.Meter {
     options?: types.MetricOptions
   ): Metric<GaugeHandle> {
     const opt: MetricOptions = {
+      // Gauges are defined as non-monotonic by default
       monotonic: false,
       ...DEFAULT_METRIC_OPTIONS,
       ...options,

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -15,14 +15,29 @@
  */
 
 import * as types from '@opentelemetry/types';
+import { ConsoleLogger } from '@opentelemetry/core';
 import { CounterHandle, GaugeHandle, MeasureHandle } from './Handle';
 import { Metric, CounterMetric, GaugeMetric } from './Metric';
-import { MetricOptions, DEFAULT_METRIC_OPTIONS } from './types';
+import {
+  MetricOptions,
+  DEFAULT_METRIC_OPTIONS,
+  DEFAULT_CONFIG,
+  MeterConfig,
+} from './types';
 
 /**
  * Meter is an implementation of the {@link Meter} interface.
  */
 export class Meter implements types.Meter {
+  private readonly _logger: types.Logger;
+
+  /**
+   * Constructs a new Meter instance.
+   */
+  constructor(config: MeterConfig = DEFAULT_CONFIG) {
+    this._logger = config.logger || new ConsoleLogger(config.logLevel);
+  }
+
   /**
    * Creates and returns a new {@link Measure}.
    * @param name the name of the metric.
@@ -50,6 +65,7 @@ export class Meter implements types.Meter {
     const opt: MetricOptions = {
       // Counters are defined as monotonic by default
       monotonic: true,
+      logger: this._logger,
       ...DEFAULT_METRIC_OPTIONS,
       ...options,
     };
@@ -71,6 +87,7 @@ export class Meter implements types.Meter {
     const opt: MetricOptions = {
       // Gauges are defined as non-monotonic by default
       monotonic: false,
+      logger: this._logger,
       ...DEFAULT_METRIC_OPTIONS,
       ...options,
     };

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -23,11 +23,13 @@ import { MetricOptions } from './types';
 export abstract class Metric<T> implements types.Metric<T> {
   protected readonly _monotonic: boolean;
   protected readonly _disabled: boolean;
+  protected readonly _logger: types.Logger;
   private readonly _handles: Map<String, T> = new Map();
 
   constructor(name: string, options: MetricOptions) {
     this._monotonic = options.monotonic;
     this._disabled = options.disabled;
+    this._logger = options.logger;
   }
 
   /**
@@ -50,6 +52,7 @@ export abstract class Metric<T> implements types.Metric<T> {
    */
   getDefaultHandle(): T {
     // @todo: implement this method
+    this._logger.error('not implemented yet');
     throw new Error('not implemented yet');
   }
 
@@ -70,6 +73,7 @@ export abstract class Metric<T> implements types.Metric<T> {
 
   setCallback(fn: () => void): void {
     // @todo: implement this method
+    this._logger.error('not implemented yet');
     return;
   }
 
@@ -82,7 +86,12 @@ export class CounterMetric extends Metric<CounterHandle> {
     super(name, options);
   }
   protected _makeHandle(labelValues: string[]): CounterHandle {
-    return new CounterHandle(this._disabled, this._monotonic, labelValues);
+    return new CounterHandle(
+      this._disabled,
+      this._monotonic,
+      labelValues,
+      this._logger
+    );
   }
 }
 
@@ -92,6 +101,11 @@ export class GaugeMetric extends Metric<GaugeHandle> {
     super(name, options);
   }
   protected _makeHandle(labelValues: string[]): GaugeHandle {
-    return new GaugeHandle(this._disabled, this._monotonic, labelValues);
+    return new GaugeHandle(
+      this._disabled,
+      this._monotonic,
+      labelValues,
+      this._logger
+    );
   }
 }

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -1,0 +1,72 @@
+/*!
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as types from '@opentelemetry/types';
+import { hashLabelValues } from './Utils';
+import { CounterHandle } from './Handle';
+
+export class Metric<T> implements types.Metric<T> {
+  private readonly _monotonic: boolean;
+  private readonly _disabled: boolean;
+  private readonly _handles: Map<String, T> = new Map();
+
+  constructor(name: string, options: types.MetricOptions) {
+    this._monotonic = options.monotonic!;
+    this._disabled = options.disabled!;
+  }
+
+  /**
+   * Returns a Handle associated with specified label values.
+   * It is recommended to keep a reference to the Handle instead of always
+   * calling this method for every operations.
+   * @param labelValues the list of label values.
+   */
+  getHandle(labelValues: string[]): T {
+    const hash = hashLabelValues(labelValues);
+    if (this._handles.has(hash)) return this._handles.get(hash)!;
+
+    const handle = new CounterHandle(this._disabled, this._monotonic);
+    this._handles.set(hash, handle as never);
+    return handle as never;
+  }
+
+  /**
+   * Returns a Handle for a metric with all labels not set.
+   */
+  getDefaultHandle(): T {
+    throw new Error('not implemented yet');
+  }
+
+  /**
+   * Removes the Handle from the metric, if it is present.
+   * @param labelValues the list of label values.
+   */
+  removeHandle(labelValues: string[]): void {
+    this._handles.delete(hashLabelValues(labelValues));
+  }
+
+  /**
+   * Clears all Handle from the Metric.
+   */
+  clear(): void {
+    this._handles.clear();
+  }
+
+  setCallback(fn: () => void): void {
+    // @todo: implement this method
+    return;
+  }
+}

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -40,7 +40,7 @@ export abstract class Metric<T> implements types.Metric<T> {
     const hash = hashLabelValues(labelValues);
     if (this._handles.has(hash)) return this._handles.get(hash)!;
 
-    const handle = this._makeHandle();
+    const handle = this._makeHandle(labelValues);
     this._handles.set(hash, handle);
     return handle;
   }
@@ -73,7 +73,7 @@ export abstract class Metric<T> implements types.Metric<T> {
     return;
   }
 
-  protected abstract _makeHandle(): T;
+  protected abstract _makeHandle(labelValues: string[]): T;
 }
 
 /** This is a SDK implementation of Counter Metric. */
@@ -81,8 +81,8 @@ export class CounterMetric extends Metric<CounterHandle> {
   constructor(name: string, options: MetricOptions) {
     super(name, options);
   }
-  protected _makeHandle(): CounterHandle {
-    return new CounterHandle(this._disabled, this._monotonic);
+  protected _makeHandle(labelValues: string[]): CounterHandle {
+    return new CounterHandle(this._disabled, this._monotonic, labelValues);
   }
 }
 
@@ -91,7 +91,7 @@ export class GaugeMetric extends Metric<GaugeHandle> {
   constructor(name: string, options: MetricOptions) {
     super(name, options);
   }
-  protected _makeHandle(): GaugeHandle {
-    return new GaugeHandle(this._disabled, this._monotonic);
+  protected _makeHandle(labelValues: string[]): GaugeHandle {
+    return new GaugeHandle(this._disabled, this._monotonic, labelValues);
   }
 }

--- a/packages/opentelemetry-metrics/src/Utils.ts
+++ b/packages/opentelemetry-metrics/src/Utils.ts
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
-export * from './Handle';
-export * from './Meter';
-export * from './Metric';
+const COMMA_SEPARATOR = ',';
+
+/**
+ * Returns a string(comma separated) from the list of label values.
+ *
+ * @param labelValues The list of the label values.
+ * @returns The hashed label values string.
+ */
+export function hashLabelValues(labelValues: string[]): string {
+  return labelValues.sort().join(COMMA_SEPARATOR);
+}

--- a/packages/opentelemetry-metrics/src/types.ts
+++ b/packages/opentelemetry-metrics/src/types.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { LogLevel } from '@opentelemetry/core';
+import { Logger } from '@opentelemetry/types';
+
 /** Options needed for SDK metric creation. */
 export interface MetricOptions {
   /** The name of the component that reports the Metric. */
@@ -36,7 +39,24 @@ export interface MetricOptions {
 
   /** Monotonic allows this metric to accept negative values. */
   monotonic: boolean;
+
+  /** User provided logger. */
+  logger: Logger;
 }
+
+/** MeterConfig provides an interface for configuring a Meter. */
+export interface MeterConfig {
+  /** User provided logger. */
+  logger?: Logger;
+
+  /** level of logger.  */
+  logLevel?: LogLevel;
+}
+
+/** Default Meter configuration. */
+export const DEFAULT_CONFIG = {
+  logLevel: LogLevel.DEBUG,
+};
 
 /** The default metric creation options value. */
 export const DEFAULT_METRIC_OPTIONS = {

--- a/packages/opentelemetry-metrics/src/types.ts
+++ b/packages/opentelemetry-metrics/src/types.ts
@@ -1,0 +1,47 @@
+/*!
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Options needed for SDK metric creation. */
+export interface MetricOptions {
+  /** The name of the component that reports the Metric. */
+  component?: string;
+
+  /** The description of the Metric. */
+  description: string;
+
+  /** The unit of the Metric values. */
+  unit: string;
+
+  /** The list of label keys for the Metric. */
+  labelKeys: string[];
+
+  /** The map of constant labels for the Metric. */
+  constantLabels?: Map<string, string>;
+
+  /** Indicates the metric is a verbose metric that is disabled by default */
+  disabled: boolean;
+
+  /** Monotonic allows this metric to accept negative values. */
+  monotonic: boolean;
+}
+
+/** The default metric creation options value. */
+export const DEFAULT_METRIC_OPTIONS = {
+  disabled: false,
+  description: '',
+  unit: '1',
+  labelKeys: [],
+};

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -1,0 +1,107 @@
+/*!
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { Meter, Metric } from '../src';
+
+describe('Meter', () => {
+  let meter: Meter;
+  const labelValues = ['value'];
+
+  beforeEach(() => {
+    meter = new Meter();
+  });
+
+  describe('#counter', () => {
+    it('should create a counter without options', () => {
+      const counter = meter.createCounter('name');
+      assert.ok(counter instanceof Metric);
+    });
+
+    it('should create a counter without options', () => {
+      const counter = meter.createCounter('name', {
+        description: 'desc',
+        unit: '1',
+        disabled: false,
+        monotonic: false,
+      });
+      assert.ok(counter instanceof Metric);
+    });
+
+    describe('.getHandle()', () => {
+      it('should create the counter handle', () => {
+        const counter = meter.createCounter('name');
+        const handle = counter.getHandle(labelValues);
+        handle.add(10);
+        assert.strictEqual(handle['_data'], 10);
+        handle.add(10);
+        assert.strictEqual(handle['_data'], 20);
+      });
+
+      it('should not update the handle when disabled = true', () => {
+        const counter = meter.createCounter('name', {
+          disabled: true,
+        });
+        const handle = counter.getHandle(labelValues);
+        handle.add(10);
+        assert.strictEqual(handle['_data'], 0);
+      });
+
+      it('should not add negative value when monotonic = true', () => {
+        const counter = meter.createCounter('name', {
+          monotonic: true,
+        });
+        const handle = counter.getHandle(labelValues);
+        handle.add(10);
+        assert.strictEqual(handle['_data'], 10);
+        handle.add(-100);
+        assert.strictEqual(handle['_data'], 10);
+      });
+
+      it('should add negative value when monotonic = false', () => {
+        const counter = meter.createCounter('name');
+        const handle = counter.getHandle(labelValues);
+        handle.add(-10);
+        assert.strictEqual(handle['_data'], -10);
+      });
+
+      it('should return same handle on same label values', () => {
+        const counter = meter.createCounter('name');
+        const handle = counter.getHandle(labelValues);
+        handle.add(10);
+        const handle1 = counter.getHandle(labelValues);
+        handle1.add(10);
+        assert.strictEqual(handle['_data'], 20);
+        assert.strictEqual(handle, handle1);
+      });
+    });
+
+    describe('.removeHandle()', () => {
+      it('should remove the counter handle', () => {
+        const counter = meter.createCounter('name');
+        const handle = counter.getHandle(labelValues);
+        counter.removeHandle(labelValues);
+        const handle1 = counter.getHandle(labelValues);
+        assert.notStrictEqual(handle, handle1);
+      });
+
+      it('should not fail when removing non existing handle', () => {
+        const counter = meter.createCounter('name');
+        counter.removeHandle([]);
+      });
+    });
+  });
+});

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -17,6 +17,7 @@
 import * as assert from 'assert';
 import { Meter, Metric } from '../src';
 import * as types from '@opentelemetry/types';
+import { NoopLogger } from '@opentelemetry/core';
 
 describe('Meter', () => {
   let meter: Meter;
@@ -24,7 +25,9 @@ describe('Meter', () => {
   const hrTime: types.HrTime = [22, 400000000];
 
   beforeEach(() => {
-    meter = new Meter();
+    meter = new Meter({
+      logger: new NoopLogger(),
+    });
   });
 
   describe('#counter', () => {

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -16,10 +16,12 @@
 
 import * as assert from 'assert';
 import { Meter, Metric } from '../src';
+import * as types from '@opentelemetry/types';
 
 describe('Meter', () => {
   let meter: Meter;
   const labelValues = ['value'];
+  const hrTime: types.HrTime = [22, 400000000];
 
   beforeEach(() => {
     meter = new Meter();
@@ -49,6 +51,16 @@ describe('Meter', () => {
         assert.strictEqual(handle['_data'], 10);
         handle.add(10);
         assert.strictEqual(handle['_data'], 20);
+      });
+
+      it('should return the timeseries', () => {
+        const counter = meter.createCounter('name');
+        const handle = counter.getHandle(['value1', 'value2']);
+        handle.add(20);
+        assert.deepStrictEqual(handle.getTimeSeries(hrTime), {
+          labelValues: [{ value: 'value1' }, { value: 'value2' }],
+          points: [{ value: 20, timestamp: hrTime }],
+        });
       });
 
       it('should add positive values by default', () => {
@@ -140,6 +152,16 @@ describe('Meter', () => {
         assert.strictEqual(handle['_data'], 10);
         handle.set(250);
         assert.strictEqual(handle['_data'], 250);
+      });
+
+      it('should return the timeseries', () => {
+        const gauge = meter.createGauge('name');
+        const handle = gauge.getHandle(['v1', 'v2']);
+        handle.set(150);
+        assert.deepStrictEqual(handle.getTimeSeries(hrTime), {
+          labelValues: [{ value: 'v1' }, { value: 'v2' }],
+          points: [{ value: 150, timestamp: hrTime }],
+        });
       });
 
       it('should go up and down by default', () => {

--- a/packages/opentelemetry-types/src/metrics/Meter.ts
+++ b/packages/opentelemetry-types/src/metrics/Meter.ts
@@ -33,7 +33,9 @@ export interface Meter {
   createMeasure(name: string, options?: MetricOptions): Metric<MeasureHandle>;
 
   /**
-   * Creates a new counter metric.
+   * Creates a new counter metric. Generally, this kind of metric when the
+   * value is a quantity, the sum is of primary interest, and the event count
+   * and value distribution are not of primary interest.
    * @param name the name of the metric.
    * @param [options] the metric options.
    */
@@ -48,7 +50,10 @@ export interface Meter {
   // Maybe include the type as a metrics option? Probs a good gh issue, the same goes for Measure types.
 
   /**
-   * Creates a new gauge metric.
+   * Creates a new gauge metric. Generally, this kind of metric should be used
+   * when the metric cannot be expressed as a sum or because the measurement
+   * interval is arbitrary. Use this kind of metric when the measurement is not
+   * a quantity, and the sum and event count are not of interest.
    * @param name the name of the metric.
    * @param [options] the metric options.
    */

--- a/packages/opentelemetry-types/src/metrics/Metric.ts
+++ b/packages/opentelemetry-types/src/metrics/Metric.ts
@@ -46,25 +46,10 @@ export interface MetricOptions {
   disabled?: boolean;
 
   /**
-   * Bidirectional allows counter metrics to accept negative values.
-   * Otherwise, as false, the counter is unidirectional and rejects negative values.
-   * @default false
+   * Monotonic allows this metric to accept negative values. If `true` only
+   * non-negative values are expected.
    */
-  bidirectional?: boolean;
-
-  /**
-   * Unidirectional indicates a gauge metric only ascends, indicating it is for
-   * rate calculations.
-   * @default false
-   */
-  unidirectional?: boolean;
-
-  /**
-   * nonNegative indicates a measure is never negative, indicating it is for rate
-   * calculations.
-   * @default false
-   */
-  nonNegative?: boolean;
+  monotonic?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Updates #402 

- First take on metrics SDK. In order to keep short PR, only `Counter` metric support is added.

- The monotonic concept is based on https://github.com/open-telemetry/opentelemetry-specification/pull/250/files.
i.e. `Counter`s are defined as monotonic by default, meaning that positive values are expected and `Gauge`s are defined as non-monotonic by default, meaning that any value (positive or negative) is allowed.

- Record call is still missing, will do it in the follow-up PR.

**Update 1**: Added support for `Gauge` Metric.
**Update 2**: Added `MeterConfig` with `Logger` option.