### PR TITLE
Prevent loading plugins for incorrect module #626

### DIFF
--- a/packages/opentelemetry-api/src/trace/instrumentation/Plugin.ts
+++ b/packages/opentelemetry-api/src/trace/instrumentation/Plugin.ts
@@ -29,6 +29,11 @@ export interface Plugin<T = any> {
   supportedVersions?: string[];
 
   /**
+   * Name of the module that the plugin instrument.
+   */
+  moduleName: string;
+
+  /**
    * Method that enables the instrumentation patch.
    * @param moduleExports The value of the `module.exports` property that would
    *     normally be exposed by the required module. ex: `http`, `https` etc.

--- a/packages/opentelemetry-core/src/trace/instrumentation/BasePlugin.ts
+++ b/packages/opentelemetry-core/src/trace/instrumentation/BasePlugin.ts
@@ -29,7 +29,7 @@ import * as path from 'path';
 /** This class represent the base to patch plugin. */
 export abstract class BasePlugin<T> implements Plugin<T> {
   supportedVersions?: string[];
-  readonly moduleName?: string; // required for internalFilesExports
+  abstract readonly moduleName: string; // required for internalFilesExports
   readonly version?: string; // required for internalFilesExports
   protected readonly _basedir?: string; // required for internalFilesExports
 

--- a/packages/opentelemetry-node/src/instrumentation/PluginLoader.ts
+++ b/packages/opentelemetry-node/src/instrumentation/PluginLoader.ts
@@ -132,8 +132,16 @@ export class PluginLoader {
         // Expecting a plugin from module;
         try {
           const plugin: Plugin = require(modulePath).plugin;
-
           if (!utils.isSupportedVersion(version, plugin.supportedVersions)) {
+            this.logger.error(
+              `PluginLoader#load: Plugin ${name} only support module ${plugin.moduleName} with the versions: ${plugin.supportedVersions}`
+            );
+            return exports;
+          }
+          if (plugin.moduleName !== name) {
+            this.logger.error(
+              `PluginLoader#load: Entry ${name} use a plugin that instrument ${plugin.moduleName}`
+            );
             return exports;
           }
 

--- a/packages/opentelemetry-node/src/instrumentation/PluginLoader.ts
+++ b/packages/opentelemetry-node/src/instrumentation/PluginLoader.ts
@@ -134,13 +134,13 @@ export class PluginLoader {
           const plugin: Plugin = require(modulePath).plugin;
           if (!utils.isSupportedVersion(version, plugin.supportedVersions)) {
             this.logger.error(
-              `PluginLoader#load: Plugin ${name} only support module ${plugin.moduleName} with the versions: ${plugin.supportedVersions}`
+              `PluginLoader#load: Plugin ${name} only supports module ${plugin.moduleName} with the versions: ${plugin.supportedVersions}`
             );
             return exports;
           }
           if (plugin.moduleName !== name) {
             this.logger.error(
-              `PluginLoader#load: Entry ${name} use a plugin that instrument ${plugin.moduleName}`
+              `PluginLoader#load: Entry ${name} use a plugin that instruments ${plugin.moduleName}`
             );
             return exports;
           }

--- a/packages/opentelemetry-node/test/instrumentation/PluginLoader.test.ts
+++ b/packages/opentelemetry-node/test/instrumentation/PluginLoader.test.ts
@@ -93,6 +93,13 @@ const alreadyRequiredPlugins: Plugins = {
   },
 };
 
+const differentNamePlugins: Plugins = {
+  'random-module': {
+    enabled: true,
+    path: '@opentelemetry/plugin-http-module',
+  },
+};
+
 describe('PluginLoader', () => {
   const provider = new NoopTracerProvider();
   const logger = new NoopLogger();
@@ -241,6 +248,16 @@ describe('PluginLoader', () => {
       require('already-require-module');
       const pluginLoader = new PluginLoader(provider, verifyWarnLogger);
       pluginLoader.load(alreadyRequiredPlugins);
+      pluginLoader.unload();
+    });
+
+    it('should not load a plugin that patch a different module that the one configured', () => {
+      const pluginLoader = new PluginLoader(provider, logger);
+      assert.strictEqual(pluginLoader['_plugins'].length, 0);
+      pluginLoader.load(differentNamePlugins);
+      // @ts-ignore only to trigger the loading of the plugin
+      const randomModule = require('random-module');
+      assert.strictEqual(pluginLoader['_plugins'].length, 0);
       pluginLoader.unload();
     });
   });

--- a/packages/opentelemetry-node/test/instrumentation/PluginLoader.test.ts
+++ b/packages/opentelemetry-node/test/instrumentation/PluginLoader.test.ts
@@ -251,7 +251,7 @@ describe('PluginLoader', () => {
       pluginLoader.unload();
     });
 
-    it('should not load a plugin that patch a different module that the one configured', () => {
+    it('should not load a plugin that patches a different module that the one configured', () => {
       const pluginLoader = new PluginLoader(provider, logger);
       assert.strictEqual(pluginLoader['_plugins'].length, 0);
       pluginLoader.load(differentNamePlugins);

--- a/packages/opentelemetry-node/test/instrumentation/node_modules/@opentelemetry/plugin-http-module/http-module.js
+++ b/packages/opentelemetry-node/test/instrumentation/node_modules/@opentelemetry/plugin-http-module/http-module.js
@@ -5,6 +5,7 @@ const shimmer = require("shimmer");
 class HttpModulePlugin extends core_1.BasePlugin {
     constructor() {
         super();
+        this.moduleName = 'http';
     }
 
     patch() {

--- a/packages/opentelemetry-node/test/instrumentation/node_modules/@opentelemetry/plugin-notsupported-module/simple-module.js
+++ b/packages/opentelemetry-node/test/instrumentation/node_modules/@opentelemetry/plugin-notsupported-module/simple-module.js
@@ -5,6 +5,7 @@ const shimmer = require("shimmer");
 class SimpleModulePlugin extends core_1.BasePlugin {
     constructor() {
         super();
+        this.moduleName = 'notsupported-module';
     }
 
     patch() {

--- a/packages/opentelemetry-node/test/instrumentation/node_modules/@opentelemetry/plugin-simple-module/simple-module.js
+++ b/packages/opentelemetry-node/test/instrumentation/node_modules/@opentelemetry/plugin-simple-module/simple-module.js
@@ -5,6 +5,7 @@ const shimmer = require("shimmer");
 class SimpleModulePlugin extends core_1.BasePlugin {
     constructor() {
         super();
+        this.moduleName = 'simple-module';
     }
 
     patch() {

--- a/packages/opentelemetry-node/test/instrumentation/node_modules/@opentelemetry/plugin-supported-module/simple-module.js
+++ b/packages/opentelemetry-node/test/instrumentation/node_modules/@opentelemetry/plugin-supported-module/simple-module.js
@@ -5,6 +5,7 @@ const shimmer = require("shimmer");
 class SimpleModulePlugin extends core_1.BasePlugin {
     constructor() {
         super();
+        this.moduleName = 'supported-module';
     }
 
     patch() {

--- a/packages/opentelemetry-node/test/instrumentation/node_modules/random-module/index.js
+++ b/packages/opentelemetry-node/test/instrumentation/node_modules/random-module/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+    name: () => 'random-module',
+    value: () => 0,
+};

--- a/packages/opentelemetry-node/test/instrumentation/node_modules/random-module/package.json
+++ b/packages/opentelemetry-node/test/instrumentation/node_modules/random-module/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "random-module",
+  "version": "0.1.0"
+}

--- a/packages/opentelemetry-web/test/WebTracer.test.ts
+++ b/packages/opentelemetry-web/test/WebTracer.test.ts
@@ -27,6 +27,8 @@ class DummyPlugin extends BasePlugin<unknown> {
   constructor() {
     super('dummy');
   }
+  moduleName = 'dummy';
+
   patch() {}
   unpatch() {}
 }


### PR DESCRIPTION
we needed to avoid loading a plugin if the module name in the config was different than the one that the plugin instrument. 
It requires that every package expose `moduleName` as the name of the module they instrument so i changes the `BasePlugin` interface and `Plugin` type.