### PR TITLE
fix: prevent crash when SDT exporter constructed without options

### DIFF
--- a/packages/opentelemetry-exporter-stackdriver-trace/src/trace.ts
+++ b/packages/opentelemetry-exporter-stackdriver-trace/src/trace.ts
@@ -37,7 +37,7 @@ export class StackdriverTraceExporter implements SpanExporter {
 
   private static readonly _cloudTrace = google.cloudtrace('v2');
 
-  constructor(options: StackdriverExporterOptions) {
+  constructor(options: StackdriverExporterOptions = {}) {
     this._logger = options.logger || new NoopLogger();
 
     this._auth = new GoogleAuth({


### PR DESCRIPTION
Fixes #774 