### PR TITLE
feat: validate metric names

### DIFF
--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -19,7 +19,7 @@ import {
   ConsoleLogger,
   NOOP_COUNTER_METRIC,
   NOOP_GAUGE_METRIC,
-  NOOP_MEASURE_METRIC
+  NOOP_MEASURE_METRIC,
 } from '@opentelemetry/core';
 import { CounterMetric, GaugeMetric } from './Metric';
 import {
@@ -52,7 +52,9 @@ export class Meter implements types.Meter {
     options?: types.MetricOptions
   ): types.Metric<types.MeasureHandle> {
     if (!this._isValidName(name)) {
-      this._logger.warn(`Invalid metric name ${name}. Defaulting to noop metric implementation.`)
+      this._logger.warn(
+        `Invalid metric name ${name}. Defaulting to noop metric implementation.`
+      );
       return NOOP_MEASURE_METRIC;
     }
     // @todo: implement this method
@@ -71,7 +73,9 @@ export class Meter implements types.Meter {
     options?: types.MetricOptions
   ): types.Metric<types.CounterHandle> {
     if (!this._isValidName(name)) {
-      this._logger.warn(`Invalid metric name ${name}. Defaulting to noop metric implementation.`)
+      this._logger.warn(
+        `Invalid metric name ${name}. Defaulting to noop metric implementation.`
+      );
       return NOOP_COUNTER_METRIC;
     }
     const opt: MetricOptions = {
@@ -97,7 +101,9 @@ export class Meter implements types.Meter {
     options?: types.MetricOptions
   ): types.Metric<types.GaugeHandle> {
     if (!this._isValidName(name)) {
-      this._logger.warn(`Invalid metric name ${name}. Defaulting to noop metric implementation.`)
+      this._logger.warn(
+        `Invalid metric name ${name}. Defaulting to noop metric implementation.`
+      );
       return NOOP_GAUGE_METRIC;
     }
     const opt: MetricOptions = {

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -52,6 +52,7 @@ export class Meter implements types.Meter {
     options?: types.MetricOptions
   ): types.Metric<types.MeasureHandle> {
     if (!this._isValidName(name)) {
+      this._logger.warn(`Invalid metric name ${name}. Defaulting to noop metric implementation.`)
       return NOOP_MEASURE_METRIC;
     }
     // @todo: implement this method
@@ -70,6 +71,7 @@ export class Meter implements types.Meter {
     options?: types.MetricOptions
   ): types.Metric<types.CounterHandle> {
     if (!this._isValidName(name)) {
+      this._logger.warn(`Invalid metric name ${name}. Defaulting to noop metric implementation.`)
       return NOOP_COUNTER_METRIC;
     }
     const opt: MetricOptions = {
@@ -95,6 +97,7 @@ export class Meter implements types.Meter {
     options?: types.MetricOptions
   ): types.Metric<types.GaugeHandle> {
     if (!this._isValidName(name)) {
+      this._logger.warn(`Invalid metric name ${name}. Defaulting to noop metric implementation.`)
       return NOOP_GAUGE_METRIC;
     }
     const opt: MetricOptions = {

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -15,9 +15,13 @@
  */
 
 import * as types from '@opentelemetry/types';
-import { ConsoleLogger } from '@opentelemetry/core';
-import { CounterHandle, GaugeHandle, MeasureHandle } from './Handle';
-import { Metric, CounterMetric, GaugeMetric } from './Metric';
+import {
+  ConsoleLogger,
+  NOOP_COUNTER_METRIC,
+  NOOP_GAUGE_METRIC,
+  NOOP_MEASURE_METRIC
+} from '@opentelemetry/core';
+import { CounterMetric, GaugeMetric } from './Metric';
 import {
   MetricOptions,
   DEFAULT_METRIC_OPTIONS,
@@ -46,7 +50,10 @@ export class Meter implements types.Meter {
   createMeasure(
     name: string,
     options?: types.MetricOptions
-  ): Metric<MeasureHandle> {
+  ): types.Metric<types.MeasureHandle> {
+    if (!this._isValidName(name)) {
+      return NOOP_MEASURE_METRIC;
+    }
     // @todo: implement this method
     throw new Error('not implemented yet');
   }
@@ -61,7 +68,10 @@ export class Meter implements types.Meter {
   createCounter(
     name: string,
     options?: types.MetricOptions
-  ): Metric<CounterHandle> {
+  ): types.Metric<types.CounterHandle> {
+    if (!this._isValidName(name)) {
+      return NOOP_COUNTER_METRIC;
+    }
     const opt: MetricOptions = {
       // Counters are defined as monotonic by default
       monotonic: true,
@@ -83,7 +93,10 @@ export class Meter implements types.Meter {
   createGauge(
     name: string,
     options?: types.MetricOptions
-  ): Metric<GaugeHandle> {
+  ): types.Metric<types.GaugeHandle> {
+    if (!this._isValidName(name)) {
+      return NOOP_GAUGE_METRIC;
+    }
     const opt: MetricOptions = {
       // Gauges are defined as non-monotonic by default
       monotonic: false,
@@ -92,5 +105,22 @@ export class Meter implements types.Meter {
       ...options,
     };
     return new GaugeMetric(name, opt);
+  }
+
+  /**
+   * Ensure a metric name conforms to the following rules:
+   *
+   * 1. They are non-empty strings
+   *
+   * 2. The first character must be non-numeric, non-space, non-punctuation
+   *
+   * 3. Subsequent characters must be belong to the alphanumeric characters, '_', '.', and '-'.
+   *
+   * Names are case insensitive
+   *
+   * @param name Name of metric to be created
+   */
+  private _isValidName(name: string): boolean {
+    return Boolean(name.match(/^[a-z][a-z0-9_.\-]*$/i));
   }
 }

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -133,28 +133,30 @@ describe('Meter', () => {
     describe('names', () => {
       it('should create counter with valid names', () => {
         const counter1 = meter.createCounter('name1');
-        const counter2 = meter.createCounter('Name_with-all.valid_CharacterClasses');
-        assert.ok(counter1 instanceof CounterMetric)
-        assert.ok(counter2 instanceof CounterMetric)
+        const counter2 = meter.createCounter(
+          'Name_with-all.valid_CharacterClasses'
+        );
+        assert.ok(counter1 instanceof CounterMetric);
+        assert.ok(counter2 instanceof CounterMetric);
       });
 
       it('should return no op metric if name is an empty string', () => {
         const counter = meter.createCounter('');
-        assert.ok(counter instanceof NoopMetric)
-      })
+        assert.ok(counter instanceof NoopMetric);
+      });
 
       it('should return no op metric if name does not start with a letter', () => {
         const counter1 = meter.createCounter('1name');
         const counter_ = meter.createCounter('_name');
-        assert.ok(counter1 instanceof NoopMetric)
-        assert.ok(counter_ instanceof NoopMetric)
+        assert.ok(counter1 instanceof NoopMetric);
+        assert.ok(counter_ instanceof NoopMetric);
       });
 
       it('should return no op metric if name is an empty string contain only letters, numbers, ".", "_", and "-"', () => {
         const counter = meter.createCounter('name with invalid characters^&*(');
-        assert.ok(counter instanceof NoopMetric)
+        assert.ok(counter instanceof NoopMetric);
       });
-    })
+    });
   });
 
   describe('#gauge', () => {
@@ -260,27 +262,29 @@ describe('Meter', () => {
     describe('names', () => {
       it('should create gauges with valid names', () => {
         const gauge1 = meter.createGauge('name1');
-        const gauge2 = meter.createGauge('Name_with-all.valid_CharacterClasses');
-        assert.ok(gauge1 instanceof GaugeMetric)
-        assert.ok(gauge2 instanceof GaugeMetric)
+        const gauge2 = meter.createGauge(
+          'Name_with-all.valid_CharacterClasses'
+        );
+        assert.ok(gauge1 instanceof GaugeMetric);
+        assert.ok(gauge2 instanceof GaugeMetric);
       });
 
       it('should return no op metric if name is an empty string', () => {
         const gauge = meter.createGauge('');
-        assert.ok(gauge instanceof NoopMetric)
-      })
+        assert.ok(gauge instanceof NoopMetric);
+      });
 
       it('should return no op metric if name does not start with a letter', () => {
         const gauge1 = meter.createGauge('1name');
         const gauge_ = meter.createGauge('_name');
-        assert.ok(gauge1 instanceof NoopMetric)
-        assert.ok(gauge_ instanceof NoopMetric)
+        assert.ok(gauge1 instanceof NoopMetric);
+        assert.ok(gauge_ instanceof NoopMetric);
       });
 
       it('should return no op metric if name is an empty string contain only letters, numbers, ".", "_", and "-"', () => {
         const gauge = meter.createGauge('name with invalid characters^&*(');
-        assert.ok(gauge instanceof NoopMetric)
+        assert.ok(gauge instanceof NoopMetric);
       });
-    })
+    });
   });
 });

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -287,4 +287,25 @@ describe('Meter', () => {
       });
     });
   });
+
+  describe('#measure', () => {
+    describe('names', () => {
+      it('should return no op metric if name is an empty string', () => {
+        const gauge = meter.createMeasure('');
+        assert.ok(gauge instanceof NoopMetric);
+      });
+
+      it('should return no op metric if name does not start with a letter', () => {
+        const gauge1 = meter.createMeasure('1name');
+        const gauge_ = meter.createMeasure('_name');
+        assert.ok(gauge1 instanceof NoopMetric);
+        assert.ok(gauge_ instanceof NoopMetric);
+      });
+
+      it('should return no op metric if name is an empty string contain only letters, numbers, ".", "_", and "-"', () => {
+        const gauge = meter.createMeasure('name with invalid characters^&*(');
+        assert.ok(gauge instanceof NoopMetric);
+      });
+    });
+  });
 });

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -15,9 +15,9 @@
  */
 
 import * as assert from 'assert';
-import { Meter, Metric } from '../src';
+import { Meter, Metric, CounterMetric, GaugeMetric } from '../src';
 import * as types from '@opentelemetry/types';
-import { NoopLogger } from '@opentelemetry/core';
+import { NoopLogger, NoopMetric } from '@opentelemetry/core';
 
 describe('Meter', () => {
   let meter: Meter;
@@ -129,6 +129,32 @@ describe('Meter', () => {
         assert.strictEqual(counter['_handles'].size, 0);
       });
     });
+
+    describe('names', () => {
+      it('should create counter with valid names', () => {
+        const counter1 = meter.createCounter('name1');
+        const counter2 = meter.createCounter('Name_with-all.valid_CharacterClasses');
+        assert.ok(counter1 instanceof CounterMetric)
+        assert.ok(counter2 instanceof CounterMetric)
+      });
+
+      it('should return no op metric if name is an empty string', () => {
+        const counter = meter.createCounter('');
+        assert.ok(counter instanceof NoopMetric)
+      })
+
+      it('should return no op metric if name does not start with a letter', () => {
+        const counter1 = meter.createCounter('1name');
+        const counter_ = meter.createCounter('_name');
+        assert.ok(counter1 instanceof NoopMetric)
+        assert.ok(counter_ instanceof NoopMetric)
+      });
+
+      it('should return no op metric if name is an empty string contain only letters, numbers, ".", "_", and "-"', () => {
+        const counter = meter.createCounter('name with invalid characters^&*(');
+        assert.ok(counter instanceof NoopMetric)
+      });
+    })
   });
 
   describe('#gauge', () => {
@@ -230,5 +256,31 @@ describe('Meter', () => {
         assert.strictEqual(gauge['_handles'].size, 0);
       });
     });
+
+    describe('names', () => {
+      it('should create gauges with valid names', () => {
+        const gauge1 = meter.createGauge('name1');
+        const gauge2 = meter.createGauge('Name_with-all.valid_CharacterClasses');
+        assert.ok(gauge1 instanceof GaugeMetric)
+        assert.ok(gauge2 instanceof GaugeMetric)
+      });
+
+      it('should return no op metric if name is an empty string', () => {
+        const gauge = meter.createGauge('');
+        assert.ok(gauge instanceof NoopMetric)
+      })
+
+      it('should return no op metric if name does not start with a letter', () => {
+        const gauge1 = meter.createGauge('1name');
+        const gauge_ = meter.createGauge('_name');
+        assert.ok(gauge1 instanceof NoopMetric)
+        assert.ok(gauge_ instanceof NoopMetric)
+      });
+
+      it('should return no op metric if name is an empty string contain only letters, numbers, ".", "_", and "-"', () => {
+        const gauge = meter.createGauge('name with invalid characters^&*(');
+        assert.ok(gauge instanceof NoopMetric)
+      });
+    })
   });
 });

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -48,7 +48,7 @@ describe('Meter', () => {
 
     describe('.getHandle()', () => {
       it('should create a counter handle', () => {
-        const counter = meter.createCounter('name');
+        const counter = meter.createCounter('name') as CounterMetric;
         const handle = counter.getHandle(labelValues);
         handle.add(10);
         assert.strictEqual(handle['_data'], 10);
@@ -57,7 +57,7 @@ describe('Meter', () => {
       });
 
       it('should return the timeseries', () => {
-        const counter = meter.createCounter('name');
+        const counter = meter.createCounter('name') as CounterMetric;
         const handle = counter.getHandle(['value1', 'value2']);
         handle.add(20);
         assert.deepStrictEqual(handle.getTimeSeries(hrTime), {
@@ -67,7 +67,7 @@ describe('Meter', () => {
       });
 
       it('should add positive values by default', () => {
-        const counter = meter.createCounter('name');
+        const counter = meter.createCounter('name') as CounterMetric;
         const handle = counter.getHandle(labelValues);
         handle.add(10);
         assert.strictEqual(handle['_data'], 10);
@@ -78,7 +78,7 @@ describe('Meter', () => {
       it('should not add the handle data when disabled', () => {
         const counter = meter.createCounter('name', {
           disabled: true,
-        });
+        }) as CounterMetric;
         const handle = counter.getHandle(labelValues);
         handle.add(10);
         assert.strictEqual(handle['_data'], 0);
@@ -87,14 +87,14 @@ describe('Meter', () => {
       it('should add negative value when monotonic is set to false', () => {
         const counter = meter.createCounter('name', {
           monotonic: false,
-        });
+        }) as CounterMetric;
         const handle = counter.getHandle(labelValues);
         handle.add(-10);
         assert.strictEqual(handle['_data'], -10);
       });
 
       it('should return same handle on same label values', () => {
-        const counter = meter.createCounter('name');
+        const counter = meter.createCounter('name') as CounterMetric;
         const handle = counter.getHandle(labelValues);
         handle.add(10);
         const handle1 = counter.getHandle(labelValues);
@@ -106,7 +106,7 @@ describe('Meter', () => {
 
     describe('.removeHandle()', () => {
       it('should remove a counter handle', () => {
-        const counter = meter.createCounter('name');
+        const counter = meter.createCounter('name') as CounterMetric;
         const handle = counter.getHandle(labelValues);
         assert.strictEqual(counter['_handles'].size, 1);
         counter.removeHandle(labelValues);
@@ -122,7 +122,7 @@ describe('Meter', () => {
       });
 
       it('should clear all handles', () => {
-        const counter = meter.createCounter('name');
+        const counter = meter.createCounter('name') as CounterMetric;
         counter.getHandle(labelValues);
         assert.strictEqual(counter['_handles'].size, 1);
         counter.clear();
@@ -159,7 +159,7 @@ describe('Meter', () => {
 
   describe('#gauge', () => {
     it('should create a gauge', () => {
-      const gauge = meter.createGauge('name');
+      const gauge = meter.createGauge('name') as GaugeMetric;
       assert.ok(gauge instanceof Metric);
     });
 
@@ -175,7 +175,7 @@ describe('Meter', () => {
 
     describe('.getHandle()', () => {
       it('should create a gauge handle', () => {
-        const gauge = meter.createGauge('name');
+        const gauge = meter.createGauge('name') as GaugeMetric;
         const handle = gauge.getHandle(labelValues);
         handle.set(10);
         assert.strictEqual(handle['_data'], 10);
@@ -184,7 +184,7 @@ describe('Meter', () => {
       });
 
       it('should return the timeseries', () => {
-        const gauge = meter.createGauge('name');
+        const gauge = meter.createGauge('name') as GaugeMetric;
         const handle = gauge.getHandle(['v1', 'v2']);
         handle.set(150);
         assert.deepStrictEqual(handle.getTimeSeries(hrTime), {
@@ -194,7 +194,7 @@ describe('Meter', () => {
       });
 
       it('should go up and down by default', () => {
-        const gauge = meter.createGauge('name');
+        const gauge = meter.createGauge('name') as GaugeMetric;
         const handle = gauge.getHandle(labelValues);
         handle.set(10);
         assert.strictEqual(handle['_data'], 10);
@@ -205,7 +205,7 @@ describe('Meter', () => {
       it('should not set the handle data when disabled', () => {
         const gauge = meter.createGauge('name', {
           disabled: true,
-        });
+        }) as GaugeMetric;
         const handle = gauge.getHandle(labelValues);
         handle.set(10);
         assert.strictEqual(handle['_data'], 0);
@@ -214,14 +214,14 @@ describe('Meter', () => {
       it('should not set negative value when monotonic is set to true', () => {
         const gauge = meter.createGauge('name', {
           monotonic: true,
-        });
+        }) as GaugeMetric;
         const handle = gauge.getHandle(labelValues);
         handle.set(-10);
         assert.strictEqual(handle['_data'], 0);
       });
 
       it('should return same handle on same label values', () => {
-        const gauge = meter.createGauge('name');
+        const gauge = meter.createGauge('name') as GaugeMetric;
         const handle = gauge.getHandle(labelValues);
         handle.set(10);
         const handle1 = gauge.getHandle(labelValues);
@@ -233,7 +233,7 @@ describe('Meter', () => {
 
     describe('.removeHandle()', () => {
       it('should remove the gauge handle', () => {
-        const gauge = meter.createGauge('name');
+        const gauge = meter.createGauge('name') as GaugeMetric;
         const handle = gauge.getHandle(labelValues);
         assert.strictEqual(gauge['_handles'].size, 1);
         gauge.removeHandle(labelValues);
@@ -249,7 +249,7 @@ describe('Meter', () => {
       });
 
       it('should clear all handles', () => {
-        const gauge = meter.createGauge('name');
+        const gauge = meter.createGauge('name') as GaugeMetric;
         gauge.getHandle(labelValues);
         assert.strictEqual(gauge['_handles'].size, 1);
         gauge.clear();


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes #465 

## Short description of the changes

- Ensure metric names are valid according to the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-metrics-user.md#metric-names)
- Invalid metric names return noop implementations (per SIG meeting)
