### PR TITLE
Use global API instances

### DIFF
--- a/packages/opentelemetry-api/README.md
+++ b/packages/opentelemetry-api/README.md
@@ -91,6 +91,10 @@ const meterProvider = new MeterProvider({
 api.metrics.setGlobalMeterProvider(meterProvider);
 ```
 
+## Version Compatibility
+
+Because the npm installer and node module resolution algorithm could potentially allow two or more copies of any given package to exist within the same `node_modules` structure, the OpenTelemetry API takes advantage of a variable on the `global` object to store the global API. When an API method in the API package is called, it checks if this `global` API exists and proxies calls to it if and only if it is a compatible API version. This means if a package has a dependency on an OpenTelemetry API version which is not compatible with the API used by the end user, the package will receive a no-op implementation of the API.
+
 ## Advanced Use
 ### API Registration Options
 

--- a/packages/opentelemetry-api/src/api/context.ts
+++ b/packages/opentelemetry-api/src/api/context.ts
@@ -104,6 +104,7 @@ export class ContextAPI {
     return (global as any)[GLOBAL_CONTEXT_MANAGER_API_KEY](API_VERSION);
   }
 
+  /** Disable and remove the global context manager */
   public disable() {
     this._getContextManager().disable();
     delete (global as any)[GLOBAL_CONTEXT_MANAGER_API_KEY];

--- a/packages/opentelemetry-api/src/api/context.ts
+++ b/packages/opentelemetry-api/src/api/context.ts
@@ -20,13 +20,13 @@ import {
   NoopContextManager,
 } from '@opentelemetry/context-base';
 import {
+  API_BACKWARDS_COMPATIBILITY_VERSION,
   GLOBAL_CONTEXT_MANAGER_API_KEY,
   makeGetter,
   _global,
 } from './global-utils';
 
 const NOOP_CONTEXT_MANAGER = new NoopContextManager();
-const API_VERSION = 0;
 
 /**
  * Singleton object which represents the entry point to the OpenTelemetry Context API
@@ -54,11 +54,11 @@ export class ContextAPI {
   ): ContextManager {
     if (_global[GLOBAL_CONTEXT_MANAGER_API_KEY]) {
       // global context manager has already been set
-      return NOOP_CONTEXT_MANAGER;
+      return this._getContextManager();
     }
 
     _global[GLOBAL_CONTEXT_MANAGER_API_KEY] = makeGetter(
-      API_VERSION,
+      API_BACKWARDS_COMPATIBILITY_VERSION,
       contextManager,
       NOOP_CONTEXT_MANAGER
     );
@@ -97,11 +97,11 @@ export class ContextAPI {
   }
 
   private _getContextManager(): ContextManager {
-    if (!_global[GLOBAL_CONTEXT_MANAGER_API_KEY]) {
-      return NOOP_CONTEXT_MANAGER;
-    }
-
-    return _global[GLOBAL_CONTEXT_MANAGER_API_KEY]!(API_VERSION);
+    return (
+      _global[GLOBAL_CONTEXT_MANAGER_API_KEY]?.(
+        API_BACKWARDS_COMPATIBILITY_VERSION
+      ) ?? NOOP_CONTEXT_MANAGER
+    );
   }
 
   /** Disable and remove the global context manager */

--- a/packages/opentelemetry-api/src/api/context.ts
+++ b/packages/opentelemetry-api/src/api/context.ts
@@ -22,7 +22,9 @@ import {
 
 const NOOP_CONTEXT_MANAGER = new NoopContextManager();
 
-const GLOBAL_CONTEXT_MANAGER_API_KEY = Symbol.for("io.opentelemetry.js.api.context");
+const GLOBAL_CONTEXT_MANAGER_API_KEY = Symbol.for(
+  'io.opentelemetry.js.api.context'
+);
 const API_VERSION = 0;
 
 /**
@@ -54,17 +56,18 @@ export class ContextAPI {
       return NOOP_CONTEXT_MANAGER;
     }
 
-    (global as any)[GLOBAL_CONTEXT_MANAGER_API_KEY] = function getTraceApi (version: number) {
+    (global as any)[GLOBAL_CONTEXT_MANAGER_API_KEY] = function getTraceApi(
+      version: number
+    ) {
       if (version !== API_VERSION) {
         return NOOP_CONTEXT_MANAGER;
       }
 
       return contextManager;
-    }
+    };
 
     return contextManager;
   }
-
 
   /**
    * Get the currently active context

--- a/packages/opentelemetry-api/src/api/global-utils.ts
+++ b/packages/opentelemetry-api/src/api/global-utils.ts
@@ -40,6 +40,14 @@ type MyGlobals = Partial<{
 
 export const _global = global as typeof global & MyGlobals;
 
+/**
+ * Make a function which accepts a version integer and returns the instance of an API if the version
+ * is compatible, or a fallback version (usually NOOP) if it is not.
+ *
+ * @param requiredVersion Backwards compatibility version which is required to return the instance
+ * @param instance Instance which should be returned if the required version is compatible
+ * @param fallback Fallback instance, usually NOOP, which will be returned if the required version is not compatible
+ */
 export function makeGetter<T>(
   requiredVersion: number,
   instance: T,
@@ -48,3 +56,12 @@ export function makeGetter<T>(
   return (version: number): T =>
     version === requiredVersion ? instance : fallback;
 }
+
+/**
+ * A number which should be incremented each time a backwards incompatible
+ * change is made to the API. This number is used when an API package
+ * attempts to access the global API to ensure it is getting a compatible
+ * version. If the global API is not compatible with the API package
+ * attempting to get it, a NOOP API implementation will be returned.
+ */
+export const API_BACKWARDS_COMPATIBILITY_VERSION = 0;

--- a/packages/opentelemetry-api/src/api/global-utils.ts
+++ b/packages/opentelemetry-api/src/api/global-utils.ts
@@ -1,0 +1,50 @@
+/*!
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ContextManager } from '@opentelemetry/context-base';
+import { HttpTextPropagator } from '../context/propagation/HttpTextPropagator';
+import { MeterProvider } from '../metrics/MeterProvider';
+import { TracerProvider } from '../trace/tracer_provider';
+
+export const GLOBAL_CONTEXT_MANAGER_API_KEY = Symbol.for(
+  'io.opentelemetry.js.api.context'
+);
+export const GLOBAL_METRICS_API_KEY = Symbol.for(
+  'io.opentelemetry.js.api.metrics'
+);
+export const GLOBAL_PROPAGATION_API_KEY = Symbol.for(
+  'io.opentelemetry.js.api.propagation'
+);
+export const GLOBAL_TRACE_API_KEY = Symbol.for('io.opentelemetry.js.api.trace');
+
+type Get<T> = (version: number) => T;
+type MyGlobals = Partial<{
+  [GLOBAL_CONTEXT_MANAGER_API_KEY]: Get<ContextManager>;
+  [GLOBAL_METRICS_API_KEY]: Get<MeterProvider>;
+  [GLOBAL_PROPAGATION_API_KEY]: Get<HttpTextPropagator>;
+  [GLOBAL_TRACE_API_KEY]: Get<TracerProvider>;
+}>;
+
+export const _global = global as typeof global & MyGlobals;
+
+export function makeGetter<T>(
+  requiredVersion: number,
+  instance: T,
+  fallback: T
+): Get<T> {
+  return (version: number): T =>
+    version === requiredVersion ? instance : fallback;
+}

--- a/packages/opentelemetry-api/src/api/metrics.ts
+++ b/packages/opentelemetry-api/src/api/metrics.ts
@@ -18,7 +18,7 @@ import { Meter } from '../metrics/Meter';
 import { MeterProvider } from '../metrics/MeterProvider';
 import { NOOP_METER_PROVIDER } from '../metrics/NoopMeterProvider';
 
-const GLOBAL_METRICS_API_KEY = Symbol.for("io.opentelemetry.js.api.metrics");
+const GLOBAL_METRICS_API_KEY = Symbol.for('io.opentelemetry.js.api.metrics');
 const API_VERSION = 0;
 
 /**
@@ -48,13 +48,15 @@ export class MetricsAPI {
       return NOOP_METER_PROVIDER;
     }
 
-    (global as any)[GLOBAL_METRICS_API_KEY] = function getTraceApi (version: number) {
+    (global as any)[GLOBAL_METRICS_API_KEY] = function getTraceApi(
+      version: number
+    ) {
       if (version !== API_VERSION) {
         return NOOP_METER_PROVIDER;
       }
 
       return provider;
-    }
+    };
 
     return provider;
   }

--- a/packages/opentelemetry-api/src/api/metrics.ts
+++ b/packages/opentelemetry-api/src/api/metrics.ts
@@ -48,7 +48,7 @@ export class MetricsAPI {
   public setGlobalMeterProvider(provider: MeterProvider): MeterProvider {
     if (_global[GLOBAL_METRICS_API_KEY]) {
       // global meter provider has already been set
-      return NOOP_METER_PROVIDER;
+      return this.getMeterProvider();
     }
 
     _global[GLOBAL_METRICS_API_KEY] = makeGetter(

--- a/packages/opentelemetry-api/src/api/metrics.ts
+++ b/packages/opentelemetry-api/src/api/metrics.ts
@@ -77,6 +77,7 @@ export class MetricsAPI {
     return this.getMeterProvider().getMeter(name, version);
   }
 
+  /** Remove the global meter provider */
   public disable() {
     delete (global as any)[GLOBAL_METRICS_API_KEY];
   }

--- a/packages/opentelemetry-api/src/api/metrics.ts
+++ b/packages/opentelemetry-api/src/api/metrics.ts
@@ -17,9 +17,12 @@
 import { Meter } from '../metrics/Meter';
 import { MeterProvider } from '../metrics/MeterProvider';
 import { NOOP_METER_PROVIDER } from '../metrics/NoopMeterProvider';
-import { GLOBAL_METRICS_API_KEY, makeGetter, _global } from './global-utils';
-
-const API_VERSION = 0;
+import {
+  API_BACKWARDS_COMPATIBILITY_VERSION,
+  GLOBAL_METRICS_API_KEY,
+  makeGetter,
+  _global,
+} from './global-utils';
 
 /**
  * Singleton object which represents the entry point to the OpenTelemetry Metrics API
@@ -49,7 +52,7 @@ export class MetricsAPI {
     }
 
     _global[GLOBAL_METRICS_API_KEY] = makeGetter(
-      API_VERSION,
+      API_BACKWARDS_COMPATIBILITY_VERSION,
       provider,
       NOOP_METER_PROVIDER
     );
@@ -61,11 +64,10 @@ export class MetricsAPI {
    * Returns the global meter provider.
    */
   public getMeterProvider(): MeterProvider {
-    if (!_global[GLOBAL_METRICS_API_KEY]) {
-      return NOOP_METER_PROVIDER;
-    }
-
-    return _global[GLOBAL_METRICS_API_KEY]!(API_VERSION);
+    return (
+      _global[GLOBAL_METRICS_API_KEY]?.(API_BACKWARDS_COMPATIBILITY_VERSION) ??
+      NOOP_METER_PROVIDER
+    );
   }
 
   /**

--- a/packages/opentelemetry-api/src/api/propagation.ts
+++ b/packages/opentelemetry-api/src/api/propagation.ts
@@ -23,7 +23,9 @@ import { ContextAPI } from './context';
 
 const contextApi = ContextAPI.getInstance();
 
-const GLOBAL_PROPAGATION_API_KEY = Symbol.for("io.opentelemetry.js.api.propagation");
+const GLOBAL_PROPAGATION_API_KEY = Symbol.for(
+  'io.opentelemetry.js.api.propagation'
+);
 const API_VERSION = 0;
 
 /**
@@ -55,13 +57,15 @@ export class PropagationAPI {
       return NOOP_HTTP_TEXT_PROPAGATOR;
     }
 
-    (global as any)[GLOBAL_PROPAGATION_API_KEY] = function getTraceApi (version: number) {
+    (global as any)[GLOBAL_PROPAGATION_API_KEY] = function getTraceApi(
+      version: number
+    ) {
       if (version !== API_VERSION) {
         return NOOP_HTTP_TEXT_PROPAGATOR;
       }
 
       return propagator;
-    }
+    };
 
     return propagator;
   }

--- a/packages/opentelemetry-api/src/api/propagation.ts
+++ b/packages/opentelemetry-api/src/api/propagation.ts
@@ -55,7 +55,7 @@ export class PropagationAPI {
   ): HttpTextPropagator {
     if (_global[GLOBAL_PROPAGATION_API_KEY]) {
       // global propagator has already been set
-      return NOOP_HTTP_TEXT_PROPAGATOR;
+      return this._getGlobalPropagator();
     }
 
     _global[GLOBAL_PROPAGATION_API_KEY] = makeGetter(

--- a/packages/opentelemetry-api/src/api/propagation.ts
+++ b/packages/opentelemetry-api/src/api/propagation.ts
@@ -21,14 +21,13 @@ import { NOOP_HTTP_TEXT_PROPAGATOR } from '../context/propagation/NoopHttpTextPr
 import { defaultSetter, SetterFunction } from '../context/propagation/setter';
 import { ContextAPI } from './context';
 import {
+  API_BACKWARDS_COMPATIBILITY_VERSION,
   GLOBAL_PROPAGATION_API_KEY,
   makeGetter,
   _global,
 } from './global-utils';
 
 const contextApi = ContextAPI.getInstance();
-
-const API_VERSION = 0;
 
 /**
  * Singleton object which represents the entry point to the OpenTelemetry Propagation API
@@ -60,7 +59,7 @@ export class PropagationAPI {
     }
 
     _global[GLOBAL_PROPAGATION_API_KEY] = makeGetter(
-      API_VERSION,
+      API_BACKWARDS_COMPATIBILITY_VERSION,
       propagator,
       NOOP_HTTP_TEXT_PROPAGATOR
     );
@@ -104,10 +103,10 @@ export class PropagationAPI {
   }
 
   private _getGlobalPropagator(): HttpTextPropagator {
-    if (!_global[GLOBAL_PROPAGATION_API_KEY]) {
-      return NOOP_HTTP_TEXT_PROPAGATOR;
-    }
-
-    return _global[GLOBAL_PROPAGATION_API_KEY]!(API_VERSION);
+    return (
+      _global[GLOBAL_PROPAGATION_API_KEY]?.(
+        API_BACKWARDS_COMPATIBILITY_VERSION
+      ) ?? NOOP_HTTP_TEXT_PROPAGATOR
+    );
   }
 }

--- a/packages/opentelemetry-api/src/api/propagation.ts
+++ b/packages/opentelemetry-api/src/api/propagation.ts
@@ -96,6 +96,7 @@ export class PropagationAPI {
     return this._getGlobalPropagator().extract(context, carrier, getter);
   }
 
+  /** Remove the global propagator */
   public disable() {
     delete (global as any)[GLOBAL_PROPAGATION_API_KEY];
   }

--- a/packages/opentelemetry-api/src/api/trace.ts
+++ b/packages/opentelemetry-api/src/api/trace.ts
@@ -48,7 +48,7 @@ export class TraceAPI {
   public setGlobalTracerProvider(provider: TracerProvider): TracerProvider {
     if (_global[GLOBAL_TRACE_API_KEY]) {
       // global tracer provider has already been set
-      return NOOP_TRACER_PROVIDER;
+      return this.getTracerProvider();
     }
 
     _global[GLOBAL_TRACE_API_KEY] = makeGetter(

--- a/packages/opentelemetry-api/src/api/trace.ts
+++ b/packages/opentelemetry-api/src/api/trace.ts
@@ -17,9 +17,12 @@
 import { NOOP_TRACER_PROVIDER } from '../trace/NoopTracerProvider';
 import { Tracer } from '../trace/tracer';
 import { TracerProvider } from '../trace/tracer_provider';
-import { GLOBAL_TRACE_API_KEY, makeGetter, _global } from './global-utils';
-
-const API_VERSION = 0;
+import {
+  API_BACKWARDS_COMPATIBILITY_VERSION,
+  GLOBAL_TRACE_API_KEY,
+  makeGetter,
+  _global,
+} from './global-utils';
 
 /**
  * Singleton object which represents the entry point to the OpenTelemetry Tracing API
@@ -49,7 +52,7 @@ export class TraceAPI {
     }
 
     _global[GLOBAL_TRACE_API_KEY] = makeGetter(
-      API_VERSION,
+      API_BACKWARDS_COMPATIBILITY_VERSION,
       provider,
       NOOP_TRACER_PROVIDER
     );
@@ -61,12 +64,10 @@ export class TraceAPI {
    * Returns the global tracer provider.
    */
   public getTracerProvider(): TracerProvider {
-    if (!_global[GLOBAL_TRACE_API_KEY]) {
-      // global tracer provider has already been set
-      return NOOP_TRACER_PROVIDER;
-    }
-
-    return _global[GLOBAL_TRACE_API_KEY]!(API_VERSION);
+    return (
+      _global[GLOBAL_TRACE_API_KEY]?.(API_BACKWARDS_COMPATIBILITY_VERSION) ??
+      NOOP_TRACER_PROVIDER
+    );
   }
 
   /**

--- a/packages/opentelemetry-api/src/api/trace.ts
+++ b/packages/opentelemetry-api/src/api/trace.ts
@@ -78,6 +78,7 @@ export class TraceAPI {
     return this.getTracerProvider().getTracer(name, version);
   }
 
+  /** Remove the global tracer provider */
   public disable() {
     delete (global as any)[GLOBAL_TRACE_API_KEY];
   }

--- a/packages/opentelemetry-api/src/api/trace.ts
+++ b/packages/opentelemetry-api/src/api/trace.ts
@@ -18,7 +18,7 @@ import { NOOP_TRACER_PROVIDER } from '../trace/NoopTracerProvider';
 import { TracerProvider } from '../trace/tracer_provider';
 import { Tracer } from '../trace/tracer';
 
-const GLOBAL_TRACE_API_KEY = Symbol.for("io.opentelemetry.js.api.trace");
+const GLOBAL_TRACE_API_KEY = Symbol.for('io.opentelemetry.js.api.trace');
 const API_VERSION = 0;
 
 /**
@@ -48,13 +48,15 @@ export class TraceAPI {
       return NOOP_TRACER_PROVIDER;
     }
 
-    (global as any)[GLOBAL_TRACE_API_KEY] = function getTraceApi (version: number) {
+    (global as any)[GLOBAL_TRACE_API_KEY] = function getTraceApi(
+      version: number
+    ) {
       if (version !== API_VERSION) {
         return NOOP_TRACER_PROVIDER;
       }
 
       return provider;
-    }
+    };
 
     return this.getTracerProvider();
   }

--- a/packages/opentelemetry-api/test/api/api.test.ts
+++ b/packages/opentelemetry-api/test/api/api.test.ts
@@ -46,11 +46,11 @@ describe('API', () => {
     const dummySpan = new NoopSpan(spanContext);
 
     beforeEach(() => {
-      context.disable()
+      context.disable();
       trace.disable();
       propagation.disable();
       metrics.disable();
-    })
+    });
 
     it('should not crash', () => {
       functions.forEach(fn => {

--- a/packages/opentelemetry-api/test/api/api.test.ts
+++ b/packages/opentelemetry-api/test/api/api.test.ts
@@ -22,6 +22,10 @@ import api, {
   NoopTracer,
   SpanOptions,
   Span,
+  context,
+  trace,
+  propagation,
+  metrics,
 } from '../../src';
 
 describe('API', () => {
@@ -41,9 +45,12 @@ describe('API', () => {
     };
     const dummySpan = new NoopSpan(spanContext);
 
-    afterEach(() => {
-      api.trace.setGlobalTracerProvider(new NoopTracerProvider());
-    });
+    beforeEach(() => {
+      context.disable()
+      trace.disable();
+      propagation.disable();
+      metrics.disable();
+    })
 
     it('should not crash', () => {
       functions.forEach(fn => {

--- a/packages/opentelemetry-api/test/api/global.test.ts
+++ b/packages/opentelemetry-api/test/api/global.test.ts
@@ -1,0 +1,81 @@
+/*!
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { NoopContextManager } from '@opentelemetry/context-base';
+import {
+  _global,
+  GLOBAL_CONTEXT_MANAGER_API_KEY,
+} from '../../src/api/global-utils';
+
+const api1 = require('../../src') as typeof import('../../src');
+
+// clear cache and load a second instance of the api
+for (const key of Object.keys(require.cache)) {
+  delete require.cache[key];
+}
+const api2 = require('../../src') as typeof import('../../src');
+
+describe('Global Utils', () => {
+  // prove they are separate instances
+  assert.notEqual(api1, api2);
+  // that return separate noop instances to start
+  assert.notStrictEqual(
+    api1.context['_getContextManager'](),
+    api2.context['_getContextManager']()
+  );
+
+  beforeEach(() => {
+    api1.context.disable();
+    api1.propagation.disable();
+    api1.trace.disable();
+    api1.metrics.disable();
+  });
+
+  it('should change the global context manager', () => {
+    const original = api1.context['_getContextManager']();
+    const newContextManager = new NoopContextManager();
+    api1.context.setGlobalContextManager(newContextManager);
+    assert.notStrictEqual(api1.context['_getContextManager'](), original);
+    assert.strictEqual(api1.context['_getContextManager'](), newContextManager);
+  });
+
+  it('should load an instance from one which was set in the other', () => {
+    api1.context.setGlobalContextManager(new NoopContextManager());
+    assert.strictEqual(
+      api1.context['_getContextManager'](),
+      api2.context['_getContextManager']()
+    );
+  });
+
+  it('should disable both if one is disabled', () => {
+    const original = api1.context['_getContextManager']();
+
+    api1.context.setGlobalContextManager(new NoopContextManager());
+
+    assert.notStrictEqual(original, api1.context['_getContextManager']());
+    api2.context.disable();
+    assert.strictEqual(original, api1.context['_getContextManager']());
+  });
+
+  it('should return the module NoOp implementation if the version is a mismatch', () => {
+    const original = api1.context['_getContextManager']();
+    api1.context.setGlobalContextManager(new NoopContextManager());
+    const afterSet = _global[GLOBAL_CONTEXT_MANAGER_API_KEY]!(-1);
+
+    assert.strictEqual(original, afterSet);
+  });
+});

--- a/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
+++ b/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
@@ -58,7 +58,7 @@ describe('NodeTracerProvider', () => {
     Object.keys(require.cache).forEach(key => delete require.cache[key]);
     provider.stop();
     contextManager.disable();
-    context.disable()
+    context.disable();
   });
 
   describe('constructor', () => {

--- a/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
+++ b/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
@@ -58,6 +58,7 @@ describe('NodeTracerProvider', () => {
     Object.keys(require.cache).forEach(key => delete require.cache[key]);
     provider.stop();
     contextManager.disable();
+    context.disable()
   });
 
   describe('constructor', () => {

--- a/packages/opentelemetry-node/test/registration.test.ts
+++ b/packages/opentelemetry-node/test/registration.test.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { context, NoopHttpTextPropagator, propagation, trace } from '@opentelemetry/api';
+import {
+  context,
+  NoopHttpTextPropagator,
+  propagation,
+  trace,
+} from '@opentelemetry/api';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { NoopContextManager } from '@opentelemetry/context-base';
 import { HttpTraceContext } from '@opentelemetry/core';
@@ -23,7 +28,7 @@ import { NodeTracerProvider } from '../src';
 
 describe('API registration', () => {
   beforeEach(() => {
-    context.disable()
+    context.disable();
     trace.disable();
     propagation.disable();
   });
@@ -32,8 +37,12 @@ describe('API registration', () => {
     const tracerProvider = new NodeTracerProvider();
     tracerProvider.register();
 
-    assert.ok(context['_getContextManager']() instanceof AsyncHooksContextManager);
-    assert.ok(propagation['_getGlobalPropagator']() instanceof HttpTraceContext);
+    assert.ok(
+      context['_getContextManager']() instanceof AsyncHooksContextManager
+    );
+    assert.ok(
+      propagation['_getGlobalPropagator']() instanceof HttpTraceContext
+    );
     assert.ok(trace.getTracerProvider() === tracerProvider);
   });
 
@@ -62,7 +71,9 @@ describe('API registration', () => {
 
     assert.ok(context['_getContextManager']() instanceof NoopContextManager);
 
-    assert.ok(propagation['_getGlobalPropagator']() instanceof HttpTraceContext);
+    assert.ok(
+      propagation['_getGlobalPropagator']() instanceof HttpTraceContext
+    );
     assert.ok(trace.getTracerProvider() === tracerProvider);
   });
 
@@ -72,9 +83,13 @@ describe('API registration', () => {
       propagator: null,
     });
 
-    assert.ok(propagation['_getGlobalPropagator']() instanceof NoopHttpTextPropagator);
+    assert.ok(
+      propagation['_getGlobalPropagator']() instanceof NoopHttpTextPropagator
+    );
 
-    assert.ok(context['_getContextManager']() instanceof AsyncHooksContextManager);
+    assert.ok(
+      context['_getContextManager']() instanceof AsyncHooksContextManager
+    );
     assert.ok(trace.getTracerProvider() === tracerProvider);
   });
 });

--- a/packages/opentelemetry-node/test/registration.test.ts
+++ b/packages/opentelemetry-node/test/registration.test.ts
@@ -14,33 +14,27 @@
  * limitations under the License.
  */
 
-import {
-  context,
-  NoopHttpTextPropagator,
-  NoopTracerProvider,
-  propagation,
-  trace,
-} from '@opentelemetry/api';
-import { HttpTraceContext } from '@opentelemetry/core';
+import { context, NoopHttpTextPropagator, propagation, trace } from '@opentelemetry/api';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { NoopContextManager } from '@opentelemetry/context-base';
+import { HttpTraceContext } from '@opentelemetry/core';
 import * as assert from 'assert';
 import { NodeTracerProvider } from '../src';
 
 describe('API registration', () => {
   beforeEach(() => {
-    context.setGlobalContextManager(new NoopContextManager());
-    propagation.setGlobalPropagator(new NoopHttpTextPropagator());
-    trace.setGlobalTracerProvider(new NoopTracerProvider());
+    context.disable()
+    trace.disable();
+    propagation.disable();
   });
 
   it('should register default implementations', () => {
     const tracerProvider = new NodeTracerProvider();
     tracerProvider.register();
 
-    assert.ok(context['_contextManager'] instanceof AsyncHooksContextManager);
-    assert.ok(propagation['_propagator'] instanceof HttpTraceContext);
-    assert.ok(trace['_tracerProvider'] === tracerProvider);
+    assert.ok(context['_getContextManager']() instanceof AsyncHooksContextManager);
+    assert.ok(propagation['_getGlobalPropagator']() instanceof HttpTraceContext);
+    assert.ok(trace.getTracerProvider() === tracerProvider);
   });
 
   it('should register configured implementations', () => {
@@ -54,10 +48,10 @@ describe('API registration', () => {
       propagator,
     });
 
-    assert.ok(context['_contextManager'] === contextManager);
-    assert.ok(propagation['_propagator'] === propagator);
+    assert.ok(context['_getContextManager']() === contextManager);
+    assert.ok(propagation['_getGlobalPropagator']() === propagator);
 
-    assert.ok(trace['_tracerProvider'] === tracerProvider);
+    assert.ok(trace.getTracerProvider() === tracerProvider);
   });
 
   it('should skip null context manager', () => {
@@ -66,10 +60,10 @@ describe('API registration', () => {
       contextManager: null,
     });
 
-    assert.ok(context['_contextManager'] instanceof NoopContextManager);
+    assert.ok(context['_getContextManager']() instanceof NoopContextManager);
 
-    assert.ok(propagation['_propagator'] instanceof HttpTraceContext);
-    assert.ok(trace['_tracerProvider'] === tracerProvider);
+    assert.ok(propagation['_getGlobalPropagator']() instanceof HttpTraceContext);
+    assert.ok(trace.getTracerProvider() === tracerProvider);
   });
 
   it('should skip null propagator', () => {
@@ -78,9 +72,9 @@ describe('API registration', () => {
       propagator: null,
     });
 
-    assert.ok(propagation['_propagator'] instanceof NoopHttpTextPropagator);
+    assert.ok(propagation['_getGlobalPropagator']() instanceof NoopHttpTextPropagator);
 
-    assert.ok(context['_contextManager'] instanceof AsyncHooksContextManager);
-    assert.ok(trace['_tracerProvider'] === tracerProvider);
+    assert.ok(context['_getContextManager']() instanceof AsyncHooksContextManager);
+    assert.ok(trace.getTracerProvider() === tracerProvider);
   });
 });

--- a/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
+++ b/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
@@ -312,7 +312,7 @@ describe('GrpcPlugin', () => {
   });
 
   afterEach(() => {
-    context.disable()
+    context.disable();
   });
 
   it('should return a plugin', () => {

--- a/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
+++ b/packages/opentelemetry-plugin-grpc/test/grpc.test.ts
@@ -312,7 +312,7 @@ describe('GrpcPlugin', () => {
   });
 
   afterEach(() => {
-    contextManager.disable();
+    context.disable()
   });
 
   it('should return a plugin', () => {

--- a/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
@@ -85,7 +85,7 @@ describe('HttpPlugin', () => {
   });
 
   afterEach(() => {
-    context.disable()
+    context.disable();
   });
 
   it('should return a plugin', () => {

--- a/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
@@ -85,7 +85,7 @@ describe('HttpPlugin', () => {
   });
 
   afterEach(() => {
-    contextManager.disable();
+    context.disable()
   });
 
   it('should return a plugin', () => {

--- a/packages/opentelemetry-plugin-http/test/functionals/http-package.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-package.test.ts
@@ -18,7 +18,10 @@ import { context, SpanKind } from '@opentelemetry/api';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { NoopLogger } from '@opentelemetry/core';
 import { NodeTracerProvider } from '@opentelemetry/node';
-import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/tracing';
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/tracing';
 import * as assert from 'assert';
 import axios, { AxiosResponse } from 'axios';
 import * as got from 'got';
@@ -43,7 +46,7 @@ describe('Packages', () => {
   });
 
   afterEach(() => {
-    context.disable()
+    context.disable();
   });
   describe('get', () => {
     const logger = new NoopLogger();

--- a/packages/opentelemetry-plugin-http/test/functionals/http-package.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-package.test.ts
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-import { SpanKind } from '@opentelemetry/api';
+import { context, SpanKind } from '@opentelemetry/api';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { NoopLogger } from '@opentelemetry/core';
 import { NodeTracerProvider } from '@opentelemetry/node';
-import {
-  InMemorySpanExporter,
-  SimpleSpanProcessor,
-} from '@opentelemetry/tracing';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/tracing';
 import * as assert from 'assert';
 import axios, { AxiosResponse } from 'axios';
 import * as got from 'got';
@@ -40,6 +38,13 @@ const memoryExporter = new InMemorySpanExporter();
 const protocol = 'http';
 
 describe('Packages', () => {
+  beforeEach(() => {
+    context.setGlobalContextManager(new AsyncHooksContextManager().enable());
+  });
+
+  afterEach(() => {
+    context.disable()
+  });
   describe('get', () => {
     const logger = new NoopLogger();
     const provider = new NodeTracerProvider({

--- a/packages/opentelemetry-plugin-http/test/integrations/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/integrations/http-enable.test.ts
@@ -48,8 +48,8 @@ describe('HttpPlugin Integration tests', () => {
   });
 
   afterEach(() => {
-    context.disable()
-  })
+    context.disable();
+  });
   describe('enable()', () => {
     before(function(done) {
       // mandatory

--- a/packages/opentelemetry-plugin-http/test/integrations/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/integrations/http-enable.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { NoopLogger } from '@opentelemetry/core';
-import { SpanKind, Span } from '@opentelemetry/api';
+import { SpanKind, Span, context } from '@opentelemetry/api';
 import * as assert from 'assert';
 import * as http from 'http';
 import { plugin } from '../../src/http';
@@ -31,6 +31,7 @@ import {
 } from '@opentelemetry/tracing';
 import { HttpPluginConfig } from '../../src/types';
 import { AttributeNames } from '../../src/enums/AttributeNames';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 const protocol = 'http';
 const serverPort = 32345;
 const hostname = 'localhost';
@@ -41,6 +42,14 @@ export const customAttributeFunction = (span: Span): void => {
 };
 
 describe('HttpPlugin Integration tests', () => {
+  beforeEach(() => {
+    memoryExporter.reset();
+    context.setGlobalContextManager(new AsyncHooksContextManager().enable());
+  });
+
+  afterEach(() => {
+    context.disable()
+  })
   describe('enable()', () => {
     before(function(done) {
       // mandatory

--- a/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
@@ -92,6 +92,7 @@ describe('HttpsPlugin', () => {
 
   afterEach(() => {
     contextManager.disable();
+    context.disable()
   });
 
   it('should return a plugin', () => {

--- a/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
@@ -92,7 +92,7 @@ describe('HttpsPlugin', () => {
 
   afterEach(() => {
     contextManager.disable();
-    context.disable()
+    context.disable();
   });
 
   it('should return a plugin', () => {

--- a/packages/opentelemetry-plugin-https/test/functionals/https-package.test.ts
+++ b/packages/opentelemetry-plugin-https/test/functionals/https-package.test.ts
@@ -19,7 +19,10 @@ import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { NoopLogger } from '@opentelemetry/core';
 import { NodeTracerProvider } from '@opentelemetry/node';
 import { Http } from '@opentelemetry/plugin-http';
-import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/tracing';
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/tracing';
 import * as assert from 'assert';
 import axios, { AxiosResponse } from 'axios';
 import * as got from 'got';
@@ -47,8 +50,8 @@ describe('Packages', () => {
   });
 
   afterEach(() => {
-    context.disable()
-  })
+    context.disable();
+  });
   describe('get', () => {
     const logger = new NoopLogger();
 

--- a/packages/opentelemetry-plugin-https/test/functionals/https-package.test.ts
+++ b/packages/opentelemetry-plugin-https/test/functionals/https-package.test.ts
@@ -14,27 +14,25 @@
  * limitations under the License.
  */
 
+import { context, Span, SpanKind } from '@opentelemetry/api';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { NoopLogger } from '@opentelemetry/core';
-import { SpanKind, Span } from '@opentelemetry/api';
+import { NodeTracerProvider } from '@opentelemetry/node';
+import { Http } from '@opentelemetry/plugin-http';
+import { InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/tracing';
 import * as assert from 'assert';
-import * as https from 'https';
+import axios, { AxiosResponse } from 'axios';
+import * as got from 'got';
 import * as http from 'http';
+import * as https from 'https';
 import * as nock from 'nock';
+import * as path from 'path';
+import * as request from 'request-promise-native';
+import * as superagent from 'superagent';
+import * as url from 'url';
 import { plugin } from '../../src/https';
 import { assertSpan } from '../utils/assertSpan';
 import { DummyPropagation } from '../utils/DummyPropagation';
-import * as url from 'url';
-import axios, { AxiosResponse } from 'axios';
-import * as superagent from 'superagent';
-import * as got from 'got';
-import * as request from 'request-promise-native';
-import * as path from 'path';
-import {
-  InMemorySpanExporter,
-  SimpleSpanProcessor,
-} from '@opentelemetry/tracing';
-import { Http } from '@opentelemetry/plugin-http';
-import { NodeTracerProvider } from '@opentelemetry/node';
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -43,6 +41,14 @@ export const customAttributeFunction = (span: Span): void => {
 };
 
 describe('Packages', () => {
+  beforeEach(() => {
+    memoryExporter.reset();
+    context.setGlobalContextManager(new AsyncHooksContextManager().enable());
+  });
+
+  afterEach(() => {
+    context.disable()
+  })
   describe('get', () => {
     const logger = new NoopLogger();
 

--- a/packages/opentelemetry-plugin-https/test/integrations/https-enable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/integrations/https-enable.test.ts
@@ -20,7 +20,7 @@ import {
   Http,
   AttributeNames,
 } from '@opentelemetry/plugin-http';
-import { SpanKind, Span } from '@opentelemetry/api';
+import { SpanKind, Span, context } from '@opentelemetry/api';
 import * as assert from 'assert';
 import * as http from 'http';
 import * as https from 'https';
@@ -35,6 +35,7 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/tracing';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 
 const protocol = 'https';
 const serverPort = 42345;
@@ -46,6 +47,15 @@ export const customAttributeFunction = (span: Span): void => {
 };
 
 describe('HttpsPlugin Integration tests', () => {
+  beforeEach(() => {
+    memoryExporter.reset();
+    context.setGlobalContextManager(new AsyncHooksContextManager().enable());
+  });
+
+  afterEach(() => {
+    context.disable()
+  })
+
   describe('enable()', () => {
     before(function(done) {
       // mandatory

--- a/packages/opentelemetry-plugin-https/test/integrations/https-enable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/integrations/https-enable.test.ts
@@ -53,8 +53,8 @@ describe('HttpsPlugin Integration tests', () => {
   });
 
   afterEach(() => {
-    context.disable()
-  })
+    context.disable();
+  });
 
   describe('enable()', () => {
     before(function(done) {

--- a/packages/opentelemetry-plugin-xml-http-request/test/xhr.test.ts
+++ b/packages/opentelemetry-plugin-xml-http-request/test/xhr.test.ts
@@ -105,7 +105,7 @@ describe('xhr', () => {
   });
 
   afterEach(() => {
-    types.context.disable()
+    types.context.disable();
   });
 
   before(() => {

--- a/packages/opentelemetry-plugin-xml-http-request/test/xhr.test.ts
+++ b/packages/opentelemetry-plugin-xml-http-request/test/xhr.test.ts
@@ -105,7 +105,7 @@ describe('xhr', () => {
   });
 
   afterEach(() => {
-    contextManager.disable();
+    types.context.disable()
   });
 
   before(() => {

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -15,26 +15,15 @@
  */
 
 import { Context, context, SpanContext, TraceFlags } from '@opentelemetry/api';
-import {
-  ALWAYS_SAMPLER,
-  NEVER_SAMPLER,
-  NoopLogger,
-  NoRecordingSpan,
-  setActiveSpan,
-  setExtractedSpanContext,
-  TraceState,
-} from '@opentelemetry/core';
+import { ContextManager } from '@opentelemetry/context-base';
+import { ALWAYS_SAMPLER, NEVER_SAMPLER, NoopLogger, NoRecordingSpan, setActiveSpan, setExtractedSpanContext, TraceState } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
-import {
-  NoopContextManager,
-  ContextManager,
-} from '@opentelemetry/context-base';
 import * as assert from 'assert';
 import { BasicTracerProvider, Span } from '../src';
 
 describe('BasicTracerProvider', () => {
   beforeEach(() => {
-    context.setGlobalContextManager(new NoopContextManager());
+    context.disable()
   });
 
   describe('constructor', () => {
@@ -338,6 +327,7 @@ describe('BasicTracerProvider', () => {
       context.setGlobalContextManager({
         active: () =>
           setActiveSpan(Context.ROOT_CONTEXT, ('foo' as any) as Span),
+        disable: () => {},
       } as ContextManager);
 
       const tracer = new BasicTracerProvider().getTracer('default');

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -16,14 +16,22 @@
 
 import { Context, context, SpanContext, TraceFlags } from '@opentelemetry/api';
 import { ContextManager } from '@opentelemetry/context-base';
-import { ALWAYS_SAMPLER, NEVER_SAMPLER, NoopLogger, NoRecordingSpan, setActiveSpan, setExtractedSpanContext, TraceState } from '@opentelemetry/core';
+import {
+  ALWAYS_SAMPLER,
+  NEVER_SAMPLER,
+  NoopLogger,
+  NoRecordingSpan,
+  setActiveSpan,
+  setExtractedSpanContext,
+  TraceState,
+} from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import { BasicTracerProvider, Span } from '../src';
 
 describe('BasicTracerProvider', () => {
   beforeEach(() => {
-    context.disable()
+    context.disable();
   });
 
   describe('constructor', () => {

--- a/packages/opentelemetry-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-web/test/WebTracerProvider.test.ts
@@ -31,8 +31,8 @@ class DummyPlugin extends BasePlugin<unknown> {
   }
   moduleName = 'dummy';
 
-  patch() { }
-  unpatch() { }
+  patch() {}
+  unpatch() {}
 }
 
 describe('WebTracerProvider', () => {
@@ -48,7 +48,7 @@ describe('WebTracerProvider', () => {
 
     afterEach(() => {
       contextManager.disable();
-      context.disable()
+      context.disable();
     });
 
     it('should construct an instance with required only options', () => {
@@ -92,7 +92,7 @@ describe('WebTracerProvider', () => {
       assert.strictEqual(
         error,
         'contextManager should be defined in' +
-        ' register method not in constructor'
+          ' register method not in constructor'
       );
     });
 
@@ -108,7 +108,7 @@ describe('WebTracerProvider', () => {
       assert.strictEqual(
         error,
         'propagator should be defined in register' +
-        ' method not in constructor'
+          ' method not in constructor'
       );
     });
 

--- a/packages/opentelemetry-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-web/test/WebTracerProvider.test.ts
@@ -15,11 +15,11 @@
  */
 
 import { context } from '@opentelemetry/api';
-import { B3Propagator, BasePlugin, NoopLogger } from '@opentelemetry/core';
 import { ContextManager } from '@opentelemetry/context-base';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
-import { Tracer, Span } from '@opentelemetry/tracing';
+import { B3Propagator, BasePlugin, NoopLogger } from '@opentelemetry/core';
 import { Resource, TELEMETRY_SDK_RESOURCE } from '@opentelemetry/resources';
+import { Span, Tracer } from '@opentelemetry/tracing';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { WebTracerConfig } from '../src';
@@ -31,8 +31,8 @@ class DummyPlugin extends BasePlugin<unknown> {
   }
   moduleName = 'dummy';
 
-  patch() {}
-  unpatch() {}
+  patch() { }
+  unpatch() { }
 }
 
 describe('WebTracerProvider', () => {
@@ -48,6 +48,7 @@ describe('WebTracerProvider', () => {
 
     afterEach(() => {
       contextManager.disable();
+      context.disable()
     });
 
     it('should construct an instance with required only options', () => {
@@ -91,7 +92,7 @@ describe('WebTracerProvider', () => {
       assert.strictEqual(
         error,
         'contextManager should be defined in' +
-          ' register method not in constructor'
+        ' register method not in constructor'
       );
     });
 
@@ -107,7 +108,7 @@ describe('WebTracerProvider', () => {
       assert.strictEqual(
         error,
         'propagator should be defined in register' +
-          ' method not in constructor'
+        ' method not in constructor'
       );
     });
 

--- a/packages/opentelemetry-web/test/registration.test.ts
+++ b/packages/opentelemetry-web/test/registration.test.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { context, NoopHttpTextPropagator, propagation, trace } from '@opentelemetry/api';
+import {
+  context,
+  NoopHttpTextPropagator,
+  propagation,
+  trace,
+} from '@opentelemetry/api';
 import { NoopContextManager } from '@opentelemetry/context-base';
 import { HttpTraceContext } from '@opentelemetry/core';
 import * as assert from 'assert';
@@ -22,7 +27,7 @@ import { StackContextManager, WebTracerProvider } from '../src';
 
 describe('API registration', () => {
   beforeEach(() => {
-    context.disable()
+    context.disable();
     trace.disable();
     propagation.disable();
   });
@@ -31,9 +36,10 @@ describe('API registration', () => {
     const tracerProvider = new WebTracerProvider();
     tracerProvider.register();
 
-
     assert.ok(context['_getContextManager']() instanceof StackContextManager);
-    assert.ok(propagation['_getGlobalPropagator']() instanceof HttpTraceContext);
+    assert.ok(
+      propagation['_getGlobalPropagator']() instanceof HttpTraceContext
+    );
     assert.ok(trace.getTracerProvider() === tracerProvider);
   });
 
@@ -62,7 +68,9 @@ describe('API registration', () => {
 
     assert.ok(context['_getContextManager']() instanceof NoopContextManager);
 
-    assert.ok(propagation['_getGlobalPropagator']() instanceof HttpTraceContext);
+    assert.ok(
+      propagation['_getGlobalPropagator']() instanceof HttpTraceContext
+    );
     assert.ok(trace.getTracerProvider() === tracerProvider);
   });
 
@@ -72,7 +80,9 @@ describe('API registration', () => {
       propagator: null,
     });
 
-    assert.ok(propagation['_getGlobalPropagator']() instanceof NoopHttpTextPropagator);
+    assert.ok(
+      propagation['_getGlobalPropagator']() instanceof NoopHttpTextPropagator
+    );
 
     assert.ok(context['_getContextManager']() instanceof StackContextManager);
     assert.ok(trace.getTracerProvider() === tracerProvider);

--- a/packages/opentelemetry-web/test/registration.test.ts
+++ b/packages/opentelemetry-web/test/registration.test.ts
@@ -14,32 +14,27 @@
  * limitations under the License.
  */
 
-import {
-  context,
-  NoopHttpTextPropagator,
-  NoopTracerProvider,
-  propagation,
-  trace,
-} from '@opentelemetry/api';
-import { HttpTraceContext } from '@opentelemetry/core';
+import { context, NoopHttpTextPropagator, propagation, trace } from '@opentelemetry/api';
 import { NoopContextManager } from '@opentelemetry/context-base';
+import { HttpTraceContext } from '@opentelemetry/core';
 import * as assert from 'assert';
-import { WebTracerProvider, StackContextManager } from '../src';
+import { StackContextManager, WebTracerProvider } from '../src';
 
 describe('API registration', () => {
   beforeEach(() => {
-    context.setGlobalContextManager(new NoopContextManager());
-    propagation.setGlobalPropagator(new NoopHttpTextPropagator());
-    trace.setGlobalTracerProvider(new NoopTracerProvider());
+    context.disable()
+    trace.disable();
+    propagation.disable();
   });
 
   it('should register default implementations', () => {
     const tracerProvider = new WebTracerProvider();
     tracerProvider.register();
 
-    assert.ok(context['_contextManager'] instanceof StackContextManager);
-    assert.ok(propagation['_propagator'] instanceof HttpTraceContext);
-    assert.ok(trace['_tracerProvider'] === tracerProvider);
+
+    assert.ok(context['_getContextManager']() instanceof StackContextManager);
+    assert.ok(propagation['_getGlobalPropagator']() instanceof HttpTraceContext);
+    assert.ok(trace.getTracerProvider() === tracerProvider);
   });
 
   it('should register configured implementations', () => {
@@ -53,10 +48,10 @@ describe('API registration', () => {
       propagator,
     });
 
-    assert.ok(context['_contextManager'] === contextManager);
-    assert.ok(propagation['_propagator'] === propagator);
+    assert.ok(context['_getContextManager']() === contextManager);
+    assert.ok(propagation['_getGlobalPropagator']() === propagator);
 
-    assert.ok(trace['_tracerProvider'] === tracerProvider);
+    assert.ok(trace.getTracerProvider() === tracerProvider);
   });
 
   it('should skip null context manager', () => {
@@ -65,10 +60,10 @@ describe('API registration', () => {
       contextManager: null,
     });
 
-    assert.ok(context['_contextManager'] instanceof NoopContextManager);
+    assert.ok(context['_getContextManager']() instanceof NoopContextManager);
 
-    assert.ok(propagation['_propagator'] instanceof HttpTraceContext);
-    assert.ok(trace['_tracerProvider'] === tracerProvider);
+    assert.ok(propagation['_getGlobalPropagator']() instanceof HttpTraceContext);
+    assert.ok(trace.getTracerProvider() === tracerProvider);
   });
 
   it('should skip null propagator', () => {
@@ -77,9 +72,9 @@ describe('API registration', () => {
       propagator: null,
     });
 
-    assert.ok(propagation['_propagator'] instanceof NoopHttpTextPropagator);
+    assert.ok(propagation['_getGlobalPropagator']() instanceof NoopHttpTextPropagator);
 
-    assert.ok(context['_contextManager'] instanceof StackContextManager);
-    assert.ok(trace['_tracerProvider'] === tracerProvider);
+    assert.ok(context['_getContextManager']() instanceof StackContextManager);
+    assert.ok(trace.getTracerProvider() === tracerProvider);
   });
 });


### PR DESCRIPTION
As discussed in the SIG and on issue #885, this uses the `global` object to store references to the global APIs. When an API method is called, it tries to get the global API instance by calling a method with its API version. If the version matches, the call is properly proxied through to the API, else it calls a no-op version.