### PR TITLE
fix: observers should not expose bind/unbind method

### DIFF
--- a/packages/opentelemetry-api/src/metrics/BoundInstrument.ts
+++ b/packages/opentelemetry-api/src/metrics/BoundInstrument.ts
@@ -16,7 +16,6 @@
 
 import { CorrelationContext } from '../correlation_context/CorrelationContext';
 import { SpanContext } from '../trace/span_context';
-import { ObserverResult } from './ObserverResult';
 
 /** An Instrument for Counter Metric. */
 export interface BoundCounter {
@@ -44,15 +43,4 @@ export interface BoundMeasure {
     correlationContext: CorrelationContext,
     spanContext: SpanContext
   ): void;
-}
-
-/** Base interface for the Observer metrics. */
-export interface BoundObserver {
-  /**
-   * Sets callback for the observer. The callback is called once and then it
-   * sets observers for values. The observers are called periodically to
-   * retrieve the value.
-   * @param callback
-   */
-  setCallback(callback: (observerResult: ObserverResult) => void): void;
 }

--- a/packages/opentelemetry-api/src/metrics/Meter.ts
+++ b/packages/opentelemetry-api/src/metrics/Meter.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Metric, MetricOptions } from './Metric';
-import { BoundCounter, BoundMeasure, BoundObserver } from './BoundInstrument';
+import { MetricOptions, Counter, Measure, Observer } from './Metric';
 
 /**
  * An interface to allow the recording metrics.
@@ -30,7 +29,7 @@ export interface Meter {
    * @param name the name of the metric.
    * @param [options] the metric options.
    */
-  createMeasure(name: string, options?: MetricOptions): Metric<BoundMeasure>;
+  createMeasure(name: string, options?: MetricOptions): Measure;
 
   /**
    * Creates a new `Counter` metric. Generally, this kind of metric when the
@@ -39,12 +38,12 @@ export interface Meter {
    * @param name the name of the metric.
    * @param [options] the metric options.
    */
-  createCounter(name: string, options?: MetricOptions): Metric<BoundCounter>;
+  createCounter(name: string, options?: MetricOptions): Counter;
 
   /**
    * Creates a new `Observer` metric.
    * @param name the name of the metric.
    * @param [options] the metric options.
    */
-  createObserver(name: string, options?: MetricOptions): Metric<BoundObserver>;
+  createObserver(name: string, options?: MetricOptions): Observer;
 }

--- a/packages/opentelemetry-metrics/src/BoundInstrument.ts
+++ b/packages/opentelemetry-metrics/src/BoundInstrument.ts
@@ -16,7 +16,6 @@
 
 import * as api from '@opentelemetry/api';
 import { Aggregator } from './export/types';
-import { ObserverResult } from './ObserverResult';
 
 /**
  * This class represent the base to BoundInstrument, which is responsible for generating
@@ -134,8 +133,7 @@ export class BoundMeasure extends BaseBoundInstrument
 /**
  * BoundObserver is an implementation of the {@link BoundObserver} interface.
  */
-export class BoundObserver extends BaseBoundInstrument
-  implements api.BoundObserver {
+export class BoundObserver extends BaseBoundInstrument {
   constructor(
     labels: api.Labels,
     disabled: boolean,
@@ -145,10 +143,5 @@ export class BoundObserver extends BaseBoundInstrument
     aggregator: Aggregator
   ) {
     super(labels, logger, monotonic, disabled, valueType, aggregator);
-  }
-
-  setCallback(callback: (observerResult: api.ObserverResult) => void): void {
-    const observerResult = new ObserverResult();
-    callback(observerResult);
   }
 }

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -56,10 +56,7 @@ export class Meter implements api.Meter {
    * @param name the name of the metric.
    * @param [options] the metric options.
    */
-  createMeasure(
-    name: string,
-    options?: api.MetricOptions
-  ): api.Metric<api.BoundMeasure> {
+  createMeasure(name: string, options?: api.MetricOptions): api.Measure {
     if (!this._isValidName(name)) {
       this._logger.warn(
         `Invalid metric name ${name}. Defaulting to noop metric implementation.`
@@ -86,10 +83,7 @@ export class Meter implements api.Meter {
    * @param name the name of the metric.
    * @param [options] the metric options.
    */
-  createCounter(
-    name: string,
-    options?: api.MetricOptions
-  ): api.Metric<api.BoundCounter> {
+  createCounter(name: string, options?: api.MetricOptions): api.Counter {
     if (!this._isValidName(name)) {
       this._logger.warn(
         `Invalid metric name ${name}. Defaulting to noop metric implementation.`
@@ -113,10 +107,7 @@ export class Meter implements api.Meter {
    * @param name the name of the metric.
    * @param [options] the metric options.
    */
-  createObserver(
-    name: string,
-    options?: api.MetricOptions
-  ): api.Metric<api.BoundObserver> {
+  createObserver(name: string, options?: api.MetricOptions): api.Observer {
     if (!this._isValidName(name)) {
       this._logger.warn(
         `Invalid metric name ${name}. Defaulting to noop metric implementation.`

--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -30,7 +30,7 @@ import { hashLabels } from './Utils';
 
 /** This is a SDK implementation of {@link Metric} interface. */
 export abstract class Metric<T extends BaseBoundInstrument>
-  implements api.Metric<T> {
+  implements api.UnboundMetric<T> {
   protected readonly _monotonic: boolean;
   protected readonly _disabled: boolean;
   protected readonly _valueType: api.ValueType;
@@ -106,8 +106,7 @@ export abstract class Metric<T extends BaseBoundInstrument>
 }
 
 /** This is a SDK implementation of Counter Metric. */
-export class CounterMetric extends Metric<BoundCounter>
-  implements Pick<api.MetricUtils, 'add'> {
+export class CounterMetric extends Metric<BoundCounter> implements api.Counter {
   constructor(
     name: string,
     options: MetricOptions,
@@ -139,8 +138,7 @@ export class CounterMetric extends Metric<BoundCounter>
   }
 }
 
-export class MeasureMetric extends Metric<BoundMeasure>
-  implements Pick<api.MetricUtils, 'record'> {
+export class MeasureMetric extends Metric<BoundMeasure> implements api.Measure {
   protected readonly _absolute: boolean;
 
   constructor(
@@ -172,7 +170,7 @@ export class MeasureMetric extends Metric<BoundMeasure>
 
 /** This is a SDK implementation of Observer Metric. */
 export class ObserverMetric extends Metric<BoundObserver>
-  implements Pick<api.MetricUtils, 'setCallback'> {
+  implements api.Observer {
   private _observerResult = new ObserverResult();
 
   constructor(

--- a/packages/opentelemetry-metrics/test/Batcher.test.ts
+++ b/packages/opentelemetry-metrics/test/Batcher.test.ts
@@ -24,7 +24,7 @@ describe('Batcher', () => {
     let meter: Meter;
     let fooCounter: api.BoundCounter;
     let barCounter: api.BoundCounter;
-    let counter: api.Metric<api.BoundCounter>;
+    let counter: api.Counter;
     beforeEach(() => {
       meter = new MeterProvider({
         logger: new NoopLogger(),


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #997 

## Short description of the changes

- `@opentelemetry/api`: Add new interface UnboundMetric, with bind/unbind method, which extends Metric.
- `@opentelemetry/metrics`: Removed problematic setCallback method from BoundObserver. BoundObsever now acts as merely an instrument hold values, should not be exposed as public API.