### PR TITLE
Remove @bg451 from @open-telemetry/js-approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @dyladan @mayurkale22 @bg451 @OlivierAlbertini @vmarchaud @markwolff @obecny @mwear @naseemkullah @legendecas
+* @dyladan @mayurkale22 @OlivierAlbertini @vmarchaud @markwolff @obecny @mwear @naseemkullah @legendecas

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 
 Approvers ([@open-telemetry/js-approvers](https://github.com/orgs/open-telemetry/teams/javascript-approvers)):
 
-- [Brandon Gonzalez](https://github.com/bg451), LightStep
 - [Olivier Albertini](https://github.com/OlivierAlbertini), Ville de Montréal
 - [Valentin Marchaud](https://github.com/vmarchaud), Open Source Contributor
 - [Mark Wolff](https://github.com/markwolff), Microsoft


### PR DESCRIPTION
- This is based on offline discussion with @bg451.

- @bg451 was in the original team to kick off this project

- Many thanks to @bg451 for your [contributions](https://github.com/open-telemetry/opentelemetry-js/pulls?q=is%3Apr+sort%3Aupdated-desc+author%3Abg451+is%3Aclosed) and [valuable reviews](https://github.com/open-telemetry/opentelemetry-js/pulls?q=is%3Apr+sort%3Aupdated-desc+reviewed-by%3Abg451+is%3Aclosed) on the many PRs especially OpenTracing-shim and Metrics-API work.

/cc @dyladan @obecny 