### PR TITLE
fix(opentelemetry-plugin-xml-http-request): define span kind as CLIENT for xmlhttprequests

### DIFF
--- a/packages/opentelemetry-plugin-xml-http-request/src/xhr.ts
+++ b/packages/opentelemetry-plugin-xml-http-request/src/xhr.ts
@@ -316,6 +316,7 @@ export class XMLHttpRequestPlugin extends BasePlugin<XMLHttpRequest> {
     }
 
     const currentSpan = this._tracer.startSpan(url, {
+      kind: api.SpanKind.CLIENT,
       attributes: {
         [AttributeNames.COMPONENT]: this.component,
         [AttributeNames.HTTP_METHOD]: method,

--- a/packages/opentelemetry-plugin-xml-http-request/test/xhr.test.ts
+++ b/packages/opentelemetry-plugin-xml-http-request/test/xhr.test.ts
@@ -212,7 +212,11 @@ describe('xhr', () => {
 
     it('span should have correct kind', () => {
       const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-      assert.strictEqual(span.kind, types.SpanKind.CLIENT, 'span has wrong kind');
+      assert.strictEqual(
+        span.kind,
+        types.SpanKind.CLIENT,
+        'span has wrong kind'
+      );
     });
 
     it('span should have correct attributes', () => {

--- a/packages/opentelemetry-plugin-xml-http-request/test/xhr.test.ts
+++ b/packages/opentelemetry-plugin-xml-http-request/test/xhr.test.ts
@@ -210,6 +210,11 @@ describe('xhr', () => {
       assert.strictEqual(span.name, url, 'span has wrong name');
     });
 
+    it('span should have correct kind', () => {
+      const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+      assert.strictEqual(span.kind, types.SpanKind.CLIENT, 'span has wrong kind');
+    });
+
     it('span should have correct attributes', () => {
       const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
       const attributes = span.attributes;


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The `xml-http-request` plugin does not correctly set the span kind to `CLIENT` when creating the span on the open method. This makes all spans that represent XHR requests having the default span kind of `INTERNAL`. 

Per spec `INTERNAL -> Default value. Indicates that the span is used internally.`, which in this case is not true and should be `CLIENT -> Indicates that the span covers the client-side wrapper around an RPC or other remote request.`.

## Short description of the changes

One-liner to set the span kind to `CLIENT`.
