### PR TITLE
fix(plugin-http): correct handling of WHATWG urls

### DIFF
--- a/packages/opentelemetry-plugin-http/src/http.ts
+++ b/packages/opentelemetry-plugin-http/src/http.ts
@@ -402,12 +402,14 @@ export class HttpPlugin extends BasePlugin<Http> {
         return original.apply(this, [options, ...args]);
       }
 
+      const extraOptions =
+        typeof args[0] === 'object' &&
+        (typeof options === 'string' || options instanceof url.URL)
+          ? (args.shift() as RequestOptions)
+          : undefined;
       const { origin, pathname, method, optionsParsed } = utils.getRequestInfo(
         options,
-        typeof args[0] === 'object' &&
-          (typeof options === 'string' || options instanceof url.URL)
-          ? (args.shift() as RequestOptions)
-          : undefined
+        extraOptions
       );
 
       options = optionsParsed;

--- a/packages/opentelemetry-plugin-http/src/http.ts
+++ b/packages/opentelemetry-plugin-http/src/http.ts
@@ -395,7 +395,7 @@ export class HttpPlugin extends BasePlugin<Http> {
     const plugin = this;
     return function outgoingRequest(
       this: {},
-      options: RequestOptions | string,
+      options: url.URL | RequestOptions | string,
       ...args: unknown[]
     ): ClientRequest {
       if (!utils.isValidOptionsType(options)) {
@@ -404,7 +404,8 @@ export class HttpPlugin extends BasePlugin<Http> {
 
       const { origin, pathname, method, optionsParsed } = utils.getRequestInfo(
         options,
-        typeof args[0] === 'object' && typeof options === 'string'
+        typeof args[0] === 'object' &&
+          (typeof options === 'string' || options instanceof url.URL)
           ? (args.shift() as RequestOptions)
           : undefined
       );

--- a/packages/opentelemetry-plugin-http/src/utils.ts
+++ b/packages/opentelemetry-plugin-http/src/utils.ts
@@ -222,7 +222,7 @@ export const getRequestInfo = (
           : options.hostname,
       path: `${options.pathname || ''}${options.search || ''}`,
     };
-    if (optionsParsed.port !== '') {
+    if (options.port !== '') {
       optionsParsed.port = Number(options.port);
     }
     if (options.username || options.password) {

--- a/packages/opentelemetry-plugin-http/src/utils.ts
+++ b/packages/opentelemetry-plugin-http/src/utils.ts
@@ -250,8 +250,7 @@ export const getRequestInfo = (
   }
   // some packages return method in lowercase..
   // ensure upperCase for consistency
-  let method = optionsParsed.method;
-  method = method ? method.toUpperCase() : 'GET';
+  const method = optionsParsed.method ? optionsParsed.method.toUpperCase() : 'GET';
 
   return { origin, pathname, method, optionsParsed };
 };

--- a/packages/opentelemetry-plugin-http/src/utils.ts
+++ b/packages/opentelemetry-plugin-http/src/utils.ts
@@ -200,12 +200,12 @@ export const setSpanWithError = (
  * @param [extraOptions] additional options for the request
  */
 export const getRequestInfo = (
-  options: RequestOptions | string,
+  options: url.URL | RequestOptions | string,
   extraOptions?: RequestOptions
 ) => {
   let pathname = '/';
   let origin = '';
-  let optionsParsed: url.URL | url.UrlWithStringQuery | RequestOptions;
+  let optionsParsed: RequestOptions;
   if (typeof options === 'string') {
     optionsParsed = url.parse(options);
     pathname = (optionsParsed as url.UrlWithStringQuery).pathname || '/';
@@ -213,8 +213,28 @@ export const getRequestInfo = (
     if (extraOptions !== undefined) {
       Object.assign(optionsParsed, extraOptions);
     }
+  } else if (options instanceof url.URL) {
+    optionsParsed = {
+      protocol: options.protocol,
+      hostname:
+        typeof options.hostname === 'string' && options.hostname.startsWith('[')
+          ? options.hostname.slice(1, -1)
+          : options.hostname,
+      path: `${options.pathname || ''}${options.search || ''}`,
+    };
+    if (optionsParsed.port !== '') {
+      optionsParsed.port = Number(options.port);
+    }
+    if (options.username || options.password) {
+      optionsParsed.auth = `${options.username}:${options.password}`;
+    }
+    pathname = options.pathname;
+    origin = options.origin;
+    if (extraOptions !== undefined) {
+      Object.assign(optionsParsed, extraOptions);
+    }
   } else {
-    optionsParsed = options as RequestOptions;
+    optionsParsed = options;
     pathname = (options as url.URL).pathname;
     if (!pathname && optionsParsed.path) {
       pathname = url.parse(optionsParsed.path).pathname || '/';
@@ -224,16 +244,13 @@ export const getRequestInfo = (
   }
 
   if (hasExpectHeader(optionsParsed)) {
-    (optionsParsed as RequestOptions).headers = Object.assign(
-      {},
-      (optionsParsed as RequestOptions).headers
-    );
-  } else if (!(optionsParsed as RequestOptions).headers) {
-    (optionsParsed as RequestOptions).headers = {};
+    optionsParsed.headers = Object.assign({}, optionsParsed.headers);
+  } else if (!optionsParsed.headers) {
+    optionsParsed.headers = {};
   }
   // some packages return method in lowercase..
   // ensure upperCase for consistency
-  let method = (optionsParsed as RequestOptions).method;
+  let method = optionsParsed.method;
   method = method ? method.toUpperCase() : 'GET';
 
   return { origin, pathname, method, optionsParsed };

--- a/packages/opentelemetry-plugin-http/src/utils.ts
+++ b/packages/opentelemetry-plugin-http/src/utils.ts
@@ -234,7 +234,7 @@ export const getRequestInfo = (
       Object.assign(optionsParsed, extraOptions);
     }
   } else {
-    optionsParsed = options;
+    optionsParsed = Object.assign({}, options);
     pathname = (options as url.URL).pathname;
     if (!pathname && optionsParsed.path) {
       pathname = url.parse(optionsParsed.path).pathname || '/';

--- a/packages/opentelemetry-plugin-http/src/utils.ts
+++ b/packages/opentelemetry-plugin-http/src/utils.ts
@@ -250,7 +250,9 @@ export const getRequestInfo = (
   }
   // some packages return method in lowercase..
   // ensure upperCase for consistency
-  const method = optionsParsed.method ? optionsParsed.method.toUpperCase() : 'GET';
+  const method = optionsParsed.method
+    ? optionsParsed.method.toUpperCase()
+    : 'GET';
 
   return { origin, pathname, method, optionsParsed };
 };

--- a/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
@@ -23,6 +23,7 @@ import { NodeTracer } from '@opentelemetry/node';
 import { CanonicalCode, Span as ISpan, SpanKind } from '@opentelemetry/types';
 import * as assert from 'assert';
 import * as http from 'http';
+import * as path from 'path';
 import * as nock from 'nock';
 import { HttpPlugin, plugin } from '../../src/http';
 import { assertSpan } from '../utils/assertSpan';
@@ -393,7 +394,7 @@ describe('HttpPlugin', () => {
         });
       }
 
-      for (const arg of ['string', '', {}, new Date()]) {
+      for (const arg of ['string', {}, new Date()]) {
         it(`should be tracable and not throw exception in http plugin when passing the following argument ${JSON.stringify(
           arg
         )}`, async () => {
@@ -409,7 +410,7 @@ describe('HttpPlugin', () => {
         });
       }
 
-      for (const arg of [true, 1, false, 0]) {
+      for (const arg of [true, 1, false, 0, '']) {
         it(`should not throw exception in http plugin when passing the following argument ${JSON.stringify(
           arg
         )}`, async () => {
@@ -420,7 +421,9 @@ describe('HttpPlugin', () => {
             // http request has been made
             // nock throw
             assert.ok(
-              error.stack.indexOf('/node_modules/nock/lib/intercept.js') > 0
+              error.stack.indexOf(
+                path.normalize('/node_modules/nock/lib/intercept.js')
+              ) > 0
             );
           }
           const spans = memoryExporter.getFinishedSpans();

--- a/packages/opentelemetry-plugin-http/test/functionals/utils.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/utils.test.ts
@@ -74,18 +74,25 @@ describe('Utility', () => {
 
   describe('getRequestInfo()', () => {
     it('should get options object', () => {
-      const webUrl = 'http://google.fr/';
+      const webUrl = 'http://u:p@google.fr/aPath?qu=ry';
       const urlParsed = url.parse(webUrl);
       const urlParsedWithoutPathname = {
         ...urlParsed,
         pathname: undefined,
       };
-      for (const param of [webUrl, urlParsed, urlParsedWithoutPathname]) {
+      const whatWgUrl = new url.URL(webUrl);
+      for (const param of [
+        webUrl,
+        urlParsed,
+        urlParsedWithoutPathname,
+        whatWgUrl,
+      ]) {
         const result = utils.getRequestInfo(param);
         assert.strictEqual(result.optionsParsed.hostname, 'google.fr');
         assert.strictEqual(result.optionsParsed.protocol, 'http:');
-        assert.strictEqual(result.optionsParsed.path, '/');
-        assert.strictEqual(result.pathname, '/');
+        assert.strictEqual(result.optionsParsed.path, '/aPath?qu=ry');
+        assert.strictEqual(result.pathname, '/aPath');
+        assert.strictEqual(result.origin, 'http://google.fr');
       }
     });
   });

--- a/packages/opentelemetry-plugin-http/test/utils/httpRequest.ts
+++ b/packages/opentelemetry-plugin-http/test/utils/httpRequest.ts
@@ -15,7 +15,7 @@
  */
 
 import * as http from 'http';
-import * as url from 'url';
+import { URL } from 'url';
 import { RequestOptions } from 'https';
 
 type GetResult = Promise<{
@@ -26,9 +26,9 @@ type GetResult = Promise<{
   method: string | undefined;
 }>;
 
-function get(url: string | url.URL, options?: RequestOptions): GetResult;
-function get(url: RequestOptions): GetResult;
-function get(url: any, options?: any): GetResult {
+function get(input: string | URL, options?: RequestOptions): GetResult;
+function get(input: RequestOptions): GetResult;
+function get(input: any, options?: any): GetResult {
   return new Promise((resolve, reject) => {
     let req: http.ClientRequest;
     function getResponseCb(resp: http.IncomingMessage): void {
@@ -54,8 +54,8 @@ function get(url: any, options?: any): GetResult {
     }
     req =
       options != null
-        ? http.get(url, options, getResponseCb)
-        : http.get(url, getResponseCb);
+        ? http.get(input, options, getResponseCb)
+        : http.get(input, getResponseCb);
     req.on('error', err => {
       reject(err);
     });

--- a/packages/opentelemetry-plugin-http/test/utils/httpRequest.ts
+++ b/packages/opentelemetry-plugin-http/test/utils/httpRequest.ts
@@ -31,7 +31,8 @@ function get(input: RequestOptions): GetResult;
 function get(input: any, options?: any): GetResult {
   return new Promise((resolve, reject) => {
     let req: http.ClientRequest;
-    function getResponseCb(resp: http.IncomingMessage): void {
+
+    function onGetResponseCb(resp: http.IncomingMessage): void {
       const res = (resp as unknown) as http.IncomingMessage & {
         req: http.IncomingMessage;
       };
@@ -54,8 +55,8 @@ function get(input: any, options?: any): GetResult {
     }
     req =
       options != null
-        ? http.get(input, options, getResponseCb)
-        : http.get(input, getResponseCb);
+        ? http.get(input, options, onGetResponseCb)
+        : http.get(input, onGetResponseCb);
     req.on('error', err => {
       reject(err);
     });

--- a/packages/opentelemetry-plugin-http/test/utils/httpRequest.ts
+++ b/packages/opentelemetry-plugin-http/test/utils/httpRequest.ts
@@ -16,7 +16,6 @@
 
 import * as http from 'http';
 import { URL } from 'url';
-import { RequestOptions } from 'https';
 
 type GetResult = Promise<{
   data: string;
@@ -26,8 +25,8 @@ type GetResult = Promise<{
   method: string | undefined;
 }>;
 
-function get(input: string | URL, options?: RequestOptions): GetResult;
-function get(input: RequestOptions): GetResult;
+function get(input: string | URL, options?: http.RequestOptions): GetResult;
+function get(input: http.RequestOptions): GetResult;
 function get(input: any, options?: any): GetResult {
   return new Promise((resolve, reject) => {
     let req: http.ClientRequest;

--- a/packages/opentelemetry-plugin-http/test/utils/httpRequest.ts
+++ b/packages/opentelemetry-plugin-http/test/utils/httpRequest.ts
@@ -18,54 +18,51 @@ import * as http from 'http';
 import * as url from 'url';
 import { RequestOptions } from 'https';
 
-export const httpRequest = {
-  get: (
-    options: string | RequestOptions
-  ): Promise<{
-    data: string;
-    statusCode: number | undefined;
-    resHeaders: http.IncomingHttpHeaders;
-    reqHeaders: http.OutgoingHttpHeaders;
-    method: string | undefined;
-  }> => {
-    const _options =
-      typeof options === 'string'
-        ? Object.assign(url.parse(options), {
-            headers: {
-              'user-agent': 'http-plugin-test',
-            },
-          })
-        : options;
-    return new Promise((resolve, reject) => {
-      const req = http.get(_options, (resp: http.IncomingMessage) => {
-        const res = (resp as unknown) as http.IncomingMessage & {
-          req: http.IncomingMessage;
-        };
-        let data = '';
-        resp.on('data', chunk => {
-          data += chunk;
-        });
-        resp.on('end', () => {
-          resolve({
-            data,
-            statusCode: res.statusCode,
-            /* tslint:disable:no-any */
-            reqHeaders: (res.req as any).getHeaders
-              ? (res.req as any).getHeaders()
-              : (res.req as any)._headers,
-            /* tslint:enable:no-any */
-            resHeaders: res.headers,
-            method: res.req.method,
-          });
-        });
-        resp.on('error', err => {
-          reject(err);
+type GetResult = Promise<{
+  data: string;
+  statusCode: number | undefined;
+  resHeaders: http.IncomingHttpHeaders;
+  reqHeaders: http.OutgoingHttpHeaders;
+  method: string | undefined;
+}>;
+
+function get(url: string | url.URL, options?: RequestOptions): GetResult;
+function get(url: RequestOptions): GetResult;
+function get(url: any, options?: any): GetResult {
+  return new Promise((resolve, reject) => {
+    let req: http.ClientRequest;
+    function getResponseCb(resp: http.IncomingMessage): void {
+      const res = (resp as unknown) as http.IncomingMessage & {
+        req: http.IncomingMessage;
+      };
+      let data = '';
+      resp.on('data', chunk => {
+        data += chunk;
+      });
+      resp.on('end', () => {
+        resolve({
+          data,
+          statusCode: res.statusCode,
+          reqHeaders: req.getHeaders ? req.getHeaders() : (req as any)._headers,
+          resHeaders: res.headers,
+          method: res.req.method,
         });
       });
-      req.on('error', err => {
+      resp.on('error', err => {
         reject(err);
       });
-      return req;
+    }
+    req =
+      options != null
+        ? http.get(url, options, getResponseCb)
+        : http.get(url, getResponseCb);
+    req.on('error', err => {
+      reject(err);
     });
-  },
+    return req;
+  });
+}
+
+export const httpRequest = {
+  get,
 };


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

fixes https://github.com/open-telemetry/opentelemetry-js/issues/583


## Short description of the changes

Add parsing and conversion of WHATWG URL objects for client http
requests to ensure semantics of HTTP request are not modifed and
tracestate header is correctly added.

