### PR TITLE
ci: install minimal lint & doc deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,8 +85,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install modules and dependencies.
-          command: yarn install
+          name: Install minimal doc and lint modules globally
+          command: yarn global add lerna typedoc linkinator typescript gts tslint-consistent-codestyle tslint-microsoft-contrib
+      - run:
+          name: Symlink global modules into all lerna packages
+          command: lerna exec 'ln -s $(yarn global dir)/node_modules node_modules'
       - run:
           name: Check code style and linting
           command: yarn run check

--- a/packages/opentelemetry-plugin-document-load/src/documentLoad.ts
+++ b/packages/opentelemetry-plugin-document-load/src/documentLoad.ts
@@ -198,7 +198,7 @@ export class DocumentLoad extends BasePlugin<unknown> {
       });
     } else {
       // // fallback to previous version
-      const perf: (typeof otperformance) & PerformanceLegacy = otperformance;
+      const perf: typeof otperformance & PerformanceLegacy = otperformance;
       const performanceTiming = perf.timing;
       if (performanceTiming) {
         const keys = Object.values(PTN);

--- a/packages/opentelemetry-plugin-grpc/src/grpc.ts
+++ b/packages/opentelemetry-plugin-grpc/src/grpc.ts
@@ -354,9 +354,12 @@ export class GrpcPlugin extends BasePlugin<grpc> {
             parent: currentSpan || undefined,
           })
           .setAttribute(AttributeNames.COMPONENT, GrpcPlugin.component);
-        return plugin._makeGrpcClientRemoteCall(original, args, this, plugin)(
-          span
-        );
+        return plugin._makeGrpcClientRemoteCall(
+          original,
+          args,
+          this,
+          plugin
+        )(span);
       };
     };
   }

--- a/packages/opentelemetry-plugin-http/src/http.ts
+++ b/packages/opentelemetry-plugin-http/src/http.ts
@@ -485,7 +485,7 @@ export class HttpPlugin extends BasePlugin<Http> {
     span: Span,
     execute: T,
     rethrow: K
-  ): K extends true ? ReturnType<T> : (ReturnType<T> | void);
+  ): K extends true ? ReturnType<T> : ReturnType<T> | void;
   private _safeExecute<T extends (...args: unknown[]) => ReturnType<T>>(
     span: Span,
     execute: T,

--- a/packages/opentelemetry-plugin-http/src/types.ts
+++ b/packages/opentelemetry-plugin-http/src/types.ts
@@ -39,7 +39,7 @@ export type RequestSignature = [http.RequestOptions, HttpCallbackOptional] &
 export type HttpRequestArgs = Array<HttpCallbackOptional | RequestSignature>;
 
 export type ParsedRequestOptions =
-  | http.RequestOptions & Partial<url.UrlWithParsedQuery>
+  | (http.RequestOptions & Partial<url.UrlWithParsedQuery>)
   | http.RequestOptions;
 export type Http = typeof http;
 /* tslint:disable-next-line:no-any */

--- a/packages/opentelemetry-plugin-http/src/utils.ts
+++ b/packages/opentelemetry-plugin-http/src/utils.ts
@@ -46,7 +46,9 @@ export const getAbsoluteUrl = (
   // it should be displayed if it's not 80 and 443 (default ports)
   if (
     (host as string).indexOf(':') === -1 &&
-    (port && port !== '80' && port !== '443')
+    port &&
+    port !== '80' &&
+    port !== '443'
   ) {
     host += `:${port}`;
   }

--- a/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg/src/pg.ts
+++ b/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg/src/pg.ts
@@ -97,9 +97,10 @@ export class PostgresPlugin extends BasePlugin<typeof pgTypes> {
           const parentSpan = plugin._tracer.getCurrentSpan();
           if (typeof args[args.length - 1] === 'function') {
             // Patch ParameterQuery callback
-            args[args.length - 1] = utils.patchCallback(span, args[
-              args.length - 1
-            ] as PostgresCallback);
+            args[args.length - 1] = utils.patchCallback(
+              span,
+              args[args.length - 1] as PostgresCallback
+            );
             // If a parent span exists, bind the callback
             if (parentSpan) {
               args[args.length - 1] = plugin._tracer.bind(


### PR DESCRIPTION
## Which problem is this PR solving?

- #498 

## Short description of the changes

This installs only the bare minimum required to run `yarn run check` and `yarn run docs`. The reason for the odd `lerna exec` symlinking is because `gts` looks for rules packages in the local node modules, and does not look in the global directory.
