### PR TITLE
feat: add status label

### DIFF
--- a/getting-started/monitored-example/monitoring.js
+++ b/getting-started/monitored-example/monitoring.js
@@ -18,7 +18,7 @@ meter.addExporter(
 
 const requestCount = meter.createCounter("requests", {
   monotonic: true,
-  labelKeys: ["route"],
+  labelKeys: ["route", "status"],
   description: "Count all incoming requests"
 });
 
@@ -27,7 +27,7 @@ const handles = new Map();
 module.exports.countAllRequests = () => {
   return (req, res, next) => {
     if (!handles.has(req.path)) {
-      const labelSet = meter.labels({ route: req.path });
+      const labelSet = meter.labels({ route: req.path, status: res.statusCode });
       const handle = requestCount.getHandle(labelSet);
       handles.set(req.path, handle);
     }


### PR DESCRIPTION
## Which problem is this PR solving?

To help users getting started to have a status label for requests when using metrics. This is a very useful label to have when counting requests as to calculate error ratios.

ref.: https://landing.google.com/sre/workbook/chapters/alerting-on-slos/

## Short description of the changes

- Added a `status` label that comes from `res.statusCode` to all counted requests
