### PR TITLE
chore(circleci): remove duplicate compile step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,9 +116,6 @@ browsers_unit_tests: &browsers_unit_tests
     - save_cache:
         <<: *cache_2
     - run:
-        name: Compile code
-        command: yarn compile
-    - run:
         name: Unit tests
         command: yarn test:browser
     - run:


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Updates #481

- We can save ~25secs during each build

- Compile step is already part of `prepare` script, which runs on `yarn install`.