### PR TITLE
fix(grpc): patch original client methods

### DIFF
--- a/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
+++ b/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
@@ -45,6 +45,8 @@ type TestGrpcClient = grpc.Client & {
   // tslint:disable-next-line:no-any
   unaryMethod: any;
   // tslint:disable-next-line:no-any
+  UnaryMethod: any;
+  // tslint:disable-next-line:no-any
   clientStreamMethod: any;
   // tslint:disable-next-line:no-any
   serverStreamMethod: any;
@@ -81,6 +83,24 @@ const grpcClient = {
   ): Promise<TestRequestResponse> => {
     return new Promise((resolve, reject) => {
       return client.unaryMethod(
+        request,
+        (err: grpc.ServiceError, response: TestRequestResponse) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(response);
+          }
+        }
+      );
+    });
+  },
+
+  UnaryMethod: (
+    client: TestGrpcClient,
+    request: TestRequestResponse
+  ): Promise<TestRequestResponse> => {
+    return new Promise((resolve, reject) => {
+      return client.UnaryMethod(
         request,
         (err: grpc.ServiceError, response: TestRequestResponse) => {
           if (err) {
@@ -315,6 +335,13 @@ describe('GrpcPlugin', () => {
       description: 'unary call',
       methodName: 'UnaryMethod',
       method: grpcClient.unaryMethod,
+      request: requestList[0],
+      result: requestList[0],
+    },
+    {
+      description: 'Unary call',
+      methodName: 'UnaryMethod',
+      method: grpcClient.UnaryMethod,
       request: requestList[0],
       result: requestList[0],
     },


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes #630 and #384 
- Related to https://github.com/open-telemetry/opentelemetry-js/pull/400

## Short description of the changes

- The [client constructor in the grpc module](https://github.com/grpc/grpc-node/blob/9d36d8d5c76adbd6f4159e64e41eab2a9f16b6da/packages/grpc-js/src/make-client.ts#L140-L143) creates a method alias using the **originalName** (if present). We didn't patch/trace these methods before, so this PR resolves this problem.

- Original issue https://github.com/grpc/grpc/issues/12135

- I have verified the solution with [grpc example with dynamic codegen](https://github.com/open-telemetry/opentelemetry-js/tree/master/examples/grpc_dynamic_codegen) and been confirmed to be working.

/cc @markwolff 