### PR TITLE
chore: rename registry to provider

### DIFF
--- a/benchmark/tracer.js
+++ b/benchmark/tracer.js
@@ -2,26 +2,26 @@
 
 const benchmark = require('./benchmark');
 const opentelemetry = require('@opentelemetry/core');
-const { BasicTracerRegistry, BatchSpanProcessor, InMemorySpanExporter, SimpleSpanProcessor } = require('@opentelemetry/tracing');
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { BasicTracerProvider, BatchSpanProcessor, InMemorySpanExporter, SimpleSpanProcessor } = require('@opentelemetry/tracing');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
 const exporter = new InMemorySpanExporter();
 const logger = new opentelemetry.NoopLogger();
 
 const setups = [
   {
-    name: 'BasicTracerRegistry',
-    registry: new BasicTracerRegistry({ logger })
+    name: 'BasicTracerProvider',
+    provider: new BasicTracerProvider({ logger })
   },
   {
-    name: 'NodeTracerRegistry',
-    registry: new NodeTracerRegistry({ logger })
+    name: 'NodeTracerProvider',
+    provider: new NodeTracerProvider({ logger })
   }
 ];
 
 for (const setup of setups) {
   console.log(`Beginning ${setup.name} Benchmark...`);
-  const tracer = setup.registry.getTracer("benchmark");
+  const tracer = setup.provider.getTracer("benchmark");
   const suite = benchmark()
     .add('#startSpan', function () {
       const span = tracer.startSpan('op');
@@ -55,7 +55,7 @@ for (const setup of setups) {
     .add('#startSpan with SimpleSpanProcessor', function () {
       const simpleSpanProcessor = new SimpleSpanProcessor(exporter);
 
-      registry.addSpanProcessor(simpleSpanProcessor);
+      provider.addSpanProcessor(simpleSpanProcessor);
       const span = tracer.startSpan('op');
       span.end();
 
@@ -64,7 +64,7 @@ for (const setup of setups) {
     .add('#startSpan with BatchSpanProcessor', function () {
       const batchSpanProcessor = new BatchSpanProcessor(exporter);
 
-      registry.addSpanProcessor(batchSpanProcessor);
+      provider.addSpanProcessor(batchSpanProcessor);
       const span = tracer.startSpan('op');
       span.end();
       batchSpanProcessor.shutdown();

--- a/examples/basic-tracer-node/index.js
+++ b/examples/basic-tracer-node/index.js
@@ -1,5 +1,5 @@
 const opentelemetry = require('@opentelemetry/core');
-const { BasicTracerRegistry, SimpleSpanProcessor } = require('@opentelemetry/tracing');
+const { BasicTracerProvider, SimpleSpanProcessor } = require('@opentelemetry/tracing');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
 const { CollectorExporter } =  require('@opentelemetry/exporter-collector');
@@ -20,13 +20,13 @@ if (EXPORTER.toLowerCase().startsWith('z')) {
   exporter = new CollectorExporter(options);
 }
 
-const registry = new BasicTracerRegistry();
+const provider = new BasicTracerProvider();
 
 // Configure span processor to send spans to the provided exporter
-registry.addSpanProcessor(new SimpleSpanProcessor(exporter));
+provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
 
-// Initialize the OpenTelemetry APIs to use the BasicTracerRegistry bindings
-opentelemetry.initGlobalTracerRegistry(registry);
+// Initialize the OpenTelemetry APIs to use the BasicTracerProvider bindings
+opentelemetry.initGlobalTracerProvider(provider);
 const tracer = opentelemetry.getTracer('example-basic-tracer-node')
 
 // Create a span. A span must be closed.

--- a/examples/basic-tracer-node/multi_exporter.js
+++ b/examples/basic-tracer-node/multi_exporter.js
@@ -1,10 +1,10 @@
 const opentelemetry = require('@opentelemetry/core');
-const { BasicTracerRegistry, BatchSpanProcessor, SimpleSpanProcessor } = require('@opentelemetry/tracing');
+const { BasicTracerProvider, BatchSpanProcessor, SimpleSpanProcessor } = require('@opentelemetry/tracing');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
 const { CollectorExporter } =  require('@opentelemetry/exporter-collector');
 
-const registry = new BasicTracerRegistry();
+const provider = new BasicTracerProvider();
 
 const zipkinExporter = new ZipkinExporter({serviceName: 'basic-service'});
 const jaegerExporter = new JaegerExporter({
@@ -14,18 +14,18 @@ const collectorExporter = new CollectorExporter({serviceName: 'basic-service'});
 
 // It is recommended to use this BatchSpanProcessor for better performance
 // and optimization, especially in production.
-registry.addSpanProcessor(new BatchSpanProcessor(zipkinExporter, {
+provider.addSpanProcessor(new BatchSpanProcessor(zipkinExporter, {
   bufferSize: 10 // This is added for example, default size is 100.
 }));
 
 // It is recommended to use SimpleSpanProcessor in case of Jaeger exporter as
 // it's internal client already handles the spans with batching logic.
-registry.addSpanProcessor(new SimpleSpanProcessor(jaegerExporter));
+provider.addSpanProcessor(new SimpleSpanProcessor(jaegerExporter));
 
-registry.addSpanProcessor(new SimpleSpanProcessor(collectorExporter));
+provider.addSpanProcessor(new SimpleSpanProcessor(collectorExporter));
 
-// Initialize the OpenTelemetry APIs to use the BasicTracerRegistry bindings
-opentelemetry.initGlobalTracerRegistry(registry);
+// Initialize the OpenTelemetry APIs to use the BasicTracerProvider bindings
+opentelemetry.initGlobalTracerProvider(provider);
 const tracer = opentelemetry.getTracer('default');
 
 // Create a span. A span must be closed.

--- a/examples/dns/setup.js
+++ b/examples/dns/setup.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const opentelemetry = require('@opentelemetry/core');
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 const { SimpleSpanProcessor } = require('@opentelemetry/tracing');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
 const EXPORTER = process.env.EXPORTER || '';
 
 function setupTracerAndExporters(service) {
-  const registry = new NodeTracerRegistry({
+  const provider = new NodeTracerProvider({
       plugins: {
           dns: {
             enabled: true,
@@ -30,10 +30,10 @@ function setupTracerAndExporters(service) {
     });
   }
 
-  registry.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
 
-  // Initialize the OpenTelemetry APIs to use the BasicTracerRegistry bindings
-  opentelemetry.initGlobalTracerRegistry(registry);
+  // Initialize the OpenTelemetry APIs to use the BasicTracerProvider bindings
+  opentelemetry.initGlobalTracerProvider(provider);
 }
 
 exports.setupTracerAndExporters = setupTracerAndExporters;

--- a/examples/grpc/setup.js
+++ b/examples/grpc/setup.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const opentelemetry = require('@opentelemetry/core');
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 const { SimpleSpanProcessor } = require('@opentelemetry/tracing');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
 const EXPORTER = process.env.EXPORTER || '';
 
 function setupTracerAndExporters(service) {
-  const registry = new NodeTracerRegistry({
+  const provider = new NodeTracerProvider({
     plugins: {
       grpc: {
         enabled: true,
@@ -29,10 +29,10 @@ function setupTracerAndExporters(service) {
     });
   }
 
-  registry.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
 
-  // Initialize the OpenTelemetry APIs to use the BasicTracerRegistry bindings
-  opentelemetry.initGlobalTracerRegistry(registry);
+  // Initialize the OpenTelemetry APIs to use the BasicTracerProvider bindings
+  opentelemetry.initGlobalTracerProvider(provider);
 }
 
 exports.setupTracerAndExporters = setupTracerAndExporters;

--- a/examples/grpc_dynamic_codegen/setup.js
+++ b/examples/grpc_dynamic_codegen/setup.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const opentelemetry = require('@opentelemetry/core');
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 const { SimpleSpanProcessor } = require('@opentelemetry/tracing');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
 const EXPORTER = process.env.EXPORTER || '';
 
 function setupTracerAndExporters(service) {
-  const registry = new NodeTracerRegistry({
+  const provider = new NodeTracerProvider({
     plugins: {
       grpc: {
         enabled: true,
@@ -31,10 +31,10 @@ function setupTracerAndExporters(service) {
 
   // It is recommended to use this `BatchSpanProcessor` for better performance
   // and optimization, especially in production.
-  registry.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
 
-  // Initialize the OpenTelemetry APIs to use the BasicTracerRegistry bindings
-  opentelemetry.initGlobalTracerRegistry(registry);
+  // Initialize the OpenTelemetry APIs to use the BasicTracerProvider bindings
+  opentelemetry.initGlobalTracerProvider(provider);
 }
 
 exports.setupTracerAndExporters = setupTracerAndExporters;

--- a/examples/http/setup.js
+++ b/examples/http/setup.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const opentelemetry = require('@opentelemetry/core');
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 const { SimpleSpanProcessor } = require('@opentelemetry/tracing');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
 const EXPORTER = process.env.EXPORTER || '';
 
 function setupTracerAndExporters(service) {
-  const registry = new NodeTracerRegistry();
+  const provider = new NodeTracerProvider();
 
   let exporter;
   if (EXPORTER.toLowerCase().startsWith('z')) {
@@ -21,10 +21,10 @@ function setupTracerAndExporters(service) {
     });
   }
 
-  registry.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
 
-  // Initialize the OpenTelemetry APIs to use the BasicTracerRegistry bindings
-  opentelemetry.initGlobalTracerRegistry(registry);
+  // Initialize the OpenTelemetry APIs to use the BasicTracerProvider bindings
+  opentelemetry.initGlobalTracerProvider(provider);
 }
 
 exports.setupTracerAndExporters = setupTracerAndExporters;

--- a/examples/https/setup.js
+++ b/examples/https/setup.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const opentelemetry = require('@opentelemetry/core');
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 const { SimpleSpanProcessor } = require('@opentelemetry/tracing');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
@@ -9,7 +9,7 @@ const EXPORTER = process.env.EXPORTER || '';
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 function setupTracerAndExporters(service) {
   let exporter;
-  const registry = new NodeTracerRegistry();
+  const provider = new NodeTracerProvider();
 
   if (EXPORTER.toLowerCase().startsWith('z')) {
     exporter = new ZipkinExporter({
@@ -21,10 +21,10 @@ function setupTracerAndExporters(service) {
     });
   }
 
-  registry.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
 
-  // Initialize the OpenTelemetry APIs to use the BasicTracerRegistry bindings
-  opentelemetry.initGlobalTracerRegistry(registry);
+  // Initialize the OpenTelemetry APIs to use the BasicTracerProvider bindings
+  opentelemetry.initGlobalTracerProvider(provider);
 }
 
 exports.setupTracerAndExporters = setupTracerAndExporters;

--- a/examples/mysql/setup.js
+++ b/examples/mysql/setup.js
@@ -1,13 +1,13 @@
 'use strict';
 
 const opentelemetry = require('@opentelemetry/core');
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 const { SimpleSpanProcessor } = require('@opentelemetry/tracing');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
 
 function setupTracerAndExporters(service) {
-  const registry = new NodeTracerRegistry({
+  const provider = new NodeTracerProvider({
     plugins: {
       mysql: {
         enabled: true,
@@ -20,15 +20,15 @@ function setupTracerAndExporters(service) {
     }
   });
 
-  registry.addSpanProcessor(new SimpleSpanProcessor(new ZipkinExporter({
+  provider.addSpanProcessor(new SimpleSpanProcessor(new ZipkinExporter({
     serviceName: service,
   })));
-  registry.addSpanProcessor(new SimpleSpanProcessor(new JaegerExporter({
+  provider.addSpanProcessor(new SimpleSpanProcessor(new JaegerExporter({
     serviceName: service,
   })));
 
-  // Initialize the OpenTelemetry APIs to use the BasicTracerRegistry bindings
-  opentelemetry.initGlobalTracerRegistry(registry);
+  // Initialize the OpenTelemetry APIs to use the BasicTracerProvider bindings
+  opentelemetry.initGlobalTracerProvider(provider);
 }
 
 exports.setupTracerAndExporters = setupTracerAndExporters;

--- a/examples/opentracing-shim/shim.js
+++ b/examples/opentracing-shim/shim.js
@@ -1,17 +1,17 @@
 "use strict";
 
-const { NodeTracerRegistry } = require("@opentelemetry/node");
+const { NodeTracerProvider } = require("@opentelemetry/node");
 const { SimpleSpanProcessor } = require("@opentelemetry/tracing");
 const { JaegerExporter } = require("@opentelemetry/exporter-jaeger");
 const { ZipkinExporter } = require("@opentelemetry/exporter-zipkin");
 const { TracerShim } = require("@opentelemetry/shim-opentracing");
 
 function shim(serviceName) {
-  const registry = new NodeTracerRegistry();
+  const provider = new NodeTracerProvider();
 
-  registry.addSpanProcessor(new SimpleSpanProcessor(getExporter(serviceName)));
+  provider.addSpanProcessor(new SimpleSpanProcessor(getExporter(serviceName)));
 
-  return new TracerShim(registry.getTracer("opentracing-shim"));
+  return new TracerShim(provider.getTracer("opentracing-shim"));
 }
 
 function getExporter(serviceName) {

--- a/examples/redis/setup.js
+++ b/examples/redis/setup.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const opentelemetry = require('@opentelemetry/core');
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 const { SimpleSpanProcessor } = require('@opentelemetry/tracing');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
 const EXPORTER = process.env.EXPORTER || '';
 
 function setupTracerAndExporters(service) {
-  const registry = new NodeTracerRegistry();
+  const provider = new NodeTracerProvider();
 
   let exporter;
   if (EXPORTER.toLowerCase().startsWith('z')) {
@@ -21,10 +21,10 @@ function setupTracerAndExporters(service) {
     });
   }
 
-  registry.addSpanProcessor(new SimpleSpanProcessor(exporter));
+  provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
 
-  // Initialize the OpenTelemetry APIs to use the BasicTracerRegistry bindings
-  opentelemetry.initGlobalTracerRegistry(registry);
+  // Initialize the OpenTelemetry APIs to use the BasicTracerProvider bindings
+  opentelemetry.initGlobalTracerProvider(provider);
 }
 
 exports.setupTracerAndExporters = setupTracerAndExporters;

--- a/examples/tracer-web/examples/document-load/index.js
+++ b/examples/tracer-web/examples/document-load/index.js
@@ -1,26 +1,26 @@
 import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/tracing';
-import { WebTracerRegistry } from '@opentelemetry/web';
+import { WebTracerProvider as WebTracerProvider } from '@opentelemetry/web';
 import { DocumentLoad } from '@opentelemetry/plugin-document-load';
 import { ZoneScopeManager } from '@opentelemetry/scope-zone';
 import { CollectorExporter } from '@opentelemetry/exporter-collector'
 
-const registry = new WebTracerRegistry({
+const provider = new WebTracerProvider({
   plugins: [
     new DocumentLoad()
   ]
 });
-registry.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
 
-const registryWithZone = new WebTracerRegistry({
+const providerWithZone = new WebTracerProvider({
   scopeManager: new ZoneScopeManager(),
   plugins: [
     new DocumentLoad()
   ]
 });
-registryWithZone.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
-registryWithZone.addSpanProcessor(new SimpleSpanProcessor(new CollectorExporter()));
+providerWithZone.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+providerWithZone.addSpanProcessor(new SimpleSpanProcessor(new CollectorExporter()));
 
-const tracerWithZone = registryWithZone.getTracer('example-tracer-web');
+const tracerWithZone = providerWithZone.getTracer('example-tracer-web');
 console.log('Current span is window', tracerWithZone.getCurrentSpan() === window);
 
 // example of keeping track of scope between async operations

--- a/packages/opentelemetry-core/src/index.ts
+++ b/packages/opentelemetry-core/src/index.ts
@@ -27,7 +27,7 @@ export * from './trace/globaltracer-utils';
 export * from './trace/instrumentation/BasePlugin';
 export * from './trace/NoopSpan';
 export * from './trace/NoopTracer';
-export * from './trace/NoopTracerRegistry';
+export * from './trace/NoopTracerProvider';
 export * from './trace/NoRecordingSpan';
 export * from './trace/sampler/ProbabilitySampler';
 export * from './trace/spancontext-utils';

--- a/packages/opentelemetry-core/src/trace/NoopTracerProvider.ts
+++ b/packages/opentelemetry-core/src/trace/NoopTracerProvider.ts
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 
-import { Tracer } from './tracer';
+import * as types from '@opentelemetry/types';
+import { noopTracer } from './NoopTracer';
 
 /**
- * TracerRegistry provides an interface for creating {@link Tracer}s
+ * An implementation of the {@link TracerProvider} which returns an impotent Tracer
+ * for all calls to `getTracer`
  */
-export interface TracerRegistry {
-  /**
-   * Returns a Tracer, creating one if one with the given name and version is not already created
-   *
-   * If there is no Span associated with the current context, null is returned.
-   *
-   * @returns Tracer A Tracer with the given name and version
-   */
-  getTracer(name: string, version?: string): Tracer;
+export class NoopTracerProvider implements types.TracerProvider {
+  getTracer(_name?: string, _version?: string): types.Tracer {
+    return noopTracer;
+  }
 }

--- a/packages/opentelemetry-core/src/trace/globaltracer-utils.ts
+++ b/packages/opentelemetry-core/src/trace/globaltracer-utils.ts
@@ -15,31 +15,31 @@
  */
 
 import * as types from '@opentelemetry/types';
-import { NoopTracerRegistry } from './NoopTracerRegistry';
+import { NoopTracerProvider } from './NoopTracerProvider';
 
-let globalTracerRegistry: types.TracerRegistry = new NoopTracerRegistry();
+let globalTracerProvider: types.TracerProvider = new NoopTracerProvider();
 
 /**
  * Set the current global tracer. Returns the initialized global tracer
  */
-export function initGlobalTracerRegistry(
-  tracerRegistry: types.TracerRegistry
-): types.TracerRegistry {
-  return (globalTracerRegistry = tracerRegistry);
+export function initGlobalTracerProvider(
+  tracerProvider: types.TracerProvider
+): types.TracerProvider {
+  return (globalTracerProvider = tracerProvider);
 }
 
 /**
- * Returns the global tracer registry.
+ * Returns the global tracer provider.
  */
-export function getTracerRegistry(): types.TracerRegistry {
-  // Return the global tracer registry
-  return globalTracerRegistry;
+export function getTracerProvider(): types.TracerProvider {
+  // Return the global tracer provider
+  return globalTracerProvider;
 }
 
 /**
- * Returns a tracer from the global tracer registry.
+ * Returns a tracer from the global tracer provider.
  */
 export function getTracer(name: string, version?: string): types.Tracer {
-  // Return the global tracer registry
-  return globalTracerRegistry.getTracer(name, version);
+  // Return the global tracer provider
+  return globalTracerProvider.getTracer(name, version);
 }

--- a/packages/opentelemetry-core/src/trace/instrumentation/BasePlugin.ts
+++ b/packages/opentelemetry-core/src/trace/instrumentation/BasePlugin.ts
@@ -21,7 +21,7 @@ import {
   PluginConfig,
   PluginInternalFiles,
   PluginInternalFilesVersion,
-  TracerRegistry,
+  TracerProvider,
 } from '@opentelemetry/types';
 import * as semver from 'semver';
 import * as path from 'path';
@@ -47,12 +47,12 @@ export abstract class BasePlugin<T> implements Plugin<T> {
 
   enable(
     moduleExports: T,
-    tracerRegistry: TracerRegistry,
+    tracerProvider: TracerProvider,
     logger: Logger,
     config?: PluginConfig
   ): T {
     this._moduleExports = moduleExports;
-    this._tracer = tracerRegistry.getTracer(
+    this._tracer = tracerProvider.getTracer(
       this._tracerName,
       this._tracerVersion
     );

--- a/packages/opentelemetry-core/test/trace/BasePlugin.test.ts
+++ b/packages/opentelemetry-core/test/trace/BasePlugin.test.ts
@@ -17,10 +17,10 @@
 import * as assert from 'assert';
 import * as path from 'path';
 import { BasePlugin, NoopLogger } from '../../src';
-import { NoopTracerRegistry } from '../../src/trace/NoopTracerRegistry';
+import { NoopTracerProvider } from '../../src/trace/NoopTracerProvider';
 import * as types from './fixtures/test-package/foo/bar/internal';
 
-const registry = new NoopTracerRegistry();
+const provider = new NoopTracerProvider();
 const logger = new NoopLogger();
 
 describe('BasePlugin', () => {
@@ -29,7 +29,7 @@ describe('BasePlugin', () => {
       const testPackage = require('./fixtures/test-package');
       const plugin = new TestPlugin();
       assert.doesNotThrow(() => {
-        plugin.enable(testPackage, registry, logger);
+        plugin.enable(testPackage, provider, logger);
       });
 
       // @TODO: https://github.com/open-telemetry/opentelemetry-js/issues/285

--- a/packages/opentelemetry-core/test/trace/globaltracer-utils.test.ts
+++ b/packages/opentelemetry-core/test/trace/globaltracer-utils.test.ts
@@ -17,12 +17,12 @@
 import * as assert from 'assert';
 import * as types from '@opentelemetry/types';
 import {
-  getTracerRegistry,
-  initGlobalTracerRegistry,
+  getTracerProvider,
+  initGlobalTracerProvider,
 } from '../../src/trace/globaltracer-utils';
 import { NoopTracer, NoopSpan } from '../../src';
 import { TraceFlags } from '@opentelemetry/types';
-import { NoopTracerRegistry } from '../../src/trace/NoopTracerRegistry';
+import { NoopTracerProvider } from '../../src/trace/NoopTracerProvider';
 
 describe('globaltracer-utils', () => {
   const functions = [
@@ -33,13 +33,13 @@ describe('globaltracer-utils', () => {
     'getHttpTextFormat',
   ];
 
-  it('should expose a tracer registry via getTracerRegistry', () => {
-    const tracer = getTracerRegistry();
+  it('should expose a tracer provider via getTracerProvider', () => {
+    const tracer = getTracerProvider();
     assert.ok(tracer);
     assert.strictEqual(typeof tracer, 'object');
   });
 
-  describe('GlobalTracerRegistry', () => {
+  describe('GlobalTracerProvider', () => {
     const spanContext = {
       traceId: 'd4cda95b652f4a1592b449d5929fda1b',
       spanId: '6e0c63257de34c92',
@@ -48,12 +48,12 @@ describe('globaltracer-utils', () => {
     const dummySpan = new NoopSpan(spanContext);
 
     afterEach(() => {
-      initGlobalTracerRegistry(new NoopTracerRegistry());
+      initGlobalTracerProvider(new NoopTracerProvider());
     });
 
     it('should not crash', () => {
       functions.forEach(fn => {
-        const tracer = getTracerRegistry();
+        const tracer = getTracerProvider();
         try {
           ((tracer as unknown) as { [fn: string]: Function })[fn](); // Try to run the function
           assert.ok(true, fn);
@@ -65,9 +65,9 @@ describe('globaltracer-utils', () => {
       });
     });
 
-    it('should use the global tracer registry', () => {
-      initGlobalTracerRegistry(new TestTracerRegistry());
-      const tracer = getTracerRegistry().getTracer('name');
+    it('should use the global tracer provider', () => {
+      initGlobalTracerProvider(new TestTracerProvider());
+      const tracer = getTracerProvider().getTracer('name');
       const span = tracer.startSpan('test');
       assert.deepStrictEqual(span, dummySpan);
     });
@@ -81,7 +81,7 @@ describe('globaltracer-utils', () => {
       }
     }
 
-    class TestTracerRegistry extends NoopTracerRegistry {
+    class TestTracerProvider extends NoopTracerProvider {
       getTracer(_name: string, version?: string) {
         return new TestTracer();
       }

--- a/packages/opentelemetry-exporter-collector/README.md
+++ b/packages/opentelemetry-exporter-collector/README.md
@@ -35,18 +35,18 @@ opentelemetry.initGlobalTracer(tracer);
 ## Usage in Node
 ```js
 const opentelemetry = require('@opentelemetry/core');
-const { BasicTracerRegistry, SimpleSpanProcessor } = require('@opentelemetry/tracing');
+const { BasicTracerProvider, SimpleSpanProcessor } = require('@opentelemetry/tracing');
 const { CollectorExporter } =  require('@opentelemetry/exporter-collector');
 
 const collectorOptions = {
   url: '<opentelemetry-collector-url>' // url is optional and can be omitted - default is http://localhost:55678/v1/trace
 };
 
-const registry = new BasicTracerRegistry();
+const provider = new BasicTracerProvider();
 const exporter = new CollectorExporter(collectorOptions);
-registry.addSpanProcessor(new SimpleSpanProcessor(exporter));
+provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
 
-opentelemetry.initGlobalTracerRegistry(registry);
+opentelemetry.initGlobalTracerProvider(provider);
 
 ```
 

--- a/packages/opentelemetry-exporter-zipkin/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/transform.test.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'assert';
 import * as types from '@opentelemetry/types';
-import { Span, BasicTracerRegistry } from '@opentelemetry/tracing';
+import { Span, BasicTracerProvider } from '@opentelemetry/tracing';
 import {
   NoopLogger,
   hrTimeToMicroseconds,
@@ -32,7 +32,7 @@ import {
 import * as zipkinTypes from '../src/types';
 
 const logger = new NoopLogger();
-const tracer = new BasicTracerRegistry({
+const tracer = new BasicTracerProvider({
   logger,
 }).getTracer('default');
 const parentId = '5c1c63257de34c67';

--- a/packages/opentelemetry-node/README.md
+++ b/packages/opentelemetry-node/README.md
@@ -11,14 +11,14 @@ For manual instrumentation see the
 [@opentelemetry/tracing](https://github.com/open-telemetry/opentelemetry-js/tree/master/packages/opentelemetry-tracing) package.
 
 ## How does automated instrumentation work?
-This package exposes a `NodeTracerRegistry` that will automatically hook into the module loader of Node.js.
+This package exposes a `NodeTracerProvider` that will automatically hook into the module loader of Node.js.
 
-For this to work, please make sure that `NodeTracerRegistry` is initialized before any other module of your application, (like `http` or `express`) is loaded.
+For this to work, please make sure that `NodeTracerProvider` is initialized before any other module of your application, (like `http` or `express`) is loaded.
 
 OpenTelemetry comes with a growing number of instrumentation plugins for well know modules (see [supported modules](https://github.com/open-telemetry/opentelemetry-js#plugins)) and an API to create custom plugins (see [the plugin developer guide](https://github.com/open-telemetry/opentelemetry-js/blob/master/doc/plugin-guide.md)).
 
 
-Whenever a module is loaded `NodeTracerRegistry` will check if a matching instrumentation plugin has been installed.
+Whenever a module is loaded `NodeTracerProvider` will check if a matching instrumentation plugin has been installed.
 
 > **Please note:** This module does *not* bundle any plugins. They need to be installed separately.
 
@@ -34,7 +34,7 @@ This instrumentation code will automatically
 In short, this means that this module will use provided plugins to automatically instrument your application to produce spans and provide end-to-end tracing by just adding a few lines of code.
 
 ## Creating custom spans on top of auto-instrumentation
-Additionally to automated instrumentation, `NodeTracerRegistry` exposes the same API as [@opentelemetry/tracing](https://github.com/open-telemetry/opentelemetry-js/tree/master/packages/opentelemetry-tracing), allowing creating custom spans if needed.
+Additionally to automated instrumentation, `NodeTracerProvider` exposes the same API as [@opentelemetry/tracing](https://github.com/open-telemetry/opentelemetry-js/tree/master/packages/opentelemetry-tracing), allowing creating custom spans if needed.
 
 ## Installation
 
@@ -50,14 +50,14 @@ npm install --save @opentelemetry/plugin-https
 
 ## Usage
 
-The following code will configure the `NodeTracerRegistry` to instrument `http` using `@opentelemetry/plugin-http`.
+The following code will configure the `NodeTracerProvider` to instrument `http` using `@opentelemetry/plugin-http`.
 
 ```js
 const opentelemetry = require('@opentelemetry/core');
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
-// Create and configure NodeTracerRegistry
-const registry = new NodeTracerRegistry({
+// Create and configure NodeTracerProvider
+const provider = new NodeTracerProvider({
   plugins: {
     http: {
       enabled: true,
@@ -68,25 +68,25 @@ const registry = new NodeTracerRegistry({
   }
 });
 
-// Initialize the registry
-opentelemetry.initGlobalTracerRegistry(registry);
+// Initialize the provider
+opentelemetry.initGlobalTracerProvider(provider);
 
 // Your application code - http will automatically be instrumented if
 // @opentelemetry/plugin-http is present
 const http = require('http');
 ```
 
-To enable instrumentation for all [supported modules](https://github.com/open-telemetry/opentelemetry-js#plugins), create an instance of `NodeTracerRegistry` without providing any plugin configuration to the constructor.
+To enable instrumentation for all [supported modules](https://github.com/open-telemetry/opentelemetry-js#plugins), create an instance of `NodeTracerProvider` without providing any plugin configuration to the constructor.
 
 ```js
 const opentelemetry = require('@opentelemetry/core');
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
-// Create and initialize NodeTracerRegistry
-const registry = new NodeTracerRegistry();
+// Create and initialize NodeTracerProvider
+const provider = new NodeTracerProvider();
 
-// Initialize the registry
-opentelemetry.initGlobalTracerRegistry(registry);
+// Initialize the provider
+opentelemetry.initGlobalTracerProvider(provider);
 
 // Your application code
 // ...

--- a/packages/opentelemetry-node/src/NodeTracerProvider.ts
+++ b/packages/opentelemetry-node/src/NodeTracerProvider.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { BasicTracerRegistry } from '@opentelemetry/tracing';
+import { BasicTracerProvider } from '@opentelemetry/tracing';
 import { AsyncHooksScopeManager } from '@opentelemetry/scope-async-hooks';
 import { PluginLoader } from './instrumentation/PluginLoader';
 import { NodeTracerConfig, DEFAULT_INSTRUMENTATION_PLUGINS } from './config';
@@ -22,7 +22,7 @@ import { NodeTracerConfig, DEFAULT_INSTRUMENTATION_PLUGINS } from './config';
 /**
  * This class represents a node tracer with `async_hooks` module.
  */
-export class NodeTracerRegistry extends BasicTracerRegistry {
+export class NodeTracerProvider extends BasicTracerProvider {
   private readonly _pluginLoader: PluginLoader;
 
   /**

--- a/packages/opentelemetry-node/src/index.ts
+++ b/packages/opentelemetry-node/src/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './NodeTracerRegistry';
+export * from './NodeTracerProvider';

--- a/packages/opentelemetry-node/src/instrumentation/PluginLoader.ts
+++ b/packages/opentelemetry-node/src/instrumentation/PluginLoader.ts
@@ -18,7 +18,7 @@ import {
   Logger,
   Plugin,
   PluginConfig,
-  TracerRegistry,
+  TracerProvider,
 } from '@opentelemetry/types';
 import * as hook from 'require-in-the-middle';
 import * as utils from './utils';
@@ -60,7 +60,7 @@ export class PluginLoader {
   private _hookState = HookState.UNINITIALIZED;
 
   /** Constructs a new PluginLoader instance. */
-  constructor(readonly registry: TracerRegistry, readonly logger: Logger) {}
+  constructor(readonly provider: TracerProvider, readonly logger: Logger) {}
 
   /**
    * Loads a list of plugins. Each plugin module should implement the core
@@ -120,7 +120,7 @@ export class PluginLoader {
 
           this._plugins.push(plugin);
           // Enable each supported plugin.
-          return plugin.enable(exports, this.registry, this.logger, config);
+          return plugin.enable(exports, this.provider, this.logger, config);
         } catch (e) {
           this.logger.error(
             `PluginLoader#load: could not load plugin ${modulePath} of module ${name}. Error: ${e.message}`

--- a/packages/opentelemetry-node/test/NodeTracer.test.ts
+++ b/packages/opentelemetry-node/test/NodeTracer.test.ts
@@ -23,7 +23,7 @@ import {
   NoopLogger,
   NoRecordingSpan,
 } from '@opentelemetry/core';
-import { NodeTracerRegistry } from '../src/NodeTracerRegistry';
+import { NodeTracerProvider } from '../src/NodeTracerProvider';
 import { TraceFlags } from '@opentelemetry/types';
 import { Span } from '@opentelemetry/tracing';
 import * as path from 'path';
@@ -39,8 +39,8 @@ const INSTALLED_PLUGINS_PATH = path.join(
   'node_modules'
 );
 
-describe('NodeTracerRegistry', () => {
-  let registry: NodeTracerRegistry;
+describe('NodeTracerProvider', () => {
+  let provider: NodeTracerProvider;
   before(() => {
     module.paths.push(INSTALLED_PLUGINS_PATH);
   });
@@ -48,45 +48,45 @@ describe('NodeTracerRegistry', () => {
   afterEach(() => {
     // clear require cache
     Object.keys(require.cache).forEach(key => delete require.cache[key]);
-    registry.stop();
+    provider.stop();
   });
 
   describe('constructor', () => {
     it('should construct an instance with required only options', () => {
-      registry = new NodeTracerRegistry();
-      assert.ok(registry instanceof NodeTracerRegistry);
+      provider = new NodeTracerProvider();
+      assert.ok(provider instanceof NodeTracerProvider);
     });
 
     it('should construct an instance with binary format', () => {
-      registry = new NodeTracerRegistry({
+      provider = new NodeTracerProvider({
         binaryFormat: new BinaryTraceContext(),
       });
-      assert.ok(registry instanceof NodeTracerRegistry);
+      assert.ok(provider instanceof NodeTracerProvider);
     });
 
     it('should construct an instance with http text format', () => {
-      registry = new NodeTracerRegistry({
+      provider = new NodeTracerProvider({
         httpTextFormat: new HttpTraceContext(),
       });
-      assert.ok(registry instanceof NodeTracerRegistry);
+      assert.ok(provider instanceof NodeTracerProvider);
     });
 
     it('should construct an instance with logger', () => {
-      registry = new NodeTracerRegistry({
+      provider = new NodeTracerProvider({
         logger: new NoopLogger(),
       });
-      assert.ok(registry instanceof NodeTracerRegistry);
+      assert.ok(provider instanceof NodeTracerProvider);
     });
 
     it('should construct an instance with sampler', () => {
-      registry = new NodeTracerRegistry({
+      provider = new NodeTracerProvider({
         sampler: ALWAYS_SAMPLER,
       });
-      assert.ok(registry instanceof NodeTracerRegistry);
+      assert.ok(provider instanceof NodeTracerProvider);
     });
 
     it('should load user configured plugins', () => {
-      registry = new NodeTracerRegistry({
+      provider = new NodeTracerProvider({
         logger: new NoopLogger(),
         plugins: {
           'simple-module': {
@@ -102,7 +102,7 @@ describe('NodeTracerRegistry', () => {
           },
         },
       });
-      const pluginLoader = registry['_pluginLoader'];
+      const pluginLoader = provider['_pluginLoader'];
       assert.strictEqual(pluginLoader['_plugins'].length, 0);
       require('simple-module');
       assert.strictEqual(pluginLoader['_plugins'].length, 1);
@@ -111,39 +111,39 @@ describe('NodeTracerRegistry', () => {
     });
 
     it('should construct an instance with default attributes', () => {
-      registry = new NodeTracerRegistry({
+      provider = new NodeTracerProvider({
         defaultAttributes: {
           region: 'eu-west',
           asg: 'my-asg',
         },
       });
-      assert.ok(registry instanceof NodeTracerRegistry);
+      assert.ok(provider instanceof NodeTracerProvider);
     });
   });
 
   describe('.startSpan()', () => {
     it('should start a span with name only', () => {
-      registry = new NodeTracerRegistry({
+      provider = new NodeTracerProvider({
         logger: new NoopLogger(),
       });
-      const span = registry.getTracer('default').startSpan('my-span');
+      const span = provider.getTracer('default').startSpan('my-span');
       assert.ok(span);
     });
 
     it('should start a span with name and options', () => {
-      registry = new NodeTracerRegistry({
+      provider = new NodeTracerProvider({
         logger: new NoopLogger(),
       });
-      const span = registry.getTracer('default').startSpan('my-span', {});
+      const span = provider.getTracer('default').startSpan('my-span', {});
       assert.ok(span);
     });
 
     it('should return a default span with no sampling', () => {
-      registry = new NodeTracerRegistry({
+      provider = new NodeTracerProvider({
         sampler: NEVER_SAMPLER,
         logger: new NoopLogger(),
       });
-      const span = registry.getTracer('default').startSpan('my-span');
+      const span = provider.getTracer('default').startSpan('my-span');
       assert.ok(span instanceof NoRecordingSpan);
       assert.strictEqual(span.context().traceFlags, TraceFlags.UNSAMPLED);
       assert.strictEqual(span.isRecording(), false);
@@ -156,11 +156,11 @@ describe('NodeTracerRegistry', () => {
       const defaultAttributes = {
         foo: 'bar',
       };
-      registry = new NodeTracerRegistry({
+      provider = new NodeTracerProvider({
         defaultAttributes,
       });
 
-      const span = registry.getTracer('default').startSpan('my-span') as Span;
+      const span = provider.getTracer('default').startSpan('my-span') as Span;
       assert.ok(span instanceof Span);
       assert.deepStrictEqual(span.attributes, defaultAttributes);
     });
@@ -168,9 +168,9 @@ describe('NodeTracerRegistry', () => {
 
   describe('.getCurrentSpan()', () => {
     it('should return undefined with AsyncHooksScopeManager when no span started', () => {
-      registry = new NodeTracerRegistry({});
+      provider = new NodeTracerProvider({});
       assert.deepStrictEqual(
-        registry.getTracer('default').getCurrentSpan(),
+        provider.getTracer('default').getCurrentSpan(),
         undefined
       );
     });
@@ -178,36 +178,36 @@ describe('NodeTracerRegistry', () => {
 
   describe('.withSpan()', () => {
     it('should run scope with AsyncHooksScopeManager scope manager', done => {
-      registry = new NodeTracerRegistry({});
-      const span = registry.getTracer('default').startSpan('my-span');
-      registry.getTracer('default').withSpan(span, () => {
+      provider = new NodeTracerProvider({});
+      const span = provider.getTracer('default').startSpan('my-span');
+      provider.getTracer('default').withSpan(span, () => {
         assert.deepStrictEqual(
-          registry.getTracer('default').getCurrentSpan(),
+          provider.getTracer('default').getCurrentSpan(),
           span
         );
         return done();
       });
       assert.deepStrictEqual(
-        registry.getTracer('default').getCurrentSpan(),
+        provider.getTracer('default').getCurrentSpan(),
         undefined
       );
     });
 
     it('should run scope with AsyncHooksScopeManager scope manager with multiple spans', done => {
-      registry = new NodeTracerRegistry({});
-      const span = registry.getTracer('default').startSpan('my-span');
-      registry.getTracer('default').withSpan(span, () => {
+      provider = new NodeTracerProvider({});
+      const span = provider.getTracer('default').startSpan('my-span');
+      provider.getTracer('default').withSpan(span, () => {
         assert.deepStrictEqual(
-          registry.getTracer('default').getCurrentSpan(),
+          provider.getTracer('default').getCurrentSpan(),
           span
         );
 
-        const span1 = registry
+        const span1 = provider
           .getTracer('default')
           .startSpan('my-span1', { parent: span });
-        registry.getTracer('default').withSpan(span1, () => {
+        provider.getTracer('default').withSpan(span1, () => {
           assert.deepStrictEqual(
-            registry.getTracer('default').getCurrentSpan(),
+            provider.getTracer('default').getCurrentSpan(),
             span1
           );
           assert.deepStrictEqual(
@@ -220,19 +220,19 @@ describe('NodeTracerRegistry', () => {
       // when span ended.
       // @todo: below check is not running.
       assert.deepStrictEqual(
-        registry.getTracer('default').getCurrentSpan(),
+        provider.getTracer('default').getCurrentSpan(),
         undefined
       );
     });
 
     it('should find correct scope with promises', done => {
-      registry = new NodeTracerRegistry({});
-      const span = registry.getTracer('default').startSpan('my-span');
-      registry.getTracer('default').withSpan(span, async () => {
+      provider = new NodeTracerProvider({});
+      const span = provider.getTracer('default').startSpan('my-span');
+      provider.getTracer('default').withSpan(span, async () => {
         for (let i = 0; i < 3; i++) {
           await sleep(5).then(() => {
             assert.deepStrictEqual(
-              registry.getTracer('default').getCurrentSpan(),
+              provider.getTracer('default').getCurrentSpan(),
               span
             );
           });
@@ -240,7 +240,7 @@ describe('NodeTracerRegistry', () => {
         return done();
       });
       assert.deepStrictEqual(
-        registry.getTracer('default').getCurrentSpan(),
+        provider.getTracer('default').getCurrentSpan(),
         undefined
       );
     });
@@ -248,25 +248,25 @@ describe('NodeTracerRegistry', () => {
 
   describe('.bind()', () => {
     it('should bind scope with AsyncHooksScopeManager scope manager', done => {
-      const registry = new NodeTracerRegistry({});
-      const span = registry.getTracer('default').startSpan('my-span');
+      const provider = new NodeTracerProvider({});
+      const span = provider.getTracer('default').startSpan('my-span');
       const fn = () => {
         assert.deepStrictEqual(
-          registry.getTracer('default').getCurrentSpan(),
+          provider.getTracer('default').getCurrentSpan(),
           span
         );
         return done();
       };
-      const patchedFn = registry.getTracer('default').bind(fn, span);
+      const patchedFn = provider.getTracer('default').bind(fn, span);
       return patchedFn();
     });
   });
 
   describe('.getBinaryFormat()', () => {
     it('should get default binary formatter', () => {
-      registry = new NodeTracerRegistry({});
+      provider = new NodeTracerProvider({});
       assert.ok(
-        registry.getTracer('default').getBinaryFormat() instanceof
+        provider.getTracer('default').getBinaryFormat() instanceof
           BinaryTraceContext
       );
     });
@@ -274,9 +274,9 @@ describe('NodeTracerRegistry', () => {
 
   describe('.getHttpTextFormat()', () => {
     it('should get default HTTP text formatter', () => {
-      registry = new NodeTracerRegistry({});
+      provider = new NodeTracerProvider({});
       assert.ok(
-        registry.getTracer('default').getHttpTextFormat() instanceof
+        provider.getTracer('default').getHttpTextFormat() instanceof
           HttpTraceContext
       );
     });

--- a/packages/opentelemetry-node/test/instrumentation/PluginLoader.test.ts
+++ b/packages/opentelemetry-node/test/instrumentation/PluginLoader.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { NoopLogger, NoopTracerRegistry } from '@opentelemetry/core';
+import { NoopLogger, NoopTracerProvider } from '@opentelemetry/core';
 import * as assert from 'assert';
 import * as path from 'path';
 import {
@@ -86,7 +86,7 @@ const notSupportedVersionPlugins: Plugins = {
 };
 
 describe('PluginLoader', () => {
-  const registry = new NoopTracerRegistry();
+  const provider = new NoopTracerProvider();
   const logger = new NoopLogger();
 
   before(() => {
@@ -101,19 +101,19 @@ describe('PluginLoader', () => {
 
   describe('.state()', () => {
     it('returns UNINITIALIZED when first called', () => {
-      const pluginLoader = new PluginLoader(registry, logger);
+      const pluginLoader = new PluginLoader(provider, logger);
       assert.strictEqual(pluginLoader['_hookState'], HookState.UNINITIALIZED);
     });
 
     it('transitions from UNINITIALIZED to ENABLED', () => {
-      const pluginLoader = new PluginLoader(registry, logger);
+      const pluginLoader = new PluginLoader(provider, logger);
       pluginLoader.load(simplePlugins);
       assert.strictEqual(pluginLoader['_hookState'], HookState.ENABLED);
       pluginLoader.unload();
     });
 
     it('transitions from ENABLED to DISABLED', () => {
-      const pluginLoader = new PluginLoader(registry, logger);
+      const pluginLoader = new PluginLoader(provider, logger);
       pluginLoader.load(simplePlugins).unload();
       assert.strictEqual(pluginLoader['_hookState'], HookState.DISABLED);
     });
@@ -138,7 +138,7 @@ describe('PluginLoader', () => {
     });
 
     it('should load a plugin and patch the target modules', () => {
-      const pluginLoader = new PluginLoader(registry, logger);
+      const pluginLoader = new PluginLoader(provider, logger);
       assert.strictEqual(pluginLoader['_plugins'].length, 0);
       pluginLoader.load(simplePlugins);
       // The hook is only called the first time the module is loaded.
@@ -150,7 +150,7 @@ describe('PluginLoader', () => {
     });
 
     it('should load a plugin and patch the core module', () => {
-      const pluginLoader = new PluginLoader(registry, logger);
+      const pluginLoader = new PluginLoader(provider, logger);
       assert.strictEqual(pluginLoader['_plugins'].length, 0);
       pluginLoader.load(httpPlugins);
       // The hook is only called the first time the module is loaded.
@@ -161,7 +161,7 @@ describe('PluginLoader', () => {
     });
     // @TODO: simplify this test once we can load module with custom path
     it('should not load the plugin when supported versions does not match', () => {
-      const pluginLoader = new PluginLoader(registry, logger);
+      const pluginLoader = new PluginLoader(provider, logger);
       assert.strictEqual(pluginLoader['_plugins'].length, 0);
       pluginLoader.load(notSupportedVersionPlugins);
       // The hook is only called the first time the module is loaded.
@@ -171,7 +171,7 @@ describe('PluginLoader', () => {
     });
     // @TODO: simplify this test once we can load module with custom path
     it('should load a plugin and patch the target modules when supported versions match', () => {
-      const pluginLoader = new PluginLoader(registry, logger);
+      const pluginLoader = new PluginLoader(provider, logger);
       assert.strictEqual(pluginLoader['_plugins'].length, 0);
       pluginLoader.load(supportedVersionPlugins);
       // The hook is only called the first time the module is loaded.
@@ -183,7 +183,7 @@ describe('PluginLoader', () => {
     });
 
     it('should not load a plugin when value is false', () => {
-      const pluginLoader = new PluginLoader(registry, logger);
+      const pluginLoader = new PluginLoader(provider, logger);
       assert.strictEqual(pluginLoader['_plugins'].length, 0);
       pluginLoader.load(disablePlugins);
       const simpleModule = require('simple-module');
@@ -194,7 +194,7 @@ describe('PluginLoader', () => {
     });
 
     it('should not load a plugin when value is true but path is missing', () => {
-      const pluginLoader = new PluginLoader(registry, logger);
+      const pluginLoader = new PluginLoader(provider, logger);
       assert.strictEqual(pluginLoader['_plugins'].length, 0);
       pluginLoader.load(missingPathPlugins);
       const simpleModule = require('simple-module');
@@ -205,7 +205,7 @@ describe('PluginLoader', () => {
     });
 
     it('should not load a non existing plugin', () => {
-      const pluginLoader = new PluginLoader(registry, logger);
+      const pluginLoader = new PluginLoader(provider, logger);
       assert.strictEqual(pluginLoader['_plugins'].length, 0);
       pluginLoader.load(nonexistentPlugins);
       assert.strictEqual(pluginLoader['_plugins'].length, 0);
@@ -213,7 +213,7 @@ describe('PluginLoader', () => {
     });
 
     it(`doesn't patch modules for which plugins aren't specified`, () => {
-      const pluginLoader = new PluginLoader(registry, logger);
+      const pluginLoader = new PluginLoader(provider, logger);
       pluginLoader.load({});
       assert.strictEqual(require('simple-module').value(), 0);
       pluginLoader.unload();
@@ -222,7 +222,7 @@ describe('PluginLoader', () => {
 
   describe('.unload()', () => {
     it('should unload the plugins and unpatch the target module when unloads', () => {
-      const pluginLoader = new PluginLoader(registry, logger);
+      const pluginLoader = new PluginLoader(provider, logger);
       assert.strictEqual(pluginLoader['_plugins'].length, 0);
       pluginLoader.load(simplePlugins);
       // The hook is only called the first time the module is loaded.

--- a/packages/opentelemetry-plugin-dns/README.md
+++ b/packages/opentelemetry-plugin-dns/README.md
@@ -18,9 +18,9 @@ npm install --save @opentelemetry/plugin-dns
 ## Usage
 
 ```js
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
-const registry = new NodeTracerRegistry({
+const provider = new NodeTracerProvider({
   plugins: {
     dns: {
       enabled: true,
@@ -37,7 +37,7 @@ const registry = new NodeTracerRegistry({
 If you use Zipkin, you must use `ignoreHostnames` in order to not trace those calls. If the server is local. You can set :
 
 ```
-const registry = new NodeTracerRegistry({
+const provider = new NodeTracerProvider({
   plugins: {
     dns: {
       enabled: true,

--- a/packages/opentelemetry-plugin-dns/test/functionals/dns-disable.test.ts
+++ b/packages/opentelemetry-plugin-dns/test/functionals/dns-disable.test.ts
@@ -20,20 +20,20 @@ import {
 } from '@opentelemetry/tracing';
 import * as assert from 'assert';
 import { NoopLogger } from '@opentelemetry/core';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import { plugin } from '../../src/dns';
 import * as sinon from 'sinon';
 import * as dns from 'dns';
 
 const memoryExporter = new InMemorySpanExporter();
 const logger = new NoopLogger();
-const registry = new NodeTracerRegistry({ logger });
-const tracer = registry.getTracer('default');
-registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new NodeTracerProvider({ logger });
+const tracer = provider.getTracer('default');
+provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
 describe('DnsPlugin', () => {
   before(() => {
-    plugin.enable(dns, registry, tracer.logger);
+    plugin.enable(dns, provider, tracer.logger);
     assert.strictEqual(dns.lookup.__wrapped, true);
   });
 

--- a/packages/opentelemetry-plugin-dns/test/functionals/dns-enable.test.ts
+++ b/packages/opentelemetry-plugin-dns/test/functionals/dns-enable.test.ts
@@ -20,18 +20,18 @@ import {
 } from '@opentelemetry/tracing';
 import * as assert from 'assert';
 import { NoopLogger } from '@opentelemetry/core';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import { plugin, DnsPlugin } from '../../src/dns';
 import * as dns from 'dns';
 
 const memoryExporter = new InMemorySpanExporter();
 const logger = new NoopLogger();
-const registry = new NodeTracerRegistry({ logger });
-registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new NodeTracerProvider({ logger });
+provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
 describe('DnsPlugin', () => {
   before(() => {
-    plugin.enable(dns, registry, registry.logger);
+    plugin.enable(dns, provider, provider.logger);
   });
 
   after(() => {

--- a/packages/opentelemetry-plugin-dns/test/functionals/utils.test.ts
+++ b/packages/opentelemetry-plugin-dns/test/functionals/utils.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { NoopLogger } from '@opentelemetry/core';
-import { BasicTracerRegistry, Span } from '@opentelemetry/tracing';
+import { BasicTracerProvider, Span } from '@opentelemetry/tracing';
 import { CanonicalCode, SpanKind } from '@opentelemetry/types';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
@@ -162,7 +162,7 @@ describe('Utility', () => {
     it('should have error attributes', () => {
       const errorMessage = 'test error';
       const span = new Span(
-        new BasicTracerRegistry().getTracer('default'),
+        new BasicTracerProvider().getTracer('default'),
         'test',
         { spanId: '', traceId: '' },
         SpanKind.INTERNAL

--- a/packages/opentelemetry-plugin-dns/test/integrations/dns-lookup.test.ts
+++ b/packages/opentelemetry-plugin-dns/test/integrations/dns-lookup.test.ts
@@ -20,7 +20,7 @@ import {
 } from '@opentelemetry/tracing';
 import * as assert from 'assert';
 import { NoopLogger } from '@opentelemetry/core';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import { plugin } from '../../src/dns';
 import * as dns from 'dns';
 import * as utils from '../utils/utils';
@@ -29,14 +29,14 @@ import { CanonicalCode } from '@opentelemetry/types';
 
 const memoryExporter = new InMemorySpanExporter();
 const logger = new NoopLogger();
-const registry = new NodeTracerRegistry({ logger });
-registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new NodeTracerProvider({ logger });
+provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
 describe('dns.lookup()', () => {
   before(function(done) {
     // mandatory
     if (process.env.CI) {
-      plugin.enable(dns, registry, registry.logger);
+      plugin.enable(dns, provider, provider.logger);
       done();
       return;
     }
@@ -48,7 +48,7 @@ describe('dns.lookup()', () => {
       }
       done();
     });
-    plugin.enable(dns, registry, registry.logger);
+    plugin.enable(dns, provider, provider.logger);
   });
 
   afterEach(() => {

--- a/packages/opentelemetry-plugin-dns/test/integrations/dnspromise-lookup.test.ts
+++ b/packages/opentelemetry-plugin-dns/test/integrations/dnspromise-lookup.test.ts
@@ -20,7 +20,7 @@ import {
 } from '@opentelemetry/tracing';
 import * as assert from 'assert';
 import { NoopLogger } from '@opentelemetry/core';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import { plugin } from '../../src/dns';
 import * as dns from 'dns';
 import * as utils from '../utils/utils';
@@ -30,8 +30,8 @@ import { CanonicalCode } from '@opentelemetry/types';
 
 const memoryExporter = new InMemorySpanExporter();
 const logger = new NoopLogger();
-const registry = new NodeTracerRegistry({ logger });
-registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new NodeTracerProvider({ logger });
+provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
 describe('dns.promises.lookup()', () => {
   before(function(done) {
@@ -42,7 +42,7 @@ describe('dns.promises.lookup()', () => {
 
     // if node version is supported, it's mandatory for CI
     if (process.env.CI) {
-      plugin.enable(dns, registry, registry.logger);
+      plugin.enable(dns, provider, provider.logger);
       done();
       return;
     }
@@ -54,7 +54,7 @@ describe('dns.promises.lookup()', () => {
       }
       done();
     });
-    plugin.enable(dns, registry, registry.logger);
+    plugin.enable(dns, provider, provider.logger);
   });
 
   afterEach(() => {

--- a/packages/opentelemetry-plugin-document-load/test/documentLoad.test.ts
+++ b/packages/opentelemetry-plugin-document-load/test/documentLoad.test.ts
@@ -20,7 +20,7 @@
 
 import { ConsoleLogger, TRACE_PARENT_HEADER } from '@opentelemetry/core';
 import {
-  BasicTracerRegistry,
+  BasicTracerProvider,
   ReadableSpan,
   SimpleSpanProcessor,
   SpanExporter,
@@ -191,7 +191,7 @@ function ensureNetworkEventsExists(events: TimedEvent[]) {
 describe('DocumentLoad Plugin', () => {
   let plugin: DocumentLoad;
   let moduleExports: any;
-  let registry: BasicTracerRegistry;
+  let provider: BasicTracerProvider;
   let logger: Logger;
   let config: PluginConfig;
   let spanProcessor: SimpleSpanProcessor;
@@ -203,13 +203,13 @@ describe('DocumentLoad Plugin', () => {
       value: 'complete',
     });
     moduleExports = {};
-    registry = new BasicTracerRegistry();
+    provider = new BasicTracerProvider();
     logger = new ConsoleLogger();
     config = {};
     plugin = new DocumentLoad();
     dummyExporter = new DummyExporter();
     spanProcessor = new SimpleSpanProcessor(dummyExporter);
-    registry.addSpanProcessor(spanProcessor);
+    provider.addSpanProcessor(spanProcessor);
   });
 
   afterEach(() => {
@@ -237,7 +237,7 @@ describe('DocumentLoad Plugin', () => {
       spyEntries.restore();
     });
     it('should start collecting the performance immediately', done => {
-      plugin.enable(moduleExports, registry, logger, config);
+      plugin.enable(moduleExports, provider, logger, config);
       setTimeout(() => {
         assert.strictEqual(window.document.readyState, 'complete');
         assert.strictEqual(spyEntries.callCount, 2);
@@ -264,7 +264,7 @@ describe('DocumentLoad Plugin', () => {
     it('should collect performance after document load event', done => {
       const spy = sinon.spy(window, 'addEventListener');
 
-      plugin.enable(moduleExports, registry, logger, config);
+      plugin.enable(moduleExports, provider, logger, config);
       const args = spy.args[0];
       const name = args[0];
       assert.strictEqual(name, 'load');
@@ -299,7 +299,7 @@ describe('DocumentLoad Plugin', () => {
 
     it('should export correct span with events', done => {
       const spyOnEnd = sinon.spy(dummyExporter, 'export');
-      plugin.enable(moduleExports, registry, logger, config);
+      plugin.enable(moduleExports, provider, logger, config);
 
       setTimeout(() => {
         const rootSpan = spyOnEnd.args[0][0][0] as ReadableSpan;
@@ -356,7 +356,7 @@ describe('DocumentLoad Plugin', () => {
 
       it('should create a root span with server context traceId', done => {
         const spyOnEnd = sinon.spy(dummyExporter, 'export');
-        plugin.enable(moduleExports, registry, logger, config);
+        plugin.enable(moduleExports, provider, logger, config);
         setTimeout(() => {
           const rootSpan = spyOnEnd.args[0][0][0] as ReadableSpan;
           const fetchSpan = spyOnEnd.args[1][0][0] as ReadableSpan;
@@ -392,7 +392,7 @@ describe('DocumentLoad Plugin', () => {
 
     it('should create span for each of the resource', done => {
       const spyOnEnd = sinon.spy(dummyExporter, 'export');
-      plugin.enable(moduleExports, registry, logger, config);
+      plugin.enable(moduleExports, provider, logger, config);
       setTimeout(() => {
         const spanResource1 = spyOnEnd.args[1][0][0] as ReadableSpan;
         const spanResource2 = spyOnEnd.args[2][0][0] as ReadableSpan;
@@ -430,7 +430,7 @@ describe('DocumentLoad Plugin', () => {
 
     it('should create span for each of the resource', done => {
       const spyOnEnd = sinon.spy(dummyExporter, 'export');
-      plugin.enable(moduleExports, registry, logger, config);
+      plugin.enable(moduleExports, provider, logger, config);
       setTimeout(() => {
         const spanResource1 = spyOnEnd.args[1][0][0] as ReadableSpan;
 
@@ -471,7 +471,7 @@ describe('DocumentLoad Plugin', () => {
 
     it('should still export rootSpan and fetchSpan', done => {
       const spyOnEnd = sinon.spy(dummyExporter, 'export');
-      plugin.enable(moduleExports, registry, logger, config);
+      plugin.enable(moduleExports, provider, logger, config);
 
       setTimeout(() => {
         const rootSpan = spyOnEnd.args[0][0][0] as ReadableSpan;
@@ -503,7 +503,7 @@ describe('DocumentLoad Plugin', () => {
 
     it('should export correct span with events', done => {
       const spyOnEnd = sinon.spy(dummyExporter, 'export');
-      plugin.enable(moduleExports, registry, logger, config);
+      plugin.enable(moduleExports, provider, logger, config);
       setTimeout(() => {
         const rootSpan = spyOnEnd.args[0][0][0] as ReadableSpan;
         const fetchSpan = spyOnEnd.args[1][0][0] as ReadableSpan;
@@ -551,7 +551,7 @@ describe('DocumentLoad Plugin', () => {
 
     it('should not create any span', done => {
       const spyOnEnd = sinon.spy(dummyExporter, 'export');
-      plugin.enable(moduleExports, registry, logger, config);
+      plugin.enable(moduleExports, provider, logger, config);
       setTimeout(() => {
         assert.ok(spyOnEnd.callCount === 0);
         done();

--- a/packages/opentelemetry-plugin-grpc/README.md
+++ b/packages/opentelemetry-plugin-grpc/README.md
@@ -22,9 +22,9 @@ OpenTelemetry gRPC Instrumentation allows the user to automatically collect trac
 
 To load a specific plugin (**gRPC** in this case), specify it in the Node Tracer's configuration.
 ```javascript
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
-const registry = new NodeTracerRegistry({
+const provider = new NodeTracerProvider({
   plugins: {
     grpc: {
       enabled: true,
@@ -37,9 +37,9 @@ const registry = new NodeTracerRegistry({
 
 To load all the [supported plugins](https://github.com/open-telemetry/opentelemetry-js#plugins), use below approach. Each plugin is only loaded when the module that it patches is loaded; in other words, there is no computational overhead for listing plugins for unused modules.
 ```javascript
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
-const registry = new NodeTracerRegistry();
+const provider = new NodeTracerProvider();
 ```
 
 See [examples/grpc](https://github.com/open-telemetry/opentelemetry-js/tree/master/examples/grpc) for a short example.

--- a/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
+++ b/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { NoopLogger, NoopTracerRegistry } from '@opentelemetry/core';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NoopLogger, NoopTracerProvider } from '@opentelemetry/core';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -316,7 +316,7 @@ describe('GrpcPlugin', () => {
     });
 
     it('should patch client constructor makeClientConstructor() and makeGenericClientConstructor()', () => {
-      plugin.enable(grpc, new NoopTracerRegistry(), new NoopLogger());
+      plugin.enable(grpc, new NoopTracerProvider(), new NoopLogger());
       (plugin['_moduleExports'] as any).makeGenericClientConstructor({});
       assert.strictEqual(clientPatchStub.callCount, 1);
     });
@@ -368,7 +368,7 @@ describe('GrpcPlugin', () => {
 
   const runTest = (
     method: typeof methodList[0],
-    registry: NodeTracerRegistry,
+    provider: NodeTracerProvider,
     checkSpans = true
   ) => {
     it(`should ${
@@ -408,11 +408,11 @@ describe('GrpcPlugin', () => {
       const expectEmpty = memoryExporter.getFinishedSpans();
       assert.strictEqual(expectEmpty.length, 0);
 
-      const span = registry
+      const span = provider
         .getTracer('default')
         .startSpan('TestSpan', { kind: SpanKind.PRODUCER });
-      return registry.getTracer('default').withSpan(span, async () => {
-        const rootSpan = registry.getTracer('default').getCurrentSpan();
+      return provider.getTracer('default').withSpan(span, async () => {
+        const rootSpan = provider.getTracer('default').getCurrentSpan();
         if (!rootSpan) {
           assert.ok(false);
           return; // return so typechecking passes for rootSpan.end()
@@ -465,7 +465,7 @@ describe('GrpcPlugin', () => {
     method: typeof methodList[0],
     key: string,
     errorCode: number,
-    registry: NodeTracerRegistry
+    provider: NodeTracerProvider
   ) => {
     it(`should raise an error for client/server rootSpans: method=${method.methodName}, status=${key}`, async () => {
       const expectEmpty = memoryExporter.getFinishedSpans();
@@ -503,11 +503,11 @@ describe('GrpcPlugin', () => {
       const expectEmpty = memoryExporter.getFinishedSpans();
       assert.strictEqual(expectEmpty.length, 0);
 
-      const span = registry
+      const span = provider
         .getTracer('default')
         .startSpan('TestSpan', { kind: SpanKind.PRODUCER });
-      return registry.getTracer('default').withSpan(span, async () => {
-        const rootSpan = registry.getTracer('default').getCurrentSpan();
+      return provider.getTracer('default').withSpan(span, async () => {
+        const rootSpan = provider.getTracer('default').getCurrentSpan();
         if (!rootSpan) {
           assert.ok(false);
           return; // return so typechecking passes for rootSpan.end()
@@ -554,8 +554,8 @@ describe('GrpcPlugin', () => {
 
   describe('enable()', () => {
     const logger = new NoopLogger();
-    const registry = new NodeTracerRegistry({ logger });
-    registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    const provider = new NodeTracerProvider({ logger });
+    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     beforeEach(() => {
       memoryExporter.reset();
     });
@@ -564,7 +564,7 @@ describe('GrpcPlugin', () => {
       const config = {
         // TODO: add plugin options here once supported
       };
-      plugin.enable(grpc, registry, logger, config);
+      plugin.enable(grpc, provider, logger, config);
 
       const proto = grpc.load(PROTO_PATH).pkg_test;
       server = startServer(grpc, proto);
@@ -581,7 +581,7 @@ describe('GrpcPlugin', () => {
 
     methodList.forEach(method => {
       describe(`Test automatic tracing for grpc remote method ${method.description}`, () => {
-        runTest(method, registry);
+        runTest(method, provider);
       });
     });
 
@@ -591,7 +591,7 @@ describe('GrpcPlugin', () => {
           // tslint:disable-next-line:no-any
           const errorCode = Number(grpc.status[statusKey as any]);
           if (errorCode > grpc.status.OK) {
-            runErrorTest(method, statusKey, errorCode, registry);
+            runErrorTest(method, statusKey, errorCode, provider);
           }
         });
       });
@@ -600,14 +600,14 @@ describe('GrpcPlugin', () => {
 
   describe('disable()', () => {
     const logger = new NoopLogger();
-    const registry = new NodeTracerRegistry({ logger });
-    registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    const provider = new NodeTracerProvider({ logger });
+    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     beforeEach(() => {
       memoryExporter.reset();
     });
 
     before(() => {
-      plugin.enable(grpc, registry, logger);
+      plugin.enable(grpc, provider, logger);
       plugin.disable();
 
       const proto = grpc.load(PROTO_PATH).pkg_test;
@@ -624,7 +624,7 @@ describe('GrpcPlugin', () => {
 
     methodList.map(method => {
       describe(`Test automatic tracing for grpc remote method ${method.description}`, () => {
-        runTest(method, registry, false);
+        runTest(method, provider, false);
       });
     });
   });

--- a/packages/opentelemetry-plugin-http/README.md
+++ b/packages/opentelemetry-plugin-http/README.md
@@ -22,9 +22,9 @@ OpenTelemetry HTTP Instrumentation allows the user to automatically collect trac
 
 To load a specific plugin (HTTP in this case), specify it in the Node Tracer's configuration.
 ```js
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
-const registry = new NodeTracerRegistry({
+const provider = new NodeTracerProvider({
   plugins: {
     http: {
       enabled: true,
@@ -38,9 +38,9 @@ const registry = new NodeTracerRegistry({
 
 To load all the [supported plugins](https://github.com/open-telemetry/opentelemetry-js#plugins), use below approach. Each plugin is only loaded when the module that it patches is loaded; in other words, there is no computational overhead for listing plugins for unused modules.
 ```js
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
-const registry = new NodeTracerRegistry();
+const provider = new NodeTracerProvider();
 ```
 
 See [examples/http](https://github.com/open-telemetry/opentelemetry-js/tree/master/examples/http) for a short example.

--- a/packages/opentelemetry-plugin-http/test/functionals/http-disable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-disable.test.ts
@@ -22,7 +22,7 @@ import * as sinon from 'sinon';
 import { plugin } from '../../src/http';
 import {
   NoopLogger,
-  NoopTracerRegistry,
+  NoopTracerProvider,
   noopTracer,
 } from '@opentelemetry/core';
 import { AddressInfo } from 'net';
@@ -34,12 +34,12 @@ describe('HttpPlugin', () => {
 
   describe('disable()', () => {
     const logger = new NoopLogger();
-    const registry = new NoopTracerRegistry();
+    const provider = new NoopTracerProvider();
     before(() => {
       nock.cleanAll();
       nock.enableNetConnect();
 
-      plugin.enable(http, registry, logger);
+      plugin.enable(http, provider, logger);
       // Ensure that http module is patched.
       assert.strictEqual(http.Server.prototype.emit.__wrapped, true);
       server = http.createServer((request, response) => {
@@ -65,7 +65,7 @@ describe('HttpPlugin', () => {
       server.close();
     });
     describe('unpatch()', () => {
-      it('should not call registry methods for creating span', async () => {
+      it('should not call provider methods for creating span', async () => {
         plugin.disable();
         const testPath = '/incoming/unpatch/';
 

--- a/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
@@ -19,7 +19,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/tracing';
 import { NoopLogger } from '@opentelemetry/core';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import { CanonicalCode, Span as ISpan, SpanKind } from '@opentelemetry/types';
 import * as assert from 'assert';
 import * as http from 'http';
@@ -45,11 +45,11 @@ const serverName = 'my.server.name';
 const memoryExporter = new InMemorySpanExporter();
 const httpTextFormat = new DummyPropagation();
 const logger = new NoopLogger();
-const registry = new NodeTracerRegistry({
+const provider = new NodeTracerProvider({
   logger,
   httpTextFormat,
 });
-registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
 function doNock(
   hostname: string,
@@ -109,7 +109,7 @@ describe('HttpPlugin', () => {
           plugin.component,
           process.versions.node
         );
-        pluginWithBadOptions.enable(http, registry, registry.logger, config);
+        pluginWithBadOptions.enable(http, provider, provider.logger, config);
         server = http.createServer((request, response) => {
           response.end('Test Server Response');
         });
@@ -187,7 +187,7 @@ describe('HttpPlugin', () => {
           applyCustomAttributesOnSpan: customAttributeFunction,
           serverName,
         };
-        plugin.enable(http, registry, registry.logger, config);
+        plugin.enable(http, provider, provider.logger, config);
         server = http.createServer((request, response) => {
           response.end('Test Server Response');
         });
@@ -208,7 +208,7 @@ describe('HttpPlugin', () => {
         const httpNotPatched = new HttpPlugin(
           plugin.component,
           process.versions.node
-        ).enable({} as Http, registry, registry.logger, {});
+        ).enable({} as Http, provider, provider.logger, {});
         assert.strictEqual(Object.keys(httpNotPatched).length, 0);
       });
 
@@ -323,8 +323,8 @@ describe('HttpPlugin', () => {
         const testPath = '/outgoing/rootSpan/childs/1';
         doNock(hostname, testPath, 200, 'Ok');
         const name = 'TestRootSpan';
-        const span = registry.getTracer('default').startSpan(name);
-        return registry.getTracer('default').withSpan(span, async () => {
+        const span = provider.getTracer('default').startSpan(name);
+        return provider.getTracer('default').withSpan(span, async () => {
           const result = await httpRequest.get(
             `${protocol}://${hostname}${testPath}`
           );
@@ -366,8 +366,8 @@ describe('HttpPlugin', () => {
             httpErrorCodes[i].toString()
           );
           const name = 'TestRootSpan';
-          const span = registry.getTracer('default').startSpan(name);
-          return registry.getTracer('default').withSpan(span, async () => {
+          const span = provider.getTracer('default').startSpan(name);
+          return provider.getTracer('default').withSpan(span, async () => {
             const result = await httpRequest.get(
               `${protocol}://${hostname}${testPath}`
             );
@@ -405,8 +405,8 @@ describe('HttpPlugin', () => {
         const num = 5;
         doNock(hostname, testPath, 200, 'Ok', num);
         const name = 'TestRootSpan';
-        const span = registry.getTracer('default').startSpan(name);
-        await registry.getTracer('default').withSpan(span, async () => {
+        const span = provider.getTracer('default').startSpan(name);
+        await provider.getTracer('default').withSpan(span, async () => {
           for (let i = 0; i < num; i++) {
             await httpRequest.get(`${protocol}://${hostname}${testPath}`);
             const spans = memoryExporter.getFinishedSpans();

--- a/packages/opentelemetry-plugin-http/test/functionals/http-package.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-package.test.ts
@@ -28,7 +28,7 @@ import * as superagent from 'superagent';
 import * as got from 'got';
 import * as request from 'request-promise-native';
 import * as path from 'path';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -45,11 +45,11 @@ describe('Packages', () => {
     const httpTextFormat = new DummyPropagation();
     const logger = new NoopLogger();
 
-    const registry = new NodeTracerRegistry({
+    const provider = new NodeTracerProvider({
       logger,
       httpTextFormat,
     });
-    registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     beforeEach(() => {
       memoryExporter.reset();
     });
@@ -58,7 +58,7 @@ describe('Packages', () => {
       const config: HttpPluginConfig = {
         applyCustomAttributesOnSpan: customAttributeFunction,
       };
-      plugin.enable(http, registry, registry.logger, config);
+      plugin.enable(http, provider, provider.logger, config);
     });
 
     after(() => {

--- a/packages/opentelemetry-plugin-http/test/functionals/utils.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/utils.test.ts
@@ -22,7 +22,7 @@ import { NoopScopeManager } from '@opentelemetry/scope-base';
 import { IgnoreMatcher } from '../../src/types';
 import * as utils from '../../src/utils';
 import * as http from 'http';
-import { Span, BasicTracerRegistry } from '@opentelemetry/tracing';
+import { Span, BasicTracerProvider } from '@opentelemetry/tracing';
 import { AttributeNames } from '../../src';
 import { NoopLogger } from '@opentelemetry/core';
 
@@ -248,7 +248,7 @@ describe('Utility', () => {
       const errorMessage = 'test error';
       for (const obj of [undefined, { statusCode: 400 }]) {
         const span = new Span(
-          new BasicTracerRegistry({
+          new BasicTracerProvider({
             scopeManager: new NoopScopeManager(),
           }).getTracer('default'),
           'test',

--- a/packages/opentelemetry-plugin-http/test/integrations/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/integrations/http-enable.test.ts
@@ -24,7 +24,7 @@ import { DummyPropagation } from '../utils/DummyPropagation';
 import { httpRequest } from '../utils/httpRequest';
 import * as url from 'url';
 import * as utils from '../utils/utils';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -60,11 +60,11 @@ describe('HttpPlugin Integration tests', () => {
 
     const httpTextFormat = new DummyPropagation();
     const logger = new NoopLogger();
-    const registry = new NodeTracerRegistry({
+    const provider = new NodeTracerProvider({
       logger,
       httpTextFormat,
     });
-    registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     beforeEach(() => {
       memoryExporter.reset();
     });
@@ -83,7 +83,7 @@ describe('HttpPlugin Integration tests', () => {
       try {
         plugin.disable();
       } catch (e) {}
-      plugin.enable(http, registry, registry.logger, config);
+      plugin.enable(http, provider, provider.logger, config);
     });
 
     after(() => {

--- a/packages/opentelemetry-plugin-https/README.md
+++ b/packages/opentelemetry-plugin-https/README.md
@@ -22,9 +22,9 @@ OpenTelemetry HTTPS Instrumentation allows the user to automatically collect tra
 
 To load a specific plugin (HTTPS in this case), specify it in the Node Tracer's configuration.
 ```js
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
-const registry = new NodeTracerRegistry({
+const provider = new NodeTracerProvider({
   plugins: {
     https: {
       enabled: true,
@@ -38,9 +38,9 @@ const registry = new NodeTracerRegistry({
 
 To load all the [supported plugins](https://github.com/open-telemetry/opentelemetry-js#plugins), use below approach. Each plugin is only loaded when the module that it patches is loaded; in other words, there is no computational overhead for listing plugins for unused modules.
 ```js
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
-const registry = new NodeTracerRegistry();
+const provider = new NodeTracerProvider();
 ```
 
 See [examples/https](https://github.com/open-telemetry/opentelemetry-js/tree/master/examples/https) for a short example.

--- a/packages/opentelemetry-plugin-https/test/functionals/https-disable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/functionals/https-disable.test.ts
@@ -25,7 +25,7 @@ import * as sinon from 'sinon';
 import { plugin } from '../../src/https';
 import { DummyPropagation } from '../utils/DummyPropagation';
 import { httpsRequest } from '../utils/httpsRequest';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import * as types from '@opentelemetry/types';
 
 describe('HttpsPlugin', () => {
@@ -35,17 +35,17 @@ describe('HttpsPlugin', () => {
   describe('disable()', () => {
     const httpTextFormat = new DummyPropagation();
     const logger = new NoopLogger();
-    const registry = new NodeTracerRegistry({
+    const provider = new NodeTracerProvider({
       logger,
       httpTextFormat,
     });
-    // const tracer = registry.getTracer('test-https')
+    // const tracer = provider.getTracer('test-https')
     let tracer: types.Tracer;
     before(() => {
       nock.cleanAll();
       nock.enableNetConnect();
 
-      plugin.enable((https as unknown) as Http, registry, registry.logger);
+      plugin.enable((https as unknown) as Http, provider, provider.logger);
       tracer = plugin['_tracer'];
       // Ensure that https module is patched.
       assert.strictEqual(https.Server.prototype.emit.__wrapped, true);

--- a/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
@@ -19,7 +19,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/tracing';
 import { NoopLogger } from '@opentelemetry/core';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import {
   Http,
   HttpPluginConfig,
@@ -50,12 +50,12 @@ const pathname = '/test';
 const memoryExporter = new InMemorySpanExporter();
 const httpTextFormat = new DummyPropagation();
 const logger = new NoopLogger();
-const registry = new NodeTracerRegistry({
+const provider = new NodeTracerProvider({
   logger,
   httpTextFormat,
 });
-const tracer = registry.getTracer('test-https');
-registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const tracer = provider.getTracer('test-https');
+provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
 function doNock(
   hostname: string,
@@ -114,7 +114,7 @@ describe('HttpsPlugin', () => {
         pluginWithBadOptions = new HttpsPlugin(process.versions.node);
         pluginWithBadOptions.enable(
           (https as unknown) as Http,
-          registry,
+          provider,
           tracer.logger,
           config
         );
@@ -203,7 +203,7 @@ describe('HttpsPlugin', () => {
         };
         plugin.enable(
           (https as unknown) as Http,
-          registry,
+          provider,
           tracer.logger,
           config
         );
@@ -232,7 +232,7 @@ describe('HttpsPlugin', () => {
       it(`should not patch if it's not a ${protocol} module`, () => {
         const httpsNotPatched = new HttpsPlugin(process.versions.node).enable(
           {} as Http,
-          registry,
+          provider,
           tracer.logger,
           {}
         );

--- a/packages/opentelemetry-plugin-https/test/functionals/https-package.test.ts
+++ b/packages/opentelemetry-plugin-https/test/functionals/https-package.test.ts
@@ -34,7 +34,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/tracing';
 import { Http } from '@opentelemetry/plugin-http';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -47,17 +47,17 @@ describe('Packages', () => {
     const httpTextFormat = new DummyPropagation();
     const logger = new NoopLogger();
 
-    const registry = new NodeTracerRegistry({
+    const provider = new NodeTracerProvider({
       logger,
       httpTextFormat,
     });
-    registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     beforeEach(() => {
       memoryExporter.reset();
     });
 
     before(() => {
-      plugin.enable((https as unknown) as Http, registry, registry.logger);
+      plugin.enable((https as unknown) as Http, provider, provider.logger);
     });
 
     after(() => {

--- a/packages/opentelemetry-plugin-https/test/integrations/https-enable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/integrations/https-enable.test.ts
@@ -30,7 +30,7 @@ import { DummyPropagation } from '../utils/DummyPropagation';
 import { httpsRequest } from '../utils/httpsRequest';
 import * as url from 'url';
 import * as utils from '../utils/utils';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -65,11 +65,11 @@ describe('HttpsPlugin Integration tests', () => {
 
     const httpTextFormat = new DummyPropagation();
     const logger = new NoopLogger();
-    const registry = new NodeTracerRegistry({
+    const provider = new NodeTracerProvider({
       logger,
       httpTextFormat,
     });
-    registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     beforeEach(() => {
       memoryExporter.reset();
     });
@@ -90,8 +90,8 @@ describe('HttpsPlugin Integration tests', () => {
       } catch (e) {}
       plugin.enable(
         (https as unknown) as Http,
-        registry,
-        registry.logger,
+        provider,
+        provider.logger,
         config
       );
     });

--- a/packages/opentelemetry-plugin-mongodb/README.md
+++ b/packages/opentelemetry-plugin-mongodb/README.md
@@ -23,9 +23,9 @@ OpenTelemetry Mongodb Instrumentation allows the user to automatically collect t
 
 To load a specific plugin (mongodb in this case), specify it in the Node Tracer's configuration.
 ```js
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
-const registry = new NodeTracerRegistry({
+const provider = new NodeTracerProvider({
   plugins: {
     mongodb: {
       enabled: true,
@@ -38,9 +38,9 @@ const registry = new NodeTracerRegistry({
 
 To load all the [supported plugins](https://github.com/open-telemetry/opentelemetry-js#plugins), use below approach. Each plugin is only loaded when the module that it patches is loaded; in other words, there is no computational overhead for listing plugins for unused modules.
 ```js
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
-const registry = new NodeTracerRegistry();
+const provider = new NodeTracerProvider();
 ```
 
 See [examples/mongodb](https://github.com/open-telemetry/opentelemetry-js/tree/master/examples/mongodb) for a short example.

--- a/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg-pool/test/pg-pool.test.ts
+++ b/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg-pool/test/pg-pool.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { NoopLogger } from '@opentelemetry/core';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -92,7 +92,7 @@ const runCallbackTest = (
 
 describe('pg-pool@2.x', () => {
   let pool: pgPool<pg.Client>;
-  const registry = new NodeTracerRegistry();
+  const provider = new NodeTracerProvider();
   const logger = new NoopLogger();
   const testPostgres = process.env.TEST_POSTGRES; // For CI: assumes local postgres db is already available
   const testPostgresLocally = process.env.TEST_POSTGRES_LOCAL; // For local: spins up local postgres db via docker
@@ -106,7 +106,7 @@ describe('pg-pool@2.x', () => {
       this.skip();
     }
     pool = new pgPool(CONFIG);
-    registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     if (testPostgresLocally) {
       testUtils.startDocker('postgres');
     }
@@ -123,8 +123,8 @@ describe('pg-pool@2.x', () => {
   });
 
   beforeEach(function() {
-    plugin.enable(pgPool, registry, logger);
-    pgPlugin.enable(pg, registry, logger);
+    plugin.enable(pgPool, provider, logger);
+    pgPlugin.enable(pg, provider, logger);
   });
 
   afterEach(() => {
@@ -152,8 +152,8 @@ describe('pg-pool@2.x', () => {
         [AttributeNames.DB_STATEMENT]: 'SELECT NOW()',
       };
       const events: TimedEvent[] = [];
-      const span = registry.getTracer('test-pg-pool').startSpan('test span');
-      await registry.getTracer('test-pg-pool').withSpan(span, async () => {
+      const span = provider.getTracer('test-pg-pool').startSpan('test span');
+      await provider.getTracer('test-pg-pool').withSpan(span, async () => {
         const client = await pool.connect();
         runCallbackTest(span, pgPoolattributes, events, okStatus, 1, 0);
         assert.ok(client, 'pool.connect() returns a promise');
@@ -178,10 +178,10 @@ describe('pg-pool@2.x', () => {
         [AttributeNames.DB_STATEMENT]: 'SELECT NOW()',
       };
       const events: TimedEvent[] = [];
-      const parentSpan = registry
+      const parentSpan = provider
         .getTracer('test-pg-pool')
         .startSpan('test span');
-      registry.getTracer('test-pg-pool').withSpan(parentSpan, () => {
+      provider.getTracer('test-pg-pool').withSpan(parentSpan, () => {
         const resNoPromise = pool.connect((err, client, release) => {
           if (err) {
             return done(err);
@@ -214,8 +214,8 @@ describe('pg-pool@2.x', () => {
         [AttributeNames.DB_STATEMENT]: 'SELECT NOW()',
       };
       const events: TimedEvent[] = [];
-      const span = registry.getTracer('test-pg-pool').startSpan('test span');
-      await registry.getTracer('test-pg-pool').withSpan(span, async () => {
+      const span = provider.getTracer('test-pg-pool').startSpan('test span');
+      await provider.getTracer('test-pg-pool').withSpan(span, async () => {
         try {
           const result = await pool.query('SELECT NOW()');
           runCallbackTest(span, pgPoolattributes, events, okStatus, 2, 0);
@@ -237,10 +237,10 @@ describe('pg-pool@2.x', () => {
         [AttributeNames.DB_STATEMENT]: 'SELECT NOW()',
       };
       const events: TimedEvent[] = [];
-      const parentSpan = registry
+      const parentSpan = provider
         .getTracer('test-pg-pool')
         .startSpan('test span');
-      registry.getTracer('test-pg-pool').withSpan(parentSpan, () => {
+      provider.getTracer('test-pg-pool').withSpan(parentSpan, () => {
         const resNoPromise = pool.query('SELECT NOW()', (err, result) => {
           if (err) {
             return done(err);

--- a/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg/test/pg.test.ts
+++ b/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg/test/pg.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { NoopLogger } from '@opentelemetry/core';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -81,8 +81,8 @@ const runCallbackTest = (
 
 describe('pg@7.x', () => {
   let client: pg.Client;
-  const registry = new NodeTracerRegistry();
-  const tracer = registry.getTracer('external');
+  const provider = new NodeTracerProvider();
+  const tracer = provider.getTracer('external');
   const logger = new NoopLogger();
   const testPostgres = process.env.RUN_POSTGRES_TESTS; // For CI: assumes local postgres db is already available
   const testPostgresLocally = process.env.RUN_POSTGRES_TESTS_LOCAL; // For local: spins up local postgres db via docker
@@ -95,7 +95,7 @@ describe('pg@7.x', () => {
       this.test!.parent!.pending = true;
       this.skip();
     }
-    registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     if (testPostgresLocally) {
       testUtils.startDocker('postgres');
     }
@@ -116,7 +116,7 @@ describe('pg@7.x', () => {
   });
 
   beforeEach(function() {
-    plugin.enable(pg, registry, logger);
+    plugin.enable(pg, provider, logger);
   });
 
   afterEach(() => {

--- a/packages/opentelemetry-plugin-redis/README.md
+++ b/packages/opentelemetry-plugin-redis/README.md
@@ -24,9 +24,9 @@ OpenTelemetry Redis Instrumentation allows the user to automatically collect tra
 
 To load a specific plugin (**redis** in this case), specify it in the Node Tracer's configuration
 ```js
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
-const registry = new NodeTracerRegistry({
+const provider = new NodeTracerProvider({
   plugins: {
     redis: {
       enabled: true,
@@ -39,9 +39,9 @@ const registry = new NodeTracerRegistry({
 
 To load all the [supported plugins](https://github.com/open-telemetry/opentelemetry-js#plugins), use below approach. Each plugin is only loaded when the module that it patches is loaded; in other words, there is no computational overhead for listing plugins for unused modules.
 ```javascript
-const { NodeTracerRegistry } = require('@opentelemetry/node');
+const { NodeTracerProvider } = require('@opentelemetry/node');
 
-const registry = new NodeTracerRegistry();
+const provider = new NodeTracerProvider();
 ```
 
 See [examples/redis](https://github.com/open-telemetry/opentelemetry-js/tree/master/examples/redis) for a short example.

--- a/packages/opentelemetry-plugin-redis/test/redis.test.ts
+++ b/packages/opentelemetry-plugin-redis/test/redis.test.ts
@@ -19,7 +19,7 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/tracing';
-import { NodeTracerRegistry } from '@opentelemetry/node';
+import { NodeTracerProvider } from '@opentelemetry/node';
 import { plugin, RedisPlugin } from '../src';
 import * as redisTypes from 'redis';
 import { NoopLogger } from '@opentelemetry/core';
@@ -48,8 +48,8 @@ const okStatus: Status = {
 };
 
 describe('redis@2.x', () => {
-  const registry = new NodeTracerRegistry();
-  const tracer = registry.getTracer('external');
+  const provider = new NodeTracerProvider();
+  const tracer = provider.getTracer('external');
   let redis: typeof redisTypes;
   const shouldTestLocal = process.env.RUN_REDIS_TESTS_LOCAL;
   const shouldTest = process.env.RUN_REDIS_TESTS || shouldTestLocal;
@@ -68,8 +68,8 @@ describe('redis@2.x', () => {
     }
 
     redis = require('redis');
-    registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
-    plugin.enable(redis, registry, new NoopLogger());
+    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    plugin.enable(redis, provider, new NoopLogger());
   });
 
   after(() => {

--- a/packages/opentelemetry-plugin-xml-http-request/test/xhr.test.ts
+++ b/packages/opentelemetry-plugin-xml-http-request/test/xhr.test.ts
@@ -29,7 +29,7 @@ import * as tracing from '@opentelemetry/tracing';
 import * as types from '@opentelemetry/types';
 import {
   PerformanceTimingNames as PTN,
-  WebTracerRegistry,
+  WebTracerProvider,
 } from '@opentelemetry/web';
 import { AttributeNames } from '../src/enums/AttributeNames';
 import { EventNames } from '../src/enums/EventNames';
@@ -102,7 +102,7 @@ describe('xhr', () => {
 
   describe('when request is successful', () => {
     let webTracerWithZone: Tracer;
-    let webTracerRegistryWithZone: WebTracerRegistry;
+    let webTracerProviderWithZone: WebTracerProvider;
     let dummySpanExporter: DummySpanExporter;
     let exportSpy: any;
     let rootSpan: types.Span;
@@ -141,7 +141,7 @@ describe('xhr', () => {
       spyEntries = sandbox.stub(performance, 'getEntriesByType');
       spyEntries.withArgs('resource').returns(resources);
 
-      webTracerRegistryWithZone = new WebTracerRegistry({
+      webTracerProviderWithZone = new WebTracerProvider({
         logLevel: LogLevel.ERROR,
         httpTextFormat: new B3Format(),
         scopeManager: new ZoneScopeManager(),
@@ -151,10 +151,10 @@ describe('xhr', () => {
           }),
         ],
       });
-      webTracerWithZone = webTracerRegistryWithZone.getTracer('xhr-test');
+      webTracerWithZone = webTracerProviderWithZone.getTracer('xhr-test');
       dummySpanExporter = new DummySpanExporter();
       exportSpy = sinon.stub(dummySpanExporter, 'export');
-      webTracerRegistryWithZone.addSpanProcessor(
+      webTracerProviderWithZone.addSpanProcessor(
         new tracing.SimpleSpanProcessor(dummySpanExporter)
       );
 
@@ -409,7 +409,7 @@ describe('xhr', () => {
   });
 
   describe('when request is NOT successful', () => {
-    let webTracerWithZoneRegistry: WebTracerRegistry;
+    let webTracerWithZoneProvider: WebTracerProvider;
     let webTracerWithZone: Tracer;
     let dummySpanExporter: DummySpanExporter;
     let exportSpy: any;
@@ -441,17 +441,17 @@ describe('xhr', () => {
       spyEntries = sandbox.stub(performance, 'getEntriesByType');
       spyEntries.withArgs('resource').returns(resources);
 
-      webTracerWithZoneRegistry = new WebTracerRegistry({
+      webTracerWithZoneProvider = new WebTracerProvider({
         logLevel: LogLevel.ERROR,
         scopeManager: new ZoneScopeManager(),
         plugins: [new XMLHttpRequestPlugin()],
       });
       dummySpanExporter = new DummySpanExporter();
       exportSpy = sinon.stub(dummySpanExporter, 'export');
-      webTracerWithZoneRegistry.addSpanProcessor(
+      webTracerWithZoneProvider.addSpanProcessor(
         new tracing.SimpleSpanProcessor(dummySpanExporter)
       );
-      webTracerWithZone = webTracerWithZoneRegistry.getTracer('xhr-test');
+      webTracerWithZone = webTracerWithZoneProvider.getTracer('xhr-test');
 
       rootSpan = webTracerWithZone.startSpan('root');
 

--- a/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
+++ b/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
@@ -16,15 +16,15 @@
 
 import * as assert from 'assert';
 import * as opentracing from 'opentracing';
-import { BasicTracerRegistry, Span } from '@opentelemetry/tracing';
+import { BasicTracerProvider, Span } from '@opentelemetry/tracing';
 import { TracerShim, SpanShim, SpanContextShim } from '../src/shim';
 import { INVALID_SPAN_CONTEXT, timeInputToHrTime } from '@opentelemetry/core';
 import { performance } from 'perf_hooks';
 
 describe('OpenTracing Shim', () => {
-  const registry = new BasicTracerRegistry();
+  const provider = new BasicTracerProvider();
   const shimTracer: opentracing.Tracer = new TracerShim(
-    registry.getTracer('default')
+    provider.getTracer('default')
   );
   opentracing.initGlobalTracer(shimTracer);
 

--- a/packages/opentelemetry-tracing/README.md
+++ b/packages/opentelemetry-tracing/README.md
@@ -25,11 +25,11 @@ npm install --save @opentelemetry/tracing
 
 ```js
 const opentelemetry = require('@opentelemetry/core');
-const { BasicTracerRegistry } = require('@opentelemetry/tracing');
+const { BasicTracerProvider } = require('@opentelemetry/tracing');
 
-// To start a trace, you first need to initialize the Tracer registry.
-// NOTE: the default OpenTelemetry tracer registry does not record any tracing information.
-opentelemetry.initGlobalTracer(new BasicTracerRegistry());
+// To start a trace, you first need to initialize the Tracer provider.
+// NOTE: the default OpenTelemetry tracer provider does not record any tracing information.
+opentelemetry.initGlobalTracer(new BasicTracerProvider());
 
 // To create a span in a trace, we used the global singleton tracer to start a new span.
 const span = opentelemetry.getTracer('default').startSpan('foo');

--- a/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
@@ -24,9 +24,9 @@ import { NoopSpanProcessor } from './NoopSpanProcessor';
 import { TracerConfig } from './types';
 
 /**
- * This class represents a basic tracer registry which platform libraries can extend
+ * This class represents a basic tracer provider which platform libraries can extend
  */
-export class BasicTracerRegistry implements types.TracerRegistry {
+export class BasicTracerProvider implements types.TracerProvider {
   private readonly _registeredSpanProcessors: SpanProcessor[] = [];
   private readonly _tracers: Map<string, Tracer> = new Map();
 

--- a/packages/opentelemetry-tracing/src/Tracer.ts
+++ b/packages/opentelemetry-tracing/src/Tracer.ts
@@ -33,7 +33,7 @@ import { ScopeManager } from '@opentelemetry/scope-base';
 import { Span } from './Span';
 import { mergeConfig } from './utility';
 import { DEFAULT_CONFIG } from './config';
-import { BasicTracerRegistry } from './BasicTracerRegistry';
+import { BasicTracerProvider } from './BasicTracerProvider';
 
 /**
  * This class represents a basic tracer.
@@ -52,7 +52,7 @@ export class Tracer implements types.Tracer {
    */
   constructor(
     config: TracerConfig = DEFAULT_CONFIG,
-    private _tracerRegistry: BasicTracerRegistry
+    private _tracerProvider: BasicTracerProvider
   ) {
     const localConfig = mergeConfig(config);
     this._binaryFormat = localConfig.binaryFormat;
@@ -162,7 +162,7 @@ export class Tracer implements types.Tracer {
   }
 
   getActiveSpanProcessor() {
-    return this._tracerRegistry.getActiveSpanProcessor();
+    return this._tracerProvider.getActiveSpanProcessor();
   }
 
   private _getParentSpanContext(

--- a/packages/opentelemetry-tracing/src/index.ts
+++ b/packages/opentelemetry-tracing/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 export * from './Tracer';
-export * from './BasicTracerRegistry';
+export * from './BasicTracerProvider';
 export * from './export/ConsoleSpanExporter';
 export * from './export/BatchSpanProcessor';
 export * from './export/InMemorySpanExporter';

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -26,48 +26,48 @@ import {
 import { NoopScopeManager, ScopeManager } from '@opentelemetry/scope-base';
 import { TraceFlags } from '@opentelemetry/types';
 import * as assert from 'assert';
-import { BasicTracerRegistry, Span } from '../src';
+import { BasicTracerProvider, Span } from '../src';
 
-describe('BasicTracerRegistry', () => {
+describe('BasicTracerProvider', () => {
   describe('constructor', () => {
     it('should construct an instance without any options', () => {
-      const registry = new BasicTracerRegistry();
-      assert.ok(registry instanceof BasicTracerRegistry);
+      const provider = new BasicTracerProvider();
+      assert.ok(provider instanceof BasicTracerProvider);
     });
 
     it('should construct an instance with binary format', () => {
-      const registry = new BasicTracerRegistry({
+      const provider = new BasicTracerProvider({
         binaryFormat: new BinaryTraceContext(),
       });
-      assert.ok(registry instanceof BasicTracerRegistry);
+      assert.ok(provider instanceof BasicTracerProvider);
     });
 
     it('should construct an instance with http text format', () => {
-      const registry = new BasicTracerRegistry({
+      const provider = new BasicTracerProvider({
         httpTextFormat: new HttpTraceContext(),
         scopeManager: new NoopScopeManager(),
       });
-      assert.ok(registry instanceof BasicTracerRegistry);
+      assert.ok(provider instanceof BasicTracerProvider);
     });
 
     it('should construct an instance with logger', () => {
-      const registry = new BasicTracerRegistry({
+      const provider = new BasicTracerProvider({
         logger: new NoopLogger(),
         scopeManager: new NoopScopeManager(),
       });
-      assert.ok(registry instanceof BasicTracerRegistry);
+      assert.ok(provider instanceof BasicTracerProvider);
     });
 
     it('should construct an instance with sampler', () => {
-      const registry = new BasicTracerRegistry({
+      const provider = new BasicTracerProvider({
         scopeManager: new NoopScopeManager(),
         sampler: ALWAYS_SAMPLER,
       });
-      assert.ok(registry instanceof BasicTracerRegistry);
+      assert.ok(provider instanceof BasicTracerProvider);
     });
 
     it('should construct an instance with default trace params', () => {
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         scopeManager: new NoopScopeManager(),
       }).getTracer('default');
       assert.deepStrictEqual(tracer.getActiveTraceParams(), {
@@ -78,7 +78,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should construct an instance with customized numberOfAttributesPerSpan trace params', () => {
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         scopeManager: new NoopScopeManager(),
         traceParams: {
           numberOfAttributesPerSpan: 100,
@@ -92,7 +92,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should construct an instance with customized numberOfEventsPerSpan trace params', () => {
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         scopeManager: new NoopScopeManager(),
         traceParams: {
           numberOfEventsPerSpan: 300,
@@ -106,7 +106,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should construct an instance with customized numberOfLinksPerSpan trace params', () => {
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         scopeManager: new NoopScopeManager(),
         traceParams: {
           numberOfLinksPerSpan: 10,
@@ -120,26 +120,26 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should construct an instance with default attributes', () => {
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         defaultAttributes: {
           region: 'eu-west',
           asg: 'my-asg',
         },
       });
-      assert.ok(tracer instanceof BasicTracerRegistry);
+      assert.ok(tracer instanceof BasicTracerProvider);
     });
   });
 
   describe('.startSpan()', () => {
     it('should start a span with name only', () => {
-      const tracer = new BasicTracerRegistry().getTracer('default');
+      const tracer = new BasicTracerProvider().getTracer('default');
       const span = tracer.startSpan('my-span');
       assert.ok(span);
       assert.ok(span instanceof Span);
     });
 
     it('should start a span with name and options', () => {
-      const tracer = new BasicTracerRegistry().getTracer('default');
+      const tracer = new BasicTracerProvider().getTracer('default');
       const span = tracer.startSpan('my-span', {});
       assert.ok(span);
       assert.ok(span instanceof Span);
@@ -152,7 +152,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should start a span with defaultAttributes and spanoptions->attributes', () => {
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         defaultAttributes: { foo: 'bar' },
       }).getTracer('default');
       const span = tracer.startSpan('my-span', {
@@ -163,7 +163,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should start a span with defaultAttributes and undefined spanoptions->attributes', () => {
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         defaultAttributes: { foo: 'bar' },
       }).getTracer('default');
       const span = tracer.startSpan('my-span', {}) as Span;
@@ -172,7 +172,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should start a span with spanoptions->attributes', () => {
-      const tracer = new BasicTracerRegistry().getTracer('default');
+      const tracer = new BasicTracerProvider().getTracer('default');
       const span = tracer.startSpan('my-span', {
         attributes: { foo: 'foo', bar: 'bar' },
       }) as Span;
@@ -181,7 +181,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should start a span with name and parent spancontext', () => {
-      const tracer = new BasicTracerRegistry().getTracer('default');
+      const tracer = new BasicTracerProvider().getTracer('default');
       const state = new TraceState('a=1,b=2');
       const span = tracer.startSpan('my-span', {
         parent: {
@@ -199,7 +199,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should start a span with name and parent span', () => {
-      const tracer = new BasicTracerRegistry().getTracer('default');
+      const tracer = new BasicTracerProvider().getTracer('default');
       const span = tracer.startSpan('my-span');
       const childSpan = tracer.startSpan('child-span', {
         parent: span,
@@ -212,7 +212,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should start a span with name and with invalid parent span', () => {
-      const tracer = new BasicTracerRegistry().getTracer('default');
+      const tracer = new BasicTracerProvider().getTracer('default');
       const span = tracer.startSpan('my-span', {
         parent: ('invalid-parent' as unknown) as undefined,
       }) as Span;
@@ -220,7 +220,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should start a span with name and with invalid spancontext', () => {
-      const tracer = new BasicTracerRegistry().getTracer('default');
+      const tracer = new BasicTracerProvider().getTracer('default');
       const span = tracer.startSpan('my-span', {
         parent: { traceId: '0', spanId: '0' },
       });
@@ -233,7 +233,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should return a no recording span when never sampling', () => {
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         sampler: NEVER_SAMPLER,
         logger: new NoopLogger(),
       }).getTracer('default');
@@ -248,7 +248,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should create real span when not sampled but recording events true', () => {
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         sampler: NEVER_SAMPLER,
       }).getTracer('default');
       const span = tracer.startSpan('my-span', { isRecording: true });
@@ -258,7 +258,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should not create real span when not sampled and recording events false', () => {
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         sampler: NEVER_SAMPLER,
         logger: new NoopLogger(),
       }).getTracer('default');
@@ -269,7 +269,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should not create real span when not sampled and no recording events configured', () => {
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         sampler: NEVER_SAMPLER,
         logger: new NoopLogger(),
       }).getTracer('default');
@@ -280,7 +280,7 @@ describe('BasicTracerRegistry', () => {
     });
 
     it('should create real span when sampled and recording events true', () => {
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         sampler: ALWAYS_SAMPLER,
         scopeManager: new NoopScopeManager(),
       }).getTracer('default');
@@ -294,7 +294,7 @@ describe('BasicTracerRegistry', () => {
       const defaultAttributes = {
         foo: 'bar',
       };
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         scopeManager: new NoopScopeManager(),
         defaultAttributes,
       }).getTracer('default');
@@ -307,13 +307,13 @@ describe('BasicTracerRegistry', () => {
 
   describe('.getCurrentSpan()', () => {
     it('should return null with NoopScopeManager', () => {
-      const tracer = new BasicTracerRegistry().getTracer('default');
+      const tracer = new BasicTracerProvider().getTracer('default');
       const currentSpan = tracer.getCurrentSpan();
       assert.deepStrictEqual(currentSpan, undefined);
     });
 
     it('should return current span when it exists', () => {
-      const tracer = new BasicTracerRegistry({
+      const tracer = new BasicTracerProvider({
         scopeManager: {
           active: () => 'foo',
         } as ScopeManager,
@@ -324,7 +324,7 @@ describe('BasicTracerRegistry', () => {
 
   describe('.withSpan()', () => {
     it('should run scope with NoopScopeManager scope manager', done => {
-      const tracer = new BasicTracerRegistry().getTracer('default');
+      const tracer = new BasicTracerProvider().getTracer('default');
       const span = tracer.startSpan('my-span');
       tracer.withSpan(span, () => {
         assert.deepStrictEqual(tracer.getCurrentSpan(), undefined);
@@ -335,7 +335,7 @@ describe('BasicTracerRegistry', () => {
 
   describe('.bind()', () => {
     it('should bind scope with NoopScopeManager scope manager', done => {
-      const tracer = new BasicTracerRegistry().getTracer('default');
+      const tracer = new BasicTracerProvider().getTracer('default');
       const span = tracer.startSpan('my-span');
       const fn = () => {
         assert.deepStrictEqual(tracer.getCurrentSpan(), undefined);
@@ -348,14 +348,14 @@ describe('BasicTracerRegistry', () => {
 
   describe('.getBinaryFormat()', () => {
     it('should get default binary formatter', () => {
-      const tracer = new BasicTracerRegistry().getTracer('default');
+      const tracer = new BasicTracerProvider().getTracer('default');
       assert.ok(tracer.getBinaryFormat() instanceof BinaryTraceContext);
     });
   });
 
   describe('.getHttpTextFormat()', () => {
     it('should get default HTTP text formatter', () => {
-      const tracer = new BasicTracerRegistry().getTracer('default');
+      const tracer = new BasicTracerProvider().getTracer('default');
       assert.ok(tracer.getHttpTextFormat() instanceof HttpTraceContext);
     });
   });

--- a/packages/opentelemetry-tracing/test/MultiSpanProcessor.test.ts
+++ b/packages/opentelemetry-tracing/test/MultiSpanProcessor.test.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'assert';
 import { MultiSpanProcessor } from '../src/MultiSpanProcessor';
-import { SpanProcessor, Span, BasicTracerRegistry } from '../src';
+import { SpanProcessor, Span, BasicTracerProvider } from '../src';
 
 class TestProcessor implements SpanProcessor {
   spans: Span[] = [];
@@ -30,7 +30,7 @@ class TestProcessor implements SpanProcessor {
 }
 
 describe('MultiSpanProcessor', () => {
-  const tracer = new BasicTracerRegistry().getTracer('default');
+  const tracer = new BasicTracerProvider().getTracer('default');
   const span = tracer.startSpan('one');
 
   it('should handle empty span processor', () => {

--- a/packages/opentelemetry-tracing/test/Span.test.ts
+++ b/packages/opentelemetry-tracing/test/Span.test.ts
@@ -21,7 +21,7 @@ import {
   TraceFlags,
   SpanContext,
 } from '@opentelemetry/types';
-import { BasicTracerRegistry, Span } from '../src';
+import { BasicTracerProvider, Span } from '../src';
 import {
   hrTime,
   hrTimeToNanoseconds,
@@ -33,7 +33,7 @@ import {
 const performanceTimeOrigin = hrTime();
 
 describe('Span', () => {
-  const tracer = new BasicTracerRegistry({
+  const tracer = new BasicTracerProvider({
     logger: new NoopLogger(),
   }).getTracer('default');
   const name = 'span1';

--- a/packages/opentelemetry-tracing/test/export/BatchSpanProcessor.test.ts
+++ b/packages/opentelemetry-tracing/test/export/BatchSpanProcessor.test.ts
@@ -18,14 +18,14 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import {
   Span,
-  BasicTracerRegistry,
+  BasicTracerProvider,
   InMemorySpanExporter,
   BatchSpanProcessor,
 } from '../../src';
 import { NEVER_SAMPLER, ALWAYS_SAMPLER, NoopLogger } from '@opentelemetry/core';
 
 function createSampledSpan(spanName: string): Span {
-  const tracer = new BasicTracerRegistry({
+  const tracer = new BasicTracerProvider({
     sampler: ALWAYS_SAMPLER,
   }).getTracer('default');
   const span = tracer.startSpan(spanName);
@@ -34,7 +34,7 @@ function createSampledSpan(spanName: string): Span {
 }
 
 function createUnSampledSpan(spanName: string): Span {
-  const tracer = new BasicTracerRegistry({
+  const tracer = new BasicTracerProvider({
     sampler: NEVER_SAMPLER,
     logger: new NoopLogger(),
   }).getTracer('default');

--- a/packages/opentelemetry-tracing/test/export/ConsoleSpanExporter.test.ts
+++ b/packages/opentelemetry-tracing/test/export/ConsoleSpanExporter.test.ts
@@ -17,7 +17,7 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import {
-  BasicTracerRegistry,
+  BasicTracerProvider,
   ConsoleSpanExporter,
   SimpleSpanProcessor,
 } from '../../src';
@@ -39,17 +39,17 @@ describe('ConsoleSpanExporter', () => {
   describe('.export()', () => {
     it('should export information about span', () => {
       assert.doesNotThrow(() => {
-        const basicTracerRegistry = new BasicTracerRegistry();
+        const basicTracerProvider = new BasicTracerProvider();
         consoleExporter = new ConsoleSpanExporter();
 
         const spyConsole = sinon.spy(console, 'log');
         const spyExport = sinon.spy(consoleExporter, 'export');
 
-        basicTracerRegistry.addSpanProcessor(
+        basicTracerProvider.addSpanProcessor(
           new SimpleSpanProcessor(consoleExporter)
         );
 
-        const span = basicTracerRegistry.getTracer('default').startSpan('foo');
+        const span = basicTracerProvider.getTracer('default').startSpan('foo');
         span.addEvent('foobar');
         span.end();
 

--- a/packages/opentelemetry-tracing/test/export/InMemorySpanExporter.test.ts
+++ b/packages/opentelemetry-tracing/test/export/InMemorySpanExporter.test.ts
@@ -18,14 +18,14 @@ import * as assert from 'assert';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
-  BasicTracerRegistry,
+  BasicTracerProvider,
 } from '../../src';
 import { ExportResult } from '@opentelemetry/base';
 
 describe('InMemorySpanExporter', () => {
   const memoryExporter = new InMemorySpanExporter();
-  const registry = new BasicTracerRegistry();
-  registry.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+  const provider = new BasicTracerProvider();
+  provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
   afterEach(() => {
     // reset spans in memory.
@@ -33,11 +33,11 @@ describe('InMemorySpanExporter', () => {
   });
 
   it('should get finished spans', () => {
-    const root = registry.getTracer('default').startSpan('root');
-    const child = registry
+    const root = provider.getTracer('default').startSpan('root');
+    const child = provider
       .getTracer('default')
       .startSpan('child', { parent: root });
-    const grandChild = registry
+    const grandChild = provider
       .getTracer('default')
       .startSpan('grand-child', { parent: child });
 
@@ -60,8 +60,8 @@ describe('InMemorySpanExporter', () => {
   });
 
   it('should shutdown the exorter', () => {
-    const root = registry.getTracer('default').startSpan('root');
-    registry
+    const root = provider.getTracer('default').startSpan('root');
+    provider
       .getTracer('default')
       .startSpan('child', { parent: root })
       .end();
@@ -71,7 +71,7 @@ describe('InMemorySpanExporter', () => {
     assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
 
     // after shutdown no new spans are accepted
-    registry
+    provider
       .getTracer('default')
       .startSpan('child1', { parent: root })
       .end();

--- a/packages/opentelemetry-tracing/test/export/SimpleSpanProcessor.test.ts
+++ b/packages/opentelemetry-tracing/test/export/SimpleSpanProcessor.test.ts
@@ -17,14 +17,14 @@
 import * as assert from 'assert';
 import {
   Span,
-  BasicTracerRegistry,
+  BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '../../src';
 import { SpanContext, SpanKind, TraceFlags } from '@opentelemetry/types';
 
 describe('SimpleSpanProcessor', () => {
-  const registry = new BasicTracerRegistry();
+  const provider = new BasicTracerProvider();
   const exporter = new InMemorySpanExporter();
 
   describe('constructor', () => {
@@ -43,7 +43,7 @@ describe('SimpleSpanProcessor', () => {
         traceFlags: TraceFlags.SAMPLED,
       };
       const span = new Span(
-        registry.getTracer('default'),
+        provider.getTracer('default'),
         'span-name',
         spanContext,
         SpanKind.CLIENT
@@ -66,7 +66,7 @@ describe('SimpleSpanProcessor', () => {
         traceFlags: TraceFlags.UNSAMPLED,
       };
       const span = new Span(
-        registry.getTracer('default'),
+        provider.getTracer('default'),
         'span-name',
         spanContext,
         SpanKind.CLIENT

--- a/packages/opentelemetry-types/src/index.ts
+++ b/packages/opentelemetry-types/src/index.ts
@@ -35,6 +35,6 @@ export * from './trace/span_kind';
 export * from './trace/status';
 export * from './trace/TimedEvent';
 export * from './trace/tracer';
-export * from './trace/tracer_registry';
+export * from './trace/tracer_provider';
 export * from './trace/trace_flags';
 export * from './trace/trace_state';

--- a/packages/opentelemetry-types/src/trace/instrumentation/Plugin.ts
+++ b/packages/opentelemetry-types/src/trace/instrumentation/Plugin.ts
@@ -15,7 +15,7 @@
  */
 
 import { Logger } from '../../common/Logger';
-import { TracerRegistry } from '../tracer_registry';
+import { TracerProvider } from '../tracer_provider';
 
 /** Interface Plugin to apply patch. */
 // tslint:disable-next-line:no-any
@@ -32,13 +32,13 @@ export interface Plugin<T = any> {
    * Method that enables the instrumentation patch.
    * @param moduleExports The value of the `module.exports` property that would
    *     normally be exposed by the required module. ex: `http`, `https` etc.
-   * @param TracerRegistry a tracer registry.
+   * @param TracerProvider a tracer provider.
    * @param logger a logger instance.
    * @param [config] an object to configure the plugin.
    */
   enable(
     moduleExports: T,
-    TracerRegistry: TracerRegistry,
+    TracerProvider: TracerProvider,
     logger: Logger,
     config?: PluginConfig
   ): T;

--- a/packages/opentelemetry-types/src/trace/tracer_provider.ts
+++ b/packages/opentelemetry-types/src/trace/tracer_provider.ts
@@ -14,15 +14,18 @@
  * limitations under the License.
  */
 
-import * as types from '@opentelemetry/types';
-import { noopTracer } from './NoopTracer';
+import { Tracer } from './tracer';
 
 /**
- * An implementation of the {@link TracerRegistry} which returns an impotent Tracer
- * for all calls to `getTracer`
+ * TracerProvider provides an interface for creating {@link Tracer}s
  */
-export class NoopTracerRegistry implements types.TracerRegistry {
-  getTracer(_name?: string, _version?: string): types.Tracer {
-    return noopTracer;
-  }
+export interface TracerProvider {
+  /**
+   * Returns a Tracer, creating one if one with the given name and version is not already created
+   *
+   * If there is no Span associated with the current context, null is returned.
+   *
+   * @returns Tracer A Tracer with the given name and version
+   */
+  getTracer(name: string, version?: string): Tracer;
 }

--- a/packages/opentelemetry-web/src/WebTracerProvider.ts
+++ b/packages/opentelemetry-web/src/WebTracerProvider.ts
@@ -15,7 +15,7 @@
  */
 
 import { BasePlugin } from '@opentelemetry/core';
-import { BasicTracerRegistry, TracerConfig } from '@opentelemetry/tracing';
+import { BasicTracerProvider, TracerConfig } from '@opentelemetry/tracing';
 import { StackScopeManager } from './StackScopeManager';
 
 /**
@@ -31,7 +31,7 @@ export interface WebTracerConfig extends TracerConfig {
 /**
  * This class represents a web tracer with {@link StackScopeManager}
  */
-export class WebTracerRegistry extends BasicTracerRegistry {
+export class WebTracerProvider extends BasicTracerProvider {
   /**
    * Constructs a new Tracer instance.
    * @param config Web Tracer config

--- a/packages/opentelemetry-web/src/index.ts
+++ b/packages/opentelemetry-web/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export * from './WebTracerRegistry';
+export * from './WebTracerProvider';
 export * from './StackScopeManager';
 export * from './enums/PerformanceTimingNames';
 export * from './types';

--- a/packages/opentelemetry-web/test/WebTracer.test.ts
+++ b/packages/opentelemetry-web/test/WebTracer.test.ts
@@ -21,7 +21,7 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { WebTracerConfig } from '../src';
 import { StackScopeManager } from '../src/StackScopeManager';
-import { WebTracerRegistry } from '../src/WebTracerRegistry';
+import { WebTracerProvider } from '../src/WebTracerProvider';
 
 class DummyPlugin extends BasePlugin<unknown> {
   constructor() {
@@ -42,7 +42,7 @@ describe('WebTracer', () => {
     });
 
     it('should construct an instance with required only options', () => {
-      const tracer = new WebTracerRegistry(
+      const tracer = new WebTracerProvider(
         Object.assign({}, defaultOptions)
       ).getTracer('default');
       assert.ok(tracer instanceof Tracer);
@@ -54,7 +54,7 @@ describe('WebTracer', () => {
       options = { scopeManager };
 
       const spy = sinon.spy(scopeManager, 'enable');
-      new WebTracerRegistry(options);
+      new WebTracerProvider(options);
 
       assert.ok(spy.calledOnce === true);
     });
@@ -71,7 +71,7 @@ describe('WebTracer', () => {
       const plugins = [dummyPlugin1, dummyPlugin2];
 
       options = { plugins, scopeManager };
-      new WebTracerRegistry(options);
+      new WebTracerProvider(options);
 
       assert.ok(spyEnable1.calledOnce === true);
       assert.ok(spyEnable2.calledOnce === true);
@@ -79,13 +79,13 @@ describe('WebTracer', () => {
 
     it('should work without default scope manager', () => {
       assert.doesNotThrow(() => {
-        new WebTracerRegistry({});
+        new WebTracerProvider({});
       });
     });
 
     describe('when scopeManager is "ZoneScopeManager"', () => {
       it('should correctly return the scopes for 2 parallel actions', () => {
-        const webTracerWithZone = new WebTracerRegistry({
+        const webTracerWithZone = new WebTracerProvider({
           scopeManager: new ZoneScopeManager(),
         }).getTracer('default');
 


### PR DESCRIPTION
Fixes #740 

Because of the spec changing the name they use, we need to use the "provider" naming scheme. This is a simple rename and changes no behavior.