### PR TITLE
chore: enable declaration map to allow jumping through packages

### DIFF
--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -3,6 +3,7 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "declaration": true,
+    "declarationMap": true,
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "noEmitOnError": true,


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Without a declaration map, jumping through packages in the repo by definition will target generated .d.ts files.

Like in `opentelemetry-exporter-prometheus`, `MetricExporter` is imported from `@opentelemetry/metrics`. If there is no declaration map, in vscode 'Go to definition' on `MetricExporter` will navigate to file `packages/opentelemetry-exporter-prometheus/node_modules/@opentelemetry/metrics/build/src/export/types.d.ts`.

## Short description of the changes

With this patch, we can jump by definition across packages boundaries in the repo to its original source files. 

Take the example above, 'Go to definition' of `MetricExporter` in  `opentelemetry-exporter-prometheus` can navigate to `packages/opentelemetry-metrics/src/export/types.ts`.
