### PR TITLE
chore: fixing wrong return type for metric observer callback

### DIFF
--- a/packages/opentelemetry-api/src/metrics/BoundInstrument.ts
+++ b/packages/opentelemetry-api/src/metrics/BoundInstrument.ts
@@ -54,5 +54,5 @@ export interface BoundObserver {
    * retrieve the value.
    * @param callback
    */
-  setCallback(callback: (observerResult: ObserverResult) => {}): void;
+  setCallback(callback: (observerResult: ObserverResult) => void): void;
 }

--- a/packages/opentelemetry-api/src/metrics/NoopMeter.ts
+++ b/packages/opentelemetry-api/src/metrics/NoopMeter.ts
@@ -136,7 +136,7 @@ export class NoopBoundMeasure implements BoundMeasure {
 }
 
 export class NoopBoundObserver implements BoundObserver {
-  setCallback(callback: (observerResult: ObserverResult) => {}): void {}
+  setCallback(callback: (observerResult: ObserverResult) => void): void {}
 }
 
 export const NOOP_METER = new NoopMeter();

--- a/packages/opentelemetry-metrics/src/BoundInstrument.ts
+++ b/packages/opentelemetry-metrics/src/BoundInstrument.ts
@@ -147,7 +147,7 @@ export class BoundObserver extends BaseBoundInstrument
     super(labels, logger, monotonic, disabled, valueType, aggregator);
   }
 
-  setCallback(callback: (observerResult: types.ObserverResult) => {}): void {
+  setCallback(callback: (observerResult: types.ObserverResult) => void): void {
     const observerResult = new ObserverResult();
     callback(observerResult);
   }


### PR DESCRIPTION
The callback return type should be `void` not `{}`
