### PR TITLE
docs: add note about endpoint config option

### DIFF
--- a/packages/opentelemetry-exporter-jaeger/README.md
+++ b/packages/opentelemetry-exporter-jaeger/README.md
@@ -65,8 +65,11 @@ import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
 const options = {
   serviceName: 'my-service',
   tags: [], // optional
+  // You can use the default UDPSender
   host: 'localhost', // optional
   port: 6832, // optional
+  // OR you can use the HTTPSender as follows
+  // endpoint: 'http://localhost:14268/api/traces',
   maxPacketSize: 65000 // optional
 }
 const exporter = new JaegerExporter(options);


### PR DESCRIPTION
## Which problem is this PR solving?
The documentation didn't show that the URL for the `endpoint` config option should include `/api/traces`

## Short description of the changes
I added an extra option to the usage documentation example