### PR TITLE
chore: fixing documentation for web tracer provider, fixing examples …

### DIFF
--- a/examples/tracer-web/examples/xml-http-request/index.js
+++ b/examples/tracer-web/examples/xml-http-request/index.js
@@ -42,7 +42,6 @@ const getData = (url) => new Promise((resolve, _reject) => {
 const prepareClickEvent = () => {
   const url1 = 'https://httpbin.org/get';
 
-  let document;
   const element = document.getElementById('button1');
 
   const onClick = () => {
@@ -61,5 +60,4 @@ const prepareClickEvent = () => {
   element.addEventListener('click', onClick);
 };
 
-let window;
 window.addEventListener('load', prepareClickEvent);

--- a/packages/opentelemetry-context-base/package.json
+++ b/packages/opentelemetry-context-base/package.json
@@ -15,7 +15,8 @@
     "precompile": "tsc --version",
     "version:update": "node ../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",
-    "prepare": "npm run compile"
+    "prepare": "npm run compile",
+    "watch": "tsc -w"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-core/src/context/context.ts
+++ b/packages/opentelemetry-core/src/context/context.ts
@@ -17,7 +17,10 @@
 import { Span, SpanContext } from '@opentelemetry/api';
 import { Context } from '@opentelemetry/context-base';
 
-const ACTIVE_SPAN_KEY = Context.createKey(
+/**
+ * Active span key
+ */
+export const ACTIVE_SPAN_KEY = Context.createKey(
   'OpenTelemetry Context Key ACTIVE_SPAN'
 );
 const EXTRACTED_SPAN_CONTEXT_KEY = Context.createKey(

--- a/packages/opentelemetry-plugin-document-load/src/documentLoad.ts
+++ b/packages/opentelemetry-plugin-document-load/src/documentLoad.ts
@@ -76,7 +76,7 @@ export class DocumentLoad extends BasePlugin<unknown> {
     ) as PerformanceResourceTiming[];
     if (resources) {
       resources.forEach(resource => {
-        this._initResourceSpan(resource);
+        this._initResourceSpan(resource, { parent: rootSpan });
       });
     }
   }

--- a/packages/opentelemetry-plugin-user-interaction/README.md
+++ b/packages/opentelemetry-plugin-user-interaction/README.md
@@ -102,3 +102,4 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fplugin-user-interaction.svg
 [zone-js]: https://www.npmjs.com/package/zone.js
 [@opentelemetry/context-zone]: https://www.npmjs.com/package/@opentelemetry/context-zone
+

--- a/packages/opentelemetry-web/README.md
+++ b/packages/opentelemetry-web/README.md
@@ -45,15 +45,19 @@ const provider = new WebTracerProvider({
 });
 
 provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+provider.register();
 
-// Changing default contextManager to use ZoneContextManager - supports asynchronous operations
 const providerWithZone = new WebTracerProvider({
-  contextManager: new ZoneContextManager(),
   plugins: [
     new DocumentLoad()
   ]
 });
 providerWithZone.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+
+// Changing default contextManager to use ZoneContextManager - supports asynchronous operations
+providerWithZone.register({
+  contextManager: new ZoneContextManager(),
+});
 
 ```
 

--- a/packages/opentelemetry-web/src/WebTracerProvider.ts
+++ b/packages/opentelemetry-web/src/WebTracerProvider.ts
@@ -49,6 +49,14 @@ export class WebTracerProvider extends BasicTracerProvider {
     for (const plugin of config.plugins) {
       plugin.enable([], this, this.logger);
     }
+
+    if ((config as SDKRegistrationConfig).contextManager) {
+      throw 'contextManager should be defined in register method not in' +
+        ' constructor';
+    }
+    if ((config as SDKRegistrationConfig).propagator) {
+      throw 'propagator should be defined in register method not in constructor';
+    }
   }
 
   /**
@@ -61,6 +69,8 @@ export class WebTracerProvider extends BasicTracerProvider {
   register(config: SDKRegistrationConfig = {}) {
     if (config.contextManager === undefined) {
       config.contextManager = new StackContextManager();
+    }
+    if (config.contextManager) {
       config.contextManager.enable();
     }
 

--- a/packages/opentelemetry-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-web/test/WebTracerProvider.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { context } from '@opentelemetry/api';
-import { BasePlugin, NoopLogger } from '@opentelemetry/core';
+import { B3Propagator, BasePlugin, NoopLogger } from '@opentelemetry/core';
 import { ContextManager } from '@opentelemetry/context-base';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { Tracer, Span } from '@opentelemetry/tracing';
@@ -79,8 +79,40 @@ describe('WebTracerProvider', () => {
       });
     });
 
+    it('should throw error when context manager is passed in constructor', () => {
+      let error = '';
+      try {
+        new WebTracerProvider({
+          contextManager: new ZoneContextManager(),
+        } as any);
+      } catch (e) {
+        error = e;
+      }
+      assert.strictEqual(
+        error,
+        'contextManager should be defined in' +
+          ' register method not in constructor'
+      );
+    });
+
+    it('should throw error when propagator is passed in constructor', () => {
+      let error = '';
+      try {
+        new WebTracerProvider({
+          propagator: new B3Propagator(),
+        } as any);
+      } catch (e) {
+        error = e;
+      }
+      assert.strictEqual(
+        error,
+        'propagator should be defined in register' +
+          ' method not in constructor'
+      );
+    });
+
     describe('when contextManager is "ZoneContextManager"', () => {
-      it('should correctly return the contexts for 2 parallel actions', () => {
+      it('should correctly return the contexts for 2 parallel actions', done => {
         const webTracerWithZone = new WebTracerProvider().getTracer('default');
 
         const rootSpan = webTracerWithZone.startSpan('rootSpan');
@@ -112,6 +144,7 @@ describe('WebTracerProvider', () => {
                 webTracerWithZone.getCurrentSpan() === concurrentSpan2,
                 'Current span is concurrentSpan2'
               );
+              done();
             }, 20);
           });
         });


### PR DESCRIPTION
…for web, enable manager when registering

## Which problem is this PR solving?

- Fixes #905 

## Short description of the changes

1. The documentation for web was wrong when creating web tracer provider  and changing the context manager.
2. Also examples were outdated but also broken due to strange lint fixes.
3. I have also added enabling the context manager when user passes a new one in `register`
Without this the manager is being created but in fact it never works and it was quite difficult to finally figure out what was wrong. This way the simplified form of creating new context manager will be easier for a user
for example this wasn't working - the zone was disabled, now it will be enabled
`
provider.register({
  contextManager: new ZoneContextManager(),
});
`
I have also added checking in constructor to throw  an error if someone adds either contextManager or propagator into `constructor` instead of `register` - as it is currently shown in out documentation for web. This way user will now faster what is wrong.
4. The last fix is in document-load plugin it adds parent to resources loaded during the document load
5.  One more fix: the user interaction plugin was broken after the context propagation changes