### PR TITLE
cleanup: remove unused tsconfig-release.json

### DIFF
--- a/packages/opentelemetry-base/tsconfig-release.json
+++ b/packages/opentelemetry-base/tsconfig-release.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "types": []
-  },
-  "include": ["src/**/*.ts"]
-}

--- a/packages/opentelemetry-core/tsconfig-release.json
+++ b/packages/opentelemetry-core/tsconfig-release.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "types": []
-  },
-  "include": ["src/**/*.ts"]
-}

--- a/packages/opentelemetry-exporter-collector/tsconfig-release.json
+++ b/packages/opentelemetry-exporter-collector/tsconfig-release.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "types": []
-  },
-  "include": ["src/**/*.ts"]
-}

--- a/packages/opentelemetry-plugin-xml-http-request/tsconfig-release.json
+++ b/packages/opentelemetry-plugin-xml-http-request/tsconfig-release.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "types": []
-  },
-  "include": ["src/**/*.ts"]
-}

--- a/packages/opentelemetry-propagator-jaeger/tsconfig-release.json
+++ b/packages/opentelemetry-propagator-jaeger/tsconfig-release.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "types": []
-  },
-  "include": ["src/**/*.ts"]
-}

--- a/packages/opentelemetry-web/tsconfig-release.json
+++ b/packages/opentelemetry-web/tsconfig-release.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "types": []
-  },
-  "include": ["src/**/*.ts"]
-}


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Cleanup

## Short description of the changes

- We removed `compile:release` script in [opentelemetry-js/pull/53](https://github.com/open-telemetry/opentelemetry-js/pull/53), but pay no heed to corresponding `tsconfig-release.json` and somehow it got copied to few other packages.
