### PR TITLE
feat(metrics): use MetricDescriptor to determine aggregator #989

### DIFF
--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -35,7 +35,7 @@ export abstract class Metric<T extends BaseBoundInstrument>
   protected readonly _disabled: boolean;
   protected readonly _valueType: api.ValueType;
   protected readonly _logger: api.Logger;
-  private readonly _descriptor: MetricDescriptor;
+  protected readonly _descriptor: MetricDescriptor;
   private readonly _instruments: Map<string, T> = new Map();
 
   constructor(
@@ -124,7 +124,7 @@ export class CounterMetric extends Metric<BoundCounter>
       this._valueType,
       this._logger,
       // @todo: consider to set to CounterSumAggregator always.
-      this._batcher.aggregatorFor(MetricKind.COUNTER)
+      this._batcher.aggregatorFor(this._descriptor)
     );
   }
 
@@ -161,7 +161,7 @@ export class MeasureMetric extends Metric<BoundMeasure>
       this._absolute,
       this._valueType,
       this._logger,
-      this._batcher.aggregatorFor(MetricKind.MEASURE)
+      this._batcher.aggregatorFor(this._descriptor)
     );
   }
 
@@ -191,7 +191,7 @@ export class ObserverMetric extends Metric<BoundObserver>
       this._monotonic,
       this._valueType,
       this._logger,
-      this._batcher.aggregatorFor(MetricKind.OBSERVER)
+      this._batcher.aggregatorFor(this._descriptor)
     );
   }
 

--- a/packages/opentelemetry-metrics/src/export/Batcher.ts
+++ b/packages/opentelemetry-metrics/src/export/Batcher.ts
@@ -19,7 +19,12 @@ import {
   MeasureExactAggregator,
   ObserverAggregator,
 } from './aggregators';
-import { MetricRecord, MetricKind, Aggregator } from './types';
+import {
+  MetricRecord,
+  MetricKind,
+  Aggregator,
+  MetricDescriptor,
+} from './types';
 
 /**
  * Base class for all batcher types.
@@ -31,8 +36,8 @@ import { MetricRecord, MetricKind, Aggregator } from './types';
 export abstract class Batcher {
   protected readonly _batchMap = new Map<string, MetricRecord>();
 
-  /** Returns an aggregator based off metric kind. */
-  abstract aggregatorFor(metricKind: MetricKind): Aggregator;
+  /** Returns an aggregator based off metric descriptor. */
+  abstract aggregatorFor(metricKind: MetricDescriptor): Aggregator;
 
   /** Stores record information to be ready for exporting. */
   abstract process(record: MetricRecord): void;
@@ -47,8 +52,8 @@ export abstract class Batcher {
  * passes them for exporting.
  */
 export class UngroupedBatcher extends Batcher {
-  aggregatorFor(metricKind: MetricKind): Aggregator {
-    switch (metricKind) {
+  aggregatorFor(metricDescriptor: MetricDescriptor): Aggregator {
+    switch (metricDescriptor.metricKind) {
       case MetricKind.COUNTER:
         return new CounterSumAggregator();
       case MetricKind.OBSERVER:

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -28,6 +28,7 @@ import {
   MetricRecord,
   Aggregator,
   MetricObservable,
+  MetricDescriptor,
 } from '../src';
 import * as types from '@opentelemetry/api';
 import { NoopLogger, hrTime, hrTimeToNanoseconds } from '@opentelemetry/core';
@@ -566,7 +567,7 @@ class CustomBatcher extends Batcher {
   process(record: MetricRecord): void {
     throw new Error('process method not implemented.');
   }
-  aggregatorFor(metricKind: MetricKind): Aggregator {
+  aggregatorFor(metricKind: MetricDescriptor): Aggregator {
     throw new Error('aggregatorFor method not implemented.');
   }
 }


### PR DESCRIPTION
Currently the batcher interface define the following:

```ts
export abstract class Batcher {
  // [ ... ]
  abstract aggregatorFor(metricKind: MetricKind): Aggregator;
  // [ ... ]
}
```

Which is spec compliant but from a user perspective it only possible to use a specific aggregator for each kind of metricKind. Some might want to configure that on a more granular level using the metric name or labels for example.

The go implementation already use `MetricDescriptor` instead of `MetricKind` i believe for the same reason: https://github.com/open-telemetry/opentelemetry-go/blob/master/sdk/export/metric/metric.go#L100

More details here: https://github.com/open-telemetry/opentelemetry-js/issues/989#issuecomment-622970316
