### PR TITLE
chore: move Beta v1 release date target to 3/16

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ releases will not attempt to maintain backwards compatibility with the alpha rel
 | Metrics SDK                 | Alpha v0.2.0 | November 04 2019 |
 | Prometheus Metric Exporter  | Alpha v0.3.0 | December 13 2019 |
 | Collector Exporter          | Alpha v0.3.0 | December 13 2019 |
-| Resources                   | Beta         | March 25 2020    |
-| Support for Tags/Baggage    | Beta         | March 25 2020    |
-| OpenCensus Bridge           | Beta         | March 25 2020    |
+| Resources                   | Beta v1      | March 16 2020    |
+| Support for Tags/Baggage    | Beta v1      | March 16 2020    |
+| Metrics SDK (Complete)      | Beta v1      | March 16 2020    |
+| OpenCensus Bridge           | Beta v1      | March 16 2020    |
 
 See the [project
 milestones](https://github.com/open-telemetry/opentelemetry-js/milestones)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ releases will not attempt to maintain backwards compatibility with the alpha rel
 | Resources                   | Beta v1      | March 16 2020    |
 | Support for Tags/Baggage    | Beta v1      | March 16 2020    |
 | Metrics SDK (Complete)      | Beta v1      | March 16 2020    |
-| OpenCensus Bridge           | Beta v1      | March 16 2020    |
+| OpenCensus Bridge           | Beta v1      | Unknown          |
 
 See the [project
 milestones](https://github.com/open-telemetry/opentelemetry-js/milestones)


### PR DESCRIPTION
According to [Launch Plan](https://docs.google.com/document/d/1eviggoIguOS89dgKL-8ntUOCfPP6FLWAoQkGoBDsld0/edit) and [Beta Readiness Tracker](https://github.com/open-telemetry/opentelemetry-js/issues/782).