### PR TITLE
SDK Resource

### DIFF
--- a/packages/opentelemetry-base/package.json
+++ b/packages/opentelemetry-base/package.json
@@ -3,6 +3,10 @@
   "version": "0.4.0",
   "description": "OpenTelemetry base provides base code for the SDK packages",
   "main": "build/src/index.js",
+  "browser": {
+    "./src/platform/index.ts": "./src/platform/browser/index.ts",
+    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
+  },
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {

--- a/packages/opentelemetry-base/src/index.ts
+++ b/packages/opentelemetry-base/src/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-base/src/index.ts
+++ b/packages/opentelemetry-base/src/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-base/src/platform/browser/constants.ts
+++ b/packages/opentelemetry-base/src/platform/browser/constants.ts
@@ -1,5 +1,5 @@
-/*!
- * Copyright 2019, OpenTelemetry Authors
+/**
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,5 +14,12 @@
  * limitations under the License.
  */
 
-export * from './ExportResult';
-export * from './platform';
+import { VERSION } from '../../version';
+
+/** Constants describing the SDK in use */
+export const SDK_INFO = {
+  NAME: 'opentelemetry',
+  RUNTIME: 'browser',
+  LANGUAGE: 'webjs',
+  VERSION: VERSION,
+};

--- a/packages/opentelemetry-base/src/platform/browser/index.ts
+++ b/packages/opentelemetry-base/src/platform/browser/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,5 +14,4 @@
  * limitations under the License.
  */
 
-export * from './ExportResult';
-export * from './platform';
+export * from './constants';

--- a/packages/opentelemetry-base/src/platform/index.ts
+++ b/packages/opentelemetry-base/src/platform/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,5 +14,7 @@
  * limitations under the License.
  */
 
-export * from './ExportResult';
-export * from './platform';
+// Use the node platform by default. The "browser" field of package.json is used
+// to override this file to use `./browser/index.ts` when packaged with
+// webpack, Rollup, etc.
+export * from './node';

--- a/packages/opentelemetry-base/src/platform/node/constants.ts
+++ b/packages/opentelemetry-base/src/platform/node/constants.ts
@@ -1,5 +1,5 @@
-/*!
- * Copyright 2019, OpenTelemetry Authors
+/**
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,5 +14,12 @@
  * limitations under the License.
  */
 
-export * from './ExportResult';
-export * from './platform';
+import { VERSION } from '../../version';
+
+/** Constants describing the SDK in use */
+export const SDK_INFO = {
+  NAME: 'opentelemetry',
+  RUNTIME: 'node',
+  LANGUAGE: 'nodejs',
+  VERSION: VERSION,
+};

--- a/packages/opentelemetry-base/src/platform/node/index.ts
+++ b/packages/opentelemetry-base/src/platform/node/index.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,5 +14,4 @@
  * limitations under the License.
  */
 
-export * from './ExportResult';
-export * from './platform';
+export * from './constants';

--- a/packages/opentelemetry-exporter-collector/package.json
+++ b/packages/opentelemetry-exporter-collector/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.6.0",
+    "@opentelemetry/resources": "^0.4.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.6.8",
     "@types/sinon": "^7.0.13",
@@ -82,7 +83,6 @@
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/base": "^0.4.0",
     "@opentelemetry/core": "^0.4.0",
-    "@opentelemetry/resources": "^0.4.0",
     "@opentelemetry/tracing": "^0.4.0"
   }
 }

--- a/packages/opentelemetry-exporter-collector/package.json
+++ b/packages/opentelemetry-exporter-collector/package.json
@@ -82,6 +82,7 @@
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/base": "^0.4.0",
     "@opentelemetry/core": "^0.4.0",
+    "@opentelemetry/resources": "^0.4.0",
     "@opentelemetry/tracing": "^0.4.0"
   }
 }

--- a/packages/opentelemetry-exporter-collector/test/helper.ts
+++ b/packages/opentelemetry-exporter-collector/test/helper.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-exporter-collector/test/helper.ts
+++ b/packages/opentelemetry-exporter-collector/test/helper.ts
@@ -17,6 +17,7 @@
 import { TraceFlags } from '@opentelemetry/api';
 import * as core from '@opentelemetry/core';
 import { ReadableSpan } from '@opentelemetry/tracing';
+import { Resource } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import * as transform from '../src/transform';
 import * as collectorTypes from '../src/types';
@@ -68,6 +69,7 @@ export const mockedReadableSpan: ReadableSpan = {
     },
   ],
   duration: [0, 8885000],
+  resource: Resource.empty(),
 };
 
 export function ensureSpanIsCorrect(span: collectorTypes.Span) {

--- a/packages/opentelemetry-exporter-collector/test/helper.ts
+++ b/packages/opentelemetry-exporter-collector/test/helper.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -40,6 +40,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/resources": "^0.4.0",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.6.9",
     "codecov": "^3.6.1",
@@ -57,7 +58,6 @@
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/base": "^0.4.0",
     "@opentelemetry/core": "^0.4.0",
-    "@opentelemetry/resources": "^0.4.0",
     "@opentelemetry/tracing": "^0.4.0",
     "jaeger-client": "^3.15.0"
   }

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -57,6 +57,7 @@
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/base": "^0.4.0",
     "@opentelemetry/core": "^0.4.0",
+    "@opentelemetry/resources": "^0.4.0",
     "@opentelemetry/tracing": "^0.4.0",
     "jaeger-client": "^3.15.0"
   }

--- a/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
@@ -22,6 +22,7 @@ import { ThriftProcess } from '../src/types';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import { ExportResult } from '@opentelemetry/base';
 import { TraceFlags } from '@opentelemetry/api';
