### PR TITLE
chore: add prepare script and bump the version

### DIFF
--- a/packages/opentelemetry-base/package.json
+++ b/packages/opentelemetry-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/base",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry base",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -13,7 +13,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry Core",
   "main": "build/src/index.js",
   "browser": {
@@ -19,7 +19,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-core/test/trace/fixtures/test-package/package.json
+++ b/packages/opentelemetry-core/test/trace/fixtures/test-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-package",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -12,7 +12,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-exporter-prometheus/package.json
+++ b/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
@@ -13,7 +13,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -12,7 +12,8 @@
     "check": "gts check",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-metrics/package.json
+++ b/packages/opentelemetry-metrics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentelemetry/metrics",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -13,7 +13,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -12,7 +12,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-plugin-grpc/package.json
+++ b/packages/opentelemetry-plugin-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/plugin-grpc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry grpc automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -12,7 +12,8 @@
     "check": "gts check",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-plugin-http/package.json
+++ b/packages/opentelemetry-plugin-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/plugin-http",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry http automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -12,7 +12,8 @@
     "check": "gts check",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-plugin-http2/package.json
+++ b/packages/opentelemetry-plugin-http2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/plugin-http2",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry http2 automatic instrumentation package.",
   "private": true,
   "main": "build/src/index.js",
@@ -12,7 +12,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-plugin-https/package.json
+++ b/packages/opentelemetry-plugin-https/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/plugin-https",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry https automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -11,7 +11,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-plugin-mongodb/package.json
+++ b/packages/opentelemetry-plugin-mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/plugin-mongodb",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry mongodb automatic instrumentation package.",
   "private": true,
   "main": "build/src/index.js",
@@ -12,7 +12,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-plugin-postgres/package.json
+++ b/packages/opentelemetry-plugin-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/plugin-postgres",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry postgres automatic instrumentation package.",
   "private": true,
   "main": "build/src/index.js",
@@ -12,7 +12,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-plugin-redis/package.json
+++ b/packages/opentelemetry-plugin-redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/plugin-redis",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry redis automatic instrumentation package.",
   "private": true,
   "main": "build/src/index.js",
@@ -12,7 +12,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-scope-async-hooks/package.json
+++ b/packages/opentelemetry-scope-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/scope-async-hooks",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry AsyncHooks-based Scope Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -12,7 +12,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-scope-base/package.json
+++ b/packages/opentelemetry-scope-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/scope-base",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry Base Scope Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -12,7 +12,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTracing to OpenTelemetry shim",
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js",
@@ -11,7 +11,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-tracing/package.json
+++ b/packages/opentelemetry-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/tracing",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "browser": {
@@ -17,7 +17,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-types/package.json
+++ b/packages/opentelemetry-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/types",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript types for OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -12,7 +12,8 @@
     "fix": "gts fix",
     "test": "npm run compile && npm run check",
     "docs-test": "linkinator docs/out",
-    "docs": "typedoc --tsconfig tsconfig.json"
+    "docs": "typedoc --tsconfig tsconfig.json",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-web/package.json
+++ b/packages/opentelemetry-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -12,7 +12,8 @@
     "clean": "rimraf build/*",
     "check": "gts check",
     "compile": "tsc -p .",
-    "fix": "gts fix"
+    "fix": "gts fix",
+    "prepare": "npm run compile"
   },
   "keywords": [
     "opentelemetry",


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes #426 

- The [package.json's "main"](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-types/package.json#L5) key points to "`build/src/index.js`", which means we should compile the packages before publishing to `npm`. The `prepare` script will run BEFORE the package is packed and published.

- Bump the version to `0.1.1`, we can cut a new release.
