### PR TITLE
fix(plugin-dns): remove from default plugin list

### DIFF
--- a/packages/opentelemetry-node/src/config.ts
+++ b/packages/opentelemetry-node/src/config.ts
@@ -28,7 +28,6 @@ export interface NodeTracerConfig extends BasicTracerConfig {
 /** List of all default supported plugins */
 export const DEFAULT_INSTRUMENTATION_PLUGINS: Plugins = {
   'mongodb-core': { enabled: true, path: '@opentelemetry/plugin-mongodb-core' },
-  dns: { enabled: true, path: '@opentelemetry/plugin-dns' },
   grpc: { enabled: true, path: '@opentelemetry/plugin-grpc' },
   http: { enabled: true, path: '@opentelemetry/plugin-http' },
   https: { enabled: true, path: '@opentelemetry/plugin-https' },

--- a/packages/opentelemetry-plugin-dns/README.md
+++ b/packages/opentelemetry-plugin-dns/README.md
@@ -32,6 +32,23 @@ const tracer = new NodeTracer({
 });
 ```
 
+### Zipkin
+
+If you use Zipkin, you must use `ignoreHostnames` in order to not trace those calls. If the server is local. You can set :
+
+```
+const tracer = new NodeTracer({
+  plugins: {
+    dns: {
+      enabled: true,
+      // You may use a package name or absolute path to the file.
+      path: '@opentelemetry/plugin-dns',
+      ignoreHostnames: ['localhost']
+    }
+  }
+});
+```
+
 ### Dns Plugin Options
 
 Dns plugin has currently one option. You can set the following:


### PR DESCRIPTION
## Which problem is this PR solving?
- closes #612

## Short description of the changes

- remove dns plugin from the default list
- add doc for Zipkin until with find a solution that let's us ignore http call without specifying in plugin option

