### PR TITLE
chore: update module names and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,7 @@ Maintainers ([@open-telemetry/js-maintainers](https://github.com/orgs/open-telem
 
 OpenTelemetry is vendor-agnostic and can upload data to any backend with various exporter implementations. Even though, OpenTelemetry provides support for many backends, vendors/users can also implement their own exporters for proprietary and unofficially supported backends. Currently, OpenTelemetry supports:
 
-#### Trace Exporters
-- [@opentelemetry/exporter-jaeger][otel-exporter-jaeger]
-- [@opentelemetry/exporter-zipkin][otel-exporter-zipkin]
-- [@opentelemetry/exporter-collector][otel-exporter-collector]
-
-#### Metric Exporters
-- [@opentelemetry/exporter-prometheus][otel-exporter-prometheus]
+See the [OpenTelemetry registry](https://opentelemetry.io/registry/?s=node) for a list of exporters available.
 
 ### Plugins
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,13 @@ Maintainers ([@open-telemetry/js-maintainers](https://github.com/orgs/open-telem
 
 OpenTelemetry is vendor-agnostic and can upload data to any backend with various exporter implementations. Even though, OpenTelemetry provides support for many backends, vendors/users can also implement their own exporters for proprietary and unofficially supported backends. Currently, OpenTelemetry supports:
 
-See the [OpenTelemetry registry](https://opentelemetry.io/registry/?s=node) for a list of exporters available.
+#### Trace Exporters
+- [@opentelemetry/exporter-jaeger][otel-exporter-jaeger]
+- [@opentelemetry/exporter-zipkin][otel-exporter-zipkin]
+- [@opentelemetry/exporter-collector][otel-exporter-collector]
+
+#### Metric Exporters
+- [@opentelemetry/exporter-prometheus][otel-exporter-prometheus]
 
 ### Plugins
 

--- a/packages/opentelemetry-api/README.md
+++ b/packages/opentelemetry-api/README.md
@@ -60,7 +60,7 @@ tracerProvider.addSpanProcessor(
  * Registering the provider with the API allows it to be discovered
  * and used by instrumentation libraries. The OpenTelemetry API provides
  * methods to set global SDK implementations, but the default SDK provides
- * a convenience method named `register` which registers sane defaults
+ * a convenience method named `register` which registers same defaults
  * for you.
  *
  * By default the NodeTracerProvider uses Trace Context for propagation

--- a/packages/opentelemetry-core/README.md
+++ b/packages/opentelemetry-core/README.md
@@ -5,7 +5,7 @@
 [![devDependencies][devDependencies-image]][devDependencies-url]
 [![Apache License][license-image]][license-image]
 
-This package provides default and no-op implementations of the OpenTelemetry API for trace and metrics. It's intended for use both on the server and in the browser.
+This package provides default implementations of the OpenTelemetry API for trace and metrics. It's intended for use both on the server and in the browser.
 
 ## Built-in Implementations
 

--- a/packages/opentelemetry-exporter-prometheus/README.md
+++ b/packages/opentelemetry-exporter-prometheus/README.md
@@ -1,4 +1,4 @@
-# OpenTelemetry Prometheus Exporter
+# OpenTelemetry Prometheus Metric Exporter
 [![Gitter chat][gitter-image]][gitter-url]
 [![NPM Published Version][npm-img]][npm-url]
 [![dependencies][dependencies-image]][dependencies-url]

--- a/packages/opentelemetry-node/README.md
+++ b/packages/opentelemetry-node/README.md
@@ -1,4 +1,4 @@
-# OpenTelemetry Node
+# OpenTelemetry Node SDK
 [![Gitter chat][gitter-image]][gitter-url]
 [![NPM Published Version][npm-img]][npm-url]
 [![dependencies][dependencies-image]][dependencies-url]

--- a/packages/opentelemetry-tracing/README.md
+++ b/packages/opentelemetry-tracing/README.md
@@ -1,11 +1,11 @@
-# OpenTelemetry Tracing
+# OpenTelemetry Tracing SDK
 [![Gitter chat][gitter-image]][gitter-url]
 [![NPM Published Version][npm-img]][npm-url]
 [![dependencies][dependencies-image]][dependencies-url]
 [![devDependencies][devDependencies-image]][devDependencies-url]
 [![Apache License][license-image]][license-image]
 
-`tracing` contains the foundation for all tracing SDKs of [opentelemetry-js](https://github.com/open-telemetry/opentelemetry-js).
+The `tracing` module contains the foundation for all tracing SDKs of [opentelemetry-js](https://github.com/open-telemetry/opentelemetry-js).
 
 Used standalone, this module provides methods for manual instrumentation of code, offering full control over span creation for client-side JavaScript (browser) and Node.js.
 

--- a/packages/opentelemetry-web/README.md
+++ b/packages/opentelemetry-web/README.md
@@ -1,4 +1,4 @@
-# OpenTelemetry Web
+# OpenTelemetry Web SDK
 [![Gitter chat][gitter-image]][gitter-url]
 [![NPM Published Version][npm-img]][npm-url]
 [![dependencies][dependencies-image]][dependencies-url]


### PR DESCRIPTION
~TODO: add prometheus and collector exporter in [OpenTelemetry registry](https://opentelemetry.io/registry/). Similar to https://github.com/open-telemetry/opentelemetry.io/pull/107~ Will do it later