### PR TITLE
Enable configuration of disabled instrumentation libraries

### DIFF
--- a/examples/denylist/index.js
+++ b/examples/denylist/index.js
@@ -1,0 +1,54 @@
+const opentelemetry = require('@opentelemetry/core');
+const { BasicTracerRegistry } = require('@opentelemetry/tracing');
+
+// Initialize the OpenTelemetry APIs to use the BasicTracerRegistry bindings
+opentelemetry.initGlobalTracerRegistry(
+  new BasicTracerRegistry({
+    disabledLibraries: [
+      {
+        name: "disabled-library-by-version",
+        version: "^1.0.0" // disable any version in the 1.x.x tree
+      },
+      {
+        name: "disabled-library-by-version",
+        version: "2.0.0" // disable specifically version 2.0.0
+      },
+      {
+        name: 'disabled-library',
+        // version omitted means all versions are disabled
+      }
+    ]
+  })
+);
+
+// This is a working tracer
+const t1 = opentelemetry.getTracer('disabled-library-by-version', '2.0.1');
+
+// All of these are disabled
+
+// versions match disable list
+const t2 = opentelemetry.getTracer('disabled-library-by-version', '1.2.3');
+const t3 = opentelemetry.getTracer('disabled-library-by-version', '2.0.0');
+
+// disabled library by version, but version was not provided
+const t4 = opentelemetry.getTracer('disabled-library-by-version');
+
+// all versions of this library are disabled
+const t5 = opentelemetry.getTracer('disabled-library', '5');
+
+console.log('t1', t1.constructor.name)
+console.log('t2', t2.constructor.name)
+console.log('t3', t3.constructor.name)
+console.log('t4', t4.constructor.name)
+console.log('t5', t5.constructor.name)
+
+/*
+console output:
+
+t1 Tracer
+t2 NoopTracer
+t3 NoopTracer
+t4 NoopTracer
+t5 NoopTracer
+
+*/

--- a/examples/denylist/package.json
+++ b/examples/denylist/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "denylist-example",
+  "private": true,
+  "version": "0.3.2",
+  "description": "Example of disabling named tracers using a deny list",
+  "main": "index.js",
+  "author": "OpenTelemetry Authors",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js#readme",
+  "bugs": {
+    "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/open-telemetry/opentelemetry-js.git"
+  },
+  "keywords": [
+    "opentelemetry",
+    "grpc",
+    "tracing"
+  ],
+  "engines": {
+    "node": ">=8"
+  },
+  "dependencies": {
+    "@opentelemetry/core": "file:../../packages/opentelemetry-core",
+    "@opentelemetry/tracing": "file:../../packages/opentelemetry-tracing"
+  }
+}

--- a/packages/opentelemetry-exporter-zipkin/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/transform.test.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'assert';
 import * as types from '@opentelemetry/types';
-import { Span, BasicTracerRegistry } from '@opentelemetry/tracing';
+import { Span, BasicTracerRegistry, Tracer } from '@opentelemetry/tracing';
 import {
   NoopLogger,
   hrTimeToMicroseconds,
@@ -34,7 +34,7 @@ import * as zipkinTypes from '../src/types';
 const logger = new NoopLogger();
 const tracer = new BasicTracerRegistry({
   logger,
-}).getTracer('default');
+}).getTracer('default') as Tracer;
 const parentId = '5c1c63257de34c67';
 const spanContext: types.SpanContext = {
   traceId: 'd4cda95b652f4a1592b449d5929fda1b',

--- a/packages/opentelemetry-plugin-dns/test/functionals/dns-disable.test.ts
+++ b/packages/opentelemetry-plugin-dns/test/functionals/dns-disable.test.ts
@@ -14,21 +14,22 @@
  * limitations under the License.
  */
 
+import { NoopLogger } from '@opentelemetry/core';
+import { NodeTracerRegistry } from '@opentelemetry/node';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
+  Tracer,
 } from '@opentelemetry/tracing';
 import * as assert from 'assert';
-import { NoopLogger } from '@opentelemetry/core';
-import { NodeTracerRegistry } from '@opentelemetry/node';
-import { plugin } from '../../src/dns';
-import * as sinon from 'sinon';
 import * as dns from 'dns';
+import * as sinon from 'sinon';
+import { plugin } from '../../src/dns';
 
 const memoryExporter = new InMemorySpanExporter();
 const logger = new NoopLogger();
 const registry = new NodeTracerRegistry({ logger });
