### PR TITLE
fix(opentracing-shim): update opentracing shim example

### DIFF
--- a/examples/opentracing-shim/client.js
+++ b/examples/opentracing-shim/client.js
@@ -4,7 +4,7 @@ const http = require('http');
 const opentracing = require('opentracing');
 const shim = require('./shim').shim('http_client_service');
 
-opentracing.setGlobalTracer(shim);
+opentracing.initGlobalTracer(shim);
 const tracer = opentracing.globalTracer();
 
 makeRequest();

--- a/examples/opentracing-shim/server.js
+++ b/examples/opentracing-shim/server.js
@@ -5,7 +5,7 @@ const opentracing = require('opentracing');
 const utils = require('./utils');
 const shim = require('./shim').shim('http_server_service');
 
-opentracing.setGlobalTracer(shim);
+opentracing.initGlobalTracer(shim);
 const tracer = opentracing.globalTracer();
 
 startServer(3000);


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

A previous update to the opentracing-shim example had modified to this to incorrectly use a setter method to set the global tracer. A similar method exists on the OpenTelemetry API but not the OpenTracing API. This was causing JavaScript errors when attempting to run the example.

## Short description of the changes

Update to call the correct method on the OpenTracing API to initialise the global tracer.

Fixes #988 
