### PR TITLE
fix(jaeger-exporter): set Span Kind as Tags

### DIFF
--- a/packages/opentelemetry-exporter-jaeger/src/transform.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/transform.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Link, CanonicalCode } from '@opentelemetry/types';
+import { Link, CanonicalCode, SpanKind } from '@opentelemetry/types';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import {
   hrTimeToMilliseconds,
@@ -59,6 +59,11 @@ export function spanToThrift(span: ReadableSpan): ThriftSpan {
   if (span.status.code !== CanonicalCode.OK) {
     tags.push({ key: 'error', value: true });
   }
+
+  if (span.kind !== undefined) {
+    tags.push({ key: 'span.kind', value: SpanKind[span.kind] });
+  }
+
   const spanTags: ThriftTag[] = ThriftUtils.getThriftTags(tags);
 
   const logs = span.events.map(

--- a/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
@@ -90,8 +90,8 @@ describe('transform', () => {
         thriftSpan.startTime,
         Utils.encodeInt64(hrTimeToMicroseconds(readableSpan.startTime))
       );
-      assert.strictEqual(thriftSpan.tags.length, 5);
-      const [tag1, tag2, tag3, tag4, tag5] = thriftSpan.tags;
+      assert.strictEqual(thriftSpan.tags.length, 6);
+      const [tag1, tag2, tag3, tag4, tag5, tag6] = thriftSpan.tags;
       assert.strictEqual(tag1.key, 'testBool');
       assert.strictEqual(tag1.vType, 'BOOL');
       assert.strictEqual(tag1.vBool, true);
@@ -107,6 +107,9 @@ describe('transform', () => {
       assert.strictEqual(tag5.key, 'status.name');
       assert.strictEqual(tag5.vType, 'STRING');
       assert.strictEqual(tag5.vStr, 'OK');
+      assert.strictEqual(tag6.key, 'span.kind');
+      assert.strictEqual(tag6.vType, 'STRING');
+      assert.strictEqual(tag6.vStr, 'INTERNAL');
       assert.strictEqual(thriftSpan.references.length, 0);
 
       assert.strictEqual(thriftSpan.logs.length, 1);
@@ -157,8 +160,8 @@ describe('transform', () => {
       assert.deepStrictEqual(thriftSpan.parentSpanId, ThriftUtils.emptyBuffer);
       assert.deepStrictEqual(thriftSpan.flags, 1);
       assert.strictEqual(thriftSpan.references.length, 0);
-      assert.strictEqual(thriftSpan.tags.length, 4);
-      const [tag1, tag2, tag3, tag4] = thriftSpan.tags;
+      assert.strictEqual(thriftSpan.tags.length, 5);
+      const [tag1, tag2, tag3, tag4, tag5] = thriftSpan.tags;
       assert.strictEqual(tag1.key, 'status.code');
       assert.strictEqual(tag1.vType, 'DOUBLE');
       assert.strictEqual(tag1.vDouble, 15);
@@ -171,6 +174,9 @@ describe('transform', () => {
       assert.strictEqual(tag4.key, 'error');
       assert.strictEqual(tag4.vType, 'BOOL');
       assert.strictEqual(tag4.vBool, true);
+      assert.strictEqual(tag5.key, 'span.kind');
+      assert.strictEqual(tag5.vType, 'STRING');
+      assert.strictEqual(tag5.vStr, 'CLIENT');
       assert.strictEqual(thriftSpan.logs.length, 0);
     });
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes #594 

## Short description of the changes

- Jaeger exporter doesn't have direct support for `kind` attribute, this PR will set `SpanKind` as `Tags` similar to `Status` field.
