### PR TITLE
chore: mark metapackages as public

### DIFF
--- a/metapackages/plugins-node-core/package.json
+++ b/metapackages/plugins-node-core/package.json
@@ -5,6 +5,9 @@
     "author": "OpenTelemetry Authors",
     "homepage": "https://github.com/open-telemetry/opentelemetry-js#readme",
     "license": "Apache-2.0",
+    "publishConfig": {
+        "access": "public"
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/open-telemetry/opentelemetry-js.git"

--- a/metapackages/plugins-web-core/package.json
+++ b/metapackages/plugins-web-core/package.json
@@ -5,6 +5,9 @@
     "author": "OpenTelemetry Authors",
     "homepage": "https://github.com/open-telemetry/opentelemetry-js#readme",
     "license": "Apache-2.0",
+    "publishConfig": {
+        "access": "public"
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/open-telemetry/opentelemetry-js.git"


### PR DESCRIPTION
This is required to publish npm packages publicly