### PR TITLE
feat: add OTEL_SAMPLING_PROBABILITY env var

### DIFF
--- a/packages/opentelemetry-tracing/README.md
+++ b/packages/opentelemetry-tracing/README.md
@@ -43,6 +43,13 @@ span.setAttribute('key', 'value');
 span.end();
 ```
 
+## Config
+
+Tracing configuration is a merge of user supplied configuration with both the default
+configuration as specified in [config.ts](./src/config.ts) and an
+environmentally configurable (via `OTEL_SAMPLING_PROBABILITY`) probability
+sampler delegate of a [ParentOrElse](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#parentorelse) sampler.
+
 ## Example
 
 See [examples/basic-tracer-node](https://github.com/open-telemetry/opentelemetry-js/tree/master/examples/basic-tracer-node) for an end-to-end example, including exporting created spans.

--- a/packages/opentelemetry-tracing/test/Tracer.test.ts
+++ b/packages/opentelemetry-tracing/test/Tracer.test.ts
@@ -15,7 +15,12 @@
  */
 
 import * as assert from 'assert';
-import { NoopSpan, Sampler, SamplingDecision } from '@opentelemetry/api';
+import {
+  NoopSpan,
+  Sampler,
+  SamplingDecision,
+  TraceFlags,
+} from '@opentelemetry/api';
 import { BasicTracerProvider, Tracer, Span } from '../src';
 import {
   InstrumentationLibrary,
@@ -40,6 +45,12 @@ describe('Tracer', () => {
     }
   }
 
+  afterEach(() => {
+    if (typeof process !== 'undefined' && process.release.name === 'node') {
+      delete process.env.OTEL_SAMPLING_PROBABILITY;
+    }
+  });
+
   it('should create a Tracer instance', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
@@ -47,6 +58,15 @@ describe('Tracer', () => {
       tracerProvider
     );
     assert.ok(tracer instanceof Tracer);
+  });
+
+  it('should use an AlwaysOnSampler by default', () => {
+    const tracer = new Tracer(
+      { name: 'default', version: '0.0.1' },
+      {},
+      tracerProvider
+    );
+    assert.strictEqual(tracer['_sampler'].toString(), 'AlwaysOnSampler');
   });
 
   it('should respect NO_RECORD sampling result', () => {
@@ -94,4 +114,64 @@ describe('Tracer', () => {
     assert.strictEqual(lib.name, 'default');
     assert.strictEqual(lib.version, '0.0.1');
   });
+
+  if (typeof process !== 'undefined' && process.release.name === 'node') {
+    it('should sample a trace when OTEL_SAMPLING_PROBABILITY is invalid', () => {
+      process.env.OTEL_SAMPLING_PROBABILITY = 'invalid value';
+      const tracer = new Tracer(
+        { name: 'default', version: '0.0.1' },
+        {},
+        tracerProvider
+      );
+      const span = tracer.startSpan('my-span');
+      const context = span.context();
+      assert.strictEqual(context.traceFlags, TraceFlags.SAMPLED);
+      span.end();
+    });
+  }
+
+  if (typeof process !== 'undefined' && process.release.name === 'node') {
+    it('should sample a trace when OTEL_SAMPLING_PROBABILITY is greater than 1', () => {
+      process.env.OTEL_SAMPLING_PROBABILITY = '2';
+      const tracer = new Tracer(
+        { name: 'default', version: '0.0.1' },
+        {},
+        tracerProvider
+      );
+      const span = tracer.startSpan('my-span');
+      const context = span.context();
+      assert.strictEqual(context.traceFlags, TraceFlags.SAMPLED);
+      span.end();
+    });
+  }
+
+  if (typeof process !== 'undefined' && process.release.name === 'node') {
+    it('should not sample a trace when OTEL_SAMPLING_PROBABILITY is 0', () => {
+      process.env.OTEL_SAMPLING_PROBABILITY = '0';
+      const tracer = new Tracer(
+        { name: 'default', version: '0.0.1' },
+        {},
+        tracerProvider
+      );
+      const span = tracer.startSpan('my-span');
+      const context = span.context();
+      assert.strictEqual(context.traceFlags, TraceFlags.NONE);
+      span.end();
+    });
+  }
+
+  if (typeof process !== 'undefined' && process.release.name === 'node') {
+    it('should not sample a trace when OTEL_SAMPLING_PROBABILITY is less than 0', () => {
+      process.env.OTEL_SAMPLING_PROBABILITY = '-1';
+      const tracer = new Tracer(
+        { name: 'default', version: '0.0.1' },
+        {},
+        tracerProvider
+      );
+      const span = tracer.startSpan('my-span');
+      const context = span.context();
+      assert.strictEqual(context.traceFlags, TraceFlags.NONE);
+      span.end();
+    });
+  }
 });


### PR DESCRIPTION
Allows user to configure tracer's sampling probability via env var


## Which problem is this PR solving?

- JS implementation of open-telemetry/opentelemetry-specification#567

## Short description of the changes

- `Tracer.ts` looks to see if `process.env.OTEL_SAMPLING_PROBABILITY` is set and if so determines the sampling probability by converting its contents to a number and passing it to the `ProbabilitySampler` constructor. If unset it defaults to passing in a probability of 1.
