### PR TITLE
feat(metrics): add registerMetric and getMetrics

### DIFF
--- a/packages/opentelemetry-metrics/src/Handle.ts
+++ b/packages/opentelemetry-metrics/src/Handle.ts
@@ -17,7 +17,10 @@
 import * as types from '@opentelemetry/types';
 import { TimeSeries } from './export/types';
 
-/** Base class that represents a TimeSeries. */
+/**
+ * This class represent the base to handle, which is responsible for generating
+ * the TimeSeries.
+ */
 export class BaseHandle {
   protected _data = 0;
 

--- a/packages/opentelemetry-metrics/src/Handle.ts
+++ b/packages/opentelemetry-metrics/src/Handle.ts
@@ -65,7 +65,7 @@ export class CounterHandle extends BaseHandle implements types.CounterHandle {
       );
       return;
     }
-    if (this._valueType === types.ValueType.INT && value % 1 != 0) {
+    if (this._valueType === types.ValueType.INT && !Number.isInteger(value)) {
       this._logger.warn(
         `INT counter cannot accept a floating-point value for ${this._labelValues}, ignoring the fractional digits.`
       );
@@ -100,7 +100,7 @@ export class GaugeHandle extends BaseHandle implements types.GaugeHandle {
       return;
     }
 
-    if (this._valueType === types.ValueType.INT && value % 1 != 0) {
+    if (this._valueType === types.ValueType.INT && !Number.isInteger(value)) {
       this._logger.warn(
         `INT gauge cannot accept a floating-point value for ${this._labelValues}, ignoring the fractional digits.`
       );

--- a/packages/opentelemetry-metrics/src/Handle.ts
+++ b/packages/opentelemetry-metrics/src/Handle.ts
@@ -98,7 +98,7 @@ export class GaugeHandle extends BaseHandle implements types.GaugeHandle {
 /**
  * MeasureHandle is an implementation of the {@link MeasureHandle} interface.
  */
-export class MeasureHandle implements types.MeasureHandle {
+export class MeasureHandle extends BaseHandle implements types.MeasureHandle {
   record(
     value: number,
     distContext?: types.DistributedContext,

--- a/packages/opentelemetry-metrics/src/Handle.ts
+++ b/packages/opentelemetry-metrics/src/Handle.ts
@@ -49,6 +49,7 @@ export class CounterHandle extends BaseHandle implements types.CounterHandle {
   constructor(
     private readonly _disabled: boolean,
     private readonly _monotonic: boolean,
+    private readonly _valueType: types.ValueType,
     private readonly _labelValues: string[],
     private readonly _logger: types.Logger
   ) {
@@ -64,6 +65,12 @@ export class CounterHandle extends BaseHandle implements types.CounterHandle {
       );
       return;
     }
+    if (this._valueType === types.ValueType.INT && value % 1 != 0) {
+      this._logger.warn(
+        `INT counter cannot accept a floating-point value for ${this._labelValues}, ignoring the fractional digits.`
+      );
+      value = Math.trunc(value);
+    }
     this._data = this._data + value;
   }
 }
@@ -76,6 +83,7 @@ export class GaugeHandle extends BaseHandle implements types.GaugeHandle {
   constructor(
     private readonly _disabled: boolean,
     private readonly _monotonic: boolean,
+    private readonly _valueType: types.ValueType,
     private readonly _labelValues: string[],
     private readonly _logger: types.Logger
   ) {
@@ -90,6 +98,13 @@ export class GaugeHandle extends BaseHandle implements types.GaugeHandle {
         `Monotonic gauge cannot descend for ${this._labelValues}`
       );
       return;
+    }
+
+    if (this._valueType === types.ValueType.INT && value % 1 != 0) {
+      this._logger.warn(
+        `INT gauge cannot accept a floating-point value for ${this._labelValues}, ignoring the fractional digits.`
+      );
+      value = Math.trunc(value);
     }
     this._data = value;
   }

--- a/packages/opentelemetry-metrics/src/Handle.ts
+++ b/packages/opentelemetry-metrics/src/Handle.ts
@@ -17,20 +17,21 @@
 import * as types from '@opentelemetry/types';
 import { TimeSeries } from './export/types';
 
+/** Base class that represents a TimeSeries. */
 export class BaseHandle {
   protected _data = 0;
 
-  constructor(private readonly _labelValues: string[]) {}
+  constructor(private readonly _labels: string[]) {}
 
   /**
    * Returns the TimeSeries with one or more Point.
    *
-   * @param timestamp The time at which the counter is recorded.
+   * @param timestamp The time at which the handle is recorded.
    * @returns The TimeSeries.
    */
   getTimeSeries(timestamp: types.HrTime): TimeSeries {
     return {
-      labelValues: this._labelValues.map(value => ({ value })),
+      labelValues: this._labels.map(value => ({ value })),
       points: [{ value: this._data, timestamp }],
     };
   }
@@ -45,17 +46,19 @@ export class CounterHandle extends BaseHandle implements types.CounterHandle {
   constructor(
     private readonly _disabled: boolean,
     private readonly _monotonic: boolean,
-    labelValues: string[],
+    private readonly _labelValues: string[],
     private readonly _logger: types.Logger
   ) {
-    super(labelValues);
+    super(_labelValues);
   }
 
   add(value: number): void {
     if (this._disabled) return;
 
     if (this._monotonic && value < 0) {
-      this._logger.error('Monotonic counter cannot descend.');
+      this._logger.error(
+        `Monotonic counter cannot descend for ${this._labelValues}`
+      );
       return;
     }
     this._data = this._data + value;
@@ -70,17 +73,19 @@ export class GaugeHandle extends BaseHandle implements types.GaugeHandle {
   constructor(
     private readonly _disabled: boolean,
     private readonly _monotonic: boolean,
-    labelValues: string[],
+    private readonly _labelValues: string[],
     private readonly _logger: types.Logger
   ) {
-    super(labelValues);
+    super(_labelValues);
   }
 
   set(value: number): void {
     if (this._disabled) return;
 
     if (this._monotonic && value < this._data) {
-      this._logger.error('Monotonic gauge cannot descend.');
+      this._logger.error(
+        `Monotonic gauge cannot descend for ${this._labelValues}`
+      );
       return;
     }
     this._data = value;

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -143,9 +143,10 @@ export class Meter implements types.Meter {
     metric: Metric<T>
   ): void {
     if (this._metrics.has(name)) {
-      throw new Error(
+      this._logger.error(
         `A metric with the name ${name} has already been registered.`
       );
+      return;
     }
     this._metrics.set(name, metric);
   }

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -21,12 +21,7 @@ import {
   NOOP_GAUGE_METRIC,
   NOOP_MEASURE_METRIC,
 } from '@opentelemetry/core';
-import {
-  CounterHandle,
-  GaugeHandle,
-  MeasureHandle,
-  BaseHandle,
-} from './Handle';
+import { BaseHandle } from './Handle';
 import { Metric, CounterMetric, GaugeMetric } from './Metric';
 import {
   MetricOptions,

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -143,6 +143,10 @@ export class Meter implements types.Meter {
     metric: Metric<T>
   ): void {
     if (this._metrics.has(name)) {
+      // @todo: decide how to handle already registered metric
+      // 1: Replace the old registered metric by the new
+      // 2. Throw error
+      // 3. skip duplicate metric (current approach)
       this._logger.error(
         `A metric with the name ${name} has already been registered.`
       );

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -128,7 +128,7 @@ export class Meter implements types.Meter {
    */
   getMetrics(): ReadableMetric[] {
     return Array.from(this._metrics.values())
-      .map(metric => metric.getMetric())
+      .map(metric => metric.get())
       .filter(metric => !!metric) as ReadableMetric[];
   }
 

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -89,7 +89,6 @@ export class Meter implements types.Meter {
     const opt: MetricOptions = {
       // Counters are defined as monotonic by default
       monotonic: true,
-      valueType: types.ValueType.DOUBLE,
       logger: this._logger,
       ...DEFAULT_METRIC_OPTIONS,
       ...options,
@@ -120,7 +119,6 @@ export class Meter implements types.Meter {
     const opt: MetricOptions = {
       // Gauges are defined as non-monotonic by default
       monotonic: false,
-      valueType: types.ValueType.DOUBLE,
       logger: this._logger,
       ...DEFAULT_METRIC_OPTIONS,
       ...options,

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -21,7 +21,13 @@ import {
   NOOP_GAUGE_METRIC,
   NOOP_MEASURE_METRIC,
 } from '@opentelemetry/core';
-import { CounterMetric, GaugeMetric } from './Metric';
+import {
+  CounterHandle,
+  GaugeHandle,
+  MeasureHandle,
+  BaseHandle,
+} from './Handle';
+import { Metric, CounterMetric, GaugeMetric } from './Metric';
 import {
   MetricOptions,
   DEFAULT_METRIC_OPTIONS,
@@ -137,7 +143,10 @@ export class Meter implements types.Meter {
    * @param name The name of the metric.
    * @param metric The metric to register.
    */
-  private _registerMetric<T>(name: string, metric: Metric<T>): void {
+  private _registerMetric<T extends BaseHandle>(
+    name: string,
+    metric: Metric<T>
+  ): void {
     if (this._metrics.has(name)) {
       throw new Error(
         `A metric with the name ${name} has already been registered.`

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -143,10 +143,7 @@ export class Meter implements types.Meter {
     metric: Metric<T>
   ): void {
     if (this._metrics.has(name)) {
-      // @todo: decide how to handle already registered metric
-      // 1: Replace the old registered metric by the new
-      // 2. Throw error
-      // 3. skip duplicate metric (current approach)
+      // @todo (issue/474): decide how to handle already registered metric
       this._logger.error(
         `A metric with the name ${name} has already been registered.`
       );

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -129,7 +129,7 @@ export class Meter implements types.Meter {
   getMetrics(): ReadableMetric[] {
     return Array.from(this._metrics.values())
       .map(metric => metric.get())
-      .filter(metric => !!metric) as ReadableMetric[];
+      .filter(metric => !!metric);
   }
 
   /**

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -89,6 +89,7 @@ export class Meter implements types.Meter {
     const opt: MetricOptions = {
       // Counters are defined as monotonic by default
       monotonic: true,
+      valueType: types.ValueType.DOUBLE,
       logger: this._logger,
       ...DEFAULT_METRIC_OPTIONS,
       ...options,
@@ -119,6 +120,7 @@ export class Meter implements types.Meter {
     const opt: MetricOptions = {
       // Gauges are defined as non-monotonic by default
       monotonic: false,
+      valueType: types.ValueType.DOUBLE,
       logger: this._logger,
       ...DEFAULT_METRIC_OPTIONS,
       ...options,

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -26,7 +26,7 @@ import {
 } from './export/types';
 
 /** This is a SDK implementation of {@link Metric} interface. */
-export abstract class Metric<T> implements types.Metric<T> {
+export abstract class Metric<T extends BaseHandle> implements types.Metric<T> {
   protected readonly _monotonic: boolean;
   protected readonly _disabled: boolean;
   protected readonly _logger: types.Logger;
@@ -100,7 +100,7 @@ export abstract class Metric<T> implements types.Metric<T> {
     return {
       descriptor: this._metricDescriptor,
       timeseries: Array.from(this._handles, ([_, handle]) =>
-        ((handle as unknown) as BaseHandle).getTimeSeries(timestamp)
+        handle.getTimeSeries(timestamp)
       ),
     };
   }

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -15,8 +15,9 @@
  */
 
 import * as types from '@opentelemetry/types';
+import { hrTime } from '@opentelemetry/core';
 import { hashLabelValues } from './Utils';
-import { CounterHandle, GaugeHandle } from './Handle';
+import { CounterHandle, GaugeHandle, BaseHandle } from './Handle';
 import { MetricOptions } from './types';
 import {
   ReadableMetric,
@@ -95,12 +96,12 @@ export abstract class Metric<T> implements types.Metric<T> {
   getMetric(): ReadableMetric | null {
     if (this._handles.size === 0) return null;
 
-    //const timestamp = [20, 1000];
+    const timestamp = hrTime();
     return {
       descriptor: this._metricDescriptor,
-      // timeseries: Array.from(this._handles, ([_, handle]) =>
-      //   handle.getTimeSeries(timestamp)
-      // ),
+      timeseries: Array.from(this._handles, ([_, handle]) =>
+        ((handle as unknown) as BaseHandle).getTimeSeries(timestamp)
+      ),
     };
   }
 

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -93,7 +93,7 @@ export abstract class Metric<T> implements types.Metric<T> {
    * @returns The ReadableMetric, or null if TimeSeries is not present in
    *     Metric.
    */
-  getMetric(): ReadableMetric | null {
+  get(): ReadableMetric | null {
     if (this._handles.size === 0) return null;
 
     const timestamp = hrTime();

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -31,7 +31,7 @@ export abstract class Metric<T> implements types.Metric<T> {
   protected readonly _disabled: boolean;
   protected readonly _logger: types.Logger;
   private readonly _metricDescriptor: MetricDescriptor;
-  private readonly _handles: Map<String, T> = new Map();
+  private readonly _handles: Map<string, T> = new Map();
 
   constructor(
     private readonly _name: string,

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -35,6 +35,7 @@ export abstract class Metric<T extends BaseHandle> implements types.Metric<T> {
 
   constructor(
     private readonly _name: string,
+    private readonly _type: MetricDescriptorType,
     private readonly _options: MetricOptions
   ) {
     this._monotonic = _options.monotonic;
@@ -111,7 +112,7 @@ export abstract class Metric<T extends BaseHandle> implements types.Metric<T> {
       description: this._options.description,
       unit: this._options.unit,
       labelKeys: this._options.labelKeys,
-      type: MetricDescriptorType.GAUGE_INT64,
+      type: this._type,
     };
   }
 
@@ -121,7 +122,7 @@ export abstract class Metric<T extends BaseHandle> implements types.Metric<T> {
 /** This is a SDK implementation of Counter Metric. */
 export class CounterMetric extends Metric<CounterHandle> {
   constructor(name: string, options: MetricOptions) {
-    super(name, options);
+    super(name, MetricDescriptorType.COUNTER_DOUBLE, options);
   }
   protected _makeHandle(labelValues: string[]): CounterHandle {
     return new CounterHandle(
@@ -136,7 +137,7 @@ export class CounterMetric extends Metric<CounterHandle> {
 /** This is a SDK implementation of Gauge Metric. */
 export class GaugeMetric extends Metric<GaugeHandle> {
   constructor(name: string, options: MetricOptions) {
-    super(name, options);
+    super(name, MetricDescriptorType.GAUGE_DOUBLE, options);
   }
   protected _makeHandle(labelValues: string[]): GaugeHandle {
     return new GaugeHandle(

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -29,17 +29,19 @@ import {
 export abstract class Metric<T extends BaseHandle> implements types.Metric<T> {
   protected readonly _monotonic: boolean;
   protected readonly _disabled: boolean;
+  protected readonly _valueType: types.ValueType;
   protected readonly _logger: types.Logger;
   private readonly _metricDescriptor: MetricDescriptor;
   private readonly _handles: Map<string, T> = new Map();
 
   constructor(
     private readonly _name: string,
-    private readonly _type: MetricDescriptorType,
-    private readonly _options: MetricOptions
+    private readonly _options: MetricOptions,
+    private readonly _type: MetricDescriptorType
   ) {
     this._monotonic = _options.monotonic;
     this._disabled = _options.disabled;
+    this._valueType = _options.valueType;
     this._logger = _options.logger;
     this._metricDescriptor = this._getMetricDescriptor();
   }
@@ -122,12 +124,19 @@ export abstract class Metric<T extends BaseHandle> implements types.Metric<T> {
 /** This is a SDK implementation of Counter Metric. */
 export class CounterMetric extends Metric<CounterHandle> {
   constructor(name: string, options: MetricOptions) {
-    super(name, MetricDescriptorType.COUNTER_DOUBLE, options);
+    super(
+      name,
+      options,
+      options.valueType === types.ValueType.DOUBLE
+        ? MetricDescriptorType.COUNTER_DOUBLE
+        : MetricDescriptorType.COUNTER_INT64
+    );
   }
   protected _makeHandle(labelValues: string[]): CounterHandle {
     return new CounterHandle(
       this._disabled,
       this._monotonic,
+      this._valueType,
       labelValues,
       this._logger
     );
@@ -137,12 +146,19 @@ export class CounterMetric extends Metric<CounterHandle> {
 /** This is a SDK implementation of Gauge Metric. */
 export class GaugeMetric extends Metric<GaugeHandle> {
   constructor(name: string, options: MetricOptions) {
-    super(name, MetricDescriptorType.GAUGE_DOUBLE, options);
+    super(
+      name,
+      options,
+      options.valueType === types.ValueType.DOUBLE
+        ? MetricDescriptorType.GAUGE_DOUBLE
+        : MetricDescriptorType.GAUGE_INT64
+    );
   }
   protected _makeHandle(labelValues: string[]): GaugeHandle {
     return new GaugeHandle(
       this._disabled,
       this._monotonic,
+      this._valueType,
       labelValues,
       this._logger
     );

--- a/packages/opentelemetry-metrics/src/export/types.ts
+++ b/packages/opentelemetry-metrics/src/export/types.ts
@@ -39,11 +39,11 @@ export interface ReadableMetric {
    * One or more timeseries for a single metric, where each timeseries has
    * one or more points.
    */
-  readonly timeseries: TimeSeries[];
+  readonly timeseries?: TimeSeries[];
 
   // The resource for the metric. If unset, it may be set to a default value
   // provided for a sequence of messages in an RPC stream.
-  resource: Resource;
+  resource?: Resource;
 }
 
 /** Properties of a Metric type and its schema */

--- a/packages/opentelemetry-metrics/src/export/types.ts
+++ b/packages/opentelemetry-metrics/src/export/types.ts
@@ -39,7 +39,7 @@ export interface ReadableMetric {
    * One or more timeseries for a single metric, where each timeseries has
    * one or more points.
    */
-  readonly timeseries?: TimeSeries[];
+  readonly timeseries: TimeSeries[];
 
   // The resource for the metric. If unset, it may be set to a default value
   // provided for a sequence of messages in an RPC stream.

--- a/packages/opentelemetry-metrics/src/index.ts
+++ b/packages/opentelemetry-metrics/src/index.ts
@@ -17,3 +17,4 @@
 export * from './Handle';
 export * from './Meter';
 export * from './Metric';
+export * from './export/types';

--- a/packages/opentelemetry-metrics/src/types.ts
+++ b/packages/opentelemetry-metrics/src/types.ts
@@ -67,4 +67,5 @@ export const DEFAULT_METRIC_OPTIONS = {
   description: '',
   unit: '1',
   labelKeys: [],
+  valueType: ValueType.DOUBLE,
 };

--- a/packages/opentelemetry-metrics/src/types.ts
+++ b/packages/opentelemetry-metrics/src/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { LogLevel } from '@opentelemetry/core';
-import { Logger } from '@opentelemetry/types';
+import { Logger, ValueType } from '@opentelemetry/types';
 
 /** Options needed for SDK metric creation. */
 export interface MetricOptions {
@@ -42,6 +42,9 @@ export interface MetricOptions {
 
   /** User provided logger. */
   logger: Logger;
+
+  /** Indicates the type of the recorded value. */
+  valueType: ValueType;
 }
 
 /** MeterConfig provides an interface for configuring a Meter. */

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -333,7 +333,7 @@ describe('Meter', () => {
         name: 'counter',
         description: 'test',
         unit: '1',
-        type: MetricDescriptorType.GAUGE_INT64,
+        type: MetricDescriptorType.COUNTER_DOUBLE,
         labelKeys: ['key'],
       });
       assert.strictEqual(timeseries.length, 1);
@@ -361,7 +361,7 @@ describe('Meter', () => {
         name: 'gauge',
         description: '',
         unit: 'ms',
-        type: MetricDescriptorType.GAUGE_INT64,
+        type: MetricDescriptorType.GAUGE_DOUBLE,
         labelKeys: ['gauge-key'],
       });
       assert.strictEqual(timeseries.length, 2);

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -59,13 +59,6 @@ describe('Meter', () => {
       assert.ok(counter instanceof Metric);
     });
 
-    it('should throw an error when create the same metric', () => {
-      meter.createCounter('test_metric');
-      assert.throws(() => {
-        meter.createCounter('test_metric');
-      }, /^Error: A metric with the name test_metric has already been registered.$/);
-    });
-
     describe('.getHandle()', () => {
       it('should create a counter handle', () => {
         const counter = meter.createCounter('name') as CounterMetric;

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -15,9 +15,20 @@
  */
 
 import * as assert from 'assert';
-import { Meter, Metric, CounterMetric, GaugeMetric, MetricDescriptorType } from '../src';
+import {
+  Meter,
+  Metric,
+  CounterMetric,
+  GaugeMetric,
+  MetricDescriptorType,
+} from '../src';
 import * as types from '@opentelemetry/types';
-import { NoopLogger, NoopMetric, hrTime, hrTimeToMilliseconds } from '@opentelemetry/core';
+import {
+  NoopLogger,
+  NoopMetric,
+  hrTime,
+  hrTimeToMilliseconds,
+} from '@opentelemetry/core';
 
 const performanceTimeOrigin = hrTime();
 

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -319,13 +319,13 @@ describe('Meter', () => {
   });
 
   describe('#getMetrics', () => {
-    it('should create a counter', () => {
+    it('should create a DOUBLE counter', () => {
       const counter = meter.createCounter('counter', {
         description: 'test',
         labelKeys: ['key'],
       });
       const handle = counter.getHandle(['counter-value']);
-      handle.add(10);
+      handle.add(10.45);
 
       assert.strictEqual(meter.getMetrics().length, 1);
       const [{ descriptor, timeseries }] = meter.getMetrics();
@@ -340,6 +340,35 @@ describe('Meter', () => {
       const [{ labelValues, points }] = timeseries;
       assert.deepStrictEqual(labelValues, [{ value: 'counter-value' }]);
       assert.strictEqual(points.length, 1);
+      assert.strictEqual(points[0].value, 10.45);
+      assert.ok(
+        hrTimeToMilliseconds(points[0].timestamp) >
+          hrTimeToMilliseconds(performanceTimeOrigin)
+      );
+    });
+
+    it('should create a INT counter', () => {
+      const counter = meter.createCounter('counter', {
+        description: 'test',
+        labelKeys: ['key'],
+        valueType: types.ValueType.INT,
+      });
+      const handle = counter.getHandle(['counter-value']);
+      handle.add(10.45);
+
+      assert.strictEqual(meter.getMetrics().length, 1);
+      const [{ descriptor, timeseries }] = meter.getMetrics();
+      assert.deepStrictEqual(descriptor, {
+        name: 'counter',
+        description: 'test',
+        unit: '1',
+        type: MetricDescriptorType.COUNTER_INT64,
+        labelKeys: ['key'],
+      });
+      assert.strictEqual(timeseries.length, 1);
+      const [{ labelValues, points }] = timeseries;
+      assert.deepStrictEqual(labelValues, [{ value: 'counter-value' }]);
+      assert.strictEqual(points.length, 1);
       assert.strictEqual(points[0].value, 10);
       assert.ok(
         hrTimeToMilliseconds(points[0].timestamp) >
@@ -347,13 +376,13 @@ describe('Meter', () => {
       );
     });
 
-    it('should create a gauge', () => {
+    it('should create a DOUBLE gauge', () => {
       const gauge = meter.createGauge('gauge', {
         labelKeys: ['gauge-key'],
         unit: 'ms',
       });
-      gauge.getHandle(['gauge-value1']).set(200);
-      gauge.getHandle(['gauge-value2']).set(-10);
+      gauge.getHandle(['gauge-value1']).set(200.34);
+      gauge.getHandle(['gauge-value2']).set(-10.67);
 
       assert.strictEqual(meter.getMetrics().length, 1);
       const [{ descriptor, timeseries }] = meter.getMetrics();
@@ -362,6 +391,45 @@ describe('Meter', () => {
         description: '',
         unit: 'ms',
         type: MetricDescriptorType.GAUGE_DOUBLE,
+        labelKeys: ['gauge-key'],
+      });
+      assert.strictEqual(timeseries.length, 2);
+      const [
+        { labelValues: labelValues1, points: points1 },
+        { labelValues: labelValues2, points: points2 },
+      ] = timeseries;
+      assert.deepStrictEqual(labelValues1, [{ value: 'gauge-value1' }]);
+      assert.strictEqual(points1.length, 1);
+      assert.strictEqual(points1[0].value, 200.34);
+      assert.ok(
+        hrTimeToMilliseconds(points1[0].timestamp) >
+          hrTimeToMilliseconds(performanceTimeOrigin)
+      );
+      assert.deepStrictEqual(labelValues2, [{ value: 'gauge-value2' }]);
+      assert.strictEqual(points2.length, 1);
+      assert.strictEqual(points2[0].value, -10.67);
+      assert.ok(
+        hrTimeToMilliseconds(points2[0].timestamp) >
+          hrTimeToMilliseconds(performanceTimeOrigin)
+      );
+    });
+
+    it('should create a INT gauge', () => {
+      const gauge = meter.createGauge('gauge', {
+        labelKeys: ['gauge-key'],
+        unit: 'ms',
+        valueType: types.ValueType.INT,
+      });
+      gauge.getHandle(['gauge-value1']).set(200.34);
+      gauge.getHandle(['gauge-value2']).set(-10.67);
+
+      assert.strictEqual(meter.getMetrics().length, 1);
+      const [{ descriptor, timeseries }] = meter.getMetrics();
+      assert.deepStrictEqual(descriptor, {
+        name: 'gauge',
+        description: '',
+        unit: 'ms',
+        type: MetricDescriptorType.GAUGE_INT64,
         labelKeys: ['gauge-key'],
       });
       assert.strictEqual(timeseries.length, 2);

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -143,6 +143,30 @@ describe('Meter', () => {
       });
     });
 
+    describe('.registerMetric()', () => {
+      it('skip already registered Metric', () => {
+        const counter1 = meter.createCounter('name1') as CounterMetric;
+        counter1.getHandle(labelValues).add(10);
+
+        // should skip below metric
+        const counter2 = meter.createCounter('name1', {
+          valueType: types.ValueType.INT,
+        }) as CounterMetric;
+        counter2.getHandle(labelValues).add(500);
+
+        assert.strictEqual(meter.getMetrics().length, 1);
+        const [{ descriptor, timeseries }] = meter.getMetrics();
+        assert.deepStrictEqual(descriptor.name, 'name1');
+        assert.deepStrictEqual(
+          descriptor.type,
+          MetricDescriptorType.COUNTER_DOUBLE
+        );
+        assert.strictEqual(timeseries.length, 1);
+        assert.strictEqual(timeseries[0].points.length, 1);
+        assert.strictEqual(timeseries[0].points[0].value, 10);
+      });
+    });
+
     describe('names', () => {
       it('should create counter with valid names', () => {
         const counter1 = meter.createCounter('name1');

--- a/packages/opentelemetry-types/src/metrics/Metric.ts
+++ b/packages/opentelemetry-types/src/metrics/Metric.ts
@@ -50,6 +50,18 @@ export interface MetricOptions {
    * non-negative values are expected.
    */
   monotonic?: boolean;
+
+  /**
+   * Indicates the type of the recorded value.
+   * @default {@link ValueType.DOUBLE}
+   */
+  valueType?: ValueType;
+}
+
+/** The Type of value. It describes how the data is reported. */
+export enum ValueType {
+  INT,
+  DOUBLE,
 }
 
 /**


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Updates #402

- Continuation of Metrics SDK #415.

- Added methods (`registerMetric` and `getMetrics`)  to collect recorded values in the format of [ReadableMetric](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-metrics/src/export/types.ts#L28), which can be used by metric exporters to transform and send to the backend.

- Pending stuff for next PRs:

  - Add option to register metric exporter.
  - Send data to registered exporter via `meter.getMetrics()`
  - Implement `MeasureHandle`.

TODO:
- ~Decide which `MetricDescriptorType` to assign in case of Gauge (two options are `MetricDescriptorType.GAUGE_INT64` and `MetricDescriptorType.GAUGE_DOUBLE`) and in case of counter (two options are `MetricDescriptorType.COUNTER_INT64` and `MetricDescriptorType.COUNTER_DOUBLE`)~

(update 1: 10/30)
**Implemented option 3 as per SIG discussion:** https://docs.google.com/document/d/1g0O7TZ4KH82iwbJmEdBh3qWONnHbap3ajjD2_HWA0mY/edit

/cc @danielkhan @bg451 