+import { Resource } from '@opentelemetry/resources';
 
 describe('JaegerExporter', () => {
   describe('constructor', () => {
@@ -127,6 +128,7 @@ describe('JaegerExporter', () => {
         links: [],
         events: [],
         duration: [32, 800000000],
+        resource: Resource.empty(),
       };
 
       exporter.export([readableSpan], (result: ExportResult) => {

--- a/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
@@ -17,6 +17,7 @@
 import * as assert from 'assert';
 import { spanToThrift } from '../src/transform';
 import { ReadableSpan } from '@opentelemetry/tracing';
+import { Resource } from '@opentelemetry/resources';
 import * as types from '@opentelemetry/api';
 import { ThriftUtils, Utils, ThriftReferenceType } from '../src/types';
 import { hrTimeToMicroseconds } from '@opentelemetry/core';
@@ -69,6 +70,7 @@ describe('transform', () => {
           },
         ],
         duration: [32, 800000000],
+        resource: Resource.empty(),
       };
 
       const thriftSpan = spanToThrift(readableSpan);
@@ -143,6 +145,7 @@ describe('transform', () => {
         links: [],
         events: [],
         duration: [32, 800000000],
+        resource: Resource.empty(),
       };
 
       const thriftSpan = spanToThrift(readableSpan);
@@ -207,6 +210,7 @@ describe('transform', () => {
         ],
         events: [],
         duration: [32, 800000000],
+        resource: Resource.empty(),
       };
 
       const thriftSpan = spanToThrift(readableSpan);
@@ -245,6 +249,7 @@ describe('transform', () => {
         links: [],
         events: [],
         duration: [32, 800000000],
+        resource: Resource.empty(),
       };
 
       const thriftSpan = spanToThrift(readableSpan);

--- a/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-exporter-stackdriver-trace/package.json
+++ b/packages/opentelemetry-exporter-stackdriver-trace/package.json
@@ -62,6 +62,7 @@
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/base": "^0.4.0",
     "@opentelemetry/core": "^0.4.0",
+    "@opentelemetry/resources": "^0.4.0",
     "@opentelemetry/tracing": "^0.4.0",
     "google-auth-library": "^5.7.0",
     "googleapis": "^46.0.0"

--- a/packages/opentelemetry-exporter-stackdriver-trace/package.json
+++ b/packages/opentelemetry-exporter-stackdriver-trace/package.json
@@ -41,6 +41,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/resources": "^0.4.0",
     "@types/mocha": "^5.2.7",
     "@types/nock": "^11.1.0",
     "@types/node": "^12.6.9",
@@ -62,7 +63,6 @@
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/base": "^0.4.0",
     "@opentelemetry/core": "^0.4.0",
-    "@opentelemetry/resources": "^0.4.0",
     "@opentelemetry/tracing": "^0.4.0",
     "google-auth-library": "^5.7.0",
     "googleapis": "^46.0.0"

--- a/packages/opentelemetry-exporter-stackdriver-trace/test/exporter.test.ts
+++ b/packages/opentelemetry-exporter-stackdriver-trace/test/exporter.test.ts
@@ -17,6 +17,7 @@
 import { ExportResult } from '@opentelemetry/base';
 import { ConsoleLogger, LogLevel } from '@opentelemetry/core';
 import { ReadableSpan } from '@opentelemetry/tracing';
+import { Resource } from '@opentelemetry/resources';
 import * as types from '@opentelemetry/api';
 import * as assert from 'assert';
 import * as nock from 'nock';
@@ -121,6 +122,7 @@ describe('Stackdriver Trace Exporter', () => {
           isRemote: true,
         },
         status: { code: types.CanonicalCode.OK },
+        resource: Resource.empty(),
       };
 
       const result = await new Promise((resolve, reject) => {
@@ -155,6 +157,7 @@ describe('Stackdriver Trace Exporter', () => {
           isRemote: true,
         },
         status: { code: types.CanonicalCode.OK },
+        resource: Resource.empty(),
       };
 
       getClientShouldFail = true;
@@ -188,6 +191,7 @@ describe('Stackdriver Trace Exporter', () => {
           isRemote: true,
         },
         status: { code: types.CanonicalCode.OK },
+        resource: Resource.empty(),
       };
 
       batchWriteShouldFail = true;
@@ -219,6 +223,7 @@ describe('Stackdriver Trace Exporter', () => {
           isRemote: true,
         },
         status: { code: types.CanonicalCode.OK },
+        resource: Resource.empty(),
       };
 
       await exporter['_projectId'];

--- a/packages/opentelemetry-exporter-stackdriver-trace/test/exporter.test.ts
+++ b/packages/opentelemetry-exporter-stackdriver-trace/test/exporter.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-exporter-stackdriver-trace/test/exporter.test.ts
+++ b/packages/opentelemetry-exporter-stackdriver-trace/test/exporter.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-exporter-stackdriver-trace/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-stackdriver-trace/test/transform.test.ts
@@ -16,6 +16,7 @@
 
 import { VERSION as CORE_VERSION } from '@opentelemetry/core';
 import { ReadableSpan } from '@opentelemetry/tracing';
+import { Resource } from '@opentelemetry/resources';
 import * as types from '@opentelemetry/api';
 import * as assert from 'assert';
 import { getReadableSpanTransformer } from '../src/transform';
@@ -50,6 +51,7 @@ describe('transform', () => {
       name: 'my-span',
       spanContext,
       status: { code: types.CanonicalCode.OK },
+      resource: Resource.empty(),
     };
   });
 

--- a/packages/opentelemetry-exporter-stackdriver-trace/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-stackdriver-trace/test/transform.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-exporter-stackdriver-trace/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-stackdriver-trace/test/transform.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -58,6 +58,7 @@
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/base": "^0.4.0",
     "@opentelemetry/core": "^0.4.0",
+    "@opentelemetry/resources": "0.4.0",
     "@opentelemetry/tracing": "^0.4.0"
   }
 }

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -39,6 +39,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/resources": "^0.4.0",
     "@types/mocha": "^5.2.7",
     "@types/nock": "^10.0.3",
     "@types/node": "^12.6.9",
@@ -58,7 +59,6 @@
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/base": "^0.4.0",
     "@opentelemetry/core": "^0.4.0",
-    "@opentelemetry/resources": "0.4.0",
     "@opentelemetry/tracing": "^0.4.0"
   }
 }

--- a/packages/opentelemetry-exporter-zipkin/test/zipkin.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/zipkin.test.ts
@@ -20,6 +20,7 @@ import { ReadableSpan } from '@opentelemetry/tracing';
 import { ExportResult } from '@opentelemetry/base';
 import { NoopLogger, hrTimeToMicroseconds } from '@opentelemetry/core';
 import * as types from '@opentelemetry/api';
+import { Resource } from '@opentelemetry/resources';
 import { ZipkinExporter } from '../src';
 import * as zipkinTypes from '../src/types';
 import { OT_REQUEST_HEADER } from '../src/utils';
@@ -48,6 +49,7 @@ function getReadableSpan() {
     attributes: {},
     links: [],
     events: [],
+    resource: Resource.empty(),
   };
   return readableSpan;
 }
@@ -154,6 +156,7 @@ describe('ZipkinExporter', () => {
             attributes: { key3: 'value3' },
           },
         ],
+        resource: Resource.empty(),
       };
       const span2: ReadableSpan = {
         name: 'my-span',
@@ -173,6 +176,7 @@ describe('ZipkinExporter', () => {
         attributes: {},
         links: [],
         events: [],
+        resource: Resource.empty(),
       };
 
       const exporter = new ZipkinExporter({

--- a/packages/opentelemetry-exporter-zipkin/test/zipkin.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/zipkin.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-exporter-zipkin/test/zipkin.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/zipkin.test.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-metrics/package.json
+++ b/packages/opentelemetry-metrics/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/base": "^0.4.0",
-    "@opentelemetry/core": "^0.4.0"
+    "@opentelemetry/core": "^0.4.0",
+    "@opentelemetry/resources": "^0.4.0"
   }
 }

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -16,6 +16,7 @@
 
 import * as types from '@opentelemetry/api';
 import { ConsoleLogger } from '@opentelemetry/core';
+import { Resource } from '@opentelemetry/resources';
 import { BaseBoundInstrument } from './BoundInstrument';
 import { Metric, CounterMetric, MeasureMetric, ObserverMetric } from './Metric';
 import {
@@ -37,13 +38,15 @@ export class Meter implements types.Meter {
   private readonly _metrics = new Map<string, Metric<BaseBoundInstrument>>();
   private readonly _batcher: Batcher;
   readonly labels = Meter.labels;
+  readonly resource: Resource;
 
   /**
    * Constructs a new Meter instance.
    */
-  constructor(config: MeterConfig = DEFAULT_CONFIG) {
+  constructor(config: MeterConfig = DEFAULT_CONFIG, resource: Resource) {
     this._logger = config.logger || new ConsoleLogger(config.logLevel);
     this._batcher = new UngroupedBatcher();
+    this.resource = resource;
     // start the push controller
     const exporter = config.exporter || new NoopExporter();
     const interval = config.interval;
@@ -73,7 +76,7 @@ export class Meter implements types.Meter {
       ...options,
     };
 
-    const measure = new MeasureMetric(name, opt, this._batcher);
+    const measure = new MeasureMetric(name, opt, this._batcher, this.resource);
     this._registerMetric(name, measure);
     return measure;
   }
@@ -102,7 +105,7 @@ export class Meter implements types.Meter {
       ...DEFAULT_METRIC_OPTIONS,
       ...options,
     };
-    const counter = new CounterMetric(name, opt, this._batcher);
+    const counter = new CounterMetric(name, opt, this._batcher, this.resource);
     this._registerMetric(name, counter);
     return counter;
   }
@@ -129,7 +132,12 @@ export class Meter implements types.Meter {
       ...DEFAULT_METRIC_OPTIONS,
       ...options,
     };
-    const observer = new ObserverMetric(name, opt, this._batcher);
+    const observer = new ObserverMetric(
+      name,
+      opt,
+      this._batcher,
+      this.resource
+    );
     this._registerMetric(name, observer);
     return observer;
   }

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -37,8 +37,8 @@ export class Meter implements types.Meter {
   private readonly _logger: types.Logger;
   private readonly _metrics = new Map<string, Metric<BaseBoundInstrument>>();
   private readonly _batcher: Batcher;
+  private readonly _resource: Resource;
   readonly labels = Meter.labels;
-  readonly resource: Resource;
 
   /**
    * Constructs a new Meter instance.
@@ -46,7 +46,7 @@ export class Meter implements types.Meter {
   constructor(config: MeterConfig = DEFAULT_CONFIG) {
     this._logger = config.logger || new ConsoleLogger(config.logLevel);
     this._batcher = new UngroupedBatcher();
-    this.resource = config.resource || Resource.createTelemetrySDKResource();
+    this._resource = config.resource || Resource.createTelemetrySDKResource();
     // start the push controller
     const exporter = config.exporter || new NoopExporter();
     const interval = config.interval;
@@ -76,7 +76,7 @@ export class Meter implements types.Meter {
       ...options,
     };
 
-    const measure = new MeasureMetric(name, opt, this._batcher, this.resource);
+    const measure = new MeasureMetric(name, opt, this._batcher, this._resource);
     this._registerMetric(name, measure);
     return measure;
   }
@@ -105,7 +105,7 @@ export class Meter implements types.Meter {
       ...DEFAULT_METRIC_OPTIONS,
       ...options,
     };
-    const counter = new CounterMetric(name, opt, this._batcher, this.resource);
+    const counter = new CounterMetric(name, opt, this._batcher, this._resource);
     this._registerMetric(name, counter);
     return counter;
   }
@@ -136,7 +136,7 @@ export class Meter implements types.Meter {
       name,
       opt,
       this._batcher,
-      this.resource
+      this._resource
     );
     this._registerMetric(name, observer);
     return observer;

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -43,10 +43,10 @@ export class Meter implements types.Meter {
   /**
    * Constructs a new Meter instance.
    */
-  constructor(config: MeterConfig = DEFAULT_CONFIG, resource: Resource) {
+  constructor(config: MeterConfig = DEFAULT_CONFIG) {
     this._logger = config.logger || new ConsoleLogger(config.logLevel);
     this._batcher = new UngroupedBatcher();
-    this.resource = resource;
+    this.resource = config.resource || Resource.createTelemetrySDKResource();
     // start the push controller
     const exporter = config.exporter || new NoopExporter();
     const interval = config.interval;

--- a/packages/opentelemetry-metrics/src/MeterProvider.ts
+++ b/packages/opentelemetry-metrics/src/MeterProvider.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-metrics/src/MeterProvider.ts
+++ b/packages/opentelemetry-metrics/src/MeterProvider.ts
@@ -40,7 +40,7 @@ export class MeterProvider implements types.MeterProvider {
   getMeter(name: string, version = '*', config?: MeterConfig): Meter {
     const key = `${name}@${version}`;
     if (!this._meters.has(key)) {
-      this._meters.set(key, new Meter(config || this._config, this.resource));
+      this._meters.set(key, new Meter(config || this._config));
     }
 
     return this._meters.get(key)!;

--- a/packages/opentelemetry-metrics/src/MeterProvider.ts
+++ b/packages/opentelemetry-metrics/src/MeterProvider.ts
@@ -25,7 +25,7 @@ import { DEFAULT_CONFIG, MeterConfig } from './types';
  */
 export class MeterProvider implements types.MeterProvider {
   private readonly _meters: Map<string, Meter> = new Map();
-  readonly resource: Resource = Resource.createTelemetrySDKResource('nodejs');
+  readonly resource: Resource = Resource.createTelemetrySDKResource();
   readonly logger: types.Logger;
 
   constructor(private _config: MeterConfig = DEFAULT_CONFIG) {

--- a/packages/opentelemetry-metrics/src/MeterProvider.ts
+++ b/packages/opentelemetry-metrics/src/MeterProvider.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-metrics/src/MeterProvider.ts
+++ b/packages/opentelemetry-metrics/src/MeterProvider.ts
@@ -16,6 +16,7 @@
 
 import { ConsoleLogger } from '@opentelemetry/core';
 import * as types from '@opentelemetry/api';
+import { Resource } from '@opentelemetry/resources';
 import { Meter } from '.';
 import { DEFAULT_CONFIG, MeterConfig } from './types';
 
@@ -24,6 +25,7 @@ import { DEFAULT_CONFIG, MeterConfig } from './types';
  */
 export class MeterProvider implements types.MeterProvider {
   private readonly _meters: Map<string, Meter> = new Map();
+  readonly resource: Resource = Resource.createTelemetrySDKResource('nodejs');
   readonly logger: types.Logger;
 
   constructor(private _config: MeterConfig = DEFAULT_CONFIG) {
@@ -38,7 +40,7 @@ export class MeterProvider implements types.MeterProvider {
   getMeter(name: string, version = '*', config?: MeterConfig): Meter {
     const key = `${name}@${version}`;
     if (!this._meters.has(key)) {
-      this._meters.set(key, new Meter(config || this._config));
+      this._meters.set(key, new Meter(config || this._config, this.resource));
     }
 
     return this._meters.get(key)!;

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -15,6 +15,7 @@
  */
 
 import * as types from '@opentelemetry/api';
+import { Resource } from '@opentelemetry/resources';
 import {
   BoundCounter,
   BaseBoundInstrument,
@@ -39,7 +40,8 @@ export abstract class Metric<T extends BaseBoundInstrument>
   constructor(
     private readonly _name: string,
     private readonly _options: MetricOptions,
-    private readonly _kind: MetricKind
+    private readonly _kind: MetricKind,
+    readonly resource: Resource
   ) {
     this._monotonic = _options.monotonic;
     this._disabled = _options.disabled;
@@ -108,9 +110,10 @@ export class CounterMetric extends Metric<BoundCounter>
   constructor(
     name: string,
     options: MetricOptions,
-    private readonly _batcher: Batcher
+    private readonly _batcher: Batcher,
+    resource: Resource
   ) {
-    super(name, options, MetricKind.COUNTER);
+    super(name, options, MetricKind.COUNTER, resource);
   }
   protected _makeInstrument(labelSet: types.LabelSet): BoundCounter {
     return new BoundCounter(
@@ -141,9 +144,10 @@ export class MeasureMetric extends Metric<BoundMeasure>
   constructor(
     name: string,
     options: MetricOptions,
-    private readonly _batcher: Batcher
+    private readonly _batcher: Batcher,
+    resource: Resource
   ) {
-    super(name, options, MetricKind.MEASURE);
+    super(name, options, MetricKind.MEASURE, resource);
 
     this._absolute = options.absolute !== undefined ? options.absolute : true; // Absolute default is true
   }
@@ -172,9 +176,10 @@ export class ObserverMetric extends Metric<BoundObserver>
   constructor(
     name: string,
     options: MetricOptions,
-    private readonly _batcher: Batcher
+    private readonly _batcher: Batcher,
+    resource: Resource
   ) {
-    super(name, options, MetricKind.OBSERVER);
+    super(name, options, MetricKind.OBSERVER, resource);
   }
 
   protected _makeInstrument(labelSet: types.LabelSet): BoundObserver {

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-metrics/src/types.ts
+++ b/packages/opentelemetry-metrics/src/types.ts
@@ -17,6 +17,7 @@
 import { LogLevel } from '@opentelemetry/core';
 import { Logger, ValueType } from '@opentelemetry/api';
 import { MetricExporter } from './export/types';
+import { Resource } from '@opentelemetry/resources';
 
 /** Options needed for SDK metric creation. */
 export interface MetricOptions {
@@ -64,6 +65,9 @@ export interface MeterConfig {
 
   /** Metric collect interval */
   interval?: number;
+
+  /** Resource associated with metric telemetry */
+  resource?: Resource;
 }
 
 /** Default Meter configuration. */

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -35,6 +35,7 @@ import {
   ObserverAggregator,
 } from '../src/export/Aggregator';
 import { ValueType } from '@opentelemetry/api';
+import { assertTelemetrySDKResource, SDK_INFO } from '@opentelemetry/resources';
 
 describe('Meter', () => {
   let meter: Meter;
@@ -86,6 +87,15 @@ describe('Meter', () => {
       assert.strictEqual(record1.aggregator.value(), 10);
       counter.add(10, labelSet);
       assert.strictEqual(record1.aggregator.value(), 20);
+    });
+
+    it('should return counter with resource', () => {
+      const counter = meter.createCounter('name') as CounterMetric;
+      assertTelemetrySDKResource(counter.resource, {
+        language: SDK_INFO.PLATFORM_NODE,
+        name: SDK_INFO.NAME,
+        version: SDK_INFO.VERSION,
+      });
     });
 
     describe('.bind()', () => {
@@ -275,6 +285,15 @@ describe('Meter', () => {
       assert.strictEqual((measure as MeasureMetric)['_absolute'], false);
     });
 
+    it('should return a measure with resource', () => {
+      const measure = meter.createMeasure('name') as MeasureMetric;
+      assertTelemetrySDKResource(measure.resource, {
+        language: SDK_INFO.PLATFORM_NODE,
+        name: SDK_INFO.NAME,
+        version: SDK_INFO.VERSION,
+      });
+    });
+
     describe('names', () => {
       it('should return no op metric if name is an empty string', () => {
         const measure = meter.createMeasure('');
@@ -456,6 +475,15 @@ describe('Meter', () => {
       ensureMetric(metric2);
       ensureMetric(metric3);
       ensureMetric(metric4);
+    });
+
+    it('should return an observer with resource', () => {
+      const observer = meter.createObserver('name') as ObserverMetric;
+      assertTelemetrySDKResource(observer.resource, {
+        language: SDK_INFO.PLATFORM_NODE,
+        name: SDK_INFO.NAME,
+        version: SDK_INFO.VERSION,
+      });
     });
   });
 

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -35,7 +35,7 @@ import {
   ObserverAggregator,
 } from '../src/export/Aggregator';
 import { ValueType } from '@opentelemetry/api';
-import { assertTelemetrySDKResource, SDK_INFO } from '@opentelemetry/resources';
+import { assertTelemetrySDKResource } from '@opentelemetry/resources';
 
 describe('Meter', () => {
   let meter: Meter;
@@ -92,9 +92,7 @@ describe('Meter', () => {
     it('should return counter with resource', () => {
       const counter = meter.createCounter('name') as CounterMetric;
       assertTelemetrySDKResource(counter.resource, {
-        language: SDK_INFO.PLATFORM_NODE,
-        name: SDK_INFO.NAME,
-        version: SDK_INFO.VERSION,
+        name: 'opentelemetry',
       });
     });
 
@@ -288,9 +286,7 @@ describe('Meter', () => {
     it('should return a measure with resource', () => {
       const measure = meter.createMeasure('name') as MeasureMetric;
       assertTelemetrySDKResource(measure.resource, {
-        language: SDK_INFO.PLATFORM_NODE,
-        name: SDK_INFO.NAME,
-        version: SDK_INFO.VERSION,
+        name: 'opentelemetry',
       });
     });
 
@@ -480,9 +476,7 @@ describe('Meter', () => {
     it('should return an observer with resource', () => {
       const observer = meter.createObserver('name') as ObserverMetric;
       assertTelemetrySDKResource(observer.resource, {
-        language: SDK_INFO.PLATFORM_NODE,
-        name: SDK_INFO.NAME,
-        version: SDK_INFO.VERSION,
+        name: 'opentelemetry',
       });
     });
   });

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -35,7 +35,7 @@ import {
   ObserverAggregator,
 } from '../src/export/Aggregator';
 import { ValueType } from '@opentelemetry/api';
-import { assertTelemetrySDKResource } from '@opentelemetry/resources';
+import { Resource } from '@opentelemetry/resources';
 
 describe('Meter', () => {
   let meter: Meter;
@@ -91,9 +91,7 @@ describe('Meter', () => {
 
     it('should return counter with resource', () => {
       const counter = meter.createCounter('name') as CounterMetric;
-      assertTelemetrySDKResource(counter.resource, {
-        name: 'opentelemetry',
-      });
+      assert.ok(counter.resource instanceof Resource);
     });
 
     describe('.bind()', () => {
@@ -285,9 +283,7 @@ describe('Meter', () => {
 
     it('should return a measure with resource', () => {
       const measure = meter.createMeasure('name') as MeasureMetric;
-      assertTelemetrySDKResource(measure.resource, {
-        name: 'opentelemetry',
-      });
+      assert.ok(measure.resource instanceof Resource);
     });
 
     describe('names', () => {
@@ -475,9 +471,7 @@ describe('Meter', () => {
 
     it('should return an observer with resource', () => {
       const observer = meter.createObserver('name') as ObserverMetric;
-      assertTelemetrySDKResource(observer.resource, {
-        name: 'opentelemetry',
-      });
+      assert.ok(observer.resource instanceof Resource);
     });
   });
 

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -41,6 +41,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/resources": "^0.4.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^12.6.8",
     "@opentelemetry/scope-base": "^0.4.0",
@@ -61,7 +62,6 @@
   "dependencies": {
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/core": "^0.4.0",
-    "@opentelemetry/resources": "^0.4.0",
     "@opentelemetry/scope-async-hooks": "^0.4.0",
     "@opentelemetry/tracing": "^0.4.0",
     "require-in-the-middle": "^5.0.0",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/core": "^0.4.0",
+    "@opentelemetry/resources": "^0.4.0",
     "@opentelemetry/scope-async-hooks": "^0.4.0",
     "@opentelemetry/tracing": "^0.4.0",
     "require-in-the-middle": "^5.0.0",

--- a/packages/opentelemetry-node/src/NodeTracerProvider.ts
+++ b/packages/opentelemetry-node/src/NodeTracerProvider.ts
@@ -19,7 +19,6 @@ import {
   BasicTracerProvider,
   SDKRegistrationConfig,
 } from '@opentelemetry/tracing';
-import { Resource, SDK_INFO } from '@opentelemetry/resources';
 import { DEFAULT_INSTRUMENTATION_PLUGINS, NodeTracerConfig } from './config';
 import { PluginLoader } from './instrumentation/PluginLoader';
 
@@ -31,9 +30,6 @@ import { PluginLoader } from './instrumentation/PluginLoader';
  * @param config Configuration object for SDK registration
  */
 export class NodeTracerProvider extends BasicTracerProvider {
-  readonly resource: Resource = Resource.createTelemetrySDKResource(
-    SDK_INFO.PLATFORM_NODE
-  );
   private readonly _pluginLoader: PluginLoader;
 
   /**

--- a/packages/opentelemetry-node/src/NodeTracerProvider.ts
+++ b/packages/opentelemetry-node/src/NodeTracerProvider.ts
@@ -19,6 +19,7 @@ import {
   BasicTracerProvider,
   SDKRegistrationConfig,
 } from '@opentelemetry/tracing';
+import { Resource, SDK_INFO } from '@opentelemetry/resources';
 import { DEFAULT_INSTRUMENTATION_PLUGINS, NodeTracerConfig } from './config';
 import { PluginLoader } from './instrumentation/PluginLoader';
 
@@ -30,6 +31,9 @@ import { PluginLoader } from './instrumentation/PluginLoader';
  * @param config Configuration object for SDK registration
  */
 export class NodeTracerProvider extends BasicTracerProvider {
+  readonly resource: Resource = Resource.createTelemetrySDKResource(
+    SDK_INFO.PLATFORM_NODE
+  );
   private readonly _pluginLoader: PluginLoader;
 
   /**

--- a/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
+++ b/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
+++ b/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
@@ -25,7 +25,6 @@ import {
 import { AsyncHooksScopeManager } from '@opentelemetry/scope-async-hooks';
 import { Span } from '@opentelemetry/tracing';
 import { assertTelemetrySDKResource } from '@opentelemetry/resources';
-import { SDK_INFO } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import * as path from 'path';
 import { ScopeManager } from '../../opentelemetry-scope-base/build/src';
@@ -168,9 +167,8 @@ describe('NodeTracerProvider', () => {
       const span = provider.getTracer('default').startSpan('my-span') as Span;
       assert.ok(span);
       assertTelemetrySDKResource(span.resource, {
-        language: SDK_INFO.PLATFORM_NODE,
-        name: SDK_INFO.NAME,
-        version: SDK_INFO.VERSION,
+        language: 'nodejs',
+        name: 'opentelemetry',
       });
     });
   });

--- a/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
+++ b/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
@@ -24,7 +24,7 @@ import {
 } from '@opentelemetry/core';
 import { AsyncHooksScopeManager } from '@opentelemetry/scope-async-hooks';
 import { Span } from '@opentelemetry/tracing';
-import { assertTelemetrySDKResource } from '@opentelemetry/resources';
+import { Resource, TELEMETRY_SDK_RESOURCE } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import * as path from 'path';
 import { ScopeManager } from '../../opentelemetry-scope-base/build/src';
@@ -160,16 +160,17 @@ describe('NodeTracerProvider', () => {
       assert.deepStrictEqual(span.attributes, defaultAttributes);
     });
 
-    it('should assign a telemetry sdk resource to span', () => {
+    it('should assign resource to span', () => {
       provider = new NodeTracerProvider({
         logger: new NoopLogger(),
       });
       const span = provider.getTracer('default').startSpan('my-span') as Span;
       assert.ok(span);
-      assertTelemetrySDKResource(span.resource, {
-        language: 'nodejs',
-        name: 'opentelemetry',
-      });
+      assert.ok(span.resource instanceof Resource);
+      assert.equal(
+        span.resource.labels[TELEMETRY_SDK_RESOURCE.LANGUAGE],
+        'nodejs'
+      );
     });
   });
 

--- a/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
+++ b/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
@@ -24,7 +24,7 @@ import {
 } from '@opentelemetry/core';
 import { AsyncHooksScopeManager } from '@opentelemetry/scope-async-hooks';
 import { Span } from '@opentelemetry/tracing';
-import { assertTelemetrySDKResource } from '@opentelemetry/resources/test/util/resource-assertions';
+import { assertTelemetrySDKResource } from '@opentelemetry/resources';
 import { SDK_INFO } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import * as path from 'path';

--- a/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
+++ b/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
@@ -24,6 +24,8 @@ import {
 } from '@opentelemetry/core';
 import { AsyncHooksScopeManager } from '@opentelemetry/scope-async-hooks';
 import { Span } from '@opentelemetry/tracing';
+import { assertTelemetrySDKResource } from '@opentelemetry/resources/test/util/resource-assertions';
+import { SDK_INFO } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import * as path from 'path';
 import { ScopeManager } from '../../opentelemetry-scope-base/build/src';
@@ -157,6 +159,19 @@ describe('NodeTracerProvider', () => {
       const span = provider.getTracer('default').startSpan('my-span') as Span;
       assert.ok(span instanceof Span);
       assert.deepStrictEqual(span.attributes, defaultAttributes);
+    });
+
+    it('should assign a telemetry sdk resource to span', () => {
+      provider = new NodeTracerProvider({
+        logger: new NoopLogger(),
+      });
+      const span = provider.getTracer('default').startSpan('my-span') as Span;
+      assert.ok(span);
+      assertTelemetrySDKResource(span.resource, {
+        language: SDK_INFO.PLATFORM_NODE,
+        name: SDK_INFO.NAME,
+        version: SDK_INFO.VERSION,
+      });
     });
   });
 

--- a/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
+++ b/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -54,6 +54,7 @@
     "typescript": "3.7.2"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.4.0"
+    "@opentelemetry/api": "^0.4.0",
+    "@opentelemetry/base": "^0.4.0"
   }
 }

--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import { LIBRARY_RESOURCE } from './constants';
+import { VERSION } from './version';
+
 /**
  * A Resource describes the entity for which a signals (metrics or trace) are
  * collected.
@@ -26,6 +29,14 @@ export class Resource {
    */
   static empty(): Resource {
     return Resource.EMPTY;
+  }
+
+  static createLibraryResource(language: string): Resource {
+    return new Resource({
+      [LIBRARY_RESOURCE.LANGUAGE]: language,
+      [LIBRARY_RESOURCE.NAME]: 'opentelemetry',
+      [LIBRARY_RESOURCE.VERSION]: VERSION,
+    });
   }
 
   constructor(

--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { LIBRARY_RESOURCE } from './constants';
-import { VERSION } from './version';
+import { TELEMETRY_SDK_RESOURCE, SDK_INFO } from './constants';
 
 /**
  * A Resource describes the entity for which a signals (metrics or trace) are
@@ -31,11 +30,11 @@ export class Resource {
     return Resource.EMPTY;
   }
 
-  static createLibraryResource(language: string): Resource {
+  static createTelemetrySDKResource(language: string): Resource {
     return new Resource({
-      [LIBRARY_RESOURCE.LANGUAGE]: language,
-      [LIBRARY_RESOURCE.NAME]: 'opentelemetry',
-      [LIBRARY_RESOURCE.VERSION]: VERSION,
+      [TELEMETRY_SDK_RESOURCE.LANGUAGE]: language,
+      [TELEMETRY_SDK_RESOURCE.NAME]: SDK_INFO.NAME,
+      [TELEMETRY_SDK_RESOURCE.VERSION]: SDK_INFO.VERSION,
     });
   }
 

--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { TELEMETRY_SDK_RESOURCE, SDK_INFO } from './constants';
+import { SDK_INFO } from '@opentelemetry/base';
+import { TELEMETRY_SDK_RESOURCE } from './constants';
 
 /**
  * A Resource describes the entity for which a signals (metrics or trace) are
@@ -30,9 +31,9 @@ export class Resource {
     return Resource.EMPTY;
   }
 
-  static createTelemetrySDKResource(language: string): Resource {
+  static createTelemetrySDKResource(): Resource {
     return new Resource({
-      [TELEMETRY_SDK_RESOURCE.LANGUAGE]: language,
+      [TELEMETRY_SDK_RESOURCE.LANGUAGE]: SDK_INFO.LANGUAGE,
       [TELEMETRY_SDK_RESOURCE.NAME]: SDK_INFO.NAME,
       [TELEMETRY_SDK_RESOURCE.VERSION]: SDK_INFO.VERSION,
     });

--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -25,12 +25,15 @@ export class Resource {
   static readonly EMPTY = new Resource({});
 
   /**
-   * Returns an empty resource
+   * Returns an empty Resource
    */
   static empty(): Resource {
     return Resource.EMPTY;
   }
 
+  /**
+   * Returns a Resource that indentifies the SDK in use.
+   */
   static createTelemetrySDKResource(): Resource {
     return new Resource({
       [TELEMETRY_SDK_RESOURCE.LANGUAGE]: SDK_INFO.LANGUAGE,

--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -19,6 +19,15 @@
  * collected.
  */
 export class Resource {
+  static readonly EMPTY = new Resource({});
+
+  /**
+   * Returns an empty resource
+   */
+  static empty(): Resource {
+    return Resource.EMPTY;
+  }
+
   constructor(
     /**
      * A dictionary of labels with string keys and values that provide information

--- a/packages/opentelemetry-resources/src/constants.ts
+++ b/packages/opentelemetry-resources/src/constants.ts
@@ -1,3 +1,21 @@
+/*!
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { VERSION } from './version';
+
 /**
  * Copyright 2020, OpenTelemetry Authors
  *
@@ -98,15 +116,15 @@ export const K8S_RESOURCE = {
 };
 
 /** Attributes describing the telemetry library. */
-export const LIBRARY_RESOURCE = {
+export const TELEMETRY_SDK_RESOURCE = {
   /** The name of the telemetry library. */
-  NAME: 'library.name',
+  NAME: 'telemetry.sdk.name',
 
   /** The language of telemetry library and of the code instrumented with it. */
-  LANGUAGE: 'library.language',
+  LANGUAGE: 'telemetry.sdk.language',
 
-  /** The version string of the library. */
-  VERSION: 'library.version',
+  /** The version string of the telemetry library */
+  VERSION: 'telemetry.sdk.version',
 };
 
 /** Attributes describing a service instance. */
@@ -122,4 +140,12 @@ export const SERVICE_RESOURCE = {
 
   /** The version string of the service API or implementation. */
   VERSION: 'service.version',
+};
+
+/** Constants describing the SDK in use  */
+export const SDK_INFO = {
+  NAME: 'opentelemetry',
+  VERSION: VERSION,
+  PLATFORM_NODE: 'nodejs',
+  PLATFORM_WEB: 'webjs',
 };

--- a/packages/opentelemetry-resources/src/constants.ts
+++ b/packages/opentelemetry-resources/src/constants.ts
@@ -1,21 +1,3 @@
-/*!
- * Copyright 2020, OpenTelemetry Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-import { VERSION } from './version';
-
 /**
  * Copyright 2020, OpenTelemetry Authors
  *
@@ -140,12 +122,4 @@ export const SERVICE_RESOURCE = {
 
   /** The version string of the service API or implementation. */
   VERSION: 'service.version',
-};
-
-/** Constants describing the SDK in use  */
-export const SDK_INFO = {
-  NAME: 'opentelemetry',
-  VERSION: VERSION,
-  PLATFORM_NODE: 'nodejs',
-  PLATFORM_WEB: 'webjs',
 };

--- a/packages/opentelemetry-resources/src/index.ts
+++ b/packages/opentelemetry-resources/src/index.ts
@@ -16,4 +16,3 @@
 
 export { Resource } from './Resource';
 export * from './constants';
-export * from './resource-assertions';

--- a/packages/opentelemetry-resources/src/index.ts
+++ b/packages/opentelemetry-resources/src/index.ts
@@ -16,3 +16,4 @@
 
 export { Resource } from './Resource';
 export * from './constants';
+export * from './resource-assertions';

--- a/packages/opentelemetry-resources/src/resource-assertions.ts
+++ b/packages/opentelemetry-resources/src/resource-assertions.ts
@@ -15,7 +15,7 @@
  */
 
 import * as assert from 'assert';
-import { Resource } from '../../src/Resource';
+import { Resource } from './Resource';
 import {
   CLOUD_RESOURCE,
   CONTAINER_RESOURCE,
@@ -23,7 +23,7 @@ import {
   K8S_RESOURCE,
   TELEMETRY_SDK_RESOURCE,
   SERVICE_RESOURCE,
-} from '../../src/constants';
+} from './constants';
 /**
  * Test utility method to validate a cloud resource
  *

--- a/packages/opentelemetry-resources/src/resource-assertions.ts
+++ b/packages/opentelemetry-resources/src/resource-assertions.ts
@@ -181,7 +181,7 @@ export const assertK8sResource = (
 };
 
 /**
- * Test utility method to validate a telemetry library resource
+ * Test utility method to validate a telemetry sdk resource
  *
  * @param resource the Resource to validate
  * @param validations validations for the resource labels
@@ -199,10 +199,8 @@ export const assertTelemetrySDKResource = (
     language: SDK_INFO.LANGUAGE,
     version: SDK_INFO.VERSION,
   };
-
   validations = { ...defaults, ...validations };
 
-  assertHasOneLabel(TELEMETRY_SDK_RESOURCE, resource);
   if (validations.name)
     assert.strictEqual(
       resource.labels[TELEMETRY_SDK_RESOURCE.NAME],

--- a/packages/opentelemetry-resources/src/resource-assertions.ts
+++ b/packages/opentelemetry-resources/src/resource-assertions.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { SDK_INFO } from '@opentelemetry/base';
 import * as assert from 'assert';
 import { Resource } from './Resource';
 import {
@@ -193,6 +194,14 @@ export const assertTelemetrySDKResource = (
     version?: string;
   }
 ) => {
+  const defaults = {
+    name: SDK_INFO.NAME,
+    language: SDK_INFO.LANGUAGE,
+    version: SDK_INFO.VERSION,
+  };
+
+  validations = { ...defaults, ...validations };
+
   assertHasOneLabel(TELEMETRY_SDK_RESOURCE, resource);
   if (validations.name)
     assert.strictEqual(

--- a/packages/opentelemetry-resources/test/Resource.test.ts
+++ b/packages/opentelemetry-resources/test/Resource.test.ts
@@ -16,8 +16,8 @@
 
 import * as assert from 'assert';
 import { Resource } from '../src/Resource';
-import { assertLibraryResource } from './util/resource-assertions';
-import { VERSION } from '../src/version';
+import { SDK_INFO } from '../src/constants';
+import { assertTelemetrySDKResource } from './util/resource-assertions';
 
 describe('Resource', () => {
   const resource1 = new Resource({
@@ -100,13 +100,13 @@ describe('Resource', () => {
     });
   });
 
-  describe('.createLibraryResource()', () => {
-    it('should return a library resource', () => {
-      const resource = Resource.createLibraryResource('nodejs');
-      assertLibraryResource(resource, {
+  describe('.createTelemetrySDKResource()', () => {
+    it('should return a telemetry SDK resource', () => {
+      const resource = Resource.createTelemetrySDKResource('nodejs');
+      assertTelemetrySDKResource(resource, {
         language: 'nodejs',
         name: 'opentelemetry',
-        version: VERSION,
+        version: SDK_INFO.VERSION,
       });
     });
   });

--- a/packages/opentelemetry-resources/test/Resource.test.ts
+++ b/packages/opentelemetry-resources/test/Resource.test.ts
@@ -86,4 +86,15 @@ describe('Resource', () => {
     assert.equal(resource.labels['custom.number'], 42);
     assert.equal(resource.labels['custom.boolean'], true);
   });
+
+  describe('.empty()', () => {
+    it('should return an empty resource', () => {
+      const resource = Resource.empty();
+      assert.equal(Object.entries(resource.labels), 0);
+    });
+
+    it('should return the same empty resource', () => {
+      assert.strictEqual(Resource.empty(), Resource.empty());
+    });
+  });
 });

--- a/packages/opentelemetry-resources/test/Resource.test.ts
+++ b/packages/opentelemetry-resources/test/Resource.test.ts
@@ -16,6 +16,8 @@
 
 import * as assert from 'assert';
 import { Resource } from '../src/Resource';
+import { assertLibraryResource } from './util/resource-assertions';
+import { VERSION } from '../src/version';
 
 describe('Resource', () => {
   const resource1 = new Resource({
@@ -95,6 +97,17 @@ describe('Resource', () => {
 
     it('should return the same empty resource', () => {
       assert.strictEqual(Resource.empty(), Resource.empty());
+    });
+  });
+
+  describe('.createLibraryResource()', () => {
+    it('should return a library resource', () => {
+      const resource = Resource.createLibraryResource('nodejs');
+      assertLibraryResource(resource, {
+        language: 'nodejs',
+        name: 'opentelemetry',
+        version: VERSION,
+      });
     });
   });
 });

--- a/packages/opentelemetry-resources/test/Resource.test.ts
+++ b/packages/opentelemetry-resources/test/Resource.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+import { SDK_INFO } from '@opentelemetry/base';
 import * as assert from 'assert';
 import { Resource } from '../src/Resource';
-import { SDK_INFO } from '../src/constants';
 import { assertTelemetrySDKResource } from '../src/resource-assertions';
 
 describe('Resource', () => {
@@ -102,10 +102,10 @@ describe('Resource', () => {
 
   describe('.createTelemetrySDKResource()', () => {
     it('should return a telemetry SDK resource', () => {
-      const resource = Resource.createTelemetrySDKResource('nodejs');
+      const resource = Resource.createTelemetrySDKResource();
       assertTelemetrySDKResource(resource, {
-        language: 'nodejs',
-        name: 'opentelemetry',
+        language: SDK_INFO.LANGUAGE,
+        name: SDK_INFO.NAME,
         version: SDK_INFO.VERSION,
       });
     });

--- a/packages/opentelemetry-resources/test/Resource.test.ts
+++ b/packages/opentelemetry-resources/test/Resource.test.ts
@@ -17,7 +17,7 @@
 import { SDK_INFO } from '@opentelemetry/base';
 import * as assert from 'assert';
 import { Resource } from '../src/Resource';
-import { assertTelemetrySDKResource } from '../src/resource-assertions';
+import { assertTelemetrySDKResource } from './util/resource-assertions';
 
 describe('Resource', () => {
   const resource1 = new Resource({

--- a/packages/opentelemetry-resources/test/Resource.test.ts
+++ b/packages/opentelemetry-resources/test/Resource.test.ts
@@ -17,7 +17,7 @@
 import * as assert from 'assert';
 import { Resource } from '../src/Resource';
 import { SDK_INFO } from '../src/constants';
-import { assertTelemetrySDKResource } from './util/resource-assertions';
+import { assertTelemetrySDKResource } from '../src/resource-assertions';
 
 describe('Resource', () => {
   const resource1 = new Resource({

--- a/packages/opentelemetry-resources/test/resource-assertions.test.ts
+++ b/packages/opentelemetry-resources/test/resource-assertions.test.ts
@@ -31,7 +31,7 @@ import {
   assertK8sResource,
   assertTelemetrySDKResource,
   assertServiceResource,
-} from '../src/resource-assertions';
+} from './util/resource-assertions';
 
 describe('assertCloudResource', () => {
   it('requires one cloud label', () => {

--- a/packages/opentelemetry-resources/test/resource-assertions.test.ts
+++ b/packages/opentelemetry-resources/test/resource-assertions.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { SDK_INFO } from '@opentelemetry/base';
 import { Resource } from '../src/Resource';
 import {
   CLOUD_RESOURCE,
@@ -132,9 +133,11 @@ describe('assertK8sResource', () => {
 });
 
 describe('assertTelemetrySDKResource', () => {
-  it('requires one library label', () => {
+  it('uses default validations', () => {
     const resource = new Resource({
-      [TELEMETRY_SDK_RESOURCE.NAME]: 'opentelemetry',
+      [TELEMETRY_SDK_RESOURCE.NAME]: SDK_INFO.NAME,
+      [TELEMETRY_SDK_RESOURCE.LANGUAGE]: SDK_INFO.LANGUAGE,
+      [TELEMETRY_SDK_RESOURCE.VERSION]: SDK_INFO.VERSION,
     });
     assertTelemetrySDKResource(resource, {});
   });

--- a/packages/opentelemetry-resources/test/resource-assertions.test.ts
+++ b/packages/opentelemetry-resources/test/resource-assertions.test.ts
@@ -30,7 +30,7 @@ import {
   assertK8sResource,
   assertTelemetrySDKResource,
   assertServiceResource,
-} from './util/resource-assertions';
+} from '../src/resource-assertions';
 
 describe('assertCloudResource', () => {
   it('requires one cloud label', () => {

--- a/packages/opentelemetry-resources/test/resource-assertions.test.ts
+++ b/packages/opentelemetry-resources/test/resource-assertions.test.ts
@@ -20,7 +20,7 @@ import {
   CONTAINER_RESOURCE,
   HOST_RESOURCE,
   K8S_RESOURCE,
-  LIBRARY_RESOURCE,
+  TELEMETRY_SDK_RESOURCE,
   SERVICE_RESOURCE,
 } from '../src/constants';
 import {
@@ -28,7 +28,7 @@ import {
   assertContainerResource,
   assertHostResource,
   assertK8sResource,
-  assertLibraryResource,
+  assertTelemetrySDKResource,
   assertServiceResource,
 } from './util/resource-assertions';
 
@@ -131,19 +131,21 @@ describe('assertK8sResource', () => {
   });
 });
 
-describe('assertLibraryResource', () => {
+describe('assertTelemetrySDKResource', () => {
   it('requires one library label', () => {
-    const resource = new Resource({ [LIBRARY_RESOURCE.NAME]: 'opentelemetry' });
-    assertLibraryResource(resource, {});
+    const resource = new Resource({
+      [TELEMETRY_SDK_RESOURCE.NAME]: 'opentelemetry',
+    });
+    assertTelemetrySDKResource(resource, {});
   });
 
   it('validates optional labels', () => {
     const resource = new Resource({
-      [LIBRARY_RESOURCE.NAME]: 'opentelemetry',
-      [LIBRARY_RESOURCE.LANGUAGE]: 'nodejs',
-      [LIBRARY_RESOURCE.VERSION]: '0.1.0',
+      [TELEMETRY_SDK_RESOURCE.NAME]: 'opentelemetry',
+      [TELEMETRY_SDK_RESOURCE.LANGUAGE]: 'nodejs',
+      [TELEMETRY_SDK_RESOURCE.VERSION]: '0.1.0',
     });
-    assertLibraryResource(resource, {
+    assertTelemetrySDKResource(resource, {
       name: 'opentelemetry',
       language: 'nodejs',
       version: '0.1.0',

--- a/packages/opentelemetry-resources/test/util/resource-assertions.ts
+++ b/packages/opentelemetry-resources/test/util/resource-assertions.ts
@@ -16,7 +16,7 @@
 
 import { SDK_INFO } from '@opentelemetry/base';
 import * as assert from 'assert';
-import { Resource } from './Resource';
+import { Resource } from '../../src/Resource';
 import {
   CLOUD_RESOURCE,
   CONTAINER_RESOURCE,
@@ -24,7 +24,8 @@ import {
   K8S_RESOURCE,
   TELEMETRY_SDK_RESOURCE,
   SERVICE_RESOURCE,
-} from './constants';
+} from '../../src/constants';
+
 /**
  * Test utility method to validate a cloud resource
  *

--- a/packages/opentelemetry-resources/test/util/resource-assertions.ts
+++ b/packages/opentelemetry-resources/test/util/resource-assertions.ts
@@ -21,7 +21,7 @@ import {
   CONTAINER_RESOURCE,
   HOST_RESOURCE,
   K8S_RESOURCE,
-  LIBRARY_RESOURCE,
+  TELEMETRY_SDK_RESOURCE,
   SERVICE_RESOURCE,
 } from '../../src/constants';
 /**
@@ -180,12 +180,12 @@ export const assertK8sResource = (
 };
 
 /**
- * Test utility method to validate a library resource
+ * Test utility method to validate a telemetry library resource
  *
  * @param resource the Resource to validate
  * @param validations validations for the resource labels
  */
-export const assertLibraryResource = (
+export const assertTelemetrySDKResource = (
   resource: Resource,
   validations: {
     name?: string;
@@ -193,20 +193,20 @@ export const assertLibraryResource = (
     version?: string;
   }
 ) => {
-  assertHasOneLabel(LIBRARY_RESOURCE, resource);
+  assertHasOneLabel(TELEMETRY_SDK_RESOURCE, resource);
   if (validations.name)
     assert.strictEqual(
-      resource.labels[LIBRARY_RESOURCE.NAME],
+      resource.labels[TELEMETRY_SDK_RESOURCE.NAME],
       validations.name
     );
   if (validations.language)
     assert.strictEqual(
-      resource.labels[LIBRARY_RESOURCE.LANGUAGE],
+      resource.labels[TELEMETRY_SDK_RESOURCE.LANGUAGE],
       validations.language
     );
   if (validations.version)
     assert.strictEqual(
-      resource.labels[LIBRARY_RESOURCE.VERSION],
+      resource.labels[TELEMETRY_SDK_RESOURCE.VERSION],
       validations.version
     );
 };

--- a/packages/opentelemetry-tracing/package.json
+++ b/packages/opentelemetry-tracing/package.json
@@ -76,6 +76,7 @@
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/base": "^0.4.0",
     "@opentelemetry/core": "^0.4.0",
+    "@opentelemetry/resources": "^0.4.0",
     "@opentelemetry/scope-base": "^0.4.0"
   }
 }

--- a/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
@@ -32,7 +32,7 @@ export class BasicTracerProvider implements api.TracerProvider {
 
   activeSpanProcessor = new NoopSpanProcessor();
   readonly logger: api.Logger;
-  readonly resource: Resource = Resource.empty();
+  readonly resource: Resource = Resource.createTelemetrySDKResource();
 
   constructor(private _config: TracerConfig = DEFAULT_CONFIG) {
     this.logger = _config.logger || new ConsoleLogger(_config.logLevel);

--- a/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
@@ -32,10 +32,11 @@ export class BasicTracerProvider implements api.TracerProvider {
 
   activeSpanProcessor = new NoopSpanProcessor();
   readonly logger: api.Logger;
-  readonly resource: Resource = Resource.createTelemetrySDKResource();
+  readonly resource: Resource;
 
   constructor(private _config: TracerConfig = DEFAULT_CONFIG) {
     this.logger = _config.logger || new ConsoleLogger(_config.logLevel);
+    this.resource = _config.resource || Resource.createTelemetrySDKResource();
   }
 
   getTracer(name: string, version = '*', config?: TracerConfig): Tracer {

--- a/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
@@ -21,6 +21,7 @@ import { DEFAULT_CONFIG } from './config';
 import { MultiSpanProcessor } from './MultiSpanProcessor';
 import { NoopSpanProcessor } from './NoopSpanProcessor';
 import { SDKRegistrationConfig, TracerConfig } from './types';
+import { Resource } from '@opentelemetry/resources';
 
 /**
  * This class represents a basic tracer provider which platform libraries can extend
@@ -31,6 +32,7 @@ export class BasicTracerProvider implements api.TracerProvider {
 
   activeSpanProcessor = new NoopSpanProcessor();
   readonly logger: api.Logger;
+  readonly resource: Resource = Resource.empty();
 
   constructor(private _config: TracerConfig = DEFAULT_CONFIG) {
     this.logger = _config.logger || new ConsoleLogger(_config.logLevel);

--- a/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-tracing/src/Span.ts
+++ b/packages/opentelemetry-tracing/src/Span.ts
@@ -21,6 +21,7 @@ import {
   isTimeInput,
   timeInputToHrTime,
 } from '@opentelemetry/core';
+import { Resource } from '@opentelemetry/resources';
 import { ReadableSpan } from './export/ReadableSpan';
 import { Tracer } from './Tracer';
 import { SpanProcessor } from './SpanProcessor';
@@ -39,6 +40,7 @@ export class Span implements types.Span, ReadableSpan {
   readonly links: types.Link[] = [];
   readonly events: types.TimedEvent[] = [];
   readonly startTime: types.HrTime;
+  readonly resource: Resource;
   name: string;
   status: types.Status = {
     code: types.CanonicalCode.OK,
@@ -66,6 +68,7 @@ export class Span implements types.Span, ReadableSpan {
     this.kind = kind;
     this.links = links;
     this.startTime = timeInputToHrTime(startTime);
+    this.resource = parentTracer.resource;
     this._logger = parentTracer.logger;
     this._traceParams = parentTracer.getActiveTraceParams();
     this._spanProcessor = parentTracer.getActiveSpanProcessor();

--- a/packages/opentelemetry-tracing/src/Span.ts
+++ b/packages/opentelemetry-tracing/src/Span.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-tracing/src/Span.ts
+++ b/packages/opentelemetry-tracing/src/Span.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-tracing/src/Tracer.ts
+++ b/packages/opentelemetry-tracing/src/Tracer.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-tracing/src/Tracer.ts
+++ b/packages/opentelemetry-tracing/src/Tracer.ts
@@ -25,6 +25,7 @@ import {
   randomTraceId,
   setActiveSpan,
 } from '@opentelemetry/core';
+import { Resource } from '@opentelemetry/resources';
 import { BasicTracerProvider } from './BasicTracerProvider';
 import { DEFAULT_CONFIG } from './config';
 import { Span } from './Span';
@@ -38,6 +39,7 @@ export class Tracer implements api.Tracer {
   private readonly _defaultAttributes: api.Attributes;
   private readonly _sampler: api.Sampler;
   private readonly _traceParams: TraceParams;
+  readonly resource: Resource;
   readonly logger: api.Logger;
 
   /**
@@ -51,6 +53,7 @@ export class Tracer implements api.Tracer {
     this._defaultAttributes = localConfig.defaultAttributes;
     this._sampler = localConfig.sampler;
     this._traceParams = localConfig.traceParams;
+    this.resource = _tracerProvider.resource;
     this.logger = config.logger || new ConsoleLogger(config.logLevel);
   }
 
@@ -143,6 +146,10 @@ export class Tracer implements api.Tracer {
 
   getActiveSpanProcessor() {
     return this._tracerProvider.getActiveSpanProcessor();
+  }
+
+  getResource() {
+    return this._tracerProvider.resource;
   }
 }
 

--- a/packages/opentelemetry-tracing/src/Tracer.ts
+++ b/packages/opentelemetry-tracing/src/Tracer.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,10 +146,6 @@ export class Tracer implements api.Tracer {
 
   getActiveSpanProcessor() {
     return this._tracerProvider.getActiveSpanProcessor();
-  }
-
-  getResource() {
-    return this._tracerProvider.resource;
   }
 }
 

--- a/packages/opentelemetry-tracing/src/export/ReadableSpan.ts
+++ b/packages/opentelemetry-tracing/src/export/ReadableSpan.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-tracing/src/export/ReadableSpan.ts
+++ b/packages/opentelemetry-tracing/src/export/ReadableSpan.ts
@@ -23,6 +23,7 @@ import {
   SpanContext,
   TimedEvent,
 } from '@opentelemetry/api';
+import { Resource } from '@opentelemetry/resources';
 
 export interface ReadableSpan {
   readonly name: string;
@@ -37,4 +38,5 @@ export interface ReadableSpan {
   readonly events: TimedEvent[];
   readonly duration: HrTime;
   readonly ended: boolean;
+  readonly resource: Resource;
 }

--- a/packages/opentelemetry-tracing/src/export/ReadableSpan.ts
+++ b/packages/opentelemetry-tracing/src/export/ReadableSpan.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-tracing/src/types.ts
+++ b/packages/opentelemetry-tracing/src/types.ts
@@ -22,6 +22,7 @@ import {
 } from '@opentelemetry/api';
 import { LogLevel } from '@opentelemetry/core';
 import { ScopeManager } from '@opentelemetry/scope-base';
+import { Resource } from '@opentelemetry/resources';
 
 /**
  * TracerConfig provides an interface for configuring a Basic Tracer.
@@ -48,6 +49,9 @@ export interface TracerConfig {
 
   /** Trace Parameters */
   traceParams?: TraceParams;
+
+  /** Resource associated with trace telemetry  */
+  resource?: Resource;
 }
 
 /**

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -24,6 +24,7 @@ import {
   setExtractedSpanContext,
   TraceState,
 } from '@opentelemetry/core';
+import { Resource } from '@opentelemetry/resources';
 import { NoopScopeManager, ScopeManager } from '@opentelemetry/scope-base';
 import * as assert from 'assert';
 import { BasicTracerProvider, Span } from '../src';
@@ -305,6 +306,13 @@ describe('BasicTracerProvider', () => {
       assert.ok(span instanceof Span);
       assert.deepStrictEqual(span.attributes, defaultAttributes);
     });
+
+    it('should assign a resource', () => {
+      const tracer = new BasicTracerProvider().getTracer('default');
+      const span = tracer.startSpan('my-span');
+      assert.ok(span);
+      assert.ok(span.resource instanceof Resource);
+    });
   });
 
   describe('.getCurrentSpan()', () => {
@@ -340,6 +348,13 @@ describe('BasicTracerProvider', () => {
       };
       const patchedFn = tracer.bind(fn, span);
       return patchedFn();
+    });
+  });
+
+  describe('.resource', () => {
+    it('should return a Resource', () => {
+      const tracerProvider = new BasicTracerProvider();
+      assert.ok(tracerProvider.resource instanceof Resource);
     });
   });
 });

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -309,7 +309,7 @@ describe('BasicTracerProvider', () => {
 
     it('should assign a resource', () => {
       const tracer = new BasicTracerProvider().getTracer('default');
-      const span = tracer.startSpan('my-span');
+      const span = tracer.startSpan('my-span') as Span;
       assert.ok(span);
       assert.ok(span.resource instanceof Resource);
     });

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-web/package.json
+++ b/packages/opentelemetry-web/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.6.0",
+    "@opentelemetry/resources": "^0.4.0",
     "@opentelemetry/scope-zone": "^0.4.0",
     "@types/jquery": "^3.3.31",
     "@types/mocha": "^5.2.5",
@@ -77,7 +78,6 @@
   "dependencies": {
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/core": "^0.4.0",
-    "@opentelemetry/resources": "^0.4.0",
     "@opentelemetry/scope-base": "^0.4.0",
     "@opentelemetry/tracing": "^0.4.0"
   }

--- a/packages/opentelemetry-web/package.json
+++ b/packages/opentelemetry-web/package.json
@@ -77,6 +77,7 @@
   "dependencies": {
     "@opentelemetry/api": "^0.4.0",
     "@opentelemetry/core": "^0.4.0",
+    "@opentelemetry/resources": "^0.4.0",
     "@opentelemetry/scope-base": "^0.4.0",
     "@opentelemetry/tracing": "^0.4.0"
   }

--- a/packages/opentelemetry-web/src/WebTracerProvider.ts
+++ b/packages/opentelemetry-web/src/WebTracerProvider.ts
@@ -21,7 +21,6 @@ import {
   TracerConfig,
 } from '@opentelemetry/tracing';
 import { StackScopeManager } from './StackScopeManager';
-import { Resource, SDK_INFO } from '@opentelemetry/resources';
 
 /**
  * WebTracerConfig provides an interface for configuring a Web Tracer.
@@ -37,20 +36,16 @@ export interface WebTracerConfig extends TracerConfig {
  * This class represents a web tracer with {@link StackScopeManager}
  */
 export class WebTracerProvider extends BasicTracerProvider {
-  readonly resource: Resource = Resource.createTelemetrySDKResource(
-    SDK_INFO.PLATFORM_WEB
-  );
-
   /**
    * Constructs a new Tracer instance.
    * @param config Web Tracer config
    */
   constructor(config: WebTracerConfig = {}) {
-    super(config);
-
     if (typeof config.plugins === 'undefined') {
       config.plugins = [];
     }
+
+    super(config);
 
     for (const plugin of config.plugins) {
       plugin.enable([], this, this.logger);

--- a/packages/opentelemetry-web/src/WebTracerProvider.ts
+++ b/packages/opentelemetry-web/src/WebTracerProvider.ts
@@ -21,6 +21,7 @@ import {
   TracerConfig,
 } from '@opentelemetry/tracing';
 import { StackScopeManager } from './StackScopeManager';
+import { Resource, SDK_INFO } from '@opentelemetry/resources';
 
 /**
  * WebTracerConfig provides an interface for configuring a Web Tracer.
@@ -36,15 +37,20 @@ export interface WebTracerConfig extends TracerConfig {
  * This class represents a web tracer with {@link StackScopeManager}
  */
 export class WebTracerProvider extends BasicTracerProvider {
+  readonly resource: Resource = Resource.createTelemetrySDKResource(
+    SDK_INFO.PLATFORM_WEB
+  );
+
   /**
    * Constructs a new Tracer instance.
    * @param config Web Tracer config
    */
   constructor(config: WebTracerConfig = {}) {
+    super(config);
+
     if (typeof config.plugins === 'undefined') {
       config.plugins = [];
     }
-    super(config);
 
     for (const plugin of config.plugins) {
       plugin.enable([], this, this.logger);

--- a/packages/opentelemetry-web/src/WebTracerProvider.ts
+++ b/packages/opentelemetry-web/src/WebTracerProvider.ts
@@ -44,7 +44,6 @@ export class WebTracerProvider extends BasicTracerProvider {
     if (typeof config.plugins === 'undefined') {
       config.plugins = [];
     }
-
     super(config);
 
     for (const plugin of config.plugins) {

--- a/packages/opentelemetry-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-web/test/WebTracerProvider.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2020, OpenTelemetry Authors
+ * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-web/test/WebTracerProvider.test.ts
@@ -15,10 +15,11 @@
  */
 
 import { context } from '@opentelemetry/api';
-import { BasePlugin } from '@opentelemetry/core';
+import { BasePlugin, NoopLogger } from '@opentelemetry/core';
 import { ScopeManager } from '@opentelemetry/scope-base';
 import { ZoneScopeManager } from '@opentelemetry/scope-zone';
-import { Tracer } from '@opentelemetry/tracing';
+import { Tracer, Span } from '@opentelemetry/tracing';
+import { SDK_INFO, TELEMETRY_SDK_RESOURCE } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { WebTracerConfig } from '../src';
@@ -114,6 +115,20 @@ describe('WebTracerProvider', () => {
             }, 20);
           });
         });
+      });
+    });
+
+    describe('.startSpan()', () => {
+      it('should assign a telemetry sdk resource to span', () => {
+        const provider = new WebTracerProvider({
+          logger: new NoopLogger(),
+        });
+        const span = provider.getTracer('default').startSpan('my-span') as Span;
+        assert.ok(span);
+        assert.equal(
+          span.resource.labels[TELEMETRY_SDK_RESOURCE.LANGUAGE],
+          SDK_INFO.PLATFORM_WEB
+        );
       });
     });
   });

--- a/packages/opentelemetry-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-web/test/WebTracerProvider.test.ts
@@ -19,7 +19,7 @@ import { BasePlugin, NoopLogger } from '@opentelemetry/core';
 import { ScopeManager } from '@opentelemetry/scope-base';
 import { ZoneScopeManager } from '@opentelemetry/scope-zone';
 import { Tracer, Span } from '@opentelemetry/tracing';
-import { assertTelemetrySDKResource } from '@opentelemetry/resources';
+import { Resource, TELEMETRY_SDK_RESOURCE } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { WebTracerConfig } from '../src';
@@ -119,16 +119,17 @@ describe('WebTracerProvider', () => {
     });
 
     describe('.startSpan()', () => {
-      it('should assign a telemetry sdk resource to span', () => {
+      it('should assign resource to span', () => {
         const provider = new WebTracerProvider({
           logger: new NoopLogger(),
         });
         const span = provider.getTracer('default').startSpan('my-span') as Span;
         assert.ok(span);
-        assertTelemetrySDKResource(span.resource, {
-          language: 'webjs',
-          name: 'opentelemetry',
-        });
+        assert.ok(span.resource instanceof Resource);
+        assert.equal(
+          span.resource.labels[TELEMETRY_SDK_RESOURCE.LANGUAGE],
+          'webjs'
+        );
       });
     });
   });

--- a/packages/opentelemetry-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-web/test/WebTracerProvider.test.ts
@@ -19,7 +19,7 @@ import { BasePlugin, NoopLogger } from '@opentelemetry/core';
 import { ScopeManager } from '@opentelemetry/scope-base';
 import { ZoneScopeManager } from '@opentelemetry/scope-zone';
 import { Tracer, Span } from '@opentelemetry/tracing';
-import { assertTelemetrySDKResource, SDK_INFO } from '@opentelemetry/resources';
+import { assertTelemetrySDKResource } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { WebTracerConfig } from '../src';
@@ -126,9 +126,8 @@ describe('WebTracerProvider', () => {
         const span = provider.getTracer('default').startSpan('my-span') as Span;
         assert.ok(span);
         assertTelemetrySDKResource(span.resource, {
-          language: SDK_INFO.PLATFORM_WEB,
-          name: SDK_INFO.NAME,
-          version: SDK_INFO.VERSION,
+          language: 'webjs',
+          name: 'opentelemetry',
         });
       });
     });

--- a/packages/opentelemetry-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-web/test/WebTracerProvider.test.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/opentelemetry-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-web/test/WebTracerProvider.test.ts
@@ -19,7 +19,7 @@ import { BasePlugin, NoopLogger } from '@opentelemetry/core';
 import { ScopeManager } from '@opentelemetry/scope-base';
 import { ZoneScopeManager } from '@opentelemetry/scope-zone';
 import { Tracer, Span } from '@opentelemetry/tracing';
-import { SDK_INFO, TELEMETRY_SDK_RESOURCE } from '@opentelemetry/resources';
+import { assertTelemetrySDKResource, SDK_INFO } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { WebTracerConfig } from '../src';
@@ -125,10 +125,11 @@ describe('WebTracerProvider', () => {
         });
         const span = provider.getTracer('default').startSpan('my-span') as Span;
         assert.ok(span);
-        assert.equal(
-          span.resource.labels[TELEMETRY_SDK_RESOURCE.LANGUAGE],
-          SDK_INFO.PLATFORM_WEB
-        );
+        assertTelemetrySDKResource(span.resource, {
+          language: SDK_INFO.PLATFORM_WEB,
+          name: SDK_INFO.NAME,
+          version: SDK_INFO.VERSION,
+        });
       });
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

- This PR adds a resource to TracerProvider and MeterProvider. Fixes #840.

## Short description of the changes

- This work adds a telemetry SDK resource to TracerProvider and MeterProvider and makes it available on associated spans and instruments. It uses the`telemetry.sdk` semantic conventions that are proposed as a replacement for the `library` conventions that previously represented the SDK resource (https://github.com/open-telemetry/opentelemetry-specification/pull/494)
