### PR TITLE
chore: adding npm scripts for removing node_modules and builds at once

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "bench": "node benchmark",
     "clean": "lerna run clean",
+    "clean:examples": "find examples -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
+    "clean:packages": "find packages -name 'node_modules' -path 'opentelemetry/node/test' -prune -type d -prune -exec rm -rf '{}' +",
+    "clean:all": "npm run clean && npm run clean:examples && npm run clean:packages",
     "fix": "lerna run fix",
     "postinstall": "yarn run bootstrap",
     "precompile": "tsc --version",


### PR DESCRIPTION
These are just 3 npm command line scripts for removing `node_modules`. This is helpfull when you want to quickly test all packages to see if nothing has been missing or when your `node_modules` get messed and you want to do a clean install again. Just helpful during development