### PR TITLE
fix: allow multi tenant vendor keys in TraceState

### DIFF
--- a/packages/opentelemetry-core/src/internal/validators.ts
+++ b/packages/opentelemetry-core/src/internal/validators.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-const VALID_KEY_REGEX = /^[a-z][_0-9a-z-*/]{0,255}$/;
+const VALID_KEY_CHAR_RANGE = '[_0-9a-z-*/]';
+const VALID_KEY_REGEX = new RegExp(`^[a-z]${VALID_KEY_CHAR_RANGE}{0,255}$`);
+const VALID_KEY_VENDOR_REGEX = new RegExp(
+  `^[a-z0-9]${VALID_KEY_CHAR_RANGE}{0,240}@[a-z]${VALID_KEY_CHAR_RANGE}{0,13}$`
+);
 const VALID_VALUE_BASE_REGEX = /^[ -~]{0,255}[!-~]$/;
 const INVALID_VALUE_COMMA_EQUAL_REGEX = /,|=/;
 
@@ -24,7 +28,7 @@ const INVALID_VALUE_COMMA_EQUAL_REGEX = /,|=/;
  * underscores _, dashes -, asterisks *, and forward slashes /.
  */
 export function validateKey(key: string): boolean {
-  return VALID_KEY_REGEX.test(key);
+  return VALID_KEY_REGEX.test(key) || VALID_KEY_VENDOR_REGEX.test(key);
 }
 
 /**

--- a/packages/opentelemetry-core/src/internal/validators.ts
+++ b/packages/opentelemetry-core/src/internal/validators.ts
@@ -17,9 +17,7 @@
 const VALID_KEY_CHAR_RANGE = '[_0-9a-z-*/]';
 const VALID_KEY = `[a-z]${VALID_KEY_CHAR_RANGE}{0,255}`;
 const VALID_VENDOR_KEY = `[a-z0-9]${VALID_KEY_CHAR_RANGE}{0,240}@[a-z]${VALID_KEY_CHAR_RANGE}{0,13}`;
-const VALID_KEY_REGEX = new RegExp(
-  `^(?:${VALID_KEY})|(?:${VALID_VENDOR_KEY})$`
-);
+const VALID_KEY_REGEX = new RegExp(`^(?:${VALID_KEY}|${VALID_VENDOR_KEY})$`);
 const VALID_VALUE_BASE_REGEX = /^[ -~]{0,255}[!-~]$/;
 const INVALID_VALUE_COMMA_EQUAL_REGEX = /,|=/;
 

--- a/packages/opentelemetry-core/src/internal/validators.ts
+++ b/packages/opentelemetry-core/src/internal/validators.ts
@@ -15,9 +15,10 @@
  */
 
 const VALID_KEY_CHAR_RANGE = '[_0-9a-z-*/]';
-const VALID_KEY_REGEX = new RegExp(`^[a-z]${VALID_KEY_CHAR_RANGE}{0,255}$`);
-const VALID_KEY_VENDOR_REGEX = new RegExp(
-  `^[a-z0-9]${VALID_KEY_CHAR_RANGE}{0,240}@[a-z]${VALID_KEY_CHAR_RANGE}{0,13}$`
+const VALID_KEY = `[a-z]${VALID_KEY_CHAR_RANGE}{0,255}`;
+const VALID_VENDOR_KEY = `[a-z0-9]${VALID_KEY_CHAR_RANGE}{0,240}@[a-z]${VALID_KEY_CHAR_RANGE}{0,13}`;
+const VALID_KEY_REGEX = new RegExp(
+  `^(?:${VALID_KEY})|(?:${VALID_VENDOR_KEY})$`
 );
 const VALID_VALUE_BASE_REGEX = /^[ -~]{0,255}[!-~]$/;
 const INVALID_VALUE_COMMA_EQUAL_REGEX = /,|=/;
@@ -26,9 +27,12 @@ const INVALID_VALUE_COMMA_EQUAL_REGEX = /,|=/;
  * Key is opaque string up to 256 characters printable. It MUST begin with a
  * lowercase letter, and can only contain lowercase letters a-z, digits 0-9,
  * underscores _, dashes -, asterisks *, and forward slashes /.
+ * For multi-tenant vendor scenarios, an at sign (@) can be used to prefix the
+ * vendor name. Vendors SHOULD set the tenant ID at the beginning of the key.
+ * see https://www.w3.org/TR/trace-context/#key
  */
 export function validateKey(key: string): boolean {
-  return VALID_KEY_REGEX.test(key) || VALID_KEY_VENDOR_REGEX.test(key);
+  return VALID_KEY_REGEX.test(key);
 }
 
 /**

--- a/packages/opentelemetry-core/test/internal/validators.test.ts
+++ b/packages/opentelemetry-core/test/internal/validators.test.ts
@@ -27,10 +27,12 @@ describe('validators', () => {
       'baz*bar',
       'baz/',
       'tracestate',
+      'fw529a3039@dt',
+      '6cab5bb-29a@dt',
     ];
     validKeysTestCases.forEach(testCase =>
       it(`returns true when key contains valid chars ${testCase}`, () => {
-        assert.ok(validateKey(testCase));
+        assert.ok(validateKey(testCase), `${testCase} should be valid`);
       })
     );
 
@@ -42,10 +44,11 @@ describe('validators', () => {
       'TrAcEsTaTE',
       'TRACESTATE',
       '',
+      '6num',
     ];
     invalidKeysTestCases.forEach(testCase =>
       it(`returns true when key contains invalid chars ${testCase}`, () => {
-        assert.ok(!validateKey(testCase));
+        assert.ok(!validateKey(testCase), `${testCase} should be invalid`);
       })
     );
   });


### PR DESCRIPTION
## Which problem is this PR solving?

`TraceState` doesn't allow keys holding '@' char even W3C specifies them for multi tenant vendor scenarios.

## Short description of the changes

Improve checking of TraceState keys to allow '@' char used in multi tenant vendor scenarios.

See https://www.w3.org/TR/trace-context/#key for details


