### PR TITLE
Metrics: Add lastUpdateTimestamp associated with point

### DIFF
--- a/packages/opentelemetry-metrics/src/export/Aggregator.ts
+++ b/packages/opentelemetry-metrics/src/export/Aggregator.ts
@@ -73,6 +73,7 @@ export class MeasureExactAggregator implements Aggregator {
     this._distribution.sum += value;
     this._distribution.min = Math.min(this._distribution.min, value);
     this._distribution.max = Math.max(this._distribution.max, value);
+    this._lastUpdateTime = hrTime();
   }
 
   toPoint(): Point {

--- a/packages/opentelemetry-metrics/src/export/Aggregator.ts
+++ b/packages/opentelemetry-metrics/src/export/Aggregator.ts
@@ -14,37 +14,50 @@
  * limitations under the License.
  */
 
-import { Aggregator, Distribution, LastValue, Sum } from './types';
+import { Aggregator, Distribution, Point } from './types';
+import { HrTime } from '@opentelemetry/api';
+import { hrTime } from '@opentelemetry/core';
 
 /** Basic aggregator which calculates a Sum from individual measurements. */
 export class CounterSumAggregator implements Aggregator {
   private _current: number = 0;
+  private _lastUpdateTime: HrTime = [0, 0];
 
   update(value: number): void {
     this._current += value;
+    this._lastUpdateTime = hrTime();
   }
 
-  value(): Sum {
-    return this._current;
+  toPoint(): Point {
+    return {
+      value: this._current,
+      timestamp: this._lastUpdateTime,
+    };
   }
 }
 
 /** Basic aggregator for Observer which keeps the last recorded value. */
 export class ObserverAggregator implements Aggregator {
   private _current: number = 0;
+  private _lastUpdateTime: HrTime = [0, 0];
 
   update(value: number): void {
     this._current = value;
+    this._lastUpdateTime = hrTime();
   }
 
-  value(): LastValue {
-    return this._current;
+  toPoint(): Point {
+    return {
+      value: this._current,
+      timestamp: this._lastUpdateTime,
+    };
   }
 }
 
 /** Basic aggregator keeping all raw values (events, sum, max and min). */
 export class MeasureExactAggregator implements Aggregator {
   private _distribution: Distribution;
+  private _lastUpdateTime: HrTime = [0, 0];
 
   constructor() {
     this._distribution = {
@@ -62,7 +75,10 @@ export class MeasureExactAggregator implements Aggregator {
     this._distribution.max = Math.max(this._distribution.max, value);
   }
 
-  value(): Distribution {
-    return this._distribution;
+  toPoint(): Point {
+    return {
+      value: this._distribution,
+      timestamp: this._lastUpdateTime,
+    };
   }
 }

--- a/packages/opentelemetry-metrics/src/export/ConsoleMetricExporter.ts
+++ b/packages/opentelemetry-metrics/src/export/ConsoleMetricExporter.ts
@@ -37,11 +37,12 @@ export class ConsoleMetricExporter implements MetricExporter {
       console.log(metric.labels.labels);
       switch (metric.descriptor.metricKind) {
         case MetricKind.COUNTER:
-          const sum = metric.aggregator.value() as Sum;
+          const sum = metric.aggregator.toPoint().value as Sum;
           console.log('value: ' + sum);
           break;
         default:
-          const distribution = metric.aggregator.value() as Distribution;
+          const distribution = metric.aggregator.toPoint()
+            .value as Distribution;
           console.log(
             'min: ' +
               distribution.min +

--- a/packages/opentelemetry-metrics/src/export/types.ts
+++ b/packages/opentelemetry-metrics/src/export/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ValueType } from '@opentelemetry/api';
+import { ValueType, HrTime } from '@opentelemetry/api';
 import { ExportResult } from '@opentelemetry/base';
 import { LabelSet } from '../LabelSet';
 
@@ -76,6 +76,11 @@ export interface Aggregator {
   /** Updates the current with the new value. */
   update(value: number): void;
 
-  /** Returns snapshot of the current value. */
-  value(): Sum | Distribution;
+  /** Returns snapshot of the current point (value with timestamp). */
+  toPoint(): Point;
+}
+
+export interface Point {
+  value: Sum | LastValue | Distribution;
+  timestamp: HrTime;
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Based on the specs: https://github.com/open-telemetry/opentelemetry-specification/blob/4e7cd5a7d13e09674d0c7cc8b5932ada367c4d2b/specification/api-metrics.md#time

- Feel free to add comments.