### PR TITLE
Reintroduce node 13 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,9 +184,9 @@ jobs:
       - image: node:12
         environment: *node_test_env
     <<: *node_unit_tests
-  node13:
+  node14:
     docker:
-      - image: node:13
+      - image: node:14
         environment: *node_test_env
     <<: *node_unit_tests
   node12-browsers:
@@ -213,6 +213,6 @@ workflows:
       - node8
       - node10
       - node12
-      - node13
+      - node14
       - node12-browsers
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,11 @@ jobs:
       - image: node:12
         environment: *node_test_env
     <<: *node_unit_tests
+  node13:
+    docker:
+      - image: node:13
+        environment: *node_test_env
+    <<: *node_unit_tests
   node14:
     docker:
       - image: node:14
@@ -213,6 +218,7 @@ workflows:
       - node8
       - node10
       - node12
+      - node13
       - node14
       - node12-browsers
 

--- a/README.md
+++ b/README.md
@@ -59,13 +59,14 @@ If you are a library author looking to build OpenTelemetry into your library, pl
 Platform Version | Supported
 ---------------- | ---------
 Node.JS `v14`    | ✅
+Node.JS `v13`    | ✅
 Node.JS `v12`    | ✅
 Node.JS `v10`    | ✅
 Node.JS `v8`     | See [Node Support](#node-support) below
 Web Browsers     | ✅ See [Browser Support](#browser-support) below
 
 ### Node Support
-Automated tests are run using the latest release of each currently supported LTS version of Node.JS.
+Automated tests are run using the latest release of each currently active version of Node.JS.
 While Node.JS v8 is no longer supported by the Node.JS team, the latest version of Node.JS v8 is still included in our testing suite.
 Please note that versions of Node.JS v8 prior to `v8.5.0` will NOT work, because OpenTelemetry Node depends on the `perf_hooks` module introduced in `v8.5.0`
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,22 @@ If you are a library author looking to build OpenTelemetry into your library, pl
 
 ## Supported Runtimes
 
-Node.js v10 and greater is officially supported, but the tests are also run against the latest release of Node.js v8.
-Note that versions of Node.js older than 8.5.0 are known to not work.
+Platform Version | Supported
+---------------- | ---------
+Node.JS `v14`    | ✅
+Node.JS `v12`    | ✅
+Node.JS `v10`    | ✅
+Node.JS `v8`     | See [Node Support](#node-support) below
+Web Browsers     | ✅ See [Browser Support](#browser-support) below
 
-Browser tests are run in Chrome.
-There is currently no list of officially supported browsers, but OpenTelemetry should work in supported versions of major browsers.
+### Node Support
+Automated tests are run using the latest release of each currently supported LTS version of Node.JS.
+While Node.JS v8 is no longer supported by the Node.JS team, the latest version of Node.JS v8 is still included in our testing suite.
+Please note that versions of Node.JS v8 prior to `v8.5.0` will NOT work, because OpenTelemetry Node depends on the `perf_hooks` module introduced in `v8.5.0`
+
+### Browser Support
+Automated browser tests are run in the latest version of Headless Chrome.
+There is currently no list of officially supported browsers, but OpenTelemetry is developed using standard web technologies with wide support and should work in currently supported versions of major browsers.
 
 ## Release Schedule
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ To get started tracing your own application, see the [Getting Started Guide](get
 
 If you are a library author looking to build OpenTelemetry into your library, please see [the documentation][docs]. As a library author, it is important that you only depend on properties and methods published on the public API. If you use any properties or methods from the SDK that are not officially a part of the public API, your library may break if an [Application Owner](#application-owner) uses a different SDK implementation.
 
+## Supported Runtimes
+
+Node.js v10 and greater is officially supported, but the tests are also run against the latest release of Node.js v8.
+Note that versions of Node.js older than 8.5.0 are known to not work.
+
+Browser tests are run in Chrome.
+There is currently no list of officially supported browsers, but OpenTelemetry should work in supported versions of major browsers.
+
 ## Release Schedule
 
 OpenTelemetry JS is under active development.


### PR DESCRIPTION
Continue testing on node 13 until it is officially out of support.