### PR TITLE
chore: template prometheus endpoint in examples rather than hardcode

### DIFF
--- a/examples/metrics/metrics/observer.js
+++ b/examples/metrics/metrics/observer.js
@@ -8,7 +8,9 @@ const exporter = new PrometheusExporter(
     startServer: true,
   },
   () => {
-    console.log('prometheus scrape endpoint: http://localhost:9464/metrics');
+    console.log(
+      `prometheus scrape endpoint: http://localhost:${PrometheusExporter.DEFAULT_OPTIONS.port}${PrometheusExporter.DEFAULT_OPTIONS.endpoint}`,
+    );
   },
 );
 

--- a/examples/prometheus/index.js
+++ b/examples/prometheus/index.js
@@ -8,7 +8,9 @@ const exporter = new PrometheusExporter(
     startServer: true,
   },
   () => {
-    console.log('prometheus scrape endpoint: http://localhost:9464/metrics');
+    console.log(
+      `prometheus scrape endpoint: http://localhost:${PrometheusExporter.DEFAULT_OPTIONS.port}${PrometheusExporter.DEFAULT_OPTIONS.endpoint}`,
+    );
   },
 );
 

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -303,12 +303,17 @@ Next, modify your `monitoring.js` file to look like this:
 const { MeterProvider } = require('@opentelemetry/metrics');
 const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
 
+const prometheusPort = PrometheusExporter.DEFAULT_OPTIONS.port
+const prometheusEndpoint = PrometheusExporter.DEFAULT_OPTIONS.endpoint
+
 const exporter = new PrometheusExporter(
   {
     startServer: true,
   },
   () => {
-    console.log('prometheus scrape endpoint: http://localhost:9464/metrics');
+    console.log(
+      `prometheus scrape endpoint: http://localhost:${prometheusPort}${Prometheusendpoint}`,
+    );
   },
 );
 

--- a/getting-started/monitored-example/monitoring.js
+++ b/getting-started/monitored-example/monitoring.js
@@ -8,7 +8,9 @@ const exporter = new PrometheusExporter(
     startServer: true,
   },
   () => {
-    console.log('prometheus scrape endpoint: http://localhost:9464/metrics');
+    console.log(
+      `prometheus scrape endpoint: http://localhost:${PrometheusExporter.DEFAULT_OPTIONS.port}${PrometheusExporter.DEFAULT_OPTIONS.endpoint}`,
+    );
   },
 );
 

--- a/getting-started/ts-example/README.md
+++ b/getting-started/ts-example/README.md
@@ -301,12 +301,17 @@ import { MeterProvider } from '@opentelemetry/metrics';
 import { Metric, BoundCounter } from '@opentelemetry/api';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 
+const prometheusPort = PrometheusExporter.DEFAULT_OPTIONS.port
+const prometheusEndpoint = PrometheusExporter.DEFAULT_OPTIONS.endpoint
+
 const exporter = new PrometheusExporter(
   {
     startServer: true,
   },
   () => {
-    console.log('prometheus scrape endpoint: http://localhost:9464/metrics');
+    console.log(
+      `prometheus scrape endpoint: http://localhost:${prometheusPort}${Prometheusendpoint}`,
+    );
   },
 );
 

--- a/getting-started/ts-example/monitoring.ts
+++ b/getting-started/ts-example/monitoring.ts
@@ -7,7 +7,9 @@ const exporter = new PrometheusExporter(
     startServer: true,
   },
   () => {
-    console.log('prometheus scrape endpoint: http://localhost:9464/metrics');
+    console.log(
+      `prometheus scrape endpoint: http://localhost:${PrometheusExporter.DEFAULT_OPTIONS.port}${PrometheusExporter.DEFAULT_OPTIONS.endpoint}`,
+    );
   },
 );
 


### PR DESCRIPTION
## Which problem is this PR solving?

- n/a

## Short description of the changes

- Rather than hardcode the default endpoint in prometheus examples, interpolate them  from where they are defined.
