### PR TITLE
feat: add IsRemote field to SpanContext, set by propagators

### DIFF
--- a/packages/opentelemetry-core/src/context/propagation/B3Format.ts
+++ b/packages/opentelemetry-core/src/context/propagation/B3Format.ts
@@ -76,6 +76,7 @@ export class B3Format implements HttpTextFormat {
       return {
         traceId,
         spanId,
+        isRemote: true,
         traceFlags: isNaN(Number(options))
           ? TraceFlags.UNSAMPLED
           : Number(options),

--- a/packages/opentelemetry-core/src/context/propagation/BinaryTraceContext.ts
+++ b/packages/opentelemetry-core/src/context/propagation/BinaryTraceContext.ts
@@ -86,6 +86,9 @@ export class BinaryTraceContext implements BinaryFormat {
     ) {
       return null;
     }
+
+    result.isRemote = true;
+
     // See serializeSpanContext for byte offsets.
     result.traceId = toHex(buf.slice(TRACE_ID_OFFSET, SPAN_ID_FIELD_ID_OFFSET));
     result.spanId = toHex(

--- a/packages/opentelemetry-core/src/context/propagation/HttpTraceContext.ts
+++ b/packages/opentelemetry-core/src/context/propagation/HttpTraceContext.ts
@@ -90,6 +90,8 @@ export class HttpTraceContext implements HttpTextFormat {
     const spanContext = parse(traceParent);
     if (!spanContext) return null;
 
+    spanContext.isRemote = true;
+
     const traceStateHeader = carrier[TRACE_STATE_HEADER];
     if (traceStateHeader) {
       // If more than one `tracestate` header is found, we merge them into a

--- a/packages/opentelemetry-core/test/context/B3Format.test.ts
+++ b/packages/opentelemetry-core/test/context/B3Format.test.ts
@@ -55,6 +55,7 @@ describe('B3Format', () => {
         spanId: '6e0c63257de34c92',
         traceFlags: TraceFlags.UNSAMPLED,
         traceState: new TraceState('foo=bar,baz=qux'),
+        isRemote: false,
       };
 
       b3Format.inject(spanContext, 'B3Format', carrier);
@@ -101,6 +102,7 @@ describe('B3Format', () => {
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'b7ad6b7169203331',
         traceId: '0af7651916cd43dd8448eb211c80319c',
+        isRemote: true,
         traceFlags: TraceFlags.UNSAMPLED,
       });
     });
@@ -114,6 +116,7 @@ describe('B3Format', () => {
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'b7ad6b7169203331',
         traceId: '0af7651916cd43dd8448eb211c80319c',
+        isRemote: true,
         traceFlags: TraceFlags.SAMPLED,
       });
     });
@@ -127,6 +130,7 @@ describe('B3Format', () => {
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'b7ad6b7169203331',
         traceId: '0af7651916cd43dd8448eb211c80319c',
+        isRemote: true,
         traceFlags: TraceFlags.SAMPLED,
       });
     });
@@ -140,6 +144,7 @@ describe('B3Format', () => {
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'b7ad6b7169203331',
         traceId: '0af7651916cd43dd8448eb211c80319c',
+        isRemote: true,
         traceFlags: TraceFlags.UNSAMPLED,
       });
     });
@@ -173,6 +178,7 @@ describe('B3Format', () => {
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'b7ad6b7169203331',
         traceId: '0af7651916cd43dd8448eb211c80319c',
+        isRemote: true,
         traceFlags: TraceFlags.SAMPLED,
       });
     });

--- a/packages/opentelemetry-core/test/context/BinaryTraceContext.test.ts
+++ b/packages/opentelemetry-core/test/context/BinaryTraceContext.test.ts
@@ -134,7 +134,7 @@ describe('BinaryTraceContext', () => {
           binaryTraceContext.fromBytes(testCase.binary),
           testCase.structured &&
             Object.assign(
-              { traceFlags: TraceFlags.UNSAMPLED },
+              { isRemote: true, traceFlags: TraceFlags.UNSAMPLED },
               testCase.structured
             )
         );

--- a/packages/opentelemetry-core/test/context/HttpTraceContext.test.ts
+++ b/packages/opentelemetry-core/test/context/HttpTraceContext.test.ts
@@ -76,6 +76,7 @@ describe('HttpTraceContext', () => {
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'b7ad6b7169203331',
         traceId: '0af7651916cd43dd8448eb211c80319c',
+        isRemote: true,
         traceFlags: TraceFlags.SAMPLED,
       });
     });
@@ -106,6 +107,7 @@ describe('HttpTraceContext', () => {
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'b7ad6b7169203331',
         traceId: '0af7651916cd43dd8448eb211c80319c',
+        isRemote: true,
         traceFlags: TraceFlags.SAMPLED,
       });
     });
@@ -139,6 +141,7 @@ describe('HttpTraceContext', () => {
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'b7ad6b7169203331',
         traceId: '0af7651916cd43dd8448eb211c80319c',
+        isRemote: true,
         traceFlags: TraceFlags.SAMPLED,
         traceState: new TraceState('foo=bar,baz=qux,quux=quuz'),
       });

--- a/packages/opentelemetry-types/src/trace/span_context.ts
+++ b/packages/opentelemetry-types/src/trace/span_context.ts
@@ -36,7 +36,7 @@ export interface SpanContext {
    */
   spanId: string;
   /**
-   * Indicates if the SpanContext was propagated from a remote parent.
+   * Only true if the SpanContext was propagated from a remote parent.
    */
   isRemote?: boolean;
   /**

--- a/packages/opentelemetry-types/src/trace/span_context.ts
+++ b/packages/opentelemetry-types/src/trace/span_context.ts
@@ -36,6 +36,10 @@ export interface SpanContext {
    */
   spanId: string;
   /**
+   * Indicates if the SpanContext was propagated from a remote parent.
+   */
+  isRemote?: boolean;
+  /**
    * Trace flags to propagate.
    *
    * It is represented as 1 byte (bitmap). Bit to represent whether trace is


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Closes #450 

## Short description of the changes

- Add optional `isRemote` to `SpanContext`
- Set it to true when extracting a propagated SpanContext
