### PR TITLE
feat(prom): expose measure as summary #982

### DIFF
--- a/packages/opentelemetry-exporter-prometheus/src/prometheus.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/prometheus.ts
@@ -33,7 +33,7 @@ import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
 import * as prom from 'prom-client';
 import * as url from 'url';
 import { ExporterConfig } from './export/types';
-import { MockHistogram, MockSummary } from './utils';
+import { CustomHistogram, CustomSummary } from './utils';
 
 export class PrometheusExporter implements MetricExporter {
   static readonly DEFAULT_OPTIONS = {
@@ -149,10 +149,10 @@ export class PrometheusExporter implements MetricExporter {
         point.value as number,
         hrTimeToMilliseconds(point.timestamp)
       );
-    } else if (metric instanceof MockSummary) {
+    } else if (metric instanceof CustomSummary) {
       const distribution = point.value as Distribution;
       metric.setValues(distribution, labelValues);
-    } else if (metric instanceof MockHistogram) {
+    } else if (metric instanceof CustomHistogram) {
       const histogram = point.value as Histogram;
       metric.setValues(histogram, labelValues);
     }
@@ -216,9 +216,11 @@ export class PrometheusExporter implements MetricExporter {
     } else if (record.aggregator.type === AggregatorType.OBSERVER) {
       return new prom.Gauge(metricObject);
     } else if (record.aggregator.type === AggregatorType.MEASUREEXACT) {
-      return new MockSummary(Object.assign(metricObject, { percentiles: [] }));
+      return new CustomSummary(
+        Object.assign(metricObject, { percentiles: [] })
+      );
     } else if (record.aggregator.type === AggregatorType.HISTOGRAM) {
-      return new MockHistogram(metricObject);
+      return new CustomHistogram(metricObject);
     }
     // other aggregator are not implemented right now
     return undefined;

--- a/packages/opentelemetry-exporter-prometheus/src/prometheus.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/prometheus.ts
@@ -36,7 +36,7 @@ import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
 import * as prom from 'prom-client';
 import * as url from 'url';
 import { ExporterConfig } from './export/types';
-import { FakeHistogram, FakeSummary } from './utils';
+import { MockHistogram, MockSummary } from './utils';
 
 export class PrometheusExporter implements MetricExporter {
   static readonly DEFAULT_OPTIONS = {
@@ -152,10 +152,10 @@ export class PrometheusExporter implements MetricExporter {
         point.value as number,
         hrTimeToMilliseconds(point.timestamp)
       );
-    } else if (metric instanceof FakeSummary) {
+    } else if (metric instanceof MockSummary) {
       const distribution = point.value as Distribution;
       metric.setValues(distribution, labelValues);
-    } else if (metric instanceof FakeHistogram) {
+    } else if (metric instanceof MockHistogram) {
       const histogram = point.value as Histogram;
       metric.setValues(histogram, labelValues);
     }
@@ -219,9 +219,9 @@ export class PrometheusExporter implements MetricExporter {
     } else if (record.aggregator instanceof ObserverAggregator) {
       return new prom.Gauge(metricObject);
     } else if (record.aggregator instanceof MeasureExactAggregator) {
-      return new FakeSummary(Object.assign(metricObject, { percentiles: [] }));
+      return new MockSummary(Object.assign(metricObject, { percentiles: [] }));
     } else if (record.aggregator instanceof HistogramAggregator) {
-      return new FakeHistogram(metricObject);
+      return new MockHistogram(metricObject);
     }
     // other aggregator are not implemented right now
     return undefined;

--- a/packages/opentelemetry-exporter-prometheus/src/prometheus.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/prometheus.ts
@@ -20,13 +20,10 @@ import {
   hrTimeToMilliseconds,
 } from '@opentelemetry/core';
 import {
-  CounterSumAggregator,
   MetricExporter,
   MetricRecord,
   MetricDescriptor,
-  ObserverAggregator,
-  HistogramAggregator,
-  MeasureExactAggregator,
+  AggregatorType,
   Sum,
   Histogram,
   Distribution,
@@ -209,18 +206,18 @@ export class PrometheusExporter implements MetricExporter {
     };
 
     if (
-      record.aggregator instanceof CounterSumAggregator &&
+      record.aggregator.type === AggregatorType.COUNTERSUM &&
       record.descriptor.monotonic
     ) {
       return new prom.Counter(metricObject);
-    } else if (record.aggregator instanceof CounterSumAggregator) {
+    } else if (record.aggregator.type === AggregatorType.COUNTERSUM) {
       // there is no such thing as a non-monotonic counter in prometheus
       return new prom.Gauge(metricObject);
-    } else if (record.aggregator instanceof ObserverAggregator) {
+    } else if (record.aggregator.type === AggregatorType.OBSERVER) {
       return new prom.Gauge(metricObject);
-    } else if (record.aggregator instanceof MeasureExactAggregator) {
+    } else if (record.aggregator.type === AggregatorType.MEASUREEXACT) {
       return new MockSummary(Object.assign(metricObject, { percentiles: [] }));
-    } else if (record.aggregator instanceof HistogramAggregator) {
+    } else if (record.aggregator.type === AggregatorType.HISTOGRAM) {
       return new MockHistogram(metricObject);
     }
     // other aggregator are not implemented right now

--- a/packages/opentelemetry-exporter-prometheus/src/utils.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/utils.ts
@@ -1,0 +1,99 @@
+/*!
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as prom from 'prom-client';
+import { Histogram, Distribution } from '@opentelemetry/metrics';
+
+/**
+ * Opentelemetry's metrics API match closely what is done inside `prom-client`
+ * so to avoid having to compute data both inside otel and prom. We use this
+ * wrapper that looks like a internal prom implementation but is actually just
+ * using the Opentelemetry data.
+ */
+
+// Fake implementation of the prom Histogram that allows us to set its internal state
+export class FakeHistogram extends prom.Histogram {
+  // @ts-ignore
+  // tslint:disable-next-line
+  private upperBounds: number[] = [];
+  // ref https://github.com/siimon/prom-client/blob/master/lib/histogram.js#L34
+  // tslint:disable-next-line
+  private hashMap: {
+    [key: string]: {
+      labels: prom.labelValues;
+      bucketValues: { [key: number]: number };
+      sum: number;
+      count: number;
+    };
+  } = {};
+
+  constructor(config: prom.HistogramConfiguration) {
+    super(config);
+  }
+
+  setValues(histogram: Histogram, labels: prom.labelValues) {
+    this.upperBounds = histogram.buckets.boundaries;
+    console.log(histogram);
+    // key inside the map are just hash of labels, don't need to set to a specific value
+    this.hashMap['_hash_'] = {
+      labels,
+      bucketValues: histogram.buckets.counts.reduce((agg, value, idx) => {
+        const boundary: number | undefined = histogram.buckets.boundaries[idx];
+        if (boundary === undefined) {
+          agg[-1] = value;
+        } else {
+          agg[boundary] = value;
+        }
+        return agg;
+      }, {} as { [key: number]: number }),
+      sum: histogram.sum,
+      count: histogram.count,
+    };
+  }
+}
+
+// Fake implementation of the prom Summary that allows us to set its internal state
+export class FakeSummary extends prom.Summary {
+  // ref: https://github.com/siimon/prom-client/blob/master/lib/summary.js#L29
+  // tslint:disable-next-line
+  private hashMap: {
+    [key: string]: {
+      labels: prom.labelValues;
+      td: {
+        compress: () => void;
+        percentile: (percentile: number) => undefined;
+      };
+      sum: number;
+      count: number;
+    };
+  } = {};
+
+  constructor(config: prom.SummaryConfiguration) {
+    super(config);
+  }
+
+  setValues(distribution: Distribution, labels: prom.labelValues) {
+    this.hashMap['_hash_'] = {
+      labels,
+      td: {
+        compress: () => undefined,
+        percentile: () => undefined,
+      },
+      sum: distribution.sum,
+      count: distribution.count,
+    };
+  }
+}

--- a/packages/opentelemetry-exporter-prometheus/src/utils.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/utils.ts
@@ -24,8 +24,8 @@ import { Histogram, Distribution } from '@opentelemetry/metrics';
  * using the Opentelemetry data.
  */
 
-// Mock implementation of the prom Histogram that allows us to set its internal state
-export class MockHistogram extends prom.Histogram {
+// Custom implementation of the prom Histogram that allows us to set its internal state
+export class CustomHistogram extends prom.Histogram {
   // tslint:disable-next-line naming-convention / name used by prom internally
   protected upperBounds: number[] = [];
   // ref https://github.com/siimon/prom-client/blob/master/lib/histogram.js#L34
@@ -64,8 +64,8 @@ export class MockHistogram extends prom.Histogram {
   }
 }
 
-// Mock implementation of the prom Summary that allows us to set its internal state
-export class MockSummary extends prom.Summary {
+// Custom implementation of the prom Summary that allows us to set its internal state
+export class CustomSummary extends prom.Summary {
   // ref: https://github.com/siimon/prom-client/blob/master/lib/summary.js#L29
   // tslint:disable-next-line naming-convention / name used by prom internally
   protected hashMap: Record<

--- a/packages/opentelemetry-exporter-prometheus/src/utils.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/utils.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2019, OpenTelemetry Authors
+ * Copyright 2020, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,21 +24,21 @@ import { Histogram, Distribution } from '@opentelemetry/metrics';
  * using the Opentelemetry data.
  */
 
-// Fake implementation of the prom Histogram that allows us to set its internal state
-export class FakeHistogram extends prom.Histogram {
-  // @ts-ignore
-  // tslint:disable-next-line
-  private upperBounds: number[] = [];
+// Mock implementation of the prom Histogram that allows us to set its internal state
+export class MockHistogram extends prom.Histogram {
+  // tslint:disable-next-line naming-convention / name used by prom internally
+  protected upperBounds: number[] = [];
   // ref https://github.com/siimon/prom-client/blob/master/lib/histogram.js#L34
-  // tslint:disable-next-line
-  private hashMap: {
-    [key: string]: {
+  // tslint:disable-next-line naming-convention / name used by prom internally
+  protected hashMap: Record<
+    string,
+    {
       labels: prom.labelValues;
       bucketValues: { [key: number]: number };
       sum: number;
       count: number;
-    };
-  } = {};
+    }
+  > = {};
 
   constructor(config: prom.HistogramConfiguration) {
     super(config);
@@ -46,7 +46,6 @@ export class FakeHistogram extends prom.Histogram {
 
   setValues(histogram: Histogram, labels: prom.labelValues) {
     this.upperBounds = histogram.buckets.boundaries;
-    console.log(histogram);
     // key inside the map are just hash of labels, don't need to set to a specific value
     this.hashMap['_hash_'] = {
       labels,
@@ -65,21 +64,24 @@ export class FakeHistogram extends prom.Histogram {
   }
 }
 
-// Fake implementation of the prom Summary that allows us to set its internal state
-export class FakeSummary extends prom.Summary {
+// Mock implementation of the prom Summary that allows us to set its internal state
+export class MockSummary extends prom.Summary {
   // ref: https://github.com/siimon/prom-client/blob/master/lib/summary.js#L29
-  // tslint:disable-next-line
-  private hashMap: {
-    [key: string]: {
+  // tslint:disable-next-line naming-convention / name used by prom internally
+  protected hashMap: Record<
+    string,
+    {
       labels: prom.labelValues;
+      // internal object that computes percentiles in prom-client, we are mocking it
+      // see https://github.com/siimon/prom-client/blob/master/lib/summary.js#L32
       td: {
         compress: () => void;
         percentile: (percentile: number) => undefined;
       };
       sum: number;
       count: number;
-    };
-  } = {};
+    }
+  > = {};
 
   constructor(config: prom.SummaryConfiguration) {
     super(config);

--- a/packages/opentelemetry-metrics/src/export/aggregators/countersum.ts
+++ b/packages/opentelemetry-metrics/src/export/aggregators/countersum.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { Aggregator, Point } from '../types';
+import { Aggregator, Point, AggregatorType } from '../types';
 import { HrTime } from '@opentelemetry/api';
 import { hrTime } from '@opentelemetry/core';
 
 /** Basic aggregator which calculates a Sum from individual measurements. */
 export class CounterSumAggregator implements Aggregator {
+  public type = AggregatorType.COUNTERSUM;
   private _current: number = 0;
   private _lastUpdateTime: HrTime = [0, 0];
 

--- a/packages/opentelemetry-metrics/src/export/aggregators/histogram.ts
+++ b/packages/opentelemetry-metrics/src/export/aggregators/histogram.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Aggregator, Point, Histogram } from '../types';
+import { Aggregator, Point, Histogram, AggregatorType } from '../types';
 import { hrTime } from '@opentelemetry/core';
 import { HrTime } from '@opentelemetry/api';
 
@@ -23,6 +23,7 @@ import { HrTime } from '@opentelemetry/api';
  * and provides the total sum and count of all observations.
  */
 export class HistogramAggregator implements Aggregator {
+  public type = AggregatorType.HISTOGRAM;
   private _histogram: Histogram;
   private readonly _boundaries: number[];
   private _lastUpdate: HrTime = hrTime();

--- a/packages/opentelemetry-metrics/src/export/aggregators/histogram.ts
+++ b/packages/opentelemetry-metrics/src/export/aggregators/histogram.ts
@@ -16,6 +16,7 @@
 
 import { Aggregator, Point, Histogram } from '../types';
 import { hrTime } from '@opentelemetry/core';
+import { HrTime } from '@opentelemetry/api';
 
 /**
  * Basic aggregator which observes events and counts them in pre-defined buckets
@@ -24,6 +25,7 @@ import { hrTime } from '@opentelemetry/core';
 export class HistogramAggregator implements Aggregator {
   private _histogram: Histogram;
   private readonly _boundaries: number[];
+  private _lastUpdate: HrTime = hrTime();
 
   constructor(boundaries: number[]) {
     if (boundaries === undefined || boundaries.length === 0) {
@@ -37,6 +39,7 @@ export class HistogramAggregator implements Aggregator {
 
   update(value: number): void {
     this._histogram.count += 1;
+    this._lastUpdate = hrTime();
     this._histogram.sum += value;
 
     for (let i = 0; i < this._boundaries.length; i++) {
@@ -57,7 +60,7 @@ export class HistogramAggregator implements Aggregator {
   toPoint(): Point {
     return {
       value: this._histogram,
-      timestamp: hrTime(),
+      timestamp: this._lastUpdate,
     };
   }
 

--- a/packages/opentelemetry-metrics/src/export/aggregators/measureexact.ts
+++ b/packages/opentelemetry-metrics/src/export/aggregators/measureexact.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import { Aggregator, Point } from '../types';
+import { Aggregator, Point, AggregatorType } from '../types';
 import { HrTime } from '@opentelemetry/api';
 import { hrTime } from '@opentelemetry/core';
 import { Distribution } from '../types';
 
 /** Basic aggregator keeping all raw values (events, sum, max and min). */
 export class MeasureExactAggregator implements Aggregator {
+  public type = AggregatorType.MEASUREEXACT;
   private _distribution: Distribution;
   private _lastUpdateTime: HrTime = [0, 0];
 

--- a/packages/opentelemetry-metrics/src/export/aggregators/observer.ts
+++ b/packages/opentelemetry-metrics/src/export/aggregators/observer.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import { Aggregator, Point } from '../types';
+import { Aggregator, Point, AggregatorType } from '../types';
 import { HrTime } from '@opentelemetry/api';
 import { hrTime } from '@opentelemetry/core';
 
 /** Basic aggregator for Observer which keeps the last recorded value. */
 export class ObserverAggregator implements Aggregator {
+  public type = AggregatorType.OBSERVER;
   private _current: number = 0;
   private _lastUpdateTime: HrTime = [0, 0];
 

--- a/packages/opentelemetry-metrics/src/export/types.ts
+++ b/packages/opentelemetry-metrics/src/export/types.ts
@@ -97,10 +97,26 @@ export interface MetricExporter {
 }
 
 /**
+ * Type of standard aggregator.
+ */
+export enum AggregatorType {
+  UNKNOWN = 'unknown',
+  COUNTERSUM = 'countersum',
+  HISTOGRAM = 'histogram',
+  MEASUREEXACT = 'measureexact',
+  OBSERVER = 'observer',
+}
+
+/**
  * Base interface for aggregators. Aggregators are responsible for holding
  * aggregated values and taking a snapshot of these values upon export.
  */
 export interface Aggregator {
+  /**
+   * The type of aggregator
+   */
+  type: AggregatorType;
+
   /** Updates the current with the new value. */
   update(value: number): void;
 

--- a/packages/opentelemetry-metrics/src/index.ts
+++ b/packages/opentelemetry-metrics/src/index.ts
@@ -21,4 +21,5 @@ export * from './Metric';
 export * from './MetricObservable';
 export * from './export/aggregators';
 export * from './export/ConsoleMetricExporter';
+export * from './export/Batcher';
 export * from './export/types';

--- a/packages/opentelemetry-metrics/test/export/aggregators/histogram.test.ts
+++ b/packages/opentelemetry-metrics/test/export/aggregators/histogram.test.ts
@@ -44,14 +44,13 @@ describe('HistogramAggregator', () => {
       const aggregator = new HistogramAggregator([100, 200]);
       aggregator.update(150);
       const point = aggregator.toPoint().value as Histogram;
-      assert.equal(point.count, 0);
-      assert.equal(point.sum, 0);
+      assert.equal(point.count, 1);
+      assert.equal(point.sum, 150);
     });
 
     it('should update the second bucket', () => {
       const aggregator = new HistogramAggregator([100, 200]);
       aggregator.update(150);
-      aggregator.reset();
       const point = aggregator.toPoint().value as Histogram;
       assert.equal(point.count, 1);
       assert.equal(point.sum, 150);
@@ -63,7 +62,6 @@ describe('HistogramAggregator', () => {
     it('should update the second bucket', () => {
       const aggregator = new HistogramAggregator([100, 200]);
       aggregator.update(50);
-      aggregator.reset();
       const point = aggregator.toPoint().value as Histogram;
       assert.equal(point.count, 1);
       assert.equal(point.sum, 50);
@@ -75,7 +73,6 @@ describe('HistogramAggregator', () => {
     it('should update the third bucket since value is above all boundaries', () => {
       const aggregator = new HistogramAggregator([100, 200]);
       aggregator.update(250);
-      aggregator.reset();
       const point = aggregator.toPoint().value as Histogram;
       assert.equal(point.count, 1);
       assert.equal(point.sum, 250);
@@ -85,33 +82,8 @@ describe('HistogramAggregator', () => {
     });
   });
 
-  describe('.count', () => {
-    it('should return last checkpoint count', () => {
-      const aggregator = new HistogramAggregator([100]);
-      let point = aggregator.toPoint().value as Histogram;
-      assert.equal(point.count, point.count);
-      aggregator.update(10);
-      aggregator.reset();
-      point = aggregator.toPoint().value as Histogram;
-      assert.equal(point.count, 1);
-      assert.equal(point.count, point.count);
-    });
-  });
-
-  describe('.sum', () => {
-    it('should return last checkpoint sum', () => {
-      const aggregator = new HistogramAggregator([100]);
-      let point = aggregator.toPoint().value as Histogram;
-      assert.equal(point.sum, point.sum);
-      aggregator.update(10);
-      aggregator.reset();
-      point = aggregator.toPoint().value as Histogram;
-      assert.equal(point.sum, 10);
-    });
-  });
-
   describe('.reset()', () => {
-    it('should create a empty checkoint by default', () => {
+    it('should create a empty histogram by default', () => {
       const aggregator = new HistogramAggregator([100]);
       const point = aggregator.toPoint().value as Histogram;
       assert.deepEqual(point.buckets.boundaries, [100]);
@@ -122,29 +94,17 @@ describe('HistogramAggregator', () => {
       assert.equal(point.count, 0);
       assert.equal(point.sum, 0);
     });
-
-    it('should update checkpoint', () => {
-      const aggregator = new HistogramAggregator([100]);
-      aggregator.update(10);
-      aggregator.reset();
-      const point = aggregator.toPoint().value as Histogram;
-      assert.equal(point.count, 1);
-      assert.equal(point.sum, 10);
-      assert.deepEqual(point.buckets.boundaries, [100]);
-      assert.equal(point.buckets.counts.length, 2);
-      assert.deepEqual(point.buckets.counts, [1, 0]);
-    });
   });
 
   describe('.toPoint()', () => {
-    it('should return default checkpoint', () => {
+    it('should return current data', () => {
       const aggregator = new HistogramAggregator([100]);
       const point = aggregator.toPoint().value as Histogram;
       assert.deepEqual(aggregator.toPoint().value, point);
       assert(aggregator.toPoint().timestamp.every(nbr => nbr > 0));
     });
 
-    it('should return last checkpoint if updated', () => {
+    it('should return histogram if updated', () => {
       const aggregator = new HistogramAggregator([100]);
       aggregator.update(100);
       aggregator.reset();


### PR DESCRIPTION
This turned out requiring quite some changes, i will try to explain them all:

- First, i changed to choice of the prometheus metric type that we use to depend on the aggregator that is used. The old was trying to do that depending on the metric kind which could result lead to issue if a different aggregator than the defaults was used.
- Second, the `prom-client` has its own implementation of histogram or summary that it keep over time, which we also do in the otel api, that mean we would have needed to maintain dataset in both (and could had a huge memory impact). To avoid that i've made "Fake" implementation of the internal `prom-client`'s `Histogram` and `Summary` that allows us to only change internal state of the prom metrics when we update its value.
- Finally, i've refactor our `Histogram` implementation because it was designed with the `checkpoint` concept that the Go impl use. Since our sdk don't have this logic right now, i've prefered to remove it (it was also complicating the integration with prom).

On the long term i believe we should implement the serialization as text ourselves to avoid the hack i've made in 2).