### PR TITLE
fix readme: setting labelKeys when creating the counter

### DIFF
--- a/packages/opentelemetry-exporter-prometheus/README.md
+++ b/packages/opentelemetry-exporter-prometheus/README.md
@@ -35,12 +35,15 @@ const meter = new MeterProvider({
 }).getMeter('example-prometheus');
 
 // Now, start recording data
-const counter = meter.createCounter('metric_name');
-counter.add(10, { [key]: 'value' });
+const counter = meter.createCounter('metric_name', {
+  labelKeys: ['pid'],
+  description: 'Example of a counter'
+});
+counter.add(10, { pid: process.pid });
 
 // Record data using Instrument: It is recommended to keep a reference to the Bound Instrument instead of
 // always calling `bind()` method for every operations.
-const boundCounter = counter.bind({ [key]: 'value' });
+const boundCounter = counter.bind({ pid: process.pid });
 boundCounter.add(10);
 
 // .. some other work


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Readme from "OpenTelemetry Prometheus Metric Exporter" was not working

## Short description of the changes

- setting labelKeys when creating the counter
- using pid as a nicer example for the label
