### PR TITLE
fix: npm install node path warning

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+scripts-prepend-node-path=true


### PR DESCRIPTION
## Which problem is this PR solving?

`npm i` has a warning: 

```
npm WARN lifecycle The node binary used for scripts is /tmp/yarn--1574287501801-0.6577053285852628/node but npm is using `some-path` itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
```

## Short description of the changes

added `.npmrc` file and specified suggested parameter.
