### PR TITLE
chore(plugin-pg): move dev dependencies out of `dependencies` in package.json

### DIFF
--- a/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg/package.json
+++ b/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg/package.json
@@ -44,6 +44,8 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/node": "^0.3.1",
+    "@opentelemetry/tracing": "^0.3.1",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.6.9",
     "@types/pg": "^7.11.2",
@@ -62,8 +64,6 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^0.3.1",
-    "@opentelemetry/node": "^0.3.1",
-    "@opentelemetry/tracing": "^0.3.1",
     "@opentelemetry/types": "^0.3.1",
     "shimmer": "^1.2.1"
   }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Some of the `package.json` dependencies from plugin-pg module are not necessary for running this module (only for development).

/cc @markwolff 
