### PR TITLE
chore: bump typescript version to ^3.7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ docs
 
 #lerna
 .changelog
+
+# OS generated files
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
-    "husky": "^3.0.9",
-    "benchmark": "^2.1.4",
     "beautify-benchmark": "^0.2.4",
+    "benchmark": "^2.1.4",
     "gts": "^1.0.0",
+    "husky": "^3.0.9",
     "lerna": "^3.17.0",
     "lerna-changelog": "^0.8.2",
-    "typescript": "3.6.4"
+    "typescript": "^3.7.2"
   },
   "husky": {
     "hooks": {

--- a/packages/opentelemetry-base/package.json
+++ b/packages/opentelemetry-base/package.json
@@ -52,6 +52,6 @@
     "ts-node": "^8.0.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   }
 }

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -71,7 +71,7 @@
     "ts-node": "^8.0.0",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4",
+    "typescript": "3.7.2",
     "webpack": "^4.35.2"
   },
   "dependencies": {

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -49,7 +49,7 @@
     "ts-node": "^8.3.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/base": "^0.2.0",

--- a/packages/opentelemetry-exporter-prometheus/package.json
+++ b/packages/opentelemetry-exporter-prometheus/package.json
@@ -49,7 +49,7 @@
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.3.0",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/core": "^0.2.0",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -51,7 +51,7 @@
     "ts-node": "^8.3.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/base": "^0.2.0",

--- a/packages/opentelemetry-metrics/package.json
+++ b/packages/opentelemetry-metrics/package.json
@@ -50,7 +50,7 @@
     "ts-node": "^8.3.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/base": "^0.2.0",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -54,7 +54,7 @@
     "ts-node": "^8.0.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/core": "^0.2.0",

--- a/packages/opentelemetry-plugin-dns/package.json
+++ b/packages/opentelemetry-plugin-dns/package.json
@@ -55,7 +55,7 @@
     "ts-node": "^8.4.1",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/core": "^0.2.0",

--- a/packages/opentelemetry-plugin-dns/test/integrations/dnspromise-lookup.test.ts
+++ b/packages/opentelemetry-plugin-dns/test/integrations/dnspromise-lookup.test.ts
@@ -38,8 +38,6 @@ describe('dns.promises.lookup()', () => {
     // skip tests if node version is not supported
     if (semver.lte(process.versions.node, '10.6.0')) {
       this.skip();
-      done();
-      return;
     }
 
     // if node version is supported, it's mandatory for CI
@@ -52,7 +50,7 @@ describe('dns.promises.lookup()', () => {
     utils.checkInternet(isConnected => {
       if (!isConnected) {
         this.skip();
-        // don't disturbe people
+        // don't disturb people
       }
       done();
     });

--- a/packages/opentelemetry-plugin-document-load/package.json
+++ b/packages/opentelemetry-plugin-document-load/package.json
@@ -65,7 +65,7 @@
     "ts-node": "^8.0.0",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4",
+    "typescript": "3.7.2",
     "webpack": "^4.35.2",
     "webpack-cli": "^3.3.9",
     "webpack-merge": "^4.2.2"

--- a/packages/opentelemetry-plugin-grpc/package.json
+++ b/packages/opentelemetry-plugin-grpc/package.json
@@ -56,7 +56,7 @@
     "ts-node": "^8.3.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/core": "^0.2.0",

--- a/packages/opentelemetry-plugin-grpc/src/grpc.ts
+++ b/packages/opentelemetry-plugin-grpc/src/grpc.ts
@@ -83,13 +83,11 @@ export class GrpcPlugin extends BasePlugin<grpc> {
     }
 
     // Wrap the externally exported client constructor
-    if (this._moduleExports.makeGenericClientConstructor) {
-      shimmer.wrap(
-        this._moduleExports,
-        'makeGenericClientConstructor',
-        this._patchClient()
-      );
-    }
+    shimmer.wrap(
+      this._moduleExports,
+      'makeGenericClientConstructor',
+      this._patchClient()
+    );
 
     if (this._internalFilesExports['client']) {
       grpcClientModule = this._internalFilesExports[
@@ -117,9 +115,7 @@ export class GrpcPlugin extends BasePlugin<grpc> {
       shimmer.unwrap(this._moduleExports.Server.prototype, 'register');
     }
 
-    if (this._moduleExports.makeGenericClientConstructor) {
-      shimmer.unwrap(this._moduleExports, 'makeGenericClientConstructor');
-    }
+    shimmer.unwrap(this._moduleExports, 'makeGenericClientConstructor');
 
     if (grpcClientModule) {
       shimmer.unwrap(grpcClientModule, 'makeClientConstructor');

--- a/packages/opentelemetry-plugin-http/package.json
+++ b/packages/opentelemetry-plugin-http/package.json
@@ -68,7 +68,7 @@
     "ts-node": "^8.4.1",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/core": "^0.2.0",

--- a/packages/opentelemetry-plugin-http2/package.json
+++ b/packages/opentelemetry-plugin-http2/package.json
@@ -51,7 +51,7 @@
     "ts-node": "^8.3.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/core": "^0.2.0",

--- a/packages/opentelemetry-plugin-https/package.json
+++ b/packages/opentelemetry-plugin-https/package.json
@@ -67,7 +67,7 @@
     "ts-node": "^8.4.1",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/core": "^0.2.0",

--- a/packages/opentelemetry-plugin-mongodb/package.json
+++ b/packages/opentelemetry-plugin-mongodb/package.json
@@ -51,7 +51,7 @@
     "ts-node": "^8.3.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/core": "^0.2.0",

--- a/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg-pool/package.json
+++ b/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg-pool/package.json
@@ -63,7 +63,7 @@
     "tslint-consistent-codestyle": "^1.15.1",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.3.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/core": "^0.2.0",

--- a/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg/package.json
+++ b/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg/package.json
@@ -59,7 +59,7 @@
     "ts-node": "^8.3.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/core": "^0.2.0",

--- a/packages/opentelemetry-plugin-redis/package.json
+++ b/packages/opentelemetry-plugin-redis/package.json
@@ -51,7 +51,7 @@
     "ts-node": "^8.3.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/core": "^0.2.0",

--- a/packages/opentelemetry-scope-async-hooks/package.json
+++ b/packages/opentelemetry-scope-async-hooks/package.json
@@ -52,7 +52,7 @@
     "ts-node": "^8.0.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/scope-base": "^0.2.0"

--- a/packages/opentelemetry-scope-base/package.json
+++ b/packages/opentelemetry-scope-base/package.json
@@ -52,6 +52,6 @@
     "ts-node": "^8.0.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   }
 }

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -49,7 +49,7 @@
     "ts-node": "^8.3.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "@opentelemetry/core": "^0.2.0",

--- a/packages/opentelemetry-tracing/package.json
+++ b/packages/opentelemetry-tracing/package.json
@@ -68,7 +68,7 @@
     "ts-node": "^8.0.0",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4",
+    "typescript": "3.7.2",
     "webpack": "^4.35.2"
   },
   "dependencies": {

--- a/packages/opentelemetry-types/package.json
+++ b/packages/opentelemetry-types/package.json
@@ -47,6 +47,6 @@
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typedoc": "^0.15.0",
-    "typescript": "3.6.4"
+    "typescript": "3.7.2"
   }
 }

--- a/packages/opentelemetry-web/package.json
+++ b/packages/opentelemetry-web/package.json
@@ -65,7 +65,7 @@
     "ts-node": "^8.0.0",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
-    "typescript": "3.6.4",
+    "typescript": "3.7.2",
     "webpack": "^4.35.2",
     "webpack-cli": "^3.3.9",
     "webpack-merge": "^4.2.2"


### PR DESCRIPTION
## Which problem is this PR solving?

- Fix build failures on latest typescript
- Bump to latest typescript

## Short description of the changes

1. Update typescript version to `^3.7.2` in all `package.json` files
2. Remove unreachable code from dns plugin test
3. Remove always-true if-statement from grpc plugin

## REVIEWERS PLEASE PAY PARTICULAR ATTENTION TO POINTS 2 AND 3