### PR TITLE
fix(http-plugin): strip otel custom http header #983

### DIFF
--- a/packages/opentelemetry-plugin-http/src/http.ts
+++ b/packages/opentelemetry-plugin-http/src/http.ts
@@ -392,8 +392,12 @@ export class HttpPlugin extends BasePlugin<Http> {
         extraOptions
       );
 
+      if (utils.isOpenTelemetryRequest(optionsParsed)) {
+        delete optionsParsed.headers[utils.OT_REQUEST_HEADER];
+        return original.apply(this, [optionsParsed, ...args]);
+      }
+
       if (
-        utils.isOpenTelemetryRequest(optionsParsed) ||
         utils.isIgnored(
           origin + pathname,
           plugin._config.ignoreOutgoingUrls,

--- a/packages/opentelemetry-plugin-http/src/utils.ts
+++ b/packages/opentelemetry-plugin-http/src/utils.ts
@@ -33,6 +33,10 @@ import { AttributeNames } from './enums/AttributeNames';
 import * as url from 'url';
 import { Socket } from 'net';
 
+/**
+ * Specific header used by exporters to "mark" outgoing request to avoid creating
+ * spans for request that export them which would create a infinite loop.
+ */
 export const OT_REQUEST_HEADER = 'x-opentelemetry-outgoing-request';
 
 export const HTTP_STATUS_SPECIAL_CASES: SpecialHttpStatusCodeMapping = {
@@ -298,9 +302,16 @@ export const isValidOptionsType = (options: unknown): boolean => {
  * Use case: Typically, exporter `SpanExporter` can use http module to send spans.
  * This will also generate spans (from the http-plugin) that will be sended through the exporter
  * and here we have loop.
+ *
+ * TODO: Refactor this logic when a solution is found in
+ * https://github.com/open-telemetry/opentelemetry-specification/issues/530
+ *
+ *
  * @param {RequestOptions} options
  */
-export const isOpenTelemetryRequest = (options: RequestOptions) => {
+export const isOpenTelemetryRequest = (
+  options: RequestOptions
+): options is { headers: {} } & RequestOptions => {
   return !!(options && options.headers && options.headers[OT_REQUEST_HEADER]);
 };
 

--- a/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
@@ -180,6 +180,10 @@ describe('HttpPlugin', () => {
         };
 
         const result = await httpRequest.get(options);
+        assert(
+          result.reqHeaders[OT_REQUEST_HEADER] === undefined,
+          'custom header should be stripped'
+        );
         const spans = memoryExporter.getFinishedSpans();
         assert.strictEqual(result.data, 'Ok');
         assert.strictEqual(spans.length, 0);
@@ -293,6 +297,10 @@ describe('HttpPlugin', () => {
         };
 
         const result = await httpRequest.get(options);
+        assert(
+          result.reqHeaders[OT_REQUEST_HEADER] === undefined,
+          'custom header should be stripped'
+        );
         const spans = memoryExporter.getFinishedSpans();
         assert.strictEqual(result.data, 'Ok');
         assert.strictEqual(spans.length, 0);


### PR DESCRIPTION
see https://github.com/open-telemetry/opentelemetry-js/issues/983 and https://github.com/open-telemetry/opentelemetry-js/pull/965#discussion_r415143475 for context