### PR TITLE
chore(plugin-https): sync https tests with http

### DIFF
--- a/packages/opentelemetry-plugin-http/package.json
+++ b/packages/opentelemetry-plugin-http/package.json
@@ -6,7 +6,7 @@
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
-    "test": "nyc ts-mocha -p tsconfig.json test/**/*/*.test.ts",
+    "test": "nyc ts-mocha -p tsconfig.json test/**/*.test.ts",
     "tdd": "yarn test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "check": "gts check",

--- a/packages/opentelemetry-plugin-http/test/functionals/http-package.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-package.test.ts
@@ -38,6 +38,7 @@ import { HttpPluginConfig } from '../../src/types';
 import { customAttributeFunction } from './http-enable.test';
 
 const memoryExporter = new InMemorySpanExporter();
+const protocol = 'http';
 
 describe('Packages', () => {
   describe('get', () => {
@@ -93,8 +94,8 @@ describe('Packages', () => {
               // https://github.com/nock/nock/pull/1551
               // https://github.com/sindresorhus/got/commit/bf1aa5492ae2bc78cbbec6b7d764906fb156e6c2#diff-707a4781d57c42085155dcb27edb9ccbR258
               // TODO: check if this is still the case when new version
-              'http://info.cern.ch/'
-            : `http://www.google.com/search?q=axios&oq=axios&aqs=chrome.0.69i59l2j0l3j69i60.811j0j7&sourceid=chrome&ie=UTF-8`
+              `${protocol}://info.cern.ch/`
+            : `${protocol}://www.google.com/search?q=axios&oq=axios&aqs=chrome.0.69i59l2j0l3j69i60.811j0j7&sourceid=chrome&ie=UTF-8`
         );
         const result = await httpPackage.get(urlparsed.href!);
         if (!resHeaders) {

--- a/packages/opentelemetry-plugin-https/README.md
+++ b/packages/opentelemetry-plugin-https/README.md
@@ -5,7 +5,7 @@
 [![devDependencies][devDependencies-image]][devDependencies-url]
 [![Apache License][license-image]][license-image]
 
-This module provides automatic instrumentation for [`https`](http://nodejs.org/dist/latest/docs/api/https.html).
+This module provides automatic instrumentation for [`https`](http://nodejs.org/api/https.html).
 
 For automatic instrumentation see the
 [@opentelemetry/node](https://github.com/open-telemetry/opentelemetry-js/tree/master/packages/opentelemetry-node) package.

--- a/packages/opentelemetry-plugin-https/package.json
+++ b/packages/opentelemetry-plugin-https/package.json
@@ -6,7 +6,7 @@
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
-    "test": "nyc ts-mocha -p tsconfig.json test/**/*/*.test.ts",
+    "test": "nyc ts-mocha -p tsconfig.json test/**/*.test.ts",
     "tdd": "yarn test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "check": "gts check",

--- a/packages/opentelemetry-plugin-https/package.json
+++ b/packages/opentelemetry-plugin-https/package.json
@@ -6,10 +6,11 @@
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
-    "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
+    "test": "nyc ts-mocha -p tsconfig.json test/**/*/*.test.ts",
     "tdd": "yarn test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "check": "gts check",
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "precompile": "tsc --version",
     "compile": "tsc -p .",
     "fix": "gts fix",

--- a/packages/opentelemetry-plugin-https/src/https.ts
+++ b/packages/opentelemetry-plugin-https/src/https.ts
@@ -17,6 +17,7 @@
 import { HttpPlugin, Func, HttpRequestArgs } from '@opentelemetry/plugin-http';
 import * as http from 'http';
 import * as https from 'https';
+import { URL } from 'url';
 import * as semver from 'semver';
 import * as shimmer from 'shimmer';
 import * as utils from './utils';

--- a/packages/opentelemetry-plugin-https/src/https.ts
+++ b/packages/opentelemetry-plugin-https/src/https.ts
@@ -81,12 +81,13 @@ export class HttpsPlugin extends HttpPlugin {
     return (original: Func<http.ClientRequest>): Func<http.ClientRequest> => {
       const plugin = this;
       return function httpsOutgoingRequest(
-        options,
+        options: https.RequestOptions | string | URL,
         ...args: HttpRequestArgs
       ): http.ClientRequest {
         // Makes sure options will have default HTTPS parameters
-        if (typeof options === 'object') {
-          utils.setDefaultOptions(options);
+        if (typeof options === 'object' && !(options instanceof URL)) {
+          options = Object.assign({}, options);
+          utils.setDefaultOptions(options as https.RequestOptions);
         }
         return plugin._getPatchOutgoingRequestFunction()(original)(
           options,
@@ -105,17 +106,9 @@ export class HttpsPlugin extends HttpPlugin {
   ) {
     return (original: Func<http.ClientRequest>): Func<http.ClientRequest> => {
       return function httpsOutgoingRequest(
-        options: https.RequestOptions | string,
+        options: https.RequestOptions | string | URL,
         ...args: HttpRequestArgs
       ): http.ClientRequest {
-        const optionsType = typeof options;
-        // Makes sure options will have default HTTPS parameters
-        if (optionsType === 'object') {
-          utils.setDefaultOptions(options as https.RequestOptions);
-        } else if (typeof args[0] === 'object' && optionsType === 'string') {
-          utils.setDefaultOptions(args[0] as https.RequestOptions);
-        }
-
         return plugin._getPatchOutgoingGetFunction(clientRequest)(original)(
           options,
           ...args

--- a/packages/opentelemetry-plugin-https/test/functionals/https-disable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/functionals/https-disable.test.ts
@@ -16,7 +16,6 @@
 
 import * as assert from 'assert';
 import * as fs from 'fs';
-import * as http from 'http';
 import * as https from 'https';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
@@ -24,6 +23,7 @@ import * as sinon from 'sinon';
 import { plugin } from '../../src/https';
 import { NodeTracer } from '@opentelemetry/node';
 import { NoopLogger } from '@opentelemetry/core';
+import { Http } from '@opentelemetry/plugin-http';
 import { AddressInfo } from 'net';
 import { DummyPropagation } from '../utils/DummyPropagation';
 import { httpsRequest } from '../utils/httpsRequest';
@@ -43,7 +43,7 @@ describe('HttpsPlugin', () => {
       nock.cleanAll();
       nock.enableNetConnect();
 
-      plugin.enable((https as unknown) as typeof http, tracer, tracer.logger);
+      plugin.enable((https as unknown) as Http, tracer, tracer.logger);
       // Ensure that https module is patched.
       assert.strictEqual(https.Server.prototype.emit.__wrapped, true);
       server = https.createServer(

--- a/packages/opentelemetry-plugin-https/test/functionals/https-disable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/functionals/https-disable.test.ts
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-import { NoopLogger } from '@opentelemetry/core';
-import { NodeTracer } from '@opentelemetry/node';
-import { Http } from '@opentelemetry/plugin-http';
 import * as assert from 'assert';
 import * as fs from 'fs';
+import * as http from 'http';
 import * as https from 'https';
-import { AddressInfo } from 'net';
 import * as nock from 'nock';
 import * as sinon from 'sinon';
+
 import { plugin } from '../../src/https';
+import { NodeTracer } from '@opentelemetry/node';
+import { NoopLogger } from '@opentelemetry/core';
+import { AddressInfo } from 'net';
 import { DummyPropagation } from '../utils/DummyPropagation';
 import { httpsRequest } from '../utils/httpsRequest';
 
@@ -42,7 +43,7 @@ describe('HttpsPlugin', () => {
       nock.cleanAll();
       nock.enableNetConnect();
 
-      plugin.enable((https as unknown) as Http, tracer, tracer.logger);
+      plugin.enable((https as unknown) as typeof http, tracer, tracer.logger);
       // Ensure that https module is patched.
       assert.strictEqual(https.Server.prototype.emit.__wrapped, true);
       server = https.createServer(

--- a/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
@@ -24,17 +24,22 @@ import {
   Http,
   HttpPluginConfig,
   OT_REQUEST_HEADER,
+  AttributeNames,
 } from '@opentelemetry/plugin-http';
 import { CanonicalCode, Span as ISpan, SpanKind } from '@opentelemetry/types';
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as http from 'http';
 import * as https from 'https';
+import * as path from 'path';
 import * as nock from 'nock';
 import { HttpsPlugin, plugin } from '../../src/https';
 import { assertSpan } from '../utils/assertSpan';
 import { DummyPropagation } from '../utils/DummyPropagation';
 import { httpsRequest } from '../utils/httpsRequest';
+
+const applyCustomAttributesOnSpanErrorMessage =
+  'bad applyCustomAttributesOnSpan function';
 
 let server: https.Server;
 const serverPort = 32345;
@@ -42,6 +47,13 @@ const protocol = 'https';
 const hostname = 'localhost';
 const pathname = '/test';
 const memoryExporter = new InMemorySpanExporter();
+const httpTextFormat = new DummyPropagation();
+const logger = new NoopLogger();
+const tracer = new NodeTracer({
+  logger,
+  httpTextFormat,
+});
+tracer.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
 function doNock(
   hostname: string,
@@ -70,191 +82,231 @@ describe('HttpsPlugin', () => {
     assert.strictEqual(process.versions.node, plugin.version);
   });
 
-  it('moduleName should be https', () => {
-    assert.strictEqual('https', plugin.moduleName);
+  it(`moduleName should be ${protocol}`, () => {
+    assert.strictEqual(protocol, plugin.moduleName);
   });
 
   describe('enable()', () => {
-    const httpTextFormat = new DummyPropagation();
-    const logger = new NoopLogger();
-    const tracer = new NodeTracer({
-      logger,
-      httpTextFormat,
-    });
-    tracer.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
-    beforeEach(() => {
-      memoryExporter.reset();
-    });
-
-    before(() => {
-      const config: HttpPluginConfig = {
-        ignoreIncomingPaths: [
-          `/ignored/string`,
-          /\/ignored\/regexp$/i,
-          (url: string) => url.endsWith(`/ignored/function`),
-        ],
-        ignoreOutgoingUrls: [
-          `${protocol}://${hostname}:${serverPort}/ignored/string`,
-          /\/ignored\/regexp$/i,
-          (url: string) => url.endsWith(`/ignored/function`),
-        ],
-        applyCustomAttributesOnSpan: customAttributeFunction,
-      };
-      plugin.enable((https as unknown) as Http, tracer, tracer.logger, config);
-      server = https.createServer(
-        {
-          key: fs.readFileSync('test/fixtures/server-key.pem'),
-          cert: fs.readFileSync('test/fixtures/server-cert.pem'),
-        },
-        (request, response) => {
-          response.end('Test Server Response');
-        }
-      );
-
-      server.listen(serverPort);
-    });
-
-    after(() => {
-      server.close();
-      plugin.disable();
-    });
-
-    it('https module should be patched', () => {
-      assert.strictEqual(https.Server.prototype.emit.__wrapped, true);
-    });
-
-    it("should not patch if it's not a http module", () => {
-      const httpNotPatched = new HttpsPlugin(process.versions.node).enable(
-        {} as Http,
-        tracer,
-        tracer.logger,
-        {}
-      );
-      assert.strictEqual(Object.keys(httpNotPatched).length, 0);
-    });
-
-    it('should generate valid spans (client side and server side)', async () => {
-      const result = await httpsRequest.get(
-        `${protocol}://${hostname}:${serverPort}${pathname}`
-      );
-      const spans = memoryExporter.getFinishedSpans();
-      const [incomingSpan, outgoingSpan] = spans;
-      const validations = {
-        hostname,
-        httpStatusCode: result.statusCode!,
-        httpMethod: result.method!,
-        pathname,
-        resHeaders: result.resHeaders,
-        reqHeaders: result.reqHeaders,
-        component: plugin.component,
-      };
-
-      assert.strictEqual(spans.length, 2);
-      assertSpan(incomingSpan, SpanKind.SERVER, validations);
-      assertSpan(outgoingSpan, SpanKind.CLIENT, validations);
-    });
-
-    it(`should not trace requests with '${OT_REQUEST_HEADER}' header`, async () => {
-      const testPath = '/outgoing/do-not-trace';
-      doNock(hostname, testPath, 200, 'Ok');
-
-      const options = {
-        host: hostname,
-        path: testPath,
-        headers: { [OT_REQUEST_HEADER]: 1 },
-      };
-
-      const result = await httpsRequest.get(options);
-      const spans = memoryExporter.getFinishedSpans();
-      assert.strictEqual(result.data, 'Ok');
-      assert.strictEqual(spans.length, 0);
-    });
-
-    const httpErrorCodes = [400, 401, 403, 404, 429, 501, 503, 504, 500, 505];
-
-    for (let i = 0; i < httpErrorCodes.length; i++) {
-      it(`should test span for GET requests with https error ${httpErrorCodes[i]}`, async () => {
-        const testPath = '/outgoing/rootSpan/1';
-
-        doNock(
-          hostname,
-          testPath,
-          httpErrorCodes[i],
-          httpErrorCodes[i].toString()
-        );
-
-        const isReset = memoryExporter.getFinishedSpans().length === 0;
-        assert.ok(isReset);
-
-        const result = await httpsRequest.get(
-          `${protocol}://${hostname}${testPath}`
-        );
-        const spans = memoryExporter.getFinishedSpans();
-        const reqSpan = spans[0];
-
-        assert.strictEqual(result.data, httpErrorCodes[i].toString());
-        assert.strictEqual(spans.length, 1);
-
-        const validations = {
-          hostname,
-          httpStatusCode: result.statusCode!,
-          httpMethod: 'GET',
-          pathname: testPath,
-          resHeaders: result.resHeaders,
-          reqHeaders: result.reqHeaders,
-          component: plugin.component,
-        };
-
-        assertSpan(reqSpan, SpanKind.CLIENT, validations);
+    describe('with bad plugin options', () => {
+      let pluginWithBadOptions: HttpsPlugin;
+      beforeEach(() => {
+        memoryExporter.reset();
       });
-    }
 
-    it('should create a child span for GET requests', async () => {
-      const testPath = '/outgoing/rootSpan/childs/1';
-      doNock(hostname, testPath, 200, 'Ok');
-      const name = 'TestRootSpan';
-      const span = tracer.startSpan(name);
-      return tracer.withSpan(span, async () => {
-        const result = await httpsRequest.get(
-          `${protocol}://${hostname}${testPath}`
+      before(() => {
+        const config: HttpPluginConfig = {
+          ignoreIncomingPaths: [
+            (url: string) => {
+              throw new Error('bad ignoreIncomingPaths function');
+            },
+          ],
+          ignoreOutgoingUrls: [
+            (url: string) => {
+              throw new Error('bad ignoreOutgoingUrls function');
+            },
+          ],
+          applyCustomAttributesOnSpan: () => {
+            throw new Error(applyCustomAttributesOnSpanErrorMessage);
+          },
+        };
+        pluginWithBadOptions = new HttpsPlugin(process.versions.node);
+        pluginWithBadOptions.enable(
+          (https as unknown) as Http,
+          tracer,
+          tracer.logger,
+          config
         );
-        span.end();
+        server = https.createServer(
+          {
+            key: fs.readFileSync('test/fixtures/server-key.pem'),
+            cert: fs.readFileSync('test/fixtures/server-cert.pem'),
+          },
+          (request, response) => {
+            response.end('Test Server Response');
+          }
+        );
+
+        server.listen(serverPort);
+      });
+
+      after(() => {
+        server.close();
+        pluginWithBadOptions.disable();
+      });
+
+      it('should generate valid spans (client side and server side)', async () => {
+        const result = await httpsRequest.get(
+          `${protocol}://${hostname}:${serverPort}${pathname}`
+        );
         const spans = memoryExporter.getFinishedSpans();
-        const [reqSpan, localSpan] = spans;
+        const [incomingSpan, outgoingSpan] = spans;
         const validations = {
           hostname,
           httpStatusCode: result.statusCode!,
-          httpMethod: 'GET',
-          pathname: testPath,
+          httpMethod: result.method!,
+          pathname,
           resHeaders: result.resHeaders,
           reqHeaders: result.reqHeaders,
           component: plugin.component,
         };
 
-        assert.ok(localSpan.name.indexOf('TestRootSpan') >= 0);
         assert.strictEqual(spans.length, 2);
-        assert.ok(reqSpan.name.indexOf(testPath) >= 0);
-        assert.strictEqual(
-          localSpan.spanContext.traceId,
-          reqSpan.spanContext.traceId
-        );
-        assertSpan(reqSpan, SpanKind.CLIENT, validations);
-        assert.notStrictEqual(
-          localSpan.spanContext.spanId,
-          reqSpan.spanContext.spanId
-        );
+        assertSpan(incomingSpan, SpanKind.SERVER, validations);
+        assertSpan(outgoingSpan, SpanKind.CLIENT, validations);
+      });
+
+      it(`should not trace requests with '${OT_REQUEST_HEADER}' header`, async () => {
+        const testPath = '/outgoing/do-not-trace';
+        doNock(hostname, testPath, 200, 'Ok');
+
+        const options = {
+          host: hostname,
+          path: testPath,
+          headers: { [OT_REQUEST_HEADER]: 1 },
+        };
+
+        const result = await httpsRequest.get(options);
+        const spans = memoryExporter.getFinishedSpans();
+        assert.strictEqual(result.data, 'Ok');
+        assert.strictEqual(spans.length, 0);
       });
     });
+    describe('with good plugin options', () => {
+      beforeEach(() => {
+        memoryExporter.reset();
+      });
 
-    for (let i = 0; i < httpErrorCodes.length; i++) {
-      it(`should test child spans for GET requests with https error ${httpErrorCodes[i]}`, async () => {
-        const testPath = '/outgoing/rootSpan/childs/1';
-        doNock(
-          hostname,
-          testPath,
-          httpErrorCodes[i],
-          httpErrorCodes[i].toString()
+      before(() => {
+        const config: HttpPluginConfig = {
+          ignoreIncomingPaths: [
+            `/ignored/string`,
+            /\/ignored\/regexp$/i,
+            (url: string) => url.endsWith(`/ignored/function`),
+          ],
+          ignoreOutgoingUrls: [
+            `${protocol}://${hostname}:${serverPort}/ignored/string`,
+            /\/ignored\/regexp$/i,
+            (url: string) => url.endsWith(`/ignored/function`),
+          ],
+          applyCustomAttributesOnSpan: customAttributeFunction,
+        };
+        plugin.enable(
+          (https as unknown) as Http,
+          tracer,
+          tracer.logger,
+          config
         );
+        server = https.createServer(
+          {
+            key: fs.readFileSync('test/fixtures/server-key.pem'),
+            cert: fs.readFileSync('test/fixtures/server-cert.pem'),
+          },
+          (request, response) => {
+            response.end('Test Server Response');
+          }
+        );
+
+        server.listen(serverPort);
+      });
+
+      after(() => {
+        server.close();
+        plugin.disable();
+      });
+
+      it(`${protocol} module should be patched`, () => {
+        assert.strictEqual(https.Server.prototype.emit.__wrapped, true);
+      });
+
+      it(`should not patch if it's not a ${protocol} module`, () => {
+        const httpsNotPatched = new HttpsPlugin(process.versions.node).enable(
+          {} as Http,
+          tracer,
+          tracer.logger,
+          {}
+        );
+        assert.strictEqual(Object.keys(httpsNotPatched).length, 0);
+      });
+
+      it('should generate valid spans (client side and server side)', async () => {
+        const result = await httpsRequest.get(
+          `${protocol}://${hostname}:${serverPort}${pathname}`
+        );
+        const spans = memoryExporter.getFinishedSpans();
+        const [incomingSpan, outgoingSpan] = spans;
+        const validations = {
+          hostname,
+          httpStatusCode: result.statusCode!,
+          httpMethod: result.method!,
+          pathname,
+          resHeaders: result.resHeaders,
+          reqHeaders: result.reqHeaders,
+          component: plugin.component,
+        };
+
+        assert.strictEqual(spans.length, 2);
+        assertSpan(incomingSpan, SpanKind.SERVER, validations);
+        assertSpan(outgoingSpan, SpanKind.CLIENT, validations);
+      });
+
+      it(`should not trace requests with '${OT_REQUEST_HEADER}' header`, async () => {
+        const testPath = '/outgoing/do-not-trace';
+        doNock(hostname, testPath, 200, 'Ok');
+
+        const options = {
+          host: hostname,
+          path: testPath,
+          headers: { [OT_REQUEST_HEADER]: 1 },
+        };
+
+        const result = await httpsRequest.get(options);
+        const spans = memoryExporter.getFinishedSpans();
+        assert.strictEqual(result.data, 'Ok');
+        assert.strictEqual(spans.length, 0);
+      });
+
+      const httpErrorCodes = [400, 401, 403, 404, 429, 501, 503, 504, 500, 505];
+
+      for (let i = 0; i < httpErrorCodes.length; i++) {
+        it(`should test span for GET requests with http error ${httpErrorCodes[i]}`, async () => {
+          const testPath = '/outgoing/rootSpan/1';
+
+          doNock(
+            hostname,
+            testPath,
+            httpErrorCodes[i],
+            httpErrorCodes[i].toString()
+          );
+
+          const isReset = memoryExporter.getFinishedSpans().length === 0;
+          assert.ok(isReset);
+
+          const result = await httpsRequest.get(
+            `${protocol}://${hostname}${testPath}`
+          );
+          const spans = memoryExporter.getFinishedSpans();
+          const reqSpan = spans[0];
+
+          assert.strictEqual(result.data, httpErrorCodes[i].toString());
+          assert.strictEqual(spans.length, 1);
+
+          const validations = {
+            hostname,
+            httpStatusCode: result.statusCode!,
+            httpMethod: 'GET',
+            pathname: testPath,
+            resHeaders: result.resHeaders,
+            reqHeaders: result.reqHeaders,
+            component: plugin.component,
+          };
+
+          assertSpan(reqSpan, SpanKind.CLIENT, validations);
+        });
+      }
+
+      it('should create a child span for GET requests', async () => {
+        const testPath = '/outgoing/rootSpan/childs/1';
+        doNock(hostname, testPath, 200, 'Ok');
         const name = 'TestRootSpan';
         const span = tracer.startSpan(name);
         return tracer.withSpan(span, async () => {
@@ -288,194 +340,302 @@ describe('HttpsPlugin', () => {
           );
         });
       });
-    }
 
-    it('should create multiple child spans for GET requests', async () => {
-      const testPath = '/outgoing/rootSpan/childs';
-      const num = 5;
-      doNock(hostname, testPath, 200, 'Ok', num);
-      const name = 'TestRootSpan';
-      const span = tracer.startSpan(name);
-      await tracer.withSpan(span, async () => {
-        for (let i = 0; i < num; i++) {
-          await httpsRequest.get(`${protocol}://${hostname}${testPath}`);
-          const spans = memoryExporter.getFinishedSpans();
-          assert.ok(spans[i].name.indexOf(testPath) >= 0);
-          assert.strictEqual(
-            span.context().traceId,
-            spans[i].spanContext.traceId
+      for (let i = 0; i < httpErrorCodes.length; i++) {
+        it(`should test child spans for GET requests with http error ${httpErrorCodes[i]}`, async () => {
+          const testPath = '/outgoing/rootSpan/childs/1';
+          doNock(
+            hostname,
+            testPath,
+            httpErrorCodes[i],
+            httpErrorCodes[i].toString()
           );
-        }
-        span.end();
-        const spans = memoryExporter.getFinishedSpans();
-        // 5 child spans ended + 1 span (root)
-        assert.strictEqual(spans.length, 6);
-      });
-    });
+          const name = 'TestRootSpan';
+          const span = tracer.startSpan(name);
+          return tracer.withSpan(span, async () => {
+            const result = await httpsRequest.get(
+              `${protocol}://${hostname}${testPath}`
+            );
+            span.end();
+            const spans = memoryExporter.getFinishedSpans();
+            const [reqSpan, localSpan] = spans;
+            const validations = {
+              hostname,
+              httpStatusCode: result.statusCode!,
+              httpMethod: 'GET',
+              pathname: testPath,
+              resHeaders: result.resHeaders,
+              reqHeaders: result.reqHeaders,
+              component: plugin.component,
+            };
 
-    for (const ignored of ['string', 'function', 'regexp']) {
-      it(`should not trace ignored requests (client and server side) with type ${ignored}`, async () => {
-        const testPath = `/ignored/${ignored}`;
-
-        await httpsRequest.get(
-          `${protocol}://${hostname}:${serverPort}${testPath}`
-        );
-        const spans = memoryExporter.getFinishedSpans();
-        assert.strictEqual(spans.length, 0);
-      });
-    }
-
-    for (const arg of ['string', '', {}, new Date()]) {
-      it(`should be tracable and not throw exception in https plugin when passing the following argument ${JSON.stringify(
-        arg
-      )}`, async () => {
-        try {
-          await httpsRequest.get(arg);
-        } catch (error) {
-          // https request has been made
-          // nock throw
-          assert.ok(error.message.startsWith('Nock: No match for request'));
-        }
-        const spans = memoryExporter.getFinishedSpans();
-        assert.strictEqual(spans.length, 1);
-      });
-    }
-
-    for (const arg of [true, 1, false, 0]) {
-      it(`should not throw exception in https plugin when passing the following argument ${JSON.stringify(
-        arg
-      )}`, async () => {
-        try {
-          // @ts-ignore
-          await httpsRequest.get(arg);
-        } catch (error) {
-          // https request has been made
-          // nock throw
-          assert.ok(
-            error.stack.indexOf('/node_modules/nock/lib/intercept.js') > 0
-          );
-        }
-        const spans = memoryExporter.getFinishedSpans();
-        // for this arg with don't provide trace. We pass arg to original method (https.get)
-        assert.strictEqual(spans.length, 0);
-      });
-    }
-
-    it('should have 1 ended span when request throw on bad "options" object', () => {
-      nock.cleanAll();
-      nock.enableNetConnect();
-      try {
-        https.request({ protocol: 'telnet' });
-        assert.fail();
-      } catch (error) {
-        const spans = memoryExporter.getFinishedSpans();
-        assert.strictEqual(spans.length, 1);
-      }
-    });
-
-    it('should have 1 ended span when response.end throw an exception', async () => {
-      const testPath = '/outgoing/rootSpan/childs/1';
-      doNock(hostname, testPath, 400, 'Not Ok');
-
-      const promiseRequest = new Promise((resolve, reject) => {
-        const req = https.request(
-          `${protocol}://${hostname}${testPath}`,
-          (resp: http.IncomingMessage) => {
-            let data = '';
-            resp.on('data', chunk => {
-              data += chunk;
-            });
-            resp.on('end', () => {
-              reject(new Error(data));
-            });
-          }
-        );
-        return req.end();
-      });
-
-      try {
-        await promiseRequest;
-        assert.fail();
-      } catch (error) {
-        const spans = memoryExporter.getFinishedSpans();
-        assert.strictEqual(spans.length, 1);
-      }
-    });
-
-    it('should have 1 ended span when request is aborted', async () => {
-      nock(`${protocol}://my.server.com`)
-        .get('/')
-        .socketDelay(50)
-        .reply(200, '<html></html>');
-
-      const promiseRequest = new Promise((resolve, reject) => {
-        const req = https.request(
-          `${protocol}://my.server.com`,
-          (resp: http.IncomingMessage) => {
-            let data = '';
-            resp.on('data', chunk => {
-              data += chunk;
-            });
-            resp.on('end', () => {
-              resolve(data);
-            });
-          }
-        );
-        req.setTimeout(10, () => {
-          req.abort();
-          reject('timeout');
+            assert.ok(localSpan.name.indexOf('TestRootSpan') >= 0);
+            assert.strictEqual(spans.length, 2);
+            assert.ok(reqSpan.name.indexOf(testPath) >= 0);
+            assert.strictEqual(
+              localSpan.spanContext.traceId,
+              reqSpan.spanContext.traceId
+            );
+            assertSpan(reqSpan, SpanKind.CLIENT, validations);
+            assert.notStrictEqual(
+              localSpan.spanContext.spanId,
+              reqSpan.spanContext.spanId
+            );
+          });
         });
-        return req.end();
-      });
-
-      try {
-        await promiseRequest;
-        assert.fail();
-      } catch (error) {
-        const spans = memoryExporter.getFinishedSpans();
-        const [span] = spans;
-        assert.strictEqual(spans.length, 1);
-        assert.strictEqual(span.status.code, CanonicalCode.ABORTED);
-        assert.ok(Object.keys(span.attributes).length > 6);
       }
-    });
 
-    it('should have 1 ended span when request is aborted after receiving response', async () => {
-      nock(`${protocol}://my.server.com`)
-        .get('/')
-        .delay({
-          body: 50,
-        })
-        .replyWithFile(200, `${process.cwd()}/package.json`);
-
-      const promiseRequest = new Promise((resolve, reject) => {
-        const req = https.request(
-          `${protocol}://my.server.com`,
-          (resp: http.IncomingMessage) => {
-            let data = '';
-            resp.on('data', chunk => {
-              req.abort();
-              data += chunk;
-            });
-            resp.on('end', () => {
-              resolve(data);
-            });
+      it('should create multiple child spans for GET requests', async () => {
+        const testPath = '/outgoing/rootSpan/childs';
+        const num = 5;
+        doNock(hostname, testPath, 200, 'Ok', num);
+        const name = 'TestRootSpan';
+        const span = tracer.startSpan(name);
+        await tracer.withSpan(span, async () => {
+          for (let i = 0; i < num; i++) {
+            await httpsRequest.get(`${protocol}://${hostname}${testPath}`);
+            const spans = memoryExporter.getFinishedSpans();
+            assert.ok(spans[i].name.indexOf(testPath) >= 0);
+            assert.strictEqual(
+              span.context().traceId,
+              spans[i].spanContext.traceId
+            );
           }
-        );
-
-        return req.end();
+          span.end();
+          const spans = memoryExporter.getFinishedSpans();
+          // 5 child spans ended + 1 span (root)
+          assert.strictEqual(spans.length, 6);
+        });
       });
 
-      try {
-        await promiseRequest;
-        assert.fail();
-      } catch (error) {
-        const spans = memoryExporter.getFinishedSpans();
-        const [span] = spans;
-        assert.strictEqual(spans.length, 1);
-        assert.strictEqual(span.status.code, CanonicalCode.ABORTED);
-        assert.ok(Object.keys(span.attributes).length > 7);
+      for (const ignored of ['string', 'function', 'regexp']) {
+        it(`should not trace ignored requests (client and server side) with type ${ignored}`, async () => {
+          const testPath = `/ignored/${ignored}`;
+
+          await httpsRequest.get(
+            `${protocol}://${hostname}:${serverPort}${testPath}`
+          );
+          const spans = memoryExporter.getFinishedSpans();
+          assert.strictEqual(spans.length, 0);
+        });
       }
+
+      for (const arg of ['string', {}, new Date()]) {
+        it(`should be tracable and not throw exception in ${protocol} plugin when passing the following argument ${JSON.stringify(
+          arg
+        )}`, async () => {
+          try {
+            await httpsRequest.get(arg);
+          } catch (error) {
+            // request has been made
+            // nock throw
+            assert.ok(error.message.startsWith('Nock: No match for request'));
+          }
+          const spans = memoryExporter.getFinishedSpans();
+          assert.strictEqual(spans.length, 1);
+        });
+      }
+
+      for (const arg of [true, 1, false, 0, '']) {
+        it(`should not throw exception in https plugin when passing the following argument ${JSON.stringify(
+          arg
+        )}`, async () => {
+          try {
+            // @ts-ignore
+            await httpsRequest.get(arg);
+          } catch (error) {
+            // request has been made
+            // nock throw
+            assert.ok(
+              error.stack.indexOf(
+                path.normalize('/node_modules/nock/lib/intercept.js')
+              ) > 0
+            );
+          }
+          const spans = memoryExporter.getFinishedSpans();
+          // for this arg with don't provide trace. We pass arg to original method (https.get)
+          assert.strictEqual(spans.length, 0);
+        });
+      }
+
+      it('should have 1 ended span when request throw on bad "options" object', () => {
+        try {
+          https.request({ protocol: 'telnet' });
+        } catch (error) {
+          const spans = memoryExporter.getFinishedSpans();
+          assert.strictEqual(spans.length, 1);
+        }
+      });
+
+      it('should have 1 ended span when response.end throw an exception', async () => {
+        const testPath = '/outgoing/rootSpan/childs/1';
+        doNock(hostname, testPath, 400, 'Not Ok');
+
+        const promiseRequest = new Promise((resolve, reject) => {
+          const req = https.request(
+            `${protocol}://${hostname}${testPath}`,
+            (resp: http.IncomingMessage) => {
+              let data = '';
+              resp.on('data', chunk => {
+                data += chunk;
+              });
+              resp.on('end', () => {
+                reject(new Error(data));
+              });
+            }
+          );
+          return req.end();
+        });
+
+        try {
+          await promiseRequest;
+          assert.fail();
+        } catch (error) {
+          const spans = memoryExporter.getFinishedSpans();
+          assert.strictEqual(spans.length, 1);
+        }
+      });
+
+      it('should have 1 ended span when request throw on bad "options" object', () => {
+        nock.cleanAll();
+        nock.enableNetConnect();
+        try {
+          https.request({ protocol: 'telnet' });
+          assert.fail();
+        } catch (error) {
+          const spans = memoryExporter.getFinishedSpans();
+          assert.strictEqual(spans.length, 1);
+        }
+      });
+
+      it('should have 1 ended span when response.end throw an exception', async () => {
+        const testPath = '/outgoing/rootSpan/childs/1';
+        doNock(hostname, testPath, 400, 'Not Ok');
+
+        const promiseRequest = new Promise((resolve, reject) => {
+          const req = https.request(
+            `${protocol}://${hostname}${testPath}`,
+            (resp: http.IncomingMessage) => {
+              let data = '';
+              resp.on('data', chunk => {
+                data += chunk;
+              });
+              resp.on('end', () => {
+                reject(new Error(data));
+              });
+            }
+          );
+          return req.end();
+        });
+
+        try {
+          await promiseRequest;
+          assert.fail();
+        } catch (error) {
+          const spans = memoryExporter.getFinishedSpans();
+          assert.strictEqual(spans.length, 1);
+        }
+      });
+
+      it('should have 1 ended span when request is aborted', async () => {
+        nock(`${protocol}://my.server.com`)
+          .get('/')
+          .socketDelay(50)
+          .reply(200, '<html></html>');
+
+        const promiseRequest = new Promise((resolve, reject) => {
+          const req = https.request(
+            `${protocol}://my.server.com`,
+            (resp: http.IncomingMessage) => {
+              let data = '';
+              resp.on('data', chunk => {
+                data += chunk;
+              });
+              resp.on('end', () => {
+                resolve(data);
+              });
+            }
+          );
+          req.setTimeout(10, () => {
+            req.abort();
+            reject('timeout');
+          });
+          return req.end();
+        });
+
+        try {
+          await promiseRequest;
+          assert.fail();
+        } catch (error) {
+          const spans = memoryExporter.getFinishedSpans();
+          const [span] = spans;
+          assert.strictEqual(spans.length, 1);
+          assert.strictEqual(span.status.code, CanonicalCode.ABORTED);
+          assert.ok(Object.keys(span.attributes).length > 6);
+        }
+      });
+
+      it('should have 1 ended span when request is aborted after receiving response', async () => {
+        nock(`${protocol}://my.server.com`)
+          .get('/')
+          .delay({
+            body: 50,
+          })
+          .replyWithFile(200, `${process.cwd()}/package.json`);
+
+        const promiseRequest = new Promise((resolve, reject) => {
+          const req = https.request(
+            `${protocol}://my.server.com`,
+            (resp: http.IncomingMessage) => {
+              let data = '';
+              resp.on('data', chunk => {
+                req.abort();
+                data += chunk;
+              });
+              resp.on('end', () => {
+                resolve(data);
+              });
+            }
+          );
+
+          return req.end();
+        });
+
+        try {
+          await promiseRequest;
+          assert.fail();
+        } catch (error) {
+          const spans = memoryExporter.getFinishedSpans();
+          const [span] = spans;
+          assert.strictEqual(spans.length, 1);
+          assert.strictEqual(span.status.code, CanonicalCode.ABORTED);
+          assert.ok(Object.keys(span.attributes).length > 7);
+        }
+      });
+
+      it("should have 1 ended span when response is listened by using req.on('response')", done => {
+        const host = `${protocol}://${hostname}`;
+        nock(host)
+          .get('/')
+          .reply(404);
+        const req = https.request(`${host}/`);
+        req.on('response', response => {
+          response.on('data', () => {});
+          response.on('end', () => {
+            const spans = memoryExporter.getFinishedSpans();
+            const [span] = spans;
+            assert.strictEqual(spans.length, 1);
+            assert.ok(Object.keys(span.attributes).length > 6);
+            assert.strictEqual(
+              span.attributes[AttributeNames.HTTP_STATUS_CODE],
+              404
+            );
+            assert.strictEqual(span.status.code, CanonicalCode.NOT_FOUND);
+            done();
+          });
+        });
+        req.end();
+      });
     });
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

fixes https://github.com/open-telemetry/opentelemetry-js/issues/590

## Short description of the changes

Sync http and https tests.

I have omitted `should have 1 ended span when request doesn't listening response` as it fails for https. Not sure here but I think it passes for http only because there is some service running on port 80 on CI servers.
