### PR TITLE
feat: expose withSpanAsync on NodeTracer #752

### DIFF
--- a/packages/opentelemetry-api/src/api/context.ts
+++ b/packages/opentelemetry-api/src/api/context.ts
@@ -54,7 +54,7 @@ export class ContextAPI {
   ): ContextManager {
     if (_global[GLOBAL_CONTEXT_MANAGER_API_KEY]) {
       // global context manager has already been set
-      return this._getContextManager();
+      return this.getContextManager();
     }
 
     _global[GLOBAL_CONTEXT_MANAGER_API_KEY] = makeGetter(
@@ -70,7 +70,7 @@ export class ContextAPI {
    * Get the currently active context
    */
   public active(): Context {
-    return this._getContextManager().active();
+    return this.getContextManager().active();
   }
 
   /**
@@ -83,7 +83,7 @@ export class ContextAPI {
     context: Context,
     fn: T
   ): ReturnType<T> {
-    return this._getContextManager().with(context, fn);
+    return this.getContextManager().with(context, fn);
   }
 
   /**
@@ -93,10 +93,10 @@ export class ContextAPI {
    * @param context context to bind to the event emitter or function. Defaults to the currently active context
    */
   public bind<T>(target: T, context: Context = this.active()): T {
-    return this._getContextManager().bind(target, context);
+    return this.getContextManager().bind(target, context);
   }
 
-  private _getContextManager(): ContextManager {
+  public getContextManager(): ContextManager {
     return (
       _global[GLOBAL_CONTEXT_MANAGER_API_KEY]?.(
         API_BACKWARDS_COMPATIBILITY_VERSION
@@ -106,7 +106,7 @@ export class ContextAPI {
 
   /** Disable and remove the global context manager */
   public disable() {
-    this._getContextManager().disable();
+    this.getContextManager().disable();
     delete _global[GLOBAL_CONTEXT_MANAGER_API_KEY];
   }
 }

--- a/packages/opentelemetry-api/test/api/global.test.ts
+++ b/packages/opentelemetry-api/test/api/global.test.ts
@@ -34,8 +34,8 @@ describe('Global Utils', () => {
   assert.notEqual(api1, api2);
   // that return separate noop instances to start
   assert.notStrictEqual(
-    api1.context['getContextManager'](),
-    api2.context['getContextManager']()
+    api1.context.getContextManager(),
+    api2.context.getContextManager()
   );
 
   beforeEach(() => {
@@ -46,33 +46,33 @@ describe('Global Utils', () => {
   });
 
   it('should change the global context manager', () => {
-    const original = api1.context['getContextManager']();
+    const original = api1.context.getContextManager();
     const newContextManager = new NoopContextManager();
     api1.context.setGlobalContextManager(newContextManager);
-    assert.notStrictEqual(api1.context['getContextManager'](), original);
-    assert.strictEqual(api1.context['getContextManager'](), newContextManager);
+    assert.notStrictEqual(api1.context.getContextManager(), original);
+    assert.strictEqual(api1.context.getContextManager(), newContextManager);
   });
 
   it('should load an instance from one which was set in the other', () => {
     api1.context.setGlobalContextManager(new NoopContextManager());
     assert.strictEqual(
-      api1.context['getContextManager'](),
-      api2.context['getContextManager']()
+      api1.context.getContextManager(),
+      api2.context.getContextManager()
     );
   });
 
   it('should disable both if one is disabled', () => {
-    const original = api1.context['getContextManager']();
+    const original = api1.context.getContextManager();
 
     api1.context.setGlobalContextManager(new NoopContextManager());
 
-    assert.notStrictEqual(original, api1.context['getContextManager']());
+    assert.notStrictEqual(original, api1.context.getContextManager());
     api2.context.disable();
-    assert.strictEqual(original, api1.context['getContextManager']());
+    assert.strictEqual(original, api1.context.getContextManager());
   });
 
   it('should return the module NoOp implementation if the version is a mismatch', () => {
-    const original = api1.context['getContextManager']();
+    const original = api1.context.getContextManager();
     api1.context.setGlobalContextManager(new NoopContextManager());
     const afterSet = _global[GLOBAL_CONTEXT_MANAGER_API_KEY]!(-1);
 

--- a/packages/opentelemetry-api/test/api/global.test.ts
+++ b/packages/opentelemetry-api/test/api/global.test.ts
@@ -34,8 +34,8 @@ describe('Global Utils', () => {
   assert.notEqual(api1, api2);
   // that return separate noop instances to start
   assert.notStrictEqual(
-    api1.context['_getContextManager'](),
-    api2.context['_getContextManager']()
+    api1.context['getContextManager'](),
+    api2.context['getContextManager']()
   );
 
   beforeEach(() => {
@@ -46,33 +46,33 @@ describe('Global Utils', () => {
   });
 
   it('should change the global context manager', () => {
-    const original = api1.context['_getContextManager']();
+    const original = api1.context['getContextManager']();
     const newContextManager = new NoopContextManager();
     api1.context.setGlobalContextManager(newContextManager);
-    assert.notStrictEqual(api1.context['_getContextManager'](), original);
-    assert.strictEqual(api1.context['_getContextManager'](), newContextManager);
+    assert.notStrictEqual(api1.context['getContextManager'](), original);
+    assert.strictEqual(api1.context['getContextManager'](), newContextManager);
   });
 
   it('should load an instance from one which was set in the other', () => {
     api1.context.setGlobalContextManager(new NoopContextManager());
     assert.strictEqual(
-      api1.context['_getContextManager'](),
-      api2.context['_getContextManager']()
+      api1.context['getContextManager'](),
+      api2.context['getContextManager']()
     );
   });
 
   it('should disable both if one is disabled', () => {
-    const original = api1.context['_getContextManager']();
+    const original = api1.context['getContextManager']();
 
     api1.context.setGlobalContextManager(new NoopContextManager());
 
-    assert.notStrictEqual(original, api1.context['_getContextManager']());
+    assert.notStrictEqual(original, api1.context['getContextManager']());
     api2.context.disable();
-    assert.strictEqual(original, api1.context['_getContextManager']());
+    assert.strictEqual(original, api1.context['getContextManager']());
   });
 
   it('should return the module NoOp implementation if the version is a mismatch', () => {
-    const original = api1.context['_getContextManager']();
+    const original = api1.context['getContextManager']();
     api1.context.setGlobalContextManager(new NoopContextManager());
     const afterSet = _global[GLOBAL_CONTEXT_MANAGER_API_KEY]!(-1);
 

--- a/packages/opentelemetry-node/README.md
+++ b/packages/opentelemetry-node/README.md
@@ -92,6 +92,14 @@ provider.register()
 ## Examples
 See how to automatically instrument [http](https://github.com/open-telemetry/opentelemetry-js/tree/master/examples/http) and [gRPC](https://github.com/open-telemetry/opentelemetry-js/tree/master/examples/grpc) using node-sdk.
 
+## Experimental API methods
+
+#### withSpanAsync
+
+The `NodeTracer` expose a method called `withSpanAsync` that allows you to set a current span in the context of a `async` function. This previously was a problem with `withSpan` because its synchronous behavior, read about that in [this issue](https://github.com/open-telemetry/opentelemetry-js/issues/752).
+This method have two drawback:
+ - strict requirement of the `AsyncHooksScopeManager`, you **cannot** use it without.
+ - the underlying implementation inside `AsyncHooksScopeManager` is experimental, so is this method, please open an issue if you have a problem with it.
 
 ## Useful links
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/packages/opentelemetry-node/src/NodeTracer.ts
+++ b/packages/opentelemetry-node/src/NodeTracer.ts
@@ -1,0 +1,71 @@
+/*!
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*!
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as api from '@opentelemetry/api';
+import { setActiveSpan } from '@opentelemetry/core';
+import {
+  BasicTracerProvider,
+  Tracer,
+  TracerConfig,
+} from '@opentelemetry/tracing';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+
+/**
+ * This class represents a nodejs-specific tracer.
+ */
+export class NodeTracer extends Tracer {
+  /**
+   * Constructs a new NodeTracer instance.
+   */
+  constructor(config: TracerConfig, _tracerProvider: BasicTracerProvider) {
+    super(config, _tracerProvider);
+  }
+
+  async withSpanAsync<
+    T extends Promise<any>,
+    U extends (...args: unknown[]) => T
+  >(span: api.Span, fn: U): Promise<T> {
+    // @ts-ignore
+    const contextManager = api.context._getContextManager();
+    if (contextManager instanceof AsyncHooksContextManager) {
+      return contextManager.withAsync(
+        setActiveSpan(api.context.active(), span),
+        fn
+      );
+    } else {
+      this.logger.warn(
+        `Using withAsync without AsyncHookContextManager doesn't work, please refer to`
+      );
+      return fn();
+    }
+  }
+}

--- a/packages/opentelemetry-node/src/NodeTracer.ts
+++ b/packages/opentelemetry-node/src/NodeTracer.ts
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*!
- * Copyright 2019, OpenTelemetry Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import * as api from '@opentelemetry/api';
 import { setActiveSpan } from '@opentelemetry/core';
 import {
@@ -54,8 +38,7 @@ export class NodeTracer extends Tracer {
     T extends Promise<any>,
     U extends (...args: unknown[]) => T
   >(span: api.Span, fn: U): Promise<T> {
-    // @ts-ignore
-    const contextManager = api.context._getContextManager();
+    const contextManager = api.context.getContextManager();
     if (contextManager instanceof AsyncHooksContextManager) {
       return contextManager.withAsync(
         setActiveSpan(api.context.active(), span),
@@ -63,9 +46,9 @@ export class NodeTracer extends Tracer {
       );
     } else {
       this.logger.warn(
-        `Using withAsync without AsyncHookContextManager doesn't work, please refer to`
+        `Using withAsync without AsyncHookContextManager doesn't work, please refer to https://github.com/open-telemetry/opentelemetry-js/tree/master/packages/opentelemetry-node#withspanasync`
       );
-      return fn();
+      return await fn();
     }
   }
 }

--- a/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
+++ b/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
@@ -232,25 +232,6 @@ describe('NodeTracerProvider', () => {
         undefined
       );
     });
-
-    it('should find correct context with promises', async () => {
-      provider = new NodeTracerProvider();
-      const span = provider.getTracer('default').startSpan('my-span');
-      await provider.getTracer('default').withSpan(span, async () => {
-        for (let i = 0; i < 3; i++) {
-          await sleep(5).then(() => {
-            assert.deepStrictEqual(
-              provider.getTracer('default').getCurrentSpan(),
-              span
-            );
-          });
-        }
-      });
-      assert.deepStrictEqual(
-        provider.getTracer('default').getCurrentSpan(),
-        undefined
-      );
-    });
   });
 
   describe('.bind()', () => {
@@ -288,7 +269,7 @@ describe('NodeTracerProvider', () => {
 
     it('should run context with AsyncHooksContextManager with multiple spans', async () => {
       provider = new NodeTracerProvider({});
-      let nestedHasBeenRun: boolean = false;
+      let nestedHasBeenRun = false;
       const span = provider.getTracer('default').startSpan('my-span');
       await provider.getTracer('default').withSpanAsync(span, async () => {
         assert.deepStrictEqual(

--- a/packages/opentelemetry-node/test/registration.test.ts
+++ b/packages/opentelemetry-node/test/registration.test.ts
@@ -38,7 +38,7 @@ describe('API registration', () => {
     tracerProvider.register();
 
     assert.ok(
-      context['_getContextManager']() instanceof AsyncHooksContextManager
+      context.getContextManager() instanceof AsyncHooksContextManager
     );
     assert.ok(
       propagation['_getGlobalPropagator']() instanceof HttpTraceContext
@@ -57,7 +57,7 @@ describe('API registration', () => {
       propagator,
     });
 
-    assert.ok(context['_getContextManager']() === contextManager);
+    assert.ok(context.getContextManager() === contextManager);
     assert.ok(propagation['_getGlobalPropagator']() === propagator);
 
     assert.ok(trace.getTracerProvider() === tracerProvider);
@@ -69,7 +69,7 @@ describe('API registration', () => {
       contextManager: null,
     });
 
-    assert.ok(context['_getContextManager']() instanceof NoopContextManager);
+    assert.ok(context.getContextManager() instanceof NoopContextManager);
 
     assert.ok(
       propagation['_getGlobalPropagator']() instanceof HttpTraceContext
@@ -88,7 +88,7 @@ describe('API registration', () => {
     );
 
     assert.ok(
-      context['_getContextManager']() instanceof AsyncHooksContextManager
+      context.getContextManager() instanceof AsyncHooksContextManager
     );
     assert.ok(trace.getTracerProvider() === tracerProvider);
   });

--- a/packages/opentelemetry-plugin-http/package.json
+++ b/packages/opentelemetry-plugin-http/package.json
@@ -42,7 +42,6 @@
   },
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^0.8.2",
-    "@opentelemetry/context-base": "^0.8.2",
     "@opentelemetry/node": "^0.8.2",
     "@opentelemetry/tracing": "^0.8.2",
     "@types/got": "^9.6.7",

--- a/packages/opentelemetry-plugin-https/package.json
+++ b/packages/opentelemetry-plugin-https/package.json
@@ -42,7 +42,6 @@
   },
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^0.8.2",
-    "@opentelemetry/context-base": "^0.8.2",
     "@opentelemetry/node": "^0.8.2",
     "@opentelemetry/tracing": "^0.8.2",
     "@types/got": "^9.6.7",

--- a/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
@@ -27,7 +27,7 @@ import { Resource } from '@opentelemetry/resources';
  * This class represents a basic tracer provider which platform libraries can extend
  */
 export class BasicTracerProvider implements api.TracerProvider {
-  private readonly _config: TracerConfig;
+  protected readonly _config: TracerConfig;
   private readonly _registeredSpanProcessors: SpanProcessor[] = [];
   private readonly _tracers: Map<string, Tracer> = new Map();
 


### PR DESCRIPTION
This doens't work because of some bug inside the AsyncHookContextManager but i'm opening the PR in the mean time to get feedback on how we can accomplish this. 

~~The main issue is that i need to use `// @ts-ignore` [there](https://github.com/vmarchaud/opentelemetry-js/blob/withasync-node-tracer/packages/opentelemetry-node/src/NodeTracer.ts#L57) since the `withAsync` is not exposed at the api level, don't know if we have other solutions here
WDYT ?~~