### PR TITLE
chore: add missing semver type dependency

### DIFF
--- a/packages/opentelemetry-plugin-dns/package.json
+++ b/packages/opentelemetry-plugin-dns/package.json
@@ -45,6 +45,7 @@
     "@opentelemetry/tracing": "^0.3.2",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.7.12",
+    "@types/semver": "^6.2.0",
     "@types/shimmer": "^1.0.1",
     "@types/sinon": "^7.5.0",
     "codecov": "^3.6.1",


### PR DESCRIPTION
dns plugin was missing a dev dependency. This hasn't caused a problem before because it is in the root `node_modules`.