### PR TITLE
fix(metrics): bound observers' value not been updated

### DIFF
--- a/packages/opentelemetry-api/src/metrics/ObserverResult.ts
+++ b/packages/opentelemetry-api/src/metrics/ObserverResult.ts
@@ -23,3 +23,7 @@ import { MetricObservable } from './MetricObservable';
 export interface ObserverResult {
   observe(callback: Function | MetricObservable, labels: Labels): void;
 }
+
+export interface BoundObserverResult {
+  observe(callback: Function | MetricObservable): void;
+}

--- a/packages/opentelemetry-metrics/src/BoundInstrument.ts
+++ b/packages/opentelemetry-metrics/src/BoundInstrument.ts
@@ -16,7 +16,7 @@
 
 import * as types from '@opentelemetry/api';
 import { Aggregator } from './export/types';
-import { ObserverResult } from './ObserverResult';
+import { ObserverResult, BoundObserverResult } from './ObserverResult';
 
 /**
  * This class represent the base to BoundInstrument, which is responsible for generating
@@ -136,19 +136,23 @@ export class BoundMeasure extends BaseBoundInstrument
  */
 export class BoundObserver extends BaseBoundInstrument
   implements types.BoundObserver {
+  private _observerResult: BoundObserverResult;
   constructor(
     labels: types.Labels,
     disabled: boolean,
     monotonic: boolean,
     valueType: types.ValueType,
     logger: types.Logger,
-    aggregator: Aggregator
+    aggregator: Aggregator,
+    observerResult: ObserverResult
   ) {
     super(labels, logger, monotonic, disabled, valueType, aggregator);
+    this._observerResult = new BoundObserverResult(observerResult, labels);
   }
 
-  setCallback(callback: (observerResult: types.ObserverResult) => void): void {
-    const observerResult = new ObserverResult();
-    callback(observerResult);
+  setCallback(
+    callback: (observerResult: types.BoundObserverResult) => void
+  ): void {
+    callback(this._observerResult);
   }
 }

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -191,7 +191,8 @@ export class ObserverMetric extends Metric<BoundObserver>
       this._monotonic,
       this._valueType,
       this._logger,
-      this._batcher.aggregatorFor(MetricKind.OBSERVER)
+      this._batcher.aggregatorFor(MetricKind.OBSERVER),
+      this._observerResult
     );
   }
 

--- a/packages/opentelemetry-metrics/src/ObserverResult.ts
+++ b/packages/opentelemetry-metrics/src/ObserverResult.ts
@@ -17,6 +17,7 @@
 import {
   MetricObservable,
   ObserverResult as TypeObserverResult,
+  BoundObserverResult as TypeBoundObserverResult,
   Labels,
 } from '@opentelemetry/api';
 
@@ -35,6 +36,21 @@ export class ObserverResult implements TypeObserverResult {
       this.callbackObservers.set(labels, callback);
     } else {
       this.observers.set(labels, callback);
+    }
+  }
+}
+
+export class BoundObserverResult implements TypeBoundObserverResult {
+  constructor(
+    private _observerResult: ObserverResult,
+    private _labels: Labels
+  ) {}
+
+  observe(callback: Function | MetricObservable): void {
+    if (typeof callback === 'function') {
+      this._observerResult.callbackObservers.set(this._labels, callback);
+    } else {
+      this._observerResult.observers.set(this._labels, callback);
     }
   }
 }


### PR DESCRIPTION

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- bound observer's value not been updated, i.e. observer function not been called.

## Short description of the changes

- bound observers' observer result should be inherited from its original observer and been updated along with ObserverMetric.

