### PR TITLE
[Jaeger-Exporter] host default env var

### DIFF
--- a/packages/opentelemetry-exporter-jaeger/README.md
+++ b/packages/opentelemetry-exporter-jaeger/README.md
@@ -1,4 +1,5 @@
 # OpenTelemetry Jaeger Trace Exporter
+
 [![Gitter chat][gitter-image]][gitter-url]
 [![NPM Published Version][npm-img]][npm-url]
 [![dependencies][dependencies-image]][dependencies-url]
@@ -54,6 +55,10 @@ npm install --save @opentelemetry/exporter-jaeger
 
 Install the exporter on your application and pass the options, it must contain a service name.
 
+Furthermore, the `host` option (which defaults to `localhost`), can instead be set by the
+`JAEGER_AGENT_HOST` environment variable to reduce in-code config. If both are
+set, the value set by the option in code is authoritative.
+
 ```js
 import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
 
@@ -78,8 +83,8 @@ You can use built-in `SimpleSpanProcessor` or `BatchSpanProcessor` or write your
 - [SimpleSpanProcessor](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-tracing.md#simple-processor): The implementation of `SpanProcessor` that passes ended span directly to the configured `SpanExporter`.
 - [BatchSpanProcessor](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/sdk-tracing.md#batching-processor): The implementation of the `SpanProcessor` that batches ended spans and pushes them to the configured `SpanExporter`. It is recommended to use this `SpanProcessor` for better performance and optimization.
 
-
 ## Useful links
+
 - To know more about Jaeger, visit: https://www.jaegertracing.io/docs/latest/getting-started/
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
 - For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>

--- a/packages/opentelemetry-exporter-jaeger/src/jaeger.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/jaeger.ts
@@ -37,6 +37,8 @@ export class JaegerExporter implements SpanExporter {
     this._onShutdownFlushTimeout =
       typeof config.flushTimeout === 'number' ? config.flushTimeout : 2000;
 
+    config.host = config.host || process.env.JAEGER_AGENT_HOST;
+
     this._sender = new jaegerTypes.UDPSender(config);
     if (this._sender._client instanceof Socket) {
       // unref socket to prevent it from keeping the process running


### PR DESCRIPTION
~note: I was unable to add a test as this depends on an env var. running `JAEGER_AGENT_HOST=foo npm run test` showed me that it works though by failing the host checking tests hereby added.~

## Which problem is this PR solving?

- It helpes solve open-telemetry/opentelemetry-specification#172 but does not solve it entirely.

## Short description of the changes

- Allowing the user to set env var `JAEGER_AGENT_HOST` in their app and the exporter will pick it up and use it as a value for host. setting `host` in the exporter config would trump this. Let me know if you would like the env var to take precedence.
