### PR TITLE
fix(mongodb): avoid double patching when enable is called twice #956

### DIFF
--- a/packages/opentelemetry-plugin-mongodb/package.json
+++ b/packages/opentelemetry-plugin-mongodb/package.json
@@ -42,7 +42,6 @@
   },
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^0.6.1",
-    "@opentelemetry/node": "^0.6.1",
     "@opentelemetry/tracing": "^0.6.1",
     "@types/mocha": "^7.0.0",
     "@types/mongodb": "^3.2.3",

--- a/packages/opentelemetry-plugin-mongodb/src/mongodb.ts
+++ b/packages/opentelemetry-plugin-mongodb/src/mongodb.ts
@@ -34,6 +34,7 @@ import { VERSION } from './version';
 export class MongoDBPlugin extends BasePlugin<typeof mongodb> {
   private readonly _SERVER_METHODS = ['insert', 'update', 'remove', 'command'];
   private readonly _CURSOR_METHODS = ['_next', 'next'];
+  private _hasPatched: boolean = false;
 
   private readonly _COMPONENT = 'mongodb';
   private readonly _DB_TYPE = 'mongodb';
@@ -48,7 +49,11 @@ export class MongoDBPlugin extends BasePlugin<typeof mongodb> {
    * Patches MongoDB operations.
    */
   protected patch() {
-    this._logger.debug('Patched MongoDB');
+    this._logger.debug('Patching MongoDB');
+    if (this._hasPatched === true) {
+      this._logger.debug(`Patch is already applied, ignoring.`);
+      return this._moduleExports;
+    }
 
     if (this._moduleExports.Server) {
       for (const fn of this._SERVER_METHODS) {
@@ -77,6 +82,7 @@ export class MongoDBPlugin extends BasePlugin<typeof mongodb> {
       );
     }
 
+    this._hasPatched = true;
     return this._moduleExports;
   }
 

--- a/packages/opentelemetry-plugin-mongodb/test/mongodb.test.ts
+++ b/packages/opentelemetry-plugin-mongodb/test/mongodb.test.ts
@@ -14,79 +14,18 @@
  * limitations under the License.
  */
 
-import { CanonicalCode, context, SpanKind } from '@opentelemetry/api';
+import { context, SpanKind } from '@opentelemetry/api';
 import { NoopLogger } from '@opentelemetry/core';
-import { NodeTracerProvider } from '@opentelemetry/node';
+import { BasicTracerProvider } from '@opentelemetry/tracing';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
-  ReadableSpan,
   SimpleSpanProcessor,
 } from '@opentelemetry/tracing';
 import * as assert from 'assert';
 import * as mongodb from 'mongodb';
 import { plugin } from '../src';
-import { AttributeNames } from '../src/types';
-
-interface MongoDBAccess {
-  client: mongodb.MongoClient;
-  collection: mongodb.Collection;
-}
-
-/**
- * Access the mongodb collection.
- * @param url The mongodb URL to access.
- * @param dbName The mongodb database name.
- * @param collectionName The mongodb collection name.
- */
-function accessCollection(
-  url: string,
-  dbName: string,
-  collectionName: string
-): Promise<MongoDBAccess> {
-  return new Promise((resolve, reject) => {
-    mongodb.MongoClient.connect(url, function connectedClient(err, client) {
-      if (err) {
-        reject(err);
-        return;
-      }
-      const db = client.db(dbName);
-      const collection = db.collection(collectionName);
-      resolve({ client, collection });
-    });
-  });
-}
-
-/**
- * Asserts root spans attributes.
- * @param spans Readable spans that we need to assert.
- * @param expectedName The expected name of the first root span.
- * @param expectedKind The expected kind of the first root span.
- */
-function assertSpans(
-  spans: ReadableSpan[],
-  expectedName: string,
-  expectedKind: SpanKind,
-  log = false
-) {
-  if (log) {
-    console.log(spans);
-  }
-  assert.strictEqual(spans.length, 2);
-  spans.forEach(span => {
-    assert(span.endTime instanceof Array);
-    assert(span.endTime.length === 2);
-  });
-  const [mongoSpan] = spans;
-  assert.strictEqual(mongoSpan.name, expectedName);
-  assert.strictEqual(mongoSpan.kind, expectedKind);
-  assert.strictEqual(mongoSpan.attributes[AttributeNames.COMPONENT], 'mongodb');
-  assert.strictEqual(
-    mongoSpan.attributes[AttributeNames.PEER_HOSTNAME],
-    process.env.MONGODB_HOST || 'localhost'
-  );
-  assert.strictEqual(mongoSpan.status.code, CanonicalCode.OK);
-}
+import { assertSpans, accessCollection } from './utils';
 
 describe('MongoDBPlugin', () => {
   // For these tests, mongo must be running. Add RUN_MONGODB_TESTS to run
@@ -107,7 +46,7 @@ describe('MongoDBPlugin', () => {
   let client: mongodb.MongoClient;
   let collection: mongodb.Collection;
   const logger = new NoopLogger();
-  const provider = new NodeTracerProvider();
+  const provider = new BasicTracerProvider();
   const memoryExporter = new InMemorySpanExporter();
   const spanProcessor = new SimpleSpanProcessor(memoryExporter);
   provider.addSpanProcessor(spanProcessor);

--- a/packages/opentelemetry-plugin-mongodb/test/multiple_versions.test.ts
+++ b/packages/opentelemetry-plugin-mongodb/test/multiple_versions.test.ts
@@ -1,0 +1,114 @@
+/*!
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { context, SpanKind } from '@opentelemetry/api';
+import { NoopLogger } from '@opentelemetry/core';
+import { BasicTracerProvider } from '@opentelemetry/tracing';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/tracing';
+import * as assert from 'assert';
+import * as mongodb from 'mongodb';
+import { MongoDBPlugin } from '../src/mongodb';
+import { assertSpans, accessCollection } from './utils';
+
+describe('Multiple enable on the plugin', () => {
+  // For these tests, mongo must be running. Add RUN_MONGODB_TESTS to run
+  // these tests.
+  const RUN_MONGODB_TESTS = process.env.RUN_MONGODB_TESTS as string;
+  let shouldTest = true;
+  if (!RUN_MONGODB_TESTS) {
+    console.log('Skipping test-mongodb. Run MongoDB to test');
+    shouldTest = false;
+  }
+
+  const URL = `mongodb://${process.env.MONGODB_HOST || 'localhost'}:${process
+    .env.MONGODB_PORT || '27017'}`;
+  const DB_NAME = process.env.MONGODB_DB || 'opentelemetry-tests';
+  const COLLECTION_NAME = 'test';
+
+  let contextManager: AsyncHooksContextManager;
+  let client: mongodb.MongoClient;
+  let collection: mongodb.Collection;
+  const logger = new NoopLogger();
+  const provider = new BasicTracerProvider();
+  const memoryExporter = new InMemorySpanExporter();
+  const spanProcessor = new SimpleSpanProcessor(memoryExporter);
+  const plugin = new MongoDBPlugin('mongodb');
+  provider.addSpanProcessor(spanProcessor);
+
+  before(done => {
+    // enable twice to simulate loading to different versions
+    plugin.enable(mongodb, provider, logger);
+    plugin.enable(mongodb, provider, logger);
+    accessCollection(URL, DB_NAME, COLLECTION_NAME)
+      .then(result => {
+        client = result.client;
+        collection = result.collection;
+        done();
+      })
+      .catch((err: Error) => {
+        console.log(
+          'Skipping test-mongodb. Could not connect. Run MongoDB to test'
+        );
+        shouldTest = false;
+        done();
+      });
+  });
+
+  beforeEach(function mongoBeforeEach() {
+    // Skipping all tests in beforeEach() is a workaround. Mocha does not work
+    // properly when skipping tests in before() on nested describe() calls.
+    // https://github.com/mochajs/mocha/issues/2819
+    if (!shouldTest) {
+      this.skip();
+    }
+    memoryExporter.reset();
+    contextManager = new AsyncHooksContextManager().enable();
+    context.setGlobalContextManager(contextManager);
+  });
+
+  afterEach(done => {
+    collection.deleteOne({}, done);
+    contextManager.disable();
+  });
+
+  after(() => {
+    if (client) {
+      client.close();
+    }
+  });
+
+  it('should create a child span for insert', done => {
+    const insertData = [{ a: 1 }, { a: 2 }, { a: 3 }];
+
+    const span = provider.getTracer('default').startSpan(`insertRootSpan`);
+    provider.getTracer('default').withSpan(span, () => {
+      collection.insertMany(insertData, (err, result) => {
+        span.end();
+        assert.ifError(err);
+        assertSpans(
+          memoryExporter.getFinishedSpans(),
+          `mongodb.insert`,
+          SpanKind.CLIENT
+        );
+        done();
+      });
+    });
+  });
+});

--- a/packages/opentelemetry-plugin-mongodb/test/utils.ts
+++ b/packages/opentelemetry-plugin-mongodb/test/utils.ts
@@ -1,0 +1,81 @@
+/*!
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CanonicalCode, SpanKind } from '@opentelemetry/api';
+import { ReadableSpan } from '@opentelemetry/tracing';
+import * as assert from 'assert';
+import * as mongodb from 'mongodb';
+import { AttributeNames } from '../src/types';
+
+export interface MongoDBAccess {
+  client: mongodb.MongoClient;
+  collection: mongodb.Collection;
+}
+
+/**
+ * Access the mongodb collection.
+ * @param url The mongodb URL to access.
+ * @param dbName The mongodb database name.
+ * @param collectionName The mongodb collection name.
+ */
+export function accessCollection(
+  url: string,
+  dbName: string,
+  collectionName: string
+): Promise<MongoDBAccess> {
+  return new Promise((resolve, reject) => {
+    mongodb.MongoClient.connect(url, function connectedClient(err, client) {
+      if (err) {
+        reject(err);
+        return;
+      }
+      const db = client.db(dbName);
+      const collection = db.collection(collectionName);
+      resolve({ client, collection });
+    });
+  });
+}
+
+/**
+ * Asserts root spans attributes.
+ * @param spans Readable spans that we need to assert.
+ * @param expectedName The expected name of the first root span.
+ * @param expectedKind The expected kind of the first root span.
+ */
+export function assertSpans(
+  spans: ReadableSpan[],
+  expectedName: string,
+  expectedKind: SpanKind,
+  log = false
+) {
+  if (log) {
+    console.log(spans);
+  }
+  assert.strictEqual(spans.length, 2);
+  spans.forEach(span => {
+    assert(span.endTime instanceof Array);
+    assert(span.endTime.length === 2);
+  });
+  const [mongoSpan] = spans;
+  assert.strictEqual(mongoSpan.name, expectedName);
+  assert.strictEqual(mongoSpan.kind, expectedKind);
+  assert.strictEqual(mongoSpan.attributes[AttributeNames.COMPONENT], 'mongodb');
+  assert.strictEqual(
+    mongoSpan.attributes[AttributeNames.PEER_HOSTNAME],
+    process.env.MONGODB_HOST || 'localhost'
+  );
+  assert.strictEqual(mongoSpan.status.code, CanonicalCode.OK);
+}


### PR DESCRIPTION
I could have gone with `isWrapped` from core but the plugin wrap quite a lot of functions, i would have needed to check them one per one. For simplicity sake i believe it's easier to just use a specific property.

A generic solution for all plugins would be welcome, although i don't think that would be possible on the PluginLoader.