### PR TITLE
chore: upgrade ts-node version to ^8.6.2

### DIFF
--- a/packages/opentelemetry-base/package.json
+++ b/packages/opentelemetry-base/package.json
@@ -50,7 +50,7 @@
     "nyc": "^14.1.1",
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.0.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -71,7 +71,7 @@
     "sinon": "^7.5.0",
     "ts-loader": "^6.0.4",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.0.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2",

--- a/packages/opentelemetry-exporter-collector/package.json
+++ b/packages/opentelemetry-exporter-collector/package.json
@@ -70,7 +70,7 @@
     "sinon": "^7.5.0",
     "ts-loader": "^6.0.4",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.0.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.6.4",

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -47,7 +47,7 @@
     "nyc": "^14.1.1",
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.3.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-exporter-prometheus/package.json
+++ b/packages/opentelemetry-exporter-prometheus/package.json
@@ -47,7 +47,7 @@
     "nyc": "^14.1.1",
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.3.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -49,7 +49,7 @@
     "nyc": "^14.1.1",
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.3.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-metrics/package.json
+++ b/packages/opentelemetry-metrics/package.json
@@ -50,7 +50,7 @@
     "rimraf": "^3.0.0",
     "sinon": "^7.5.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.3.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -52,7 +52,7 @@
     "rimraf": "^3.0.0",
     "shimmer": "^1.2.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.0.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-plugin-dns/package.json
+++ b/packages/opentelemetry-plugin-dns/package.json
@@ -54,7 +54,7 @@
     "rimraf": "^3.0.0",
     "sinon": "^7.5.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.4.1",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-plugin-document-load/package.json
+++ b/packages/opentelemetry-plugin-document-load/package.json
@@ -63,7 +63,7 @@
     "sinon": "^7.5.0",
     "ts-loader": "^6.0.4",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.0.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2",

--- a/packages/opentelemetry-plugin-grpc/package.json
+++ b/packages/opentelemetry-plugin-grpc/package.json
@@ -57,7 +57,7 @@
     "rimraf": "^3.0.0",
     "sinon": "^7.5.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.3.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-plugin-http/package.json
+++ b/packages/opentelemetry-plugin-http/package.json
@@ -66,7 +66,7 @@
     "sinon": "^7.5.0",
     "superagent": "5.1.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.4.1",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-plugin-https/package.json
+++ b/packages/opentelemetry-plugin-https/package.json
@@ -66,7 +66,7 @@
     "sinon": "^7.5.0",
     "superagent": "5.1.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.4.1",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-plugin-mongodb/package.json
+++ b/packages/opentelemetry-plugin-mongodb/package.json
@@ -54,7 +54,7 @@
     "nyc": "^14.1.1",
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.3.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-plugin-mysql/package.json
+++ b/packages/opentelemetry-plugin-mysql/package.json
@@ -55,7 +55,7 @@
     "nyc": "^14.1.1",
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.3.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg-pool/package.json
+++ b/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg-pool/package.json
@@ -61,7 +61,7 @@
     "pg-pool": "^2.0.7",
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.3.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg/package.json
+++ b/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg/package.json
@@ -59,7 +59,7 @@
     "pg": "^7.12.1",
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.3.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-plugin-redis/package.json
+++ b/packages/opentelemetry-plugin-redis/package.json
@@ -58,7 +58,7 @@
     "redis": "^2.8.0",
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.3.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-plugin-xml-http-request/package.json
+++ b/packages/opentelemetry-plugin-xml-http-request/package.json
@@ -67,7 +67,7 @@
     "sinon": "^7.5.0",
     "ts-loader": "^6.0.4",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.0.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.6.4",

--- a/packages/opentelemetry-scope-async-hooks/package.json
+++ b/packages/opentelemetry-scope-async-hooks/package.json
@@ -50,7 +50,7 @@
     "nyc": "^14.1.1",
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.0.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-scope-base/package.json
+++ b/packages/opentelemetry-scope-base/package.json
@@ -50,7 +50,7 @@
     "nyc": "^14.1.1",
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.0.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-scope-zone-peer-dep/package.json
+++ b/packages/opentelemetry-scope-zone-peer-dep/package.json
@@ -63,7 +63,7 @@
     "sinon": "^7.5.0",
     "ts-loader": "^6.0.4",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.0.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "^3.6.3",

--- a/packages/opentelemetry-scope-zone/package.json
+++ b/packages/opentelemetry-scope-zone/package.json
@@ -57,7 +57,7 @@
     "sinon": "^7.5.0",
     "ts-loader": "^6.0.4",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.0.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "^3.6.3",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -48,7 +48,7 @@
     "nyc": "^14.1.1",
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.3.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.15.1",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -26,7 +26,7 @@
     "@opentelemetry/tracing": "^0.3.2",
     "@opentelemetry/types": "^0.3.2",
     "gts": "^1.1.2",
-    "ts-node": "^8.5.4",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.4"

--- a/packages/opentelemetry-tracing/package.json
+++ b/packages/opentelemetry-tracing/package.json
@@ -66,7 +66,7 @@
     "sinon": "^7.5.0",
     "ts-loader": "^6.0.4",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.0.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2",

--- a/packages/opentelemetry-web/package.json
+++ b/packages/opentelemetry-web/package.json
@@ -64,7 +64,7 @@
     "sinon": "^7.5.0",
     "ts-loader": "^6.0.4",
     "ts-mocha": "^6.0.0",
-    "ts-node": "^8.0.0",
+    "ts-node": "^8.6.2",
     "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2",


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- `ts-node` old versions is no longer work on Node V8, because `yn` is enforcing Node V10 compatibility. Caused by: https://github.com/sindresorhus/yn/pull/266
