### PR TITLE
chore: pipe resource through to MetricRecord

### DIFF
--- a/packages/opentelemetry-metrics/src/Metric.ts
+++ b/packages/opentelemetry-metrics/src/Metric.ts
@@ -87,6 +87,7 @@ export abstract class Metric<T extends BaseBoundInstrument>
       descriptor: this._descriptor,
       labels: instrument.getLabels(),
       aggregator: instrument.getAggregator(),
+      resource: this.resource,
     }));
   }
 

--- a/packages/opentelemetry-metrics/src/export/types.ts
+++ b/packages/opentelemetry-metrics/src/export/types.ts
@@ -16,6 +16,7 @@
 
 import { ValueType, HrTime, Labels } from '@opentelemetry/api';
 import { ExportResult } from '@opentelemetry/core';
+import { Resource } from '@opentelemetry/resources';
 
 /** The kind of metric. */
 export enum MetricKind {
@@ -68,6 +69,7 @@ export interface MetricRecord {
   readonly descriptor: MetricDescriptor;
   readonly labels: Labels;
   readonly aggregator: Aggregator;
+  readonly resource: Resource;
 }
 
 export interface MetricDescriptor {

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -92,9 +92,14 @@ describe('Meter', () => {
       );
     });
 
-    it('should return counter with resource', () => {
+    it('should pipe through resource', () => {
       const counter = meter.createCounter('name') as CounterMetric;
       assert.ok(counter.resource instanceof Resource);
+
+      counter.add(1, { foo: 'bar' });
+
+      const [record] = counter.getMetricRecord();
+      assert.ok(record.resource instanceof Resource);
     });
 
     describe('.bind()', () => {
@@ -284,9 +289,14 @@ describe('Meter', () => {
       assert.strictEqual((measure as MeasureMetric)['_absolute'], false);
     });
 
-    it('should return a measure with resource', () => {
+    it('should pipe through resource', () => {
       const measure = meter.createMeasure('name') as MeasureMetric;
       assert.ok(measure.resource instanceof Resource);
+
+      measure.record(1, { foo: 'bar' });
+
+      const [record] = measure.getMetricRecord();
+      assert.ok(record.resource instanceof Resource);
     });
 
     describe('names', () => {
@@ -487,9 +497,16 @@ describe('Meter', () => {
       ensureMetric(metric5);
     });
 
-    it('should return an observer with resource', () => {
+    it('should pipe through resource', () => {
       const observer = meter.createObserver('name') as ObserverMetric;
       assert.ok(observer.resource instanceof Resource);
+
+      observer.setCallback(result => {
+        result.observe(() => 42, { foo: 'bar' });
+      });
+
+      const [record] = observer.getMetricRecord();
+      assert.ok(record.resource instanceof Resource);
     });
   });
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #1022 

## Short description of the changes

- This completes the process of piping the `Resource` assigned to a `MetricProvider` to the `MetricRecord`s so that it is available in the export pipeline.
