### PR TITLE
chore: fix build errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ node_test_env: &node_test_env
   MYSQL_PASSWORD: secret
   MYSQL_DATABASE: circle_database
   MYSQL_PORT: 3306
+  NPM_CONFIG_UNSAFE_PERM: true
 
 postgres_service: &postgres_service
   image: circleci/postgres:9.6-alpine
@@ -39,10 +40,10 @@ mysql_service: &mysql_service
     MYSQL_ROOT_PASSWORD: rootpw
 
 cache_1: &cache_1
-  key: npm-cache-01-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/checksums.txt" }}-1
+  key: npm-cache-01-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/checksums.txt" }}-FDF2088C
   paths:
     - ./node_modules
-    - ./yarn.lock
+    - ./package-lock.json
     - packages/opentelemetry-base/node_modules
     - packages/opentelemetry-scope-base/node_modules
     - packages/opentelemetry-api/node_modules
@@ -59,7 +60,7 @@ cache_1: &cache_1
     - packages/opentelemetry-plugin-dns/node_modules
 
 cache_2: &cache_2
-  key: npm-cache-02-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/checksums.txt" }}-2
+  key: npm-cache-02-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/checksums.txt" }}-FDF2088C
   paths:
     - packages/opentelemetry-plugin-grpc/node_modules
     - packages/opentelemetry-plugin-http/node_modules
@@ -76,6 +77,7 @@ cache_2: &cache_2
     - packages/opentelemetry-exporter-stackdriver-trace/node_modules
 
 node_unit_tests: &node_unit_tests
+  resource_class: large
   steps:
     - checkout
     - run:
@@ -93,28 +95,29 @@ node_unit_tests: &node_unit_tests
           echo "CIRCLE_NODE_VERSION=${CIRCLE_NODE_VERSION}"
     - restore_cache:
         keys:
-          - npm-cache-01-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/checksums.txt" }}-1
+          - npm-cache-01-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/checksums.txt" }}-FDF2088C
     - restore_cache:
         keys:
-          - npm-cache-02-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/checksums.txt" }}-2
+          - npm-cache-02-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/checksums.txt" }}-FDF2088C
     - run:
-        name: Install Dependencies
-        command: yarn install
+        name: Install Root Dependencies
+        command: npm install --ignore-scripts
+    - run:
+        name: Boostrap dependencies
+        command: npx lerna bootstrap --no-ci
     - save_cache:
         <<: *cache_1
     - save_cache:
         <<: *cache_2
     - run:
-        name: Compile code
-        command: yarn compile
-    - run:
         name: Unit tests
-        command: yarn test
+        command: npm run test
     - run:
         name: report coverage
-        command: if [ "${CIRCLE_NODE_VERSION}" = "v12" ]; then yarn codecov; fi
+        command: if [ "${CIRCLE_NODE_VERSION}" = "v12" ]; then npm run codecov; fi
 
 browsers_unit_tests: &browsers_unit_tests
+  resource_class: large
   steps:
     - checkout
     - run:
@@ -132,23 +135,26 @@ browsers_unit_tests: &browsers_unit_tests
           echo "CIRCLE_NODE_VERSION=${CIRCLE_NODE_VERSION}"
     - restore_cache:
         keys:
-          - npm-cache-01-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/checksums.txt" }}-1
+          - npm-cache-01-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/checksums.txt" }}-FDF2088C
     - restore_cache:
         keys:
-          - npm-cache-02-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/checksums.txt" }}-1
+          - npm-cache-02-{{ .Environment.CIRCLE_JOB }}-{{ checksum "/tmp/checksums.txt" }}-FDF2088C
     - run:
-        name: Install Dependencies
-        command: yarn install
+        name: Install Root Dependencies
+        command: npm install --ignore-scripts
+    - run:
+        name: Boostrap dependencies
+        command: npx lerna bootstrap --no-ci
     - save_cache:
         <<: *cache_1
     - save_cache:
         <<: *cache_2
     - run:
         name: Unit tests
