### PR TITLE
fix(plugin-http): adapt to current @types/node

### DIFF
--- a/packages/opentelemetry-plugin-http/package.json
+++ b/packages/opentelemetry-plugin-http/package.json
@@ -46,7 +46,7 @@
     "@types/got": "^9.6.7",
     "@types/mocha": "^5.2.7",
     "@types/nock": "^11.1.0",
-    "@types/node": "^12.7.9",
+    "@types/node": "^12.12.9",
     "@types/request-promise-native": "^1.0.17",
     "@types/semver": "^6.0.2",
     "@types/shimmer": "^1.0.1",

--- a/packages/opentelemetry-plugin-http/test/utils/assertSpan.ts
+++ b/packages/opentelemetry-plugin-http/test/utils/assertSpan.ts
@@ -33,7 +33,7 @@ export const assertSpan = (
     hostname: string;
     pathname: string;
     reqHeaders?: http.OutgoingHttpHeaders;
-    path?: string;
+    path?: string | null;
     forceStatus?: Status;
     component: string;
   }

--- a/packages/opentelemetry-plugin-https/package.json
+++ b/packages/opentelemetry-plugin-https/package.json
@@ -45,7 +45,7 @@
     "@types/got": "^9.6.7",
     "@types/mocha": "^5.2.7",
     "@types/nock": "^11.1.0",
-    "@types/node": "^12.7.8",
+    "@types/node": "^12.12.9",
     "@types/request-promise-native": "^1.0.17",
     "@types/semver": "^6.0.2",
     "@types/shimmer": "^1.0.1",

--- a/packages/opentelemetry-plugin-https/test/utils/assertSpan.ts
+++ b/packages/opentelemetry-plugin-https/test/utils/assertSpan.ts
@@ -35,7 +35,7 @@ export const assertSpan = (
     hostname: string;
     pathname: string;
     reqHeaders?: http.OutgoingHttpHeaders;
-    path?: string;
+    path?: string | null;
     component: string;
   }
 ) => {


### PR DESCRIPTION
## Which problem is this PR solving?

fixes https://github.com/open-telemetry/opentelemetry-js/issues/541

## Short description of the changes

Adapt http/https plugin to @types/node 12.12.9

Refs: https://github.com/open-telemetry/opentelemetry-js/pull/545
