### PR TITLE
feat: add OTEL_SAMPLING_PROBABILITY env var

### DIFF
--- a/packages/opentelemetry-plugin-http/src/http.ts
+++ b/packages/opentelemetry-plugin-http/src/http.ts
@@ -406,6 +406,8 @@ export class HttpPlugin extends BasePlugin<Http> {
       );
 
       if (utils.isOpenTelemetryRequest(optionsParsed)) {
+        // clone the headers so delete will not modify the user's object
+        optionsParsed.headers = Object.assign({}, optionsParsed.headers);
         delete optionsParsed.headers[utils.OT_REQUEST_HEADER];
         return original.apply(this, [optionsParsed, ...args]);
       }

--- a/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
@@ -202,6 +202,7 @@ describe('HttpPlugin', () => {
         const spans = memoryExporter.getFinishedSpans();
         assert.strictEqual(result.data, 'Ok');
         assert.strictEqual(spans.length, 0);
+        assert.strictEqual(options.headers[OT_REQUEST_HEADER], 1);
       });
     });
     describe('with good plugin options', () => {

--- a/packages/opentelemetry-tracing/src/Tracer.ts
+++ b/packages/opentelemetry-tracing/src/Tracer.ts
@@ -24,6 +24,7 @@ import {
   randomSpanId,
   randomTraceId,
   setActiveSpan,
+  ProbabilitySampler,
 } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
 import { BasicTracerProvider } from './BasicTracerProvider';
@@ -50,7 +51,11 @@ export class Tracer implements api.Tracer {
   ) {
     const localConfig = mergeConfig(config);
     this._defaultAttributes = localConfig.defaultAttributes;
-    this._sampler = localConfig.sampler;
+    this._sampler =
+      config.sampler ||
+      new ProbabilitySampler(
+        Number(process.env.OTEL_SAMPLING_PROBABILITY || 1)
+      );
     this._traceParams = localConfig.traceParams;
     this.resource = _tracerProvider.resource;
     this.logger = config.logger || new ConsoleLogger(config.logLevel);

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -358,7 +358,7 @@ describe('BasicTracerProvider', () => {
       context.setGlobalContextManager({
         active: () =>
           setActiveSpan(Context.ROOT_CONTEXT, ('foo' as any) as Span),
-        disable: () => { },
+        disable: () => {},
       } as ContextManager);
 
       const tracer = new BasicTracerProvider().getTracer('default');

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -358,7 +358,7 @@ describe('BasicTracerProvider', () => {
       context.setGlobalContextManager({
         active: () =>
           setActiveSpan(Context.ROOT_CONTEXT, ('foo' as any) as Span),
-        disable: () => {},
+        disable: () => { },
       } as ContextManager);
 
       const tracer = new BasicTracerProvider().getTracer('default');

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -307,6 +307,18 @@ describe('BasicTracerProvider', () => {
       span.end();
     });
 
+    it('should not sample a trace when OTEL_SAMPLING_PROBABILITY is 0', () => {
+      process.env.OTEL_SAMPLING_PROBABILITY = '0';
+      const tracer = new BasicTracerProvider({
+        logger: new NoopLogger(),
+      }).getTracer('default');
+      const span = tracer.startSpan('my-span');
+      const context = span.context();
+      assert.strictEqual(context.traceFlags, TraceFlags.NONE);
+      span.end();
+      delete process.env.OTEL_SAMPLING_PROBABILITY;
+    });
+
     it('should create real span when sampled', () => {
       const tracer = new BasicTracerProvider({
         sampler: ALWAYS_SAMPLER,

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -34,6 +34,10 @@ describe('BasicTracerProvider', () => {
     context.disable();
   });
 
+  afterEach(() => {
+    delete process.env.OTEL_SAMPLING_PROBABILITY;
+  });
+
   describe('constructor', () => {
     it('should construct an instance without any options', () => {
       const provider = new BasicTracerProvider();
@@ -316,7 +320,6 @@ describe('BasicTracerProvider', () => {
       const context = span.context();
       assert.strictEqual(context.traceFlags, TraceFlags.NONE);
       span.end();
-      delete process.env.OTEL_SAMPLING_PROBABILITY;
     });
 
     it('should create real span when sampled', () => {
@@ -355,7 +358,7 @@ describe('BasicTracerProvider', () => {
       context.setGlobalContextManager({
         active: () =>
           setActiveSpan(Context.ROOT_CONTEXT, ('foo' as any) as Span),
-        disable: () => {},
+        disable: () => { },
       } as ContextManager);
 
       const tracer = new BasicTracerProvider().getTracer('default');


### PR DESCRIPTION
User can now control the trace sampling rate by means of env var.

JS implementation of https://github.com/open-telemetry/opentelemetry-specification/issues/567
