### PR TITLE
fix: multi span processor should flush child span processors

### DIFF
--- a/packages/opentelemetry-tracing/src/MultiSpanProcessor.ts
+++ b/packages/opentelemetry-tracing/src/MultiSpanProcessor.ts
@@ -25,7 +25,9 @@ export class MultiSpanProcessor implements SpanProcessor {
   constructor(private readonly _spanProcessors: SpanProcessor[]) {}
 
   forceFlush(): void {
-    // do nothing as all spans are being exported without waiting
+    for (const spanProcessor of this._spanProcessors) {
+      spanProcessor.forceFlush();
+    }
   }
 
   onStart(span: Span): void {

--- a/packages/opentelemetry-tracing/test/MultiSpanProcessor.test.ts
+++ b/packages/opentelemetry-tracing/test/MultiSpanProcessor.test.ts
@@ -65,4 +65,19 @@ describe('MultiSpanProcessor', () => {
     assert.strictEqual(processor1.spans.length, 0);
     assert.strictEqual(processor1.spans.length, processor2.spans.length);
   });
+
+  it('should force span processors to flush', () => {
+    let flushed = false;
+    const processor: SpanProcessor = {
+      forceFlush: () => {
+        flushed = true;
+      },
+      onStart: span => {},
+      onEnd: span => {},
+      shutdown: () => {},
+    };
+    const multiSpanProcessor = new MultiSpanProcessor([processor]);
+    multiSpanProcessor.forceFlush();
+    assert.ok(flushed);
+  });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

- MultiSpanProcessor doesn't propagate `forceFlush` action to its child processors.

