### PR TITLE
fix: permission denied error when cloning submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "packages/opentelemetry-exporter-collector/src/platform/node/protos"]
 	path = packages/opentelemetry-exporter-collector/src/platform/node/protos
-	url = git@github.com:open-telemetry/opentelemetry-proto.git
+	url = https://github.com/open-telemetry/opentelemetry-proto.git


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

When running `npm install` a permission denied error would occur preventing Git submodules from being cloned into your local repository.

## Short description of the changes

Changing this to use a https url and clone anonymously allows these to be retrieved as expected.

Fixes #1000