### PR TITLE
chore: skip david-dm.org url from docs-test

### DIFF
--- a/packages/opentelemetry-types/package.json
+++ b/packages/opentelemetry-types/package.json
@@ -12,7 +12,7 @@
     "version:update": "node ../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",
     "fix": "gts fix",
-    "docs-test": "linkinator docs/out",
+    "docs-test": "linkinator docs/out --skip david-dm.org",
     "docs": "typedoc --tsconfig tsconfig.json",
     "prepare": "npm run compile"
   },

--- a/packages/opentelemetry-types/package.json
+++ b/packages/opentelemetry-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/types",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "TypeScript types for OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-types/package.json
+++ b/packages/opentelemetry-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/types",
-  "version": "0.3.2",
+  "version": "0.3.1",
   "description": "TypeScript types for OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- https://david-dm.org/ services (both website and badges) are generally fine, but it occasionally suffers. It causes our CircleCI builds to fail, this PR will skip checking the david urls from docs-test job.
