### PR TITLE
fix: removed pkg otel-api because imported twice

### DIFF
--- a/examples/redis/package.json
+++ b/examples/redis/package.json
@@ -37,7 +37,6 @@
     "@opentelemetry/plugin-http": "^0.4.0",
     "@opentelemetry/plugin-redis": "^0.4.0",
     "@opentelemetry/tracing": "^0.4.0",
-    "@opentelemetry/api": "^0.4.0",
     "axios": "^0.19.0",
     "express": "^4.17.1",
     "redis": "^2.8.0"


### PR DESCRIPTION
I doubt it's the cause of any trouble but I saw that otel-api is
importend twice in package.json