### PR TITLE
feat(meter): allow custom batcher #932

### DIFF
--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -43,7 +43,7 @@ export class Meter implements types.Meter {
    */
   constructor(config: MeterConfig = DEFAULT_CONFIG) {
     this._logger = config.logger || new ConsoleLogger(config.logLevel);
-    this._batcher = new UngroupedBatcher();
+    this._batcher = config.batcher ?? new UngroupedBatcher();
     this._resource = config.resource || Resource.createTelemetrySDKResource();
     // start the push controller
     const exporter = config.exporter || new NoopExporter();

--- a/packages/opentelemetry-metrics/src/types.ts
+++ b/packages/opentelemetry-metrics/src/types.ts
@@ -18,6 +18,7 @@ import { LogLevel } from '@opentelemetry/core';
 import { Logger, ValueType } from '@opentelemetry/api';
 import { MetricExporter } from './export/types';
 import { Resource } from '@opentelemetry/resources';
+import { Batcher } from './export/Batcher';
 
 /** Options needed for SDK metric creation. */
 export interface MetricOptions {
@@ -68,6 +69,9 @@ export interface MeterConfig {
 
   /** Resource associated with metric telemetry */
   resource?: Resource;
+
+  /** Metric batcher. */
+  batcher?: Batcher;
 }
 
 /** Default Meter configuration. */


### PR DESCRIPTION
From the spec [here](https://github.com/jmacd/opentelemetry-specification/blob/jmacd/draft_metric_sdk_spec/specification/sdk-metric.md#L289), there are different type of `Integrator` (which is our `Batcher`), we should allow to define a custom one for a given meter and use `UngroupedBatcher` if none is provided.
It will also allow user (like me) to implement their own aggregator :)