### PR TITLE
feat(opentelemetry-exporter-jaeger): http sender

### DIFF
--- a/packages/opentelemetry-exporter-jaeger/src/jaeger.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/jaeger.ts
@@ -38,7 +38,17 @@ export class JaegerExporter implements SpanExporter {
       typeof config.flushTimeout === 'number' ? config.flushTimeout : 2000;
 
     config.host = config.host || process.env.JAEGER_AGENT_HOST;
-
+    config.endpoint = config.endpoint || process.env.JAEGER_ENDPOINT;
+    config.username = config.username || process.env.JAEGER_USER;
+    config.password = config.password || process.env.JAEGER_PASSWORD;
+    // https://github.com/jaegertracing/jaeger-client-node#environment-variables
+    // By default, the client sends traces via UDP to the agent at localhost:6832. Use JAEGER_AGENT_HOST and
+    // JAEGER_AGENT_PORT to send UDP traces to a different host:port. If JAEGER_ENDPOINT is set, the client sends traces
+    // to the endpoint via HTTP, making the JAEGER_AGENT_HOST and JAEGER_AGENT_PORT unused. If JAEGER_ENDPOINT is secured,
+    // HTTP basic authentication can be performed by setting the JAEGER_USER and JAEGER_PASSWORD environment variables.
+    this._sender = config.endpoint
+      ? new jaegerTypes.HTTPSender(config)
+      : new jaegerTypes.UDPSender(config);
     this._sender = new jaegerTypes.UDPSender(config);
     if (this._sender._client instanceof Socket) {
       // unref socket to prevent it from keeping the process running

--- a/packages/opentelemetry-exporter-jaeger/src/types.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/types.ts
@@ -28,6 +28,13 @@ export interface ExporterConfig {
   maxPacketSize?: number; // default: 65000
   /** Time to wait for an onShutdown flush to finish before closing the sender */
   flushTimeout?: number; // default: 2000
+  //The HTTP endpoint for sending spans directly to a collector, i.e. http://jaeger-collector:14268/api/traces
+  //If setten will override host and port
+  endpoint?: string;
+  //Username to send as part of "Basic" authentication to the collector endpoint
+  username?: string;
+  //Password to send as part of "Basic" authentication to the collector endpoint
+  password?: string;
 }
 
 // Below require is needed as jaeger-client types does not expose the thrift,
@@ -40,6 +47,8 @@ export const UDPSender = require('jaeger-client/dist/src/reporters/udp_sender')
 export const Utils = require('jaeger-client/dist/src/util').default;
 // tslint:disable-next-line:variable-name
 export const ThriftUtils = require('jaeger-client/dist/src/thrift').default;
+
+export const HTTPSender = require('jaeger-client/dist/src/reporters/http_sender').default;
 
 export type TagValue = string | number | boolean;
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
Enables the usage of [jaeger-client-node](https://github.com/jaegertracing/jaeger-client-node) [HTTPSender](https://github.com/jaegertracing/jaeger-client-node/blob/master/src/reporters/http_sender.js) in order to send spans over `http`.

The behavior implemented complies with the following  [jaeger-client-node](https://github.com/jaegertracing/jaeger-client-node) documentation statement:
```
By default, the client sends traces via UDP to the agent at localhost:6832. 
Use JAEGER_AGENT_HOST and JAEGER_AGENT_PORT to send UDP traces to a different host:port. 
If JAEGER_ENDPOINT is set, the client sends traces to the endpoint via HTTP, making the JAEGER_AGENT_HOST and JAEGER_AGENT_PORT unused. 
If JAEGER_ENDPOINT is secured, HTTP basic authentication can be performed by setting the JAEGER_USER and JAEGER_PASSWORD environment variables.
```
Extracted from: https://github.com/jaegertracing/jaeger-client-node#environment-variables
-

## Short description of the changes
**1. packages/opentelemetry-exporter-jaeger/src/jaeger.ts:**
  - Populates the config fields `endpoint`, `username` and `password` at `JaegerExporter` contruction . [code](https://github.com/open-telemetry/opentelemetry-js/compare/master...leonardodalcin:http-sender?expand=1#diff-23c9170dddb3bd510e697c6720d72ea0R41-R43)
 - Checks if `config.endpoint` is setten and instanciates `this._sender` as  a [HTTPSender](https://github.com/jaegertracing/jaeger-client-node/blob/master/src/reporters/http_sender.js) and reffers original documentation in commentaries. [code](https://github.com/open-telemetry/opentelemetry-js/compare/master...leonardodalcin:http-sender?expand=1#diff-23c9170dddb3bd510e697c6720d72ea0R41-R43)

**2. packages/opentelemetry-exporter-jaeger/src/types.ts:**
  - Adds the properties `endpoint`, `username` and `password` to `ExporterConfig` interface . [code](https://github.com/open-telemetry/opentelemetry-js/compare/master...leonardodalcin:http-sender?expand=1#diff-6148ff549d7763fc13cd83623019d358R31-R37)
 - Declares `HTTPSender` as a jaeger type. [code](https://github.com/open-telemetry/opentelemetry-js/compare/master...leonardodalcin:http-sender?expand=1#diff-6148ff549d7763fc13cd83623019d358R51-R52)


