### PR TITLE
fix: prevent duplicated resource creation

### DIFF
--- a/packages/opentelemetry-metrics/src/MeterProvider.ts
+++ b/packages/opentelemetry-metrics/src/MeterProvider.ts
@@ -24,12 +24,18 @@ import { DEFAULT_CONFIG, MeterConfig } from './types';
  * This class represents a meter provider which platform libraries can extend
  */
 export class MeterProvider implements api.MeterProvider {
+  private readonly _config: MeterConfig;
   private readonly _meters: Map<string, Meter> = new Map();
-  readonly resource: Resource = Resource.createTelemetrySDKResource();
+  readonly resource: Resource;
   readonly logger: api.Logger;
 
-  constructor(private _config: MeterConfig = DEFAULT_CONFIG) {
-    this.logger = _config.logger || new ConsoleLogger(_config.logLevel);
+  constructor(config: MeterConfig = DEFAULT_CONFIG) {
+    this.logger = config.logger ?? new ConsoleLogger(config.logLevel);
+    this.resource = config.resource ?? Resource.createTelemetrySDKResource();
+    this._config = Object.assign({}, config, {
+      logger: this.logger,
+      resource: this.resource,
+    });
   }
 
   /**

--- a/packages/opentelemetry-metrics/test/MeterProvider.test.ts
+++ b/packages/opentelemetry-metrics/test/MeterProvider.test.ts
@@ -15,7 +15,7 @@
  */
 
 import * as assert from 'assert';
-import { MeterProvider, Meter } from '../src';
+import { MeterProvider, Meter, CounterMetric } from '../src';
 import { NoopLogger } from '@opentelemetry/core';
 
 describe('MeterProvider', () => {
@@ -37,6 +37,14 @@ describe('MeterProvider', () => {
     it('should return an instance of Meter', () => {
       const meter = new MeterProvider().getMeter('test-meter-provider');
       assert.ok(meter instanceof Meter);
+    });
+
+    it('should propagate resources', () => {
+      const meterProvider = new MeterProvider();
+      const meter = meterProvider.getMeter('test-meter-provider');
+      const counter = meter.createCounter('test-counter') as CounterMetric;
+      assert.strictEqual((meter as any)._resource, meterProvider.resource);
+      assert.strictEqual(counter.resource, meterProvider.resource);
     });
 
     it('should return the meter with default version without a version option', () => {

--- a/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-tracing/src/BasicTracerProvider.ts
@@ -27,6 +27,7 @@ import { Resource } from '@opentelemetry/resources';
  * This class represents a basic tracer provider which platform libraries can extend
  */
 export class BasicTracerProvider implements api.TracerProvider {
+  private readonly _config: TracerConfig;
   private readonly _registeredSpanProcessors: SpanProcessor[] = [];
   private readonly _tracers: Map<string, Tracer> = new Map();
 
@@ -34,9 +35,13 @@ export class BasicTracerProvider implements api.TracerProvider {
   readonly logger: api.Logger;
   readonly resource: Resource;
 
-  constructor(private _config: TracerConfig = DEFAULT_CONFIG) {
-    this.logger = _config.logger || new ConsoleLogger(_config.logLevel);
-    this.resource = _config.resource || Resource.createTelemetrySDKResource();
+  constructor(config: TracerConfig = DEFAULT_CONFIG) {
+    this.logger = config.logger ?? new ConsoleLogger(config.logLevel);
+    this.resource = config.resource ?? Resource.createTelemetrySDKResource();
+    this._config = Object.assign({}, config, {
+      logger: this.logger,
+      resource: this.resource,
+    });
   }
 
   getTracer(name: string, version = '*', config?: TracerConfig): Tracer {

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -121,6 +121,14 @@ describe('BasicTracerProvider', () => {
       assert.ok(span instanceof Span);
     });
 
+    it('should propagate resources', () => {
+      const tracerProvider = new BasicTracerProvider();
+      const tracer = tracerProvider.getTracer('default');
+      const span = tracer.startSpan('my-span') as Span;
+      assert.strictEqual(tracer.resource, tracerProvider.resource);
+      assert.strictEqual(span.resource, tracerProvider.resource);
+    });
+
     it('should start a span with name and options', () => {
       const tracer = new BasicTracerProvider().getTracer('default');
       const span = tracer.startSpan('my-span', {});


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- According to https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/sdk.md#resource-sdk, resource in MeterProvider/TracerProvider should be propagated to its meter and tracer.

## Short description of the changes

- Prevent default resource re-creation in Meter/Tracer by propagating default resource in MeterProvider/TracerProvider.
