### PR TITLE
chore: publish docs on all tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,7 @@ workflows:
             - lint_&_docs
           filters:
             tags:
-              only: /^v\d+\.\d+\.0$/
+              only: /^v\d+\.\d+\.\d$/
             branches:
               ignore: /.*/
       - node8


### PR DESCRIPTION
As discussed with @mayurkale22 this change makes it so that docs will publish on any new version.

Previously, it ignored patch versions. Because we are changing so quickly, we are not following typical semver patterns and it is important that the docs always represent the latest version.