### PR TITLE
Remove @rochdev from @open-telemetry/js-approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @dyladan @mayurkale22 @rochdev @bg451 @OlivierAlbertini @vmarchaud @markwolff @obecny @mwear @naseemkullah @legendecas
+* @dyladan @mayurkale22 @bg451 @OlivierAlbertini @vmarchaud @markwolff @obecny @mwear @naseemkullah @legendecas

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 
 Approvers ([@open-telemetry/js-approvers](https://github.com/orgs/open-telemetry/teams/javascript-approvers)):
 
-- [Roch Devost](https://github.com/rochdev), DataDog
 - [Brandon Gonzalez](https://github.com/bg451), LightStep
 - [Olivier Albertini](https://github.com/OlivierAlbertini), Ville de Montréal
 - [Valentin Marchaud](https://github.com/vmarchaud), Open Source Contributor


### PR DESCRIPTION
- This is based on offline discussion with @rochdev.

- (apparently) Roch is very eager to resume the contribution soon, but for now we have decided to remove him from the approvers list.

- Many thanks to @rochdev for your contributions and valuable reviews on the many PRs at early stage. 