### PR TITLE
fix: add missing `main` in package.json

### DIFF
--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -2,6 +2,7 @@
   "name": "@opentelemetry/shim-opentracing",
   "version": "0.2.0",
   "description": "OpenTracing to OpenTelemetry shim",
+  "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Add missing `main` to `package.json`

## Short description of the changes

- Missing `main` in `package.json` makes developer unable to do `require("@opentelemetry/shim-opentracing");`

<img width="816" alt="Screen Shot 2019-11-28 at 23 00 42" src="https://user-images.githubusercontent.com/5351682/69833416-fc13a780-1233-11ea-89f9-3c42455e1e0f.png">

