### PR TITLE
WIP: extend the Tracer and ScopeManager with async functionality

### DIFF
--- a/packages/opentelemetry-api/src/trace/NoopTracer.ts
+++ b/packages/opentelemetry-api/src/trace/NoopTracer.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { BinaryFormat, HttpTextFormat, Span, SpanOptions, Tracer } from '..';
-import { NOOP_BINARY_FORMAT } from '../context/propagation/NoopBinaryFormat';
-import { NOOP_HTTP_TEXT_FORMAT } from '../context/propagation/NoopHttpTextFormat';
-import { NOOP_SPAN } from './NoopSpan';
+import { BinaryFormat, HttpTextFormat, Span, SpanOptions, Tracer } from "..";
+import { NOOP_BINARY_FORMAT } from "../context/propagation/NoopBinaryFormat";
+import { NOOP_HTTP_TEXT_FORMAT } from "../context/propagation/NoopHttpTextFormat";
+import { NOOP_SPAN } from "./NoopSpan";
 
 /**
  * No-op implementations of {@link Tracer}.
@@ -37,6 +37,13 @@ export class NoopTracer implements Tracer {
     fn: T
   ): ReturnType<T> {
     return fn();
+  }
+
+  async withSpanAsync<
+    T extends (...args: unknown[]) => Promise<T2>,
+    T2 extends unknown
+  >(span: Span, fn: T): Promise<T2> {
+    return await fn();
   }
 
   bind<T>(target: T, span?: Span): T {

--- a/packages/opentelemetry-api/src/trace/tracer.ts
+++ b/packages/opentelemetry-api/src/trace/tracer.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { HttpTextFormat } from '../context/propagation/HttpTextFormat';
-import { BinaryFormat } from '../context/propagation/BinaryFormat';
-import { Span } from './span';
-import { SpanOptions } from './SpanOptions';
+import { HttpTextFormat } from "../context/propagation/HttpTextFormat";
+import { BinaryFormat } from "../context/propagation/BinaryFormat";
+import { Span } from "./span";
+import { SpanOptions } from "./SpanOptions";
 
 /**
  * Tracer provides an interface for creating {@link Span}s and propagating
@@ -56,6 +56,23 @@ export interface Tracer {
     span: Span,
     fn: T
   ): ReturnType<T>;
+
+  /**
+   * Asynchronously executes the function given by fn within the context
+   * provided by Span
+   *
+   * @param span The span that provides the context
+   * @param fn The function to be executed inside the provided context
+   * @example
+   * tracer.withSpan(span, function() { ... });
+   */
+  withSpanAsync<
+    T extends (...args: unknown[]) => Promise<T2>,
+    T2 extends unknown
+  >(
+    span: Span,
+    fn: T
+  ): Promise<T2>;
 
   /**
    * Bind a span as the target's scope or propagate the current one.

--- a/packages/opentelemetry-api/test/noop-implementations/noop-tracer.test.ts
+++ b/packages/opentelemetry-api/test/noop-implementations/noop-tracer.test.ts
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
-import { NoopTracer, NOOP_SPAN, SpanKind } from '../../src';
+import * as assert from "assert";
+import { NoopTracer, NOOP_SPAN, SpanKind } from "../../src";
 
-describe('NoopTracer', () => {
-  it('should not crash', () => {
-    const spanContext = { traceId: '', spanId: '' };
+describe("NoopTracer", () => {
+  it("should not crash", () => {
+    const spanContext = { traceId: "", spanId: "" };
     const tracer = new NoopTracer();
 
-    assert.deepStrictEqual(tracer.startSpan('span-name'), NOOP_SPAN);
+    assert.deepStrictEqual(tracer.startSpan("span-name"), NOOP_SPAN);
     assert.deepStrictEqual(
-      tracer.startSpan('span-name1', { kind: SpanKind.CLIENT }),
+      tracer.startSpan("span-name1", { kind: SpanKind.CLIENT }),
       NOOP_SPAN
     );
     assert.deepStrictEqual(
-      tracer.startSpan('span-name2', {
+      tracer.startSpan("span-name2", {
         kind: SpanKind.CLIENT,
-        isRecording: true,
+        isRecording: true
       }),
       NOOP_SPAN
     );
@@ -38,8 +38,8 @@ describe('NoopTracer', () => {
     assert.deepStrictEqual(tracer.getCurrentSpan(), NOOP_SPAN);
     const httpTextFormat = tracer.getHttpTextFormat();
     assert.ok(httpTextFormat);
-    httpTextFormat.inject(spanContext, 'HttpTextFormat', {});
-    assert.deepStrictEqual(httpTextFormat.extract('HttpTextFormat', {}), null);
+    httpTextFormat.inject(spanContext, "HttpTextFormat", {});
+    assert.deepStrictEqual(httpTextFormat.extract("HttpTextFormat", {}), null);
 
     const binaryFormat = tracer.getBinaryFormat();
     assert.ok(binaryFormat);
@@ -47,14 +47,30 @@ describe('NoopTracer', () => {
     assert.deepStrictEqual(binaryFormat.fromBytes(new ArrayBuffer(0)), null);
   });
 
-  it('should not crash when .withSpan()', done => {
+  it("should not crash when .withSpan()", done => {
     const tracer = new NoopTracer();
     tracer.withSpan(NOOP_SPAN, () => {
       return done();
     });
   });
 
-  it('should not crash when .bind()', done => {
+  it("should not crash when .withSpanAsync()", async done => {
+    const tracer = new NoopTracer();
+    await tracer.withSpanAsync(NOOP_SPAN, () => {
+      return done();
+    });
+  });
+
+  it("should return the expected value when .withSpanAsync()", async () => {
+    const tracer = new NoopTracer();
+    const result = await tracer.withSpanAsync(NOOP_SPAN, async () => {
+      return await Promise.resolve(5);
+    });
+
+    assert.equal(result, 5);
+  });
+
+  it("should not crash when .bind()", done => {
     const tracer = new NoopTracer();
     const fn = () => {
       return done();

--- a/packages/opentelemetry-scope-base/src/NoopScopeManager.ts
+++ b/packages/opentelemetry-scope-base/src/NoopScopeManager.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import * as types from './types';
+import { ScopeManager } from "./types";
 
-export class NoopScopeManager implements types.ScopeManager {
+export class NoopScopeManager implements ScopeManager {
   active(): unknown {
     return undefined;
   }
@@ -26,6 +26,13 @@ export class NoopScopeManager implements types.ScopeManager {
     fn: T
   ): ReturnType<T> {
     return fn();
+  }
+
+  async withAsync<
+    T extends (...args: unknown[]) => Promise<T2>,
+    T2 extends unknown
+  >(scope: unknown, fn: T): Promise<T2> {
+    return await fn();
   }
 
   bind<T>(target: T, scope?: unknown): T {

--- a/packages/opentelemetry-scope-base/src/types.ts
+++ b/packages/opentelemetry-scope-base/src/types.ts
@@ -31,6 +31,17 @@ export interface ScopeManager {
   ): ReturnType<T>;
 
   /**
+   * Asynchronously run the fn callback with object set as the
+   * current active scope
+   * @param scope Any object to set as the current active scope
+   * @param fn A callback to be immediately run within a specific scope
+   */
+  withAsync<T extends (...args: unknown[]) => Promise<T2>, T2 extends unknown>(
+    scope: unknown,
+    fn: T
+  ): Promise<T2>;
+
+  /**
    * Bind an object as the current scope (or a specific one)
    * @param target Any object to which a scope need to be set
    * @param [scope] Optionally specify the scope which you want to assign

--- a/packages/opentelemetry-scope-base/test/NoopScopeManager.test.ts
+++ b/packages/opentelemetry-scope-base/test/NoopScopeManager.test.ts
@@ -14,48 +14,48 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
-import { NoopScopeManager } from '../src';
+import * as assert from "assert";
+import { NoopScopeManager } from "../src";
 
-describe('NoopScopeManager', () => {
+describe("NoopScopeManager", () => {
   let scopeManager: NoopScopeManager;
 
-  describe('.enable()', () => {
-    it('should work', () => {
+  describe(".enable()", () => {
+    it("should work", () => {
       assert.doesNotThrow(() => {
         scopeManager = new NoopScopeManager();
-        assert(scopeManager.enable() === scopeManager, 'should return this');
+        assert(scopeManager.enable() === scopeManager, "should return this");
       });
     });
   });
 
-  describe('.disable()', () => {
-    it('should work', () => {
+  describe(".disable()", () => {
+    it("should work", () => {
       assert.doesNotThrow(() => {
-        assert(scopeManager.disable() === scopeManager, 'should return this');
+        assert(scopeManager.disable() === scopeManager, "should return this");
       });
       scopeManager.enable();
     });
   });
 
-  describe('.with()', () => {
-    it('should run the callback (null as target)', done => {
+  describe(".with()", () => {
+    it("should run the callback (null as target)", done => {
       scopeManager.with(null, done);
     });
 
-    it('should run the callback (object as target)', done => {
+    it("should run the callback (object as target)", done => {
       const test = { a: 1 };
       scopeManager.with(test, () => {
         assert.strictEqual(
           scopeManager.active(),
           undefined,
-          'should not have scope'
+          "should not have scope"
         );
         return done();
       });
     });
 
-    it('should run the callback (when disabled)', done => {
+    it("should run the callback (when disabled)", done => {
       scopeManager.disable();
       scopeManager.with(null, () => {
         scopeManager.enable();
@@ -64,33 +64,59 @@ describe('NoopScopeManager', () => {
     });
   });
 
-  describe('.active()', () => {
-    it('should always return null (when enabled)', () => {
+  describe(".withAsync()", () => {
+    it("should run the callback (null as target)", async done => {
+      await scopeManager.withAsync(null, async () => done());
+    });
+
+    it("should run the callback (object as target)", async done => {
+      const test = { a: 1 };
+      await scopeManager.withAsync(test, async () => {
+        assert.strictEqual(
+          scopeManager.active(),
+          undefined,
+          "should not have scope"
+        );
+        return done();
+      });
+    });
+
+    it("should run the callback (when disabled)", async done => {
+      scopeManager.disable();
+      await scopeManager.withAsync(null, async () => {
+        scopeManager.enable();
+        return done();
+      });
+    });
+  });
+
+  describe(".active()", () => {
+    it("should always return null (when enabled)", () => {
       assert.strictEqual(
         scopeManager.active(),
         undefined,
-        'should not have scope'
+        "should not have scope"
       );
     });
 
-    it('should always return null (when disabled)', () => {
+    it("should always return null (when disabled)", () => {
       scopeManager.disable();
       assert.strictEqual(
         scopeManager.active(),
         undefined,
-        'should not have scope'
+        "should not have scope"
       );
       scopeManager.enable();
     });
   });
 
-  describe('.bind()', () => {
-    it('should return the same target (when enabled)', () => {
+  describe(".bind()", () => {
+    it("should return the same target (when enabled)", () => {
       const test = { a: 1 };
       assert.deepStrictEqual(scopeManager.bind(test), test);
     });
 
-    it('should return the same target (when disabled)', () => {
+    it("should return the same target (when disabled)", () => {
       scopeManager.disable();
       const test = { a: 1 };
       assert.deepStrictEqual(scopeManager.bind(test), test);

--- a/packages/opentelemetry-scope-zone-peer-dep/src/ZoneScopeManager.ts
+++ b/packages/opentelemetry-scope-zone-peer-dep/src/ZoneScopeManager.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { ScopeManager } from '@opentelemetry/scope-base';
-import { Func, TargetWithEvents } from './types';
-import { isListenerObject } from './util';
+import { ScopeManager } from "@opentelemetry/scope-base";
+import { Func, TargetWithEvents } from "./types";
+import { isListenerObject } from "./util";
 
 /* Key name to be used to save a scope reference in Zone */
