### PR TITLE
chore: use os specific line endings for version updates

### DIFF
--- a/scripts/version-update.js
+++ b/scripts/version-update.js
@@ -15,6 +15,7 @@
  */
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const appRoot = process.cwd();
@@ -44,4 +45,4 @@ export const VERSION = '${pjson.version}';
 
 const fileUrl = path.join(appRoot, "src", "version.ts")
 
-fs.writeFileSync(fileUrl, content);
+fs.writeFileSync(fileUrl, content.replace(/\n/g, os.EOL));


### PR DESCRIPTION
## Which problem is this PR solving?
On windows (with git config core.autocrlf=true as recommended for cross os projects)
the version-update script created unix files (LF only). This caused that git sees a
lot modified files after bootstrap.

## Short description of the changes
Use `os.EOL` to ensure line endings match the os used.