-        command: yarn test:browser
+        command: npm run test:browser
     - run:
         name: report coverage
-        command: if [ "$CIRCLE_NODE_VERSION" = "v12" ]; then yarn codecov:browser; fi
+        command: if [ "$CIRCLE_NODE_VERSION" = "v12" ]; then npm run codecov:browser; fi
 
 jobs:
   lint_&_docs:
@@ -158,16 +164,16 @@ jobs:
       - checkout
       - run:
           name: Install minimal doc and lint modules globally
-          command: yarn global add lerna typedoc linkinator typescript gts tslint-consistent-codestyle tslint-microsoft-contrib
+          command: npm i -g tslint lerna typedoc linkinator typescript gts tslint-consistent-codestyle tslint-microsoft-contrib
       - run:
           name: Symlink global modules into all lerna packages
-          command: lerna exec 'ln -s $(yarn global dir)/node_modules node_modules'
+          command: lerna exec 'npm link tslint lerna typedoc linkinator typescript gts tslint-consistent-codestyle tslint-microsoft-contrib'
       - run:
           name: Check code style and linting
-          command: yarn run check
+          command: npm run check
       - run:
           name: Docs tests
-          command: yarn docs-test
+          command: npm run docs-test
       - persist_to_workspace:
           root: packages/opentelemetry-api/docs
           paths:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,20 +57,20 @@ Please also see [GitHub workflow](https://github.com/open-telemetry/community/bl
 
 The `opentelemetry-js` project is written in TypeScript.
 
-- `yarn install` or `npm install` to install dependencies.
-- `yarn compile` or `npm run compile` compiles the code, checking for type errors.
-- `yarn bootstrap` or `npm run bootstrap` Bootstrap the packages in the current Lerna repo. Installs all of their dependencies and links any cross-dependencies.
-- `yarn test` or `npm test` tests code the same way that our CI will test it.
-- `yarn fix` or `npm run fix` lint (and maybe fix) any changes.
+- `npm install` to install dependencies.
+- `npm run compile` compiles the code, checking for type errors.
+- `npm run bootstrap` Bootstrap the packages in the current Lerna repo. Installs all of their dependencies and links any cross-dependencies.
+- `npm test` tests code the same way that our CI will test it.
+- `npm run fix` lint (and maybe fix) any changes.
 
 
 ### Generating API documentation
-- `yarn docs` or `npm run docs` to generate API documentation. Generates the documentation in `packages/opentelemetry-api/docs/out`
+- `npm run docs` to generate API documentation. Generates the documentation in `packages/opentelemetry-api/docs/out`
 
 ### Generating CHANGELOG documentation
-- `yarn changelog` or `npm run changelog` to generate CHANGELOG documentation in your terminal (see [RELEASING.md](RELEASING.md) for more details).
+- `npm run changelog` to generate CHANGELOG documentation in your terminal (see [RELEASING.md](RELEASING.md) for more details).
 
 ### Benchmarks
 When two or more approaches must be compared, please write a benchmark in the benchmark/index.js module so that we can keep track of the most efficient algorithm.
 
-- `yarn bench` or `npm run bench` to run your benchmark.
+- `npm run bench` to run your benchmark.

--- a/doc/development-guide.md
+++ b/doc/development-guide.md
@@ -2,19 +2,17 @@
 
 Before contributing to this open source project, read our [CONTRIBUTING](../CONTRIBUTING.md). We gratefully welcome improvements to documentation as well as to code.
 
-The code base is a monorepo. We use [Lerna](https://lerna.js.org/) for managing inter-module dependencies, which makes it easier to develop coordinated changes between the modules. Instead of running lerna directly, the commands are wrapped with `yarn`;
+The code base is a monorepo. We use [Lerna](https://lerna.js.org/) for managing inter-module dependencies, which makes it easier to develop coordinated changes between the modules. Instead of running lerna directly, the commands are wrapped with `npm`;
 
 ### Requirements
 
 Since this project supports multiple Node versions, using a version
 manager such as [nvm](https://github.com/creationix/nvm) is recommended.
 
-We use [yarn](https://yarnpkg.com/) for its workspace functionality, so make sure to install that as well.
-
-To get started once you have Node and yarn installed, run:
+To get started once you have Node installed, run:
 
 ```sh
-$ yarn
+$ npm install
 ```
 
 This will install all the necessary modules.
@@ -26,13 +24,13 @@ This will install all the necessary modules.
 To run the all unit tests, use:
 
 ```sh
-$ yarn test
+$ npm run test
 ```
 
 To run the unit tests continuously in watch mode while developing, use:
 
 ```sh
-$ yarn tdd
+$ npm run tdd
 ```
 
 ### Linting
@@ -43,12 +41,12 @@ Before raising a pull request, make sure there are no lint problems.
 
 To check the linter, use:
 ```sh
-$ yarn run check
+$ npm run check
 ```
 
 To fix the linter, use:
 ```sh
-$ yarn fix
+$ npm run fix
 ```
 
 ### Continuous Integration
@@ -74,7 +72,7 @@ We use [typedoc](https://www.npmjs.com/package/typedoc) to generate the api docu
 
 To generate the docs, use:
 ```sh
-$ yarn docs
+$ npm run docs
 ```
 
 The document will be available under `packages/opentelemetry-api/docs/out` path.

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "3.13.4",
-  "npmClient": "yarn",
+  "npmClient": "npm",
   "packages": [
     "benchmark/*",
     "packages/*",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bench": "node benchmark",
     "clean": "lerna run clean",
     "fix": "lerna run fix",
-    "postinstall": "yarn run bootstrap",
+    "postinstall": "npm run bootstrap",
     "precompile": "tsc --version",
     "version:update": "lerna run version:update",
     "compile": "lerna run compile",
@@ -20,7 +20,7 @@
     "codecov:browser": "lerna run codecov:browser",
     "changelog": "lerna-changelog",
     "check": "lerna run check",
-    "predocs-test": "yarn docs",
+    "predocs-test": "npm run docs",
     "docs-test": "lerna run docs-test",
     "docs": "lerna run docs",
     "docs-deploy": "gh-pages --dist packages/opentelemetry-api/docs/out",
@@ -50,6 +50,7 @@
     "husky": "^3.0.9",
     "lerna": "^3.17.0",
     "lerna-changelog": "^0.8.2",
+    "tslint": "^5.0.0",
     "typescript": "^3.7.2"
   },
   "husky": {

--- a/packages/opentelemetry-api/package.json
+++ b/packages/opentelemetry-api/package.json
@@ -63,7 +63,7 @@
     "nyc": "^14.1.1",
     "ts-loader": "^6.0.4",
     "ts-mocha": "^6.0.0",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typedoc": "^0.15.0",
     "typescript": "3.7.2",

--- a/packages/opentelemetry-api/package.json
+++ b/packages/opentelemetry-api/package.json
@@ -16,7 +16,7 @@
     "version:update": "node ../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",
     "fix": "gts fix",
-    "docs-test": "linkinator docs/out --silent --skip david-dm.org --skip https://open-telemetry.github.io/opentelemetry-js/classes/.+api.html",
+    "docs-test": "linkinator docs/out --silent --skip david-dm.org --skip https://open-telemetry.github.io/opentelemetry-js/classes/.+api.html --skip https://www.npmjs.com/package/@opentelemetry/api",
     "docs": "typedoc --tsconfig tsconfig.json",
     "prepare": "npm run compile"
   },

--- a/packages/opentelemetry-base/package.json
+++ b/packages/opentelemetry-base/package.json
@@ -7,8 +7,8 @@
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json test/**/*.ts",
-    "tdd": "yarn tdd:node",
-    "tdd:node": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run tdd:node",
+    "tdd:node": "npm run test -- --watch-extensions ts --watch",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "clean": "rimraf build/*",
     "check": "gts check",
@@ -51,7 +51,7 @@
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.6.2",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   }

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json test/**/*.ts",
     "test:browser": "nyc karma start --single-run",
-    "tdd": "yarn tdd:node",
-    "tdd:node": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run tdd:node",
+    "tdd:node": "npm run test -- --watch-extensions ts --watch",
     "tdd:browser": "karma start",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "codecov:browser": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",

--- a/packages/opentelemetry-exporter-collector/package.json
+++ b/packages/opentelemetry-exporter-collector/package.json
@@ -17,7 +17,7 @@
     "compile": "npm run version:update && tsc -p .",
     "fix": "gts fix",
     "prepare": "npm run compile",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "tdd:browser": "karma start",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts' --exclude 'test/browser/**/*.ts'",
     "test:browser": "nyc karma start --single-run",

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -7,7 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "clean": "rimraf build/*",
     "check": "gts check",
@@ -49,7 +49,7 @@
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.6.2",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   },

--- a/packages/opentelemetry-exporter-prometheus/package.json
+++ b/packages/opentelemetry-exporter-prometheus/package.json
@@ -7,7 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "clean": "rimraf build/*",
     "check": "gts check",

--- a/packages/opentelemetry-exporter-stackdriver-trace/package.json
+++ b/packages/opentelemetry-exporter-stackdriver-trace/package.json
@@ -14,7 +14,7 @@
     "fix": "gts fix",
     "precompile": "tsc --version",
     "prepare": "npm run compile",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'"
   },
   "keywords": [
@@ -54,7 +54,7 @@
     "sinon": "^8.0.1",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.3.0",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   },

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -7,7 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "check": "gts check",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
@@ -50,7 +50,7 @@
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.6.2",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   },

--- a/packages/opentelemetry-metrics/package.json
+++ b/packages/opentelemetry-metrics/package.json
@@ -7,7 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "clean": "rimraf build/*",
     "check": "gts check",
@@ -51,7 +51,7 @@
     "sinon": "^7.5.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.6.2",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   },

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -7,7 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "clean": "rimraf build/*",
     "check": "gts check",
@@ -53,7 +53,7 @@
     "shimmer": "^1.2.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.6.2",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   },

--- a/packages/opentelemetry-plugin-dns/package.json
+++ b/packages/opentelemetry-plugin-dns/package.json
@@ -7,7 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "check": "gts check",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",

--- a/packages/opentelemetry-plugin-grpc/package.json
+++ b/packages/opentelemetry-plugin-grpc/package.json
@@ -7,7 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json test/**/*.test.ts",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "check": "gts check",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
@@ -58,7 +58,7 @@
     "sinon": "^7.5.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.6.2",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   },

--- a/packages/opentelemetry-plugin-http/package.json
+++ b/packages/opentelemetry-plugin-http/package.json
@@ -7,7 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json test/**/*.test.ts",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "check": "gts check",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",

--- a/packages/opentelemetry-plugin-https/package.json
+++ b/packages/opentelemetry-plugin-https/package.json
@@ -7,7 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json test/**/*.test.ts",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "check": "gts check",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",

--- a/packages/opentelemetry-plugin-ioredis/package.json
+++ b/packages/opentelemetry-plugin-ioredis/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
     "test:debug": "cross-env RUN_REDIS_TESTS_LOCAL=true ts-mocha --inspect-brk --no-timeouts -p tsconfig.json 'test/**/*.test.ts'",
-    "test:local": "cross-env RUN_REDIS_TESTS_LOCAL=true yarn test",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "test:local": "cross-env RUN_REDIS_TESTS_LOCAL=true npm run test",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "check": "gts check",
     "precompile": "tsc --version",

--- a/packages/opentelemetry-plugin-mongodb/package.json
+++ b/packages/opentelemetry-plugin-mongodb/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "check": "gts check",
     "precompile": "tsc --version",

--- a/packages/opentelemetry-plugin-mysql/package.json
+++ b/packages/opentelemetry-plugin-mysql/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "check": "gts check",
     "precompile": "tsc --version",
@@ -56,7 +56,7 @@
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.6.2",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   },

--- a/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg-pool/package.json
+++ b/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg-pool/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "test:debug": "ts-mocha --inspect-brk --no-timeouts -p tsconfig.json 'test/**/*.test.ts'",
-    "test:local": "cross-env RUN_POSTGRES_TESTS_LOCAL=true yarn test",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "test:local": "cross-env RUN_POSTGRES_TESTS_LOCAL=true npm run test",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
     "check": "gts check",
@@ -63,7 +63,7 @@
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.6.2",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   },

--- a/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg/package.json
+++ b/packages/opentelemetry-plugin-postgres/opentelemetry-plugin-pg/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "test:debug": "ts-mocha --inspect-brk --no-timeouts -p tsconfig.json 'test/**/*.test.ts'",
-    "test:local": "cross-env RUN_POSTGRES_TESTS_LOCAL=true yarn test",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "test:local": "cross-env RUN_POSTGRES_TESTS_LOCAL=true npm run test",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
     "check": "gts check",
@@ -60,7 +60,7 @@
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.6.2",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   },

--- a/packages/opentelemetry-plugin-redis/package.json
+++ b/packages/opentelemetry-plugin-redis/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
     "test:debug": "cross-env RUN_REDIS_TESTS_LOCAL=true ts-mocha --inspect-brk --no-timeouts -p tsconfig.json 'test/**/*.test.ts'",
-    "test:local": "cross-env RUN_REDIS_TESTS_LOCAL=true yarn test",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "test:local": "cross-env RUN_REDIS_TESTS_LOCAL=true npm run test",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "check": "gts check",
     "precompile": "tsc --version",
@@ -59,7 +59,7 @@
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.6.2",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   },

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts' --exclude 'test/index-webpack.ts'",
     "test:browser": "nyc karma start --single-run",
-    "tdd": "yarn tdd:node",
-    "tdd:node": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run tdd:node",
+    "tdd:node": "npm run test -- --watch-extensions ts --watch",
     "tdd:browser": "karma start",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "clean": "rimraf build/*",

--- a/packages/opentelemetry-scope-async-hooks/package.json
+++ b/packages/opentelemetry-scope-async-hooks/package.json
@@ -7,7 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "clean": "rimraf build/*",
     "check": "gts check",
@@ -51,7 +51,7 @@
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.6.2",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   },

--- a/packages/opentelemetry-scope-base/package.json
+++ b/packages/opentelemetry-scope-base/package.json
@@ -7,7 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "clean": "rimraf build/*",
     "check": "gts check",
@@ -51,7 +51,7 @@
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.6.2",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   }

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -7,7 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json test/**/*.ts",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "clean": "rimraf build/*",
     "check": "gts check",
@@ -49,7 +49,7 @@
     "rimraf": "^3.0.0",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.6.2",
-    "tslint-consistent-codestyle": "^1.15.1",
+    "tslint-consistent-codestyle": "^1.16.0",
     "tslint-microsoft-contrib": "^6.2.0",
     "typescript": "3.7.2"
   },

--- a/packages/opentelemetry-tracing/package.json
+++ b/packages/opentelemetry-tracing/package.json
@@ -18,7 +18,7 @@
     "compile": "npm run version:update && tsc -p .",
     "fix": "gts fix",
     "prepare": "npm run compile",
-    "tdd": "yarn test -- --watch-extensions ts --watch",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts' --exclude 'test/index-webpack.ts'",
     "test:browser": "nyc karma start --single-run",
     "watch": "tsc -w"


### PR DESCRIPTION
~Fixes an issue that prevented lerna from being used on node 8.~

- Switch from yarn to npm. This will install lerna even on node 8. note: technically we are installing a devDependency that is incompatible with node 8 (lerna), but it is ok because we don't use the feature which uses the broken module.
- Skip checking the broken link so build will pass.

todo: create a follow up PR that removes the skip of the broken link after it is published to npm #751 