-const ZONE_SCOPE_KEY = 'OT_ZONE_SCOPE';
+const ZONE_SCOPE_KEY = "OT_ZONE_SCOPE";
 
 /**
  * ZoneScopeManager
@@ -60,11 +60,11 @@ export class ZoneScopeManager implements ScopeManager {
     const contextWrapper = function(this: any, ...args: unknown[]) {
       return manager.with(scope, () => target.apply(this || scope, args));
     };
-    Object.defineProperty(contextWrapper, 'length', {
+    Object.defineProperty(contextWrapper, "length", {
       enumerable: false,
       configurable: true,
       writable: false,
-      value: target.length,
+      value: target.length
     });
     return (contextWrapper as unknown) as T;
   }
@@ -80,7 +80,7 @@ export class ZoneScopeManager implements ScopeManager {
     }
     target.__ot_listeners = {};
 
-    if (typeof target.addEventListener === 'function') {
+    if (typeof target.addEventListener === "function") {
       target.addEventListener = this._patchAddEventListener(
         target,
         target.addEventListener,
@@ -88,7 +88,7 @@ export class ZoneScopeManager implements ScopeManager {
       );
     }
 
-    if (typeof target.removeEventListener === 'function') {
+    if (typeof target.removeEventListener === "function") {
       target.removeEventListener = this._patchRemoveEventListener(
         target,
         target.removeEventListener
@@ -116,8 +116,8 @@ export class ZoneScopeManager implements ScopeManager {
     return Zone.root.fork({
       name: zoneName,
       properties: {
-        [ZONE_SCOPE_KEY]: scope,
-      },
+        [ZONE_SCOPE_KEY]: scope
+      }
     });
   }
 
@@ -206,7 +206,7 @@ export class ZoneScopeManager implements ScopeManager {
     if (scope === undefined) {
       scope = this.active();
     }
-    if (typeof target === 'function') {
+    if (typeof target === "function") {
       return this._bindFunction(target, scope);
     } else if (isListenerObject(target)) {
       this._bindListener(target, scope);
@@ -245,7 +245,7 @@ export class ZoneScopeManager implements ScopeManager {
     fn: () => ReturnType<T>
   ): ReturnType<T> {
     // if no scope use active from active zone
-    if (typeof scope === 'undefined' || scope === null) {
+    if (typeof scope === "undefined" || scope === null) {
       scope = this.active();
     }
 
@@ -254,5 +254,21 @@ export class ZoneScopeManager implements ScopeManager {
     const newZone = this._createZone(zoneName, scope);
 
     return newZone.run(fn, scope);
+  }
+
+  async withAsync<
+    T extends (...args: unknown[]) => Promise<T2>,
+    T2 extends unknown
+  >(scope: unknown, fn: () => Promise<T2>): Promise<T2> {
+    // if no scope use active from active zone
+    if (typeof scope === "undefined" || scope === null) {
+      scope = this.active();
+    }
+
+    const zoneName = this._createZoneName();
+
+    const newZone = this._createZone(zoneName, scope);
+
+    return await newZone.run(fn, scope);
   }
 }

--- a/packages/opentelemetry-scope-zone-peer-dep/src/ZoneScopeManager.ts
+++ b/packages/opentelemetry-scope-zone-peer-dep/src/ZoneScopeManager.ts
@@ -259,7 +259,7 @@ export class ZoneScopeManager implements ScopeManager {
   async withAsync<
     T extends (...args: unknown[]) => Promise<T2>,
     T2 extends unknown
-  >(scope: unknown, fn: () => Promise<T2>): Promise<T2> {
+  >(scope: unknown, fn: T): Promise<T2> {
     // if no scope use active from active zone
     if (typeof scope === "undefined" || scope === null) {
       scope = this.active();
@@ -269,6 +269,10 @@ export class ZoneScopeManager implements ScopeManager {
 
     const newZone = this._createZone(zoneName, scope);
 
-    return await newZone.run(fn, scope);
+    console.log("before running code", scope);
+    console.log("active: ", this.active());
+    const result = await newZone.run(fn, scope);
+    console.log("after running code", scope);
+    return result as T2;
   }
 }

--- a/packages/opentelemetry-scope-zone-peer-dep/test/ZoneScopeManager.test.ts
+++ b/packages/opentelemetry-scope-zone-peer-dep/test/ZoneScopeManager.test.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import 'zone.js';
-import * as sinon from 'sinon';
-import * as assert from 'assert';
-import { ZoneScopeManager } from '../src';
+import "zone.js";
+import * as sinon from "sinon";
+import * as assert from "assert";
+import { ZoneScopeManager } from "../src";
 
 let clock: any;
 
-describe('ZoneScopeManager', () => {
+describe("ZoneScopeManager", () => {
   let scopeManager: ZoneScopeManager;
 
   beforeEach(() => {
@@ -35,38 +35,38 @@ describe('ZoneScopeManager', () => {
     scopeManager.disable();
   });
 
-  describe('.enable()', () => {
-    it('should work', () => {
+  describe(".enable()", () => {
+    it("should work", () => {
       assert.doesNotThrow(() => {
-        assert(scopeManager.enable() === scopeManager, 'should return this');
-        assert(scopeManager.active() === window, 'should has root scope');
+        assert(scopeManager.enable() === scopeManager, "should return this");
+        assert(scopeManager.active() === window, "should has root scope");
       });
     });
   });
 
-  describe('.disable()', () => {
-    it('should work', () => {
+  describe(".disable()", () => {
+    it("should work", () => {
       assert.doesNotThrow(() => {
-        assert(scopeManager.disable() === scopeManager, 'should return this');
-        assert(scopeManager.active() === undefined, 'should has no scope');
+        assert(scopeManager.disable() === scopeManager, "should return this");
+        assert(scopeManager.active() === undefined, "should has no scope");
       });
     });
   });
 
-  describe('.with()', () => {
-    it('should run the callback (null as target)', done => {
+  describe(".with()", () => {
+    it("should run the callback (null as target)", done => {
       scopeManager.with(null, done);
     });
 
-    it('should run the callback (object as target)', done => {
+    it("should run the callback (object as target)", done => {
       const test = { a: 1 };
       scopeManager.with(test, () => {
-        assert.strictEqual(scopeManager.active(), test, 'should have scope');
+        assert.strictEqual(scopeManager.active(), test, "should have scope");
         return done();
       });
     });
 
-    it('should run the callback (when disabled)', done => {
+    it("should run the callback (when disabled)", done => {
       scopeManager.disable();
       scopeManager.with(null, () => {
         scopeManager.enable();
@@ -74,32 +74,32 @@ describe('ZoneScopeManager', () => {
       });
     });
 
-    it('should rethrow errors', done => {
+    it("should rethrow errors", done => {
       assert.throws(() => {
         scopeManager.with(null, () => {
-          throw new Error('This should be rethrown');
+          throw new Error("This should be rethrown");
         });
       });
       return done();
     });
 
-    it('should finally restore an old scope, including the async task', done => {
-      const scope1 = 'scope1';
-      const scope2 = 'scope2';
-      const scope3 = 'scope3';
+    it("should finally restore an old scope, including the async task", done => {
+      const scope1 = "scope1";
+      const scope2 = "scope2";
+      const scope3 = "scope3";
 
       scopeManager.with(scope1, () => {
-        assert.strictEqual(scopeManager.active(), 'scope1');
+        assert.strictEqual(scopeManager.active(), "scope1");
         scopeManager.with(scope2, () => {
-          assert.strictEqual(scopeManager.active(), 'scope2');
+          assert.strictEqual(scopeManager.active(), "scope2");
           scopeManager.with(scope3, () => {
-            assert.strictEqual(scopeManager.active(), 'scope3');
+            assert.strictEqual(scopeManager.active(), "scope3");
           });
-          assert.strictEqual(scopeManager.active(), 'scope2');
+          assert.strictEqual(scopeManager.active(), "scope2");
         });
-        assert.strictEqual(scopeManager.active(), 'scope1');
+        assert.strictEqual(scopeManager.active(), "scope1");
         setTimeout(() => {
-          assert.strictEqual(scopeManager.active(), 'scope1');
+          assert.strictEqual(scopeManager.active(), "scope1");
           done();
         }, 500);
         clock.tick(500);
@@ -107,7 +107,7 @@ describe('ZoneScopeManager', () => {
       assert.strictEqual(scopeManager.active(), window);
     });
 
-    it('should finally restore an old scope when scope is an object, including the async task', done => {
+    it("should finally restore an old scope when scope is an object, including the async task", done => {
       const scope1 = { a: 1 };
       const scope2 = { a: 2 };
       const scope3 = { a: 3 };
@@ -129,22 +129,22 @@ describe('ZoneScopeManager', () => {
       });
       assert.strictEqual(scopeManager.active(), window);
     });
-    it('should correctly return the scopes for 3 parallel actions', () => {
-      const rootSpan = { name: 'rootSpan' };
+    it("should correctly return the scopes for 3 parallel actions", () => {
+      const rootSpan = { name: "rootSpan" };
       scopeManager.with(rootSpan, () => {
         assert.ok(
           scopeManager.active() === rootSpan,
-          'Current span is rootSpan'
+          "Current span is rootSpan"
         );
-        const concurrentSpan1 = { name: 'concurrentSpan1' };
-        const concurrentSpan2 = { name: 'concurrentSpan2' };
-        const concurrentSpan3 = { name: 'concurrentSpan3' };
+        const concurrentSpan1 = { name: "concurrentSpan1" };
+        const concurrentSpan2 = { name: "concurrentSpan2" };
+        const concurrentSpan3 = { name: "concurrentSpan3" };
 
         scopeManager.with(concurrentSpan1, () => {
           setTimeout(() => {
             assert.ok(
               scopeManager.active() === concurrentSpan1,
-              'Current span is concurrentSpan1'
+              "Current span is concurrentSpan1"
             );
           }, 10);
         });
@@ -153,7 +153,7 @@ describe('ZoneScopeManager', () => {
           setTimeout(() => {
             assert.ok(
               scopeManager.active() === concurrentSpan2,
-              'Current span is concurrentSpan2'
+              "Current span is concurrentSpan2"
             );
           }, 20);
         });
@@ -162,7 +162,7 @@ describe('ZoneScopeManager', () => {
           setTimeout(() => {
             assert.ok(
               scopeManager.active() === concurrentSpan3,
-              'Current span is concurrentSpan3'
+              "Current span is concurrentSpan3"
             );
           }, 30);
         });
@@ -170,8 +170,132 @@ describe('ZoneScopeManager', () => {
     });
   });
 
-  describe('.bind(function)', () => {
-    it('should call the function with previously assigned scope', () => {
+  describe.only(".withAsync()", () => {
+    it("should run the callback (null as target)", async done => {
+      await scopeManager.withAsync(null, async () => done());
+    });
+
+    it("should run the callback (object as target)", async done => {
+      const test = { a: 1 };
+      await scopeManager.withAsync(test, async () => {
+        assert.strictEqual(scopeManager.active(), test, "should have scope");
+        done();
+      });
+    });
+
+    it("should run the callback (when disabled)", async done => {
+      scopeManager.disable();
+      await scopeManager.withAsync(null, async () => {
+        scopeManager.enable();
+        return done();
+      });
+    });
+
+    it("should rethrow errors", done => {
+      scopeManager
+        .withAsync(null, async () => {
+          throw new Error("This should be rethrown");
+        })
+        .then(
+          () => {
+            assert.equal("this code", "should never be executed");
+          },
+          () => {
+            done();
+          }
+        );
+    });
+
+    it.only("should finally restore an old scope, including the async task", async () => {
+      const scope1 = "scope1";
+      const scope2 = "scope2";
+      scope2;
+      const scope3 = "scope3";
+      scope3;
+
+      await scopeManager.withAsync(scope1, async () => {
+        assert.strictEqual(scopeManager.active(), "scope1");
+        await scopeManager.withAsync(scope2, async () => {
+          assert.strictEqual(scopeManager.active(), "scope2");
+          await scopeManager.withAsync(scope3, async () => {
+            assert.strictEqual(scopeManager.active(), "scope3");
+          });
+          //   assert.strictEqual(scopeManager.active(), "scope2");
+        });
+        // assert.strictEqual(scopeManager.active(), "scope1");
+        setTimeout(() => {
+          // assert.strictEqual(scopeManager.active(), "scope1");
+        }, 500);
+        clock.tick(500);
+      });
+      assert.strictEqual(scopeManager.active(), window);
+    });
+
+    it("should finally restore an old scope when scope is an object, including the async task", done => {
+      const scope1 = { a: 1 };
+      const scope2 = { a: 2 };
+      const scope3 = { a: 3 };
+      scopeManager.with(scope1, () => {
+        assert.strictEqual(scopeManager.active(), scope1);
+        scopeManager.with(scope2, () => {
+          assert.strictEqual(scopeManager.active(), scope2);
+          scopeManager.with(scope3, () => {
+            assert.strictEqual(scopeManager.active(), scope3);
+          });
+          assert.strictEqual(scopeManager.active(), scope2);
+        });
+        assert.strictEqual(scopeManager.active(), scope1);
+        setTimeout(() => {
+          assert.strictEqual(scopeManager.active(), scope1);
+          done();
+        }, 500);
+        clock.tick(500);
+      });
+      assert.strictEqual(scopeManager.active(), window);
+    });
+    it("should correctly return the scopes for 3 parallel actions", () => {
+      const rootSpan = { name: "rootSpan" };
+      scopeManager.with(rootSpan, () => {
+        assert.ok(
+          scopeManager.active() === rootSpan,
+          "Current span is rootSpan"
+        );
+        const concurrentSpan1 = { name: "concurrentSpan1" };
+        const concurrentSpan2 = { name: "concurrentSpan2" };
+        const concurrentSpan3 = { name: "concurrentSpan3" };
+
+        scopeManager.with(concurrentSpan1, () => {
+          setTimeout(() => {
+            assert.ok(
+              scopeManager.active() === concurrentSpan1,
+              "Current span is concurrentSpan1"
+            );
+          }, 10);
+        });
+
+        scopeManager.with(concurrentSpan2, () => {
+          setTimeout(() => {
+            assert.ok(
+              scopeManager.active() === concurrentSpan2,
+              "Current span is concurrentSpan2"
+            );
+          }, 20);
+        });
+
+        scopeManager.with(concurrentSpan3, () => {
+          setTimeout(() => {
+            assert.ok(
+              scopeManager.active() === concurrentSpan3,
+              "Current span is concurrentSpan3"
+            );
+          }, 30);
+        });
+      });
+    });
+  });
+
+  describe(".bind(function)", () => {
+    it("should call the function with previously assigned scope", () => {
       class Obj {
         title: string;
 
@@ -184,39 +308,39 @@ describe('ZoneScopeManager', () => {
         }
       }
 
-      const obj1 = new Obj('a1');
-      obj1.title = 'a2';
-      const obj2 = new Obj('b1');
+      const obj1 = new Obj("a1");
+      obj1.title = "a2";
+      const obj2 = new Obj("b1");
       const wrapper: any = scopeManager.bind(obj2.getTitle, obj1);
-      assert.ok(wrapper(), 'a2');
+      assert.ok(wrapper(), "a2");
     });
 
-    it('should return the same target (when enabled)', () => {
+    it("should return the same target (when enabled)", () => {
       const test = { a: 1 };
       assert.deepStrictEqual(scopeManager.bind(test), test);
     });
 
-    it('should return the same target (when disabled)', () => {
+    it("should return the same target (when disabled)", () => {
       scopeManager.disable();
       const test = { a: 1 };
       assert.deepStrictEqual(scopeManager.bind(test), test);
       scopeManager.enable();
     });
 
-    it('should return current scope (when enabled)', done => {
+    it("should return current scope (when enabled)", done => {
       const scope = { a: 1 };
       const fn: any = scopeManager.bind(() => {
-        assert.strictEqual(scopeManager.active(), scope, 'should have scope');
+        assert.strictEqual(scopeManager.active(), scope, "should have scope");
         return done();
       }, scope);
       fn();
     });
 
-    it('should return current scope (when disabled)', done => {
+    it("should return current scope (when disabled)", done => {
       scopeManager.disable();
       const scope = { a: 1 };
       const fn: any = scopeManager.bind(() => {
-        assert.strictEqual(scopeManager.active(), scope, 'should have scope');
+        assert.strictEqual(scopeManager.active(), scope, "should have scope");
         return done();
       }, scope);
       fn();
@@ -224,11 +348,11 @@ describe('ZoneScopeManager', () => {
 
     it('should bind the the certain scope to the target "addEventListener" function', done => {
       const scope1 = { a: 1 };
-      const element = document.createElement('div');
+      const element = document.createElement("div");
 
       scopeManager.bind(element, scope1);
 
-      element.addEventListener('click', () => {
+      element.addEventListener("click", () => {
         assert.strictEqual(scopeManager.active(), scope1);
         setTimeout(() => {
           assert.strictEqual(scopeManager.active(), scope1);
@@ -238,27 +362,27 @@ describe('ZoneScopeManager', () => {
       });
 
       element.dispatchEvent(
-        new CustomEvent('click', {
+        new CustomEvent("click", {
           bubbles: true,
           cancelable: false,
-          composed: true,
+          composed: true
         })
       );
     });
 
-    it('should preserve zone when creating new click event inside zone', done => {
+    it("should preserve zone when creating new click event inside zone", done => {
       const scope1 = { a: 1 };
-      const element = document.createElement('div');
+      const element = document.createElement("div");
 
       scopeManager.bind(element, scope1);
 
-      element.addEventListener('click', () => {
+      element.addEventListener("click", () => {
         assert.strictEqual(scopeManager.active(), scope1);
         setTimeout(() => {
           assert.strictEqual(scopeManager.active(), scope1);
-          const element2 = document.createElement('div');
+          const element2 = document.createElement("div");
 
-          element2.addEventListener('click', () => {
+          element2.addEventListener("click", () => {
             assert.strictEqual(scopeManager.active(), scope1);
             setTimeout(() => {
               assert.strictEqual(scopeManager.active(), scope1);
@@ -268,10 +392,10 @@ describe('ZoneScopeManager', () => {
           });
 
           element2.dispatchEvent(
-            new CustomEvent('click', {
+            new CustomEvent("click", {
               bubbles: true,
               cancelable: false,
-              composed: true,
+              composed: true
             })
           );
         }, 500);
@@ -279,10 +403,10 @@ describe('ZoneScopeManager', () => {
       });
 
       element.dispatchEvent(
-        new CustomEvent('click', {
+        new CustomEvent("click", {
           bubbles: true,
           cancelable: false,
-          composed: true,
+          composed: true
         })
       );
     });

--- a/packages/opentelemetry-scope-zone-peer-dep/test/ZoneScopeManager.test.ts
+++ b/packages/opentelemetry-scope-zone-peer-dep/test/ZoneScopeManager.test.ts
@@ -214,20 +214,26 @@ describe("ZoneScopeManager", () => {
       scope3;
 
       await scopeManager.withAsync(scope1, async () => {
+        console.log("within zone");
         assert.strictEqual(scopeManager.active(), "scope1");
         await scopeManager.withAsync(scope2, async () => {
+          console.log("within zone 2");
           assert.strictEqual(scopeManager.active(), "scope2");
           await scopeManager.withAsync(scope3, async () => {
+            console.log("within zone 3");
             assert.strictEqual(scopeManager.active(), "scope3");
           });
-          //   assert.strictEqual(scopeManager.active(), "scope2");
+          console.log("after zone 3");
+          assert.strictEqual(scopeManager.active(), "scope2");
         });
+        console.log("after zone 2");
         // assert.strictEqual(scopeManager.active(), "scope1");
-        setTimeout(() => {
-          // assert.strictEqual(scopeManager.active(), "scope1");
-        }, 500);
-        clock.tick(500);
+        // setTimeout(() => {
+        //   // assert.strictEqual(scopeManager.active(), "scope1");
+        // }, 500);
+        // clock.tick(500);
       });
+      console.log("after zone");
       assert.strictEqual(scopeManager.active(), window);
     });
 

--- a/packages/opentelemetry-tracing/src/Tracer.ts
+++ b/packages/opentelemetry-tracing/src/Tracer.ts
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-import * as types from '@opentelemetry/api';
+import * as types from "@opentelemetry/api";
 import {
   randomTraceId,
   isValid,
   randomSpanId,
   NoRecordingSpan,
-  ConsoleLogger,
-} from '@opentelemetry/core';
-import { TracerConfig, TraceParams } from './types';
-import { ScopeManager } from '@opentelemetry/scope-base';
-import { Span } from './Span';
-import { mergeConfig } from './utility';
-import { DEFAULT_CONFIG } from './config';
-import { BasicTracerRegistry } from './BasicTracerRegistry';
+  ConsoleLogger
+} from "@opentelemetry/core";
+import { TracerConfig, TraceParams } from "./types";
+import { ScopeManager } from "@opentelemetry/scope-base";
+import { Span } from "./Span";
+import { mergeConfig } from "./utility";
+import { DEFAULT_CONFIG } from "./config";
+import { BasicTracerRegistry } from "./BasicTracerRegistry";
 
 /**
  * This class represents a basic tracer.
@@ -83,7 +83,7 @@ export class Tracer implements types.Tracer {
     const spanContext = { traceId, spanId, traceFlags, traceState };
     const recordEvents = options.isRecording || false;
     if (!recordEvents && !samplingDecision) {
-      this.logger.debug('Sampling is off, starting no recording span');
+      this.logger.debug("Sampling is off, starting no recording span");
       return new NoRecordingSpan(spanContext);
     }
 
@@ -130,6 +130,17 @@ export class Tracer implements types.Tracer {
   }
 
   /**
+   * Enters the scope of code where the given Span is in the current context.
+   */
+  async withSpanAsync<T extends (...args: unknown[]) => ReturnType<T>>(
+    span: types.Span,
+    fn: T
+  ): Promise<ReturnType<T>> {
+    // Set given span to context.
+    return this._scopeManager.with(span, fn);
+  }
+
+  /**
    * Bind a span (or the current one) to the target's scope
    */
   bind<T>(target: T, span?: types.Span): T {
@@ -169,7 +180,7 @@ export class Tracer implements types.Tracer {
       return parent as types.SpanContext;
     }
 
-    if (typeof (parent as types.Span).context === 'function') {
+    if (typeof (parent as types.Span).context === "function") {
       return (parent as Span).context();
     }
     return undefined;


### PR DESCRIPTION
## Which problem is this PR solving?

- resolves the issue outlined in #752 

## Short description of the changes

introduce a `withAsync` and `withSpanAsync` to the respective types and propagate those changes through inheritance hierarchy
