### PR TITLE
fix: missing `global` in browser environments

### DIFF
--- a/packages/opentelemetry-api/package.json
+++ b/packages/opentelemetry-api/package.json
@@ -4,6 +4,10 @@
   "description": "Public API for OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
+  "browser": {
+    "./src/platform/index.ts": "./src/platform/browser/index.ts",
+    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
+  },
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json test/**/*.test.ts",

--- a/packages/opentelemetry-api/src/api/global-utils.ts
+++ b/packages/opentelemetry-api/src/api/global-utils.ts
@@ -18,6 +18,7 @@ import { ContextManager } from '@opentelemetry/context-base';
 import { HttpTextPropagator } from '../context/propagation/HttpTextPropagator';
 import { MeterProvider } from '../metrics/MeterProvider';
 import { TracerProvider } from '../trace/tracer_provider';
+import { _globalThis } from '../platform';
 
 export const GLOBAL_CONTEXT_MANAGER_API_KEY = Symbol.for(
   'io.opentelemetry.js.api.context'
@@ -31,14 +32,14 @@ export const GLOBAL_PROPAGATION_API_KEY = Symbol.for(
 export const GLOBAL_TRACE_API_KEY = Symbol.for('io.opentelemetry.js.api.trace');
 
 type Get<T> = (version: number) => T;
-type MyGlobals = Partial<{
+type OtelGlobal = Partial<{
   [GLOBAL_CONTEXT_MANAGER_API_KEY]: Get<ContextManager>;
   [GLOBAL_METRICS_API_KEY]: Get<MeterProvider>;
   [GLOBAL_PROPAGATION_API_KEY]: Get<HttpTextPropagator>;
   [GLOBAL_TRACE_API_KEY]: Get<TracerProvider>;
 }>;
 
-export const _global = global as typeof global & MyGlobals;
+export const _global = _globalThis as OtelGlobal;
 
 /**
  * Make a function which accepts a version integer and returns the instance of an API if the version

--- a/packages/opentelemetry-api/src/platform/browser/globalThis.ts
+++ b/packages/opentelemetry-api/src/platform/browser/globalThis.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** only globals that common to node and browsers are allowed */
+// eslint-disable-next-line node/no-unsupported-features/es-builtins, no-undef
+export const _globalThis = typeof globalThis === 'object' ? globalThis : window;

--- a/packages/opentelemetry-api/src/platform/browser/index.ts
+++ b/packages/opentelemetry-api/src/platform/browser/index.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './globalThis';

--- a/packages/opentelemetry-api/src/platform/index.ts
+++ b/packages/opentelemetry-api/src/platform/index.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './node';

--- a/packages/opentelemetry-api/src/platform/node/globalThis.ts
+++ b/packages/opentelemetry-api/src/platform/node/globalThis.ts
@@ -1,0 +1,19 @@
+/*!
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** only globals that common to node and browsers are allowed */
+// eslint-disable-next-line node/no-unsupported-features/es-builtins
+export const _globalThis = typeof globalThis === 'object' ? globalThis : global;

--- a/packages/opentelemetry-api/src/platform/node/index.ts
+++ b/packages/opentelemetry-api/src/platform/node/index.ts
@@ -1,0 +1,17 @@
+/*!
+ * Copyright 2020, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './globalThis';


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes https://github.com/open-telemetry/opentelemetry-js/issues/1066

## Short description of the changes

- Add fallbacks for `global` accessing.