### PR TITLE
chore(renovate): remove rebaseWhen config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "extends": [
     "config:base"
   ],
-  "rebaseWhen": "behind-base-branch",
   "schedule": [
     "after 9pm and before 5am"
   ],


### PR DESCRIPTION
- The default value is **conflicted**, which means Renovate will rebase only if the branch is conflicted. See: https://docs.renovatebot.com/configuration-options/#rebasewhen

- This is to reduce noise (too many emails from renovate-bot).

- It was my bad, I added this config in first place. :(