### PR TITLE
fix(opentracing-shim): register tracer provider for complete traces

### DIFF
--- a/examples/opentracing-shim/shim.js
+++ b/examples/opentracing-shim/shim.js
@@ -10,6 +10,8 @@ function shim(serviceName) {
   const provider = new NodeTracerProvider();
 
   provider.addSpanProcessor(new SimpleSpanProcessor(getExporter(serviceName)));
+  // Initialize the OpenTelemetry APIs to use the NodeTracerProvider bindings
+  provider.register();
 
   return new TracerShim(provider.getTracer('opentracing-shim'));
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Traces generated by the opentracing shim example were incomplete. One trace was generated per service instead of a single trace containing all spans from both services for the remote calls.

## Short description of the changes

The registration of the provider appeared to have been done in the other examples but not this one. After adding the same change a single trace is generated as expected.

Fixes #999