### PR TITLE
feat(plugin-http): sync. specs for statuscode

### DIFF
--- a/packages/opentelemetry-plugin-http/README.md
+++ b/packages/opentelemetry-plugin-http/README.md
@@ -55,6 +55,7 @@ Http plugin has few options available to choose from. You can set the following:
 | [`ignoreIncomingPaths`](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-plugin-http/src/types.ts#L28) | `IgnoreMatcher[]` | Http plugin will not trace all incoming requests that match paths |
 | [`ignoreOutgoingUrls`](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-plugin-http/src/types.ts#L28) | `IgnoreMatcher[]` | Http plugin will not trace all outgoing requests that match urls |
 | [`serverName`](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-plugin-http/src/types.ts#L28) | `string` | The primary server name of the matched virtual host. |
+
 ## Useful links
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
 - For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>

--- a/packages/opentelemetry-plugin-http/src/types.ts
+++ b/packages/opentelemetry-plugin-http/src/types.ts
@@ -78,3 +78,7 @@ export interface Err extends Error {
   syscall?: string;
   stack?: string;
 }
+
+export interface SpecialHttpStatusCodeMapping {
+  [custom: number]: number;
+}

--- a/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
@@ -280,7 +280,19 @@ describe('HttpPlugin', () => {
         assert.strictEqual(spans.length, 0);
       });
 
-      const httpErrorCodes = [400, 401, 403, 404, 429, 501, 503, 504, 500, 505];
+      const httpErrorCodes = [
+        400,
+        401,
+        403,
+        404,
+        429,
+        501,
+        503,
+        504,
+        500,
+        505,
+        597,
+      ];
 
       for (let i = 0; i < httpErrorCodes.length; i++) {
         it(`should test span for GET requests with http error ${httpErrorCodes[i]}`, async () => {

--- a/packages/opentelemetry-plugin-http/test/functionals/utils.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/utils.test.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
+import { NoopLogger } from '@opentelemetry/core';
+import { NoopScopeManager } from '@opentelemetry/scope-base';
+import { BasicTracerRegistry, Span } from '@opentelemetry/tracing';
+import { CanonicalCode, SpanKind } from '@opentelemetry/types';
 import * as assert from 'assert';
+import * as http from 'http';
 import * as sinon from 'sinon';
 import * as url from 'url';
-import { CanonicalCode, SpanKind } from '@opentelemetry/types';
-import { NoopScopeManager } from '@opentelemetry/scope-base';
+import { AttributeNames } from '../../src';
 import { IgnoreMatcher } from '../../src/types';
 import * as utils from '../../src/utils';
-import * as http from 'http';
-import { Span, BasicTracerRegistry } from '@opentelemetry/tracing';
-import { AttributeNames } from '../../src';
-import { NoopLogger } from '@opentelemetry/core';
 
 describe('Utility', () => {
   describe('parseResponseStatus()', () => {
@@ -36,16 +36,23 @@ describe('Utility', () => {
     });
 
     it('should return OK for Success HTTP status code', () => {
-      for (let index = 200; index < 400; index++) {
+      for (let index = 100; index < 400; index++) {
         const status = utils.parseResponseStatus(index);
         assert.deepStrictEqual(status, { code: CanonicalCode.OK });
       }
     });
 
     it('should not return OK for Bad HTTP status code', () => {
-      for (let index = 400; index <= 504; index++) {
+      for (let index = 400; index <= 600; index++) {
         const status = utils.parseResponseStatus(index);
         assert.notStrictEqual(status.code, CanonicalCode.OK);
+      }
+    });
+    it('should handle special HTTP status codes', () => {
+      for (const key in utils.HTTP_STATUS_SPECIAL_CASES) {
+        const status = utils.parseResponseStatus(key as any);
+        const canonicalCode = utils.HTTP_STATUS_SPECIAL_CASES[key];
+        assert.deepStrictEqual(status.code, canonicalCode);
       }
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

- closes #642 

## Short description of the changes

- Synchronise HTTP status code with `CanonicalCode` according to specs.

I try to use the benchmark system we have, see my sample code here : https://gist.github.com/OlivierAlbertini/9505254b713b9db5f60168ed3fa4e437
 
But the result is a bit random (on my macbook pro 2016). I would like to know which one is faster. Any insight ?
If we want to share this code with the web, I think we should discuss it and resolve it in a separate PR.