-const tracer = registry.getTracer('default');
+const tracer = registry.getTracer('default') as Tracer;
 registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
 describe('DnsPlugin', () => {

--- a/packages/opentelemetry-plugin-dns/test/functionals/utils.test.ts
+++ b/packages/opentelemetry-plugin-dns/test/functionals/utils.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { NoopLogger } from '@opentelemetry/core';
-import { BasicTracerRegistry, Span } from '@opentelemetry/tracing';
+import { BasicTracerRegistry, Span, Tracer } from '@opentelemetry/tracing';
 import { CanonicalCode, SpanKind } from '@opentelemetry/types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
@@ -162,7 +162,7 @@ describe('Utility', () => {
     it('should have error attributes', () => {
       const errorMessage = 'test error';
       const span = new Span(
-        new BasicTracerRegistry().getTracer('default'),
+        new BasicTracerRegistry().getTracer('default') as Tracer,
         'test',
         { spanId: '', traceId: '' },
         SpanKind.INTERNAL

--- a/packages/opentelemetry-plugin-http/test/functionals/utils.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/utils.test.ts
@@ -22,7 +22,7 @@ import { NoopScopeManager } from '@opentelemetry/scope-base';
 import { IgnoreMatcher } from '../../src/types';
 import * as utils from '../../src/utils';
 import * as http from 'http';
-import { Span, BasicTracerRegistry } from '@opentelemetry/tracing';
+import { Span, BasicTracerRegistry, Tracer } from '@opentelemetry/tracing';
 import { AttributeNames } from '../../src';
 import { NoopLogger } from '@opentelemetry/core';
 
@@ -250,7 +250,7 @@ describe('Utility', () => {
         const span = new Span(
           new BasicTracerRegistry({
             scopeManager: new NoopScopeManager(),
-          }).getTracer('default'),
+          }).getTracer('default') as Tracer,
           'test',
           { spanId: '', traceId: '' },
           SpanKind.INTERNAL

--- a/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
@@ -17,6 +17,7 @@
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
+  Tracer,
 } from '@opentelemetry/tracing';
 import { NoopLogger } from '@opentelemetry/core';
 import { NodeTracerRegistry } from '@opentelemetry/node';
@@ -54,7 +55,7 @@ const registry = new NodeTracerRegistry({
   logger,
   httpTextFormat,
 });
-const tracer = registry.getTracer('test-https');
+const tracer = registry.getTracer('test-https') as Tracer;
 registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
 function doNock(

--- a/packages/opentelemetry-tracing/package.json
+++ b/packages/opentelemetry-tracing/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.6.8",
+    "@types/semver": "^6.2.0",
     "@types/sinon": "^7.0.13",
     "@types/webpack-env": "1.13.9",
     "codecov": "^3.6.1",
@@ -76,6 +77,7 @@
     "@opentelemetry/base": "^0.3.2",
     "@opentelemetry/core": "^0.3.2",
     "@opentelemetry/scope-base": "^0.3.2",
-    "@opentelemetry/types": "^0.3.2"
+    "@opentelemetry/types": "^0.3.2",
+    "semver": "^7.1.1"
   }
 }

--- a/packages/opentelemetry-tracing/src/types.ts
+++ b/packages/opentelemetry-tracing/src/types.ts
@@ -23,6 +23,7 @@ import {
   Sampler,
 } from '@opentelemetry/types';
 import { LogLevel } from '@opentelemetry/core';
+import { Range } from 'semver';
 
 /**
  * TracerConfig provides an interface for configuring a Basic Tracer.
@@ -64,6 +65,24 @@ export interface TracerConfig {
 
   /** Trace Parameters */
   traceParams?: TraceParams;
+
+  /**
+   * A list of instrumentation library specifiers. A library which calls
+   * getTracer with a name and version which matches an entry in this list
+   * will receive a no-op tracer.
+   */
+  disabledLibraries?: InstrumentationLibrarySpecifier[];
+}
+
+export interface InstrumentationLibrarySpecifier {
+  /** The name of an instrumentation library */
+  name: string;
+  /**
+   * The version of an instrumentation library represented as a
+   * semver string. If version is omitted, it will be considered
+   * a match for all versions.
+   */
+  version?: string | Range;
 }
 
 /** Global configuration of trace service */

--- a/packages/opentelemetry-tracing/test/BasicTracerRegistry.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerRegistry.test.ts
@@ -26,7 +26,7 @@ import {
 import { NoopScopeManager, ScopeManager } from '@opentelemetry/scope-base';
 import { TraceFlags } from '@opentelemetry/types';
 import * as assert from 'assert';
-import { BasicTracerRegistry, Span } from '../src';
+import { BasicTracerRegistry, Span, Tracer } from '../src';
 
 describe('BasicTracerRegistry', () => {
   describe('constructor', () => {
@@ -69,7 +69,7 @@ describe('BasicTracerRegistry', () => {
     it('should construct an instance with default trace params', () => {
       const tracer = new BasicTracerRegistry({
         scopeManager: new NoopScopeManager(),
-      }).getTracer('default');
+      }).getTracer('default') as Tracer;
       assert.deepStrictEqual(tracer.getActiveTraceParams(), {
         numberOfAttributesPerSpan: 32,
         numberOfEventsPerSpan: 128,
@@ -83,7 +83,7 @@ describe('BasicTracerRegistry', () => {
         traceParams: {
           numberOfAttributesPerSpan: 100,
         },
-      }).getTracer('default');
+      }).getTracer('default') as Tracer;
       assert.deepStrictEqual(tracer.getActiveTraceParams(), {
         numberOfAttributesPerSpan: 100,
         numberOfEventsPerSpan: 128,
@@ -97,7 +97,7 @@ describe('BasicTracerRegistry', () => {
         traceParams: {
           numberOfEventsPerSpan: 300,
         },
-      }).getTracer('default');
+      }).getTracer('default') as Tracer;
       assert.deepStrictEqual(tracer.getActiveTraceParams(), {
         numberOfAttributesPerSpan: 32,
         numberOfEventsPerSpan: 300,
@@ -111,7 +111,7 @@ describe('BasicTracerRegistry', () => {
         traceParams: {
           numberOfLinksPerSpan: 10,
         },
-      }).getTracer('default');
+      }).getTracer('default') as Tracer;
       assert.deepStrictEqual(tracer.getActiveTraceParams(), {
         numberOfAttributesPerSpan: 32,
         numberOfEventsPerSpan: 128,

--- a/packages/opentelemetry-tracing/test/Span.test.ts
+++ b/packages/opentelemetry-tracing/test/Span.test.ts
@@ -14,28 +14,28 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
-import {
-  SpanKind,
-  CanonicalCode,
-  TraceFlags,
-  SpanContext,
-} from '@opentelemetry/types';
-import { BasicTracerRegistry, Span } from '../src';
 import {
   hrTime,
-  hrTimeToNanoseconds,
-  hrTimeToMilliseconds,
-  NoopLogger,
   hrTimeDuration,
+  hrTimeToMilliseconds,
+  hrTimeToNanoseconds,
+  NoopLogger,
 } from '@opentelemetry/core';
+import {
+  CanonicalCode,
+  SpanContext,
+  SpanKind,
+  TraceFlags,
+} from '@opentelemetry/types';
+import * as assert from 'assert';
+import { BasicTracerRegistry, Span, Tracer } from '../src';
 
 const performanceTimeOrigin = hrTime();
 
 describe('Span', () => {
   const tracer = new BasicTracerRegistry({
     logger: new NoopLogger(),
-  }).getTracer('default');
+  }).getTracer('default') as Tracer;
   const name = 'span1';
   const spanContext: SpanContext = {
     traceId: 'd4cda95b652f4a1592b449d5929fda1b',

--- a/packages/opentelemetry-tracing/test/export/SimpleSpanProcessor.test.ts
+++ b/packages/opentelemetry-tracing/test/export/SimpleSpanProcessor.test.ts
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
+import { SpanContext, SpanKind, TraceFlags } from '@opentelemetry/types';
 import * as assert from 'assert';
 import {
-  Span,
   BasicTracerRegistry,
   InMemorySpanExporter,
   SimpleSpanProcessor,
+  Span,
+  Tracer,
 } from '../../src';
-import { SpanContext, SpanKind, TraceFlags } from '@opentelemetry/types';
 
 describe('SimpleSpanProcessor', () => {
   const registry = new BasicTracerRegistry();
@@ -43,7 +44,7 @@ describe('SimpleSpanProcessor', () => {
         traceFlags: TraceFlags.SAMPLED,
       };
       const span = new Span(
-        registry.getTracer('default'),
+        registry.getTracer('default') as Tracer,
         'span-name',
         spanContext,
         SpanKind.CLIENT
@@ -66,7 +67,7 @@ describe('SimpleSpanProcessor', () => {
         traceFlags: TraceFlags.UNSAMPLED,
       };
       const span = new Span(
-        registry.getTracer('default'),
+        registry.getTracer('default') as Tracer,
         'span-name',
         spanContext,
         SpanKind.CLIENT


### PR DESCRIPTION
This implements denylist functionality where an operator of OpenTelemetry JS can disable instrumentation by providing a list of library names/versions to be disabled.