### PR TITLE
Add the missing plugin dependencies in tracing example

### DIFF
--- a/getting-started/traced-example/package.json
+++ b/getting-started/traced-example/package.json
@@ -12,7 +12,9 @@
     "@opentelemetry/core": "^0.8.1",
     "@opentelemetry/exporter-zipkin": "^0.8.1",
     "@opentelemetry/node": "^0.8.1",
+    "@opentelemetry/plugin-express": "^0.7.0",
     "@opentelemetry/plugin-http": "^0.8.1",
+    "@opentelemetry/plugin-https": "^0.8.1",
     "@opentelemetry/tracing": "^0.8.1",
     "axios": "^0.19.0",
     "express": "^4.17.1"


### PR DESCRIPTION
Currently running the node app shows an error message in loading the express and https opentelemetry plugins.
Add the two modules as dependencies to resolve this error.