### PR TITLE
feat(plugin-http): add plugin hooks before processing request and res…

### DIFF
--- a/packages/opentelemetry-plugin-http/README.md
+++ b/packages/opentelemetry-plugin-http/README.md
@@ -52,6 +52,8 @@ Http plugin has few options available to choose from. You can set the following:
 | Options | Type | Description |
 | ------- | ---- | ----------- |
 | [`applyCustomAttributesOnSpan`](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-plugin-http/src/types.ts#L52) | `HttpCustomAttributeFunction` | Function for adding custom attributes |
+| [`requestHook`](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-plugin-http/src/types.ts#L60) | `HttpRequestCustomAttributeFunction` | Function for adding custom attributes before request is handled |
+| [`responseHook`](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-plugin-http/src/types.ts#L67) | `HttpResponseCustomAttributeFunction` | Function for adding custom attributes before response is handled |
 | [`ignoreIncomingPaths`](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-plugin-http/src/types.ts#L28) | `IgnoreMatcher[]` | Http plugin will not trace all incoming requests that match paths |
 | [`ignoreOutgoingUrls`](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-plugin-http/src/types.ts#L28) | `IgnoreMatcher[]` | Http plugin will not trace all outgoing requests that match urls |
 | [`serverName`](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-plugin-http/src/types.ts#L28) | `string` | The primary server name of the matched virtual host. |

--- a/packages/opentelemetry-plugin-http/src/types.ts
+++ b/packages/opentelemetry-plugin-http/src/types.ts
@@ -57,6 +57,14 @@ export interface HttpCustomAttributeFunction {
   ): void;
 }
 
+export interface HttpRequestCustomAttributeFunction {
+  (span: Span, request: ClientRequest | IncomingMessage): void;
+}
+
+export interface HttpResponseCustomAttributeFunction {
+  (span: Span, response: IncomingMessage | ServerResponse): void;
+}
+
 /**
  * Options available for the HTTP Plugin (see [documentation](https://github.com/open-telemetry/opentelemetry-js/tree/master/packages/opentelemetry-plugin-http#http-plugin-options))
  */
@@ -65,8 +73,12 @@ export interface HttpPluginConfig extends PluginConfig {
   ignoreIncomingPaths?: IgnoreMatcher[];
   /** Not trace all outgoing requests that match urls */
   ignoreOutgoingUrls?: IgnoreMatcher[];
-  /** Function for adding custom attributes */
+  /** Function for adding custom attributes after response is handled */
   applyCustomAttributesOnSpan?: HttpCustomAttributeFunction;
+  /** Function for adding custom attributes before request is handled */
+  requestHook?: HttpRequestCustomAttributeFunction;
+  /** Function for adding custom attributes before response is handled */
+  responseHook?: HttpResponseCustomAttributeFunction;
   /** The primary server name of the matched virtual host. */
   serverName?: string;
 }

--- a/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
@@ -40,6 +40,7 @@ import { DummyPropagation } from '../utils/DummyPropagation';
 import { httpRequest } from '../utils/httpRequest';
 import { ContextManager } from '@opentelemetry/context-base';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { ClientRequest, IncomingMessage, ServerResponse } from 'http';
 
 const applyCustomAttributesOnSpanErrorMessage =
   'bad applyCustomAttributesOnSpan function';
@@ -74,6 +75,20 @@ function doNock(
 
 export const customAttributeFunction = (span: ISpan): void => {
   span.setAttribute('span kind', SpanKind.CLIENT);
+};
+
+export const requestHookFunction = (
+  span: ISpan,
+  request: ClientRequest | IncomingMessage
+): void => {
+  span.setAttribute('custom request hook attribute', 'request');
+};
+
+export const responseHookFunction = (
+  span: ISpan,
+  response: IncomingMessage | ServerResponse
+): void => {
+  span.setAttribute('custom response hook attribute', 'response');
 };
 
 describe('HttpPlugin', () => {
@@ -203,6 +218,8 @@ describe('HttpPlugin', () => {
             (url: string) => url.endsWith(`/ignored/function`),
           ],
           applyCustomAttributesOnSpan: customAttributeFunction,
+          requestHook: requestHookFunction,
+          responseHook: responseHookFunction,
           serverName,
         };
         plugin.enable(http, provider, provider.logger, config);
@@ -694,6 +711,40 @@ describe('HttpPlugin', () => {
           });
         });
         req.end();
+      });
+
+      it('custom attributes should show up on client and server spans', async () => {
+        await httpRequest.get(
+          `${protocol}://${hostname}:${serverPort}${pathname}`
+        );
+        const spans = memoryExporter.getFinishedSpans();
+        const [incomingSpan, outgoingSpan] = spans;
+
+        assert.strictEqual(
+          incomingSpan.attributes['custom request hook attribute'],
+          'request'
+        );
+        assert.strictEqual(
+          incomingSpan.attributes['custom response hook attribute'],
+          'response'
+        );
+        assert.strictEqual(
+          incomingSpan.attributes['span kind'],
+          SpanKind.CLIENT
+        );
+
+        assert.strictEqual(
+          outgoingSpan.attributes['custom request hook attribute'],
+          'request'
+        );
+        assert.strictEqual(
+          outgoingSpan.attributes['custom response hook attribute'],
+          'response'
+        );
+        assert.strictEqual(
+          outgoingSpan.attributes['span kind'],
+          SpanKind.CLIENT
+        );
       });
     });
   });


### PR DESCRIPTION
Enable users of the http plugin to register hooks on http request and response. The hooks are called before the stream begins to handle data, allowing the plugin user to register to events.

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Access to the request and response stream, which enable to capture the http body in the plugin.
- Add custom span attributes to the span ASAP. In case of error or exception in the request handling, the existing `applyCustomAttributesOnSpan` function is never called, and it is impossible to add custom attributes to span.

## Short description of the changes

- Add two new options to the `HttpPluginConfig`: `requestHook`, `responseHook`, similar to the existing `applyCustomAttributesOnSpan` option. If set, these callbacks are called by the http plugin, allowing the plugin user to add custom span attributes and execute logic right after the stream creation and before data is sent on it.



