### PR TITLE
fix: use system clock for timestamps and perf clock for durations

### DIFF
--- a/packages/opentelemetry-core/src/common/time.ts
+++ b/packages/opentelemetry-core/src/common/time.ts
@@ -173,3 +173,16 @@ export function isTimeInput(value: unknown) {
     value instanceof Date
   );
 }
+
+/** Add two high resolution times */
+export function addHrTime(t1: types.HrTime, t2: types.HrTime): types.HrTime {
+  const time: types.HrTime = [t1[0] + t2[0], t1[1] + t2[1]];
+
+  if (time[1] >= 1e9) {
+    // nanoseconds overflow, carry seconds field
+    time[0] += 1;
+    time[1] -= 1e9;
+  }
+
+  return time;
+}

--- a/packages/opentelemetry-core/src/common/time.ts
+++ b/packages/opentelemetry-core/src/common/time.ts
@@ -175,8 +175,8 @@ export function isTimeInput(value: unknown) {
 }
 
 /** Add two high resolution times */
-export function addHrTime(t1: types.HrTime, t2: types.HrTime): types.HrTime {
-  const time: types.HrTime = [t1[0] + t2[0], t1[1] + t2[1]];
+export function addHrTime(t1: api.HrTime, t2: api.HrTime): api.HrTime {
+  const time: api.HrTime = [t1[0] + t2[0], t1[1] + t2[1]];
 
   if (time[1] >= 1e9) {
     // nanoseconds overflow, carry seconds field

--- a/packages/opentelemetry-tracing/src/Span.ts
+++ b/packages/opentelemetry-tracing/src/Span.ts
@@ -170,7 +170,20 @@ export class Span implements types.Span, ReadableSpan {
     }
     this._ended = true;
 
-    if (this._inputStartTime) {
+    if (!this._inputStartTime) {
+      if (!endTime) {
+        // if no user timestamps are provided, the start time comes from Date, and the end
+        // time is calculated using duration from the performance timer
+        this._duration = hrTimeDuration(this._perfStartTime, hrTime());
+      } else {
+        // if user specifies end time but not start time, we lose the benefits of the
+        // monotonic clock, so we should used the system clock
+        this._duration = hrTimeDuration(
+          this._dateStartTime,
+          timeInputToHrTime(endTime)
+        );
+      }
+    } else {
       if (endTime) {
         // user specified start and end time
         this._duration = hrTimeDuration(
@@ -184,19 +197,6 @@ export class Span implements types.Span, ReadableSpan {
           this._inputStartTime,
           timeInputToHrTime(Date.now())
         );
-      }
-    } else {
-      if (endTime) {
-        // if user specifies end time but not start time, we lose the benefits of the
-        // monotonic clock, so we should used the system clock
-        this._duration = hrTimeDuration(
-          this._dateStartTime,
-          timeInputToHrTime(endTime)
-        );
-      } else {
-        // if no user timestamps are provided, the start time comes from Date, and the end
-        // time is calculated using duration from the performance timer
-        this._duration = hrTimeDuration(this._perfStartTime, hrTime());
       }
     }
 

--- a/packages/opentelemetry-tracing/src/Span.ts
+++ b/packages/opentelemetry-tracing/src/Span.ts
@@ -74,7 +74,7 @@ export class Span implements api.Span, ReadableSpan {
     this.kind = kind;
     this.links = links;
 
-    if (startTime != null) {
+    if (startTime != undefined) {
       this._inputStartTime = timeInputToHrTime(startTime);
     }
     this._perfStartTime = hrTime();

--- a/packages/opentelemetry-tracing/src/Span.ts
+++ b/packages/opentelemetry-tracing/src/Span.ts
@@ -170,34 +170,30 @@ export class Span implements types.Span, ReadableSpan {
     }
     this._ended = true;
 
-    if (!this._inputStartTime) {
-      if (!endTime) {
-        // if no user timestamps are provided, the start time comes from Date, and the end
-        // time is calculated using duration from the performance timer
-        this._duration = hrTimeDuration(this._perfStartTime, hrTime());
-      } else {
-        // if user specifies end time but not start time, we lose the benefits of the
-        // monotonic clock, so we should used the system clock
-        this._duration = hrTimeDuration(
-          this._dateStartTime,
-          timeInputToHrTime(endTime)
-        );
-      }
-    } else {
-      if (endTime) {
-        // user specified start and end time
-        this._duration = hrTimeDuration(
-          this._inputStartTime,
-          timeInputToHrTime(endTime)
-        );
-      } else {
-        // if user specifies start time but not end time, we lose the benefits of the
-        // monotonic clock, so we should use the system clock
-        this._duration = hrTimeDuration(
-          this._inputStartTime,
-          timeInputToHrTime(Date.now())
-        );
-      }
+    if (!this._inputStartTime && !endTime) {
+      // if no user timestamps are provided, the start time comes from Date, and the end
+      // time is calculated using duration from the performance timer
+      this._duration = hrTimeDuration(this._perfStartTime, hrTime());
+    } else if (this._inputStartTime && endTime) {
+      // user specified start and end time
+      this._duration = hrTimeDuration(
+        this._inputStartTime,
+        timeInputToHrTime(endTime)
+      );
+    } else if (this._inputStartTime) {
+      // if user specifies start time but not end time, we lose the benefits of the
+      // monotonic clock, so we should use the system clock
+      this._duration = hrTimeDuration(
+        this._inputStartTime,
+        timeInputToHrTime(Date.now())
+      );
+    } else if (endTime) {
+      // if user specifies end time but not start time, we lose the benefits of the
+      // monotonic clock, so we should used the system clock
+      this._duration = hrTimeDuration(
+        this._dateStartTime,
+        timeInputToHrTime(endTime)
+      );
     }
 
     if (this._duration[0] < 0) {

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -24,7 +24,6 @@ import {
   setActiveSpan,
   setExtractedSpanContext,
   TraceState,
-  hrTimeToMilliseconds,
   addHrTime,
 } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -30,7 +30,7 @@ import { Resource } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { BasicTracerProvider, Span, Tracer } from '../src';
-import { performance } from 'perf_hooks';
+import { otperformance } from '@opentelemetry/core';
 
 describe('BasicTracerProvider', () => {
   beforeEach(() => {
@@ -337,7 +337,7 @@ describe('BasicTracerProvider', () => {
       const tracer = new BasicTracerProvider().getTracer('default') as Tracer;
       beforeEach(() => {
         // assume the performance timer is incorrect
-        sandbox.replaceGetter(performance, 'timeOrigin', () => 10_000);
+        sandbox.replaceGetter(otperformance, 'timeOrigin', () => 10_000);
       });
 
       afterEach(() => {


### PR DESCRIPTION
Fixes #852 

Because the timestamps generated from the performance timer cannot be trusted, we can only use them to generate durations, not real timestamps. This PR introduces the following behavior:

### User provides start AND end timestamps

- Start Time from user
- Duration is calculated from input times
- End time is calculated from start time input and duration

### User provides start timestamp

- Start time from user
- Duration calculated from input start time and system clock
- End time is calculated from start time input and duration

### User provides end timestamp

- Start time from system clock
- Duration calculated from system clock start time and input end time
- End time is calculated from system clock start time and duration

### User provides no timestamps

- Start time from system clock
- Duration is calculated using the performance clock
- End time is calculated using system clock start time and duration