### PR TITLE
feat: Add types for Collector Metric Exporter

### DIFF
--- a/packages/opentelemetry-exporter-collector/src/platform/browser/CollectorTraceExporter.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/browser/CollectorTraceExporter.ts
@@ -17,7 +17,7 @@
 import { CollectorTraceExporterBase } from '../../CollectorTraceExporterBase';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import { toCollectorExportTraceServiceRequest } from '../../transform';
-import { CollectorExporterConfigBrowser } from '../../types';
+import { CollectorExporterConfigBrowser } from './types';
 import * as collectorTypes from '../../types';
 
 const DEFAULT_COLLECTOR_URL = 'http://localhost:55680/v1/trace';

--- a/packages/opentelemetry-exporter-collector/src/platform/browser/types.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/browser/types.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CollectorExporterConfigBase } from '../../types';
+
+/**
+ * Collector Exporter Config for Web
+ */
+export interface CollectorExporterConfigBrowser
+  extends CollectorExporterConfigBase {
+  headers?: { [key: string]: string };
+}

--- a/packages/opentelemetry-exporter-collector/src/platform/node/CollectorTraceExporter.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/node/CollectorTraceExporter.ts
@@ -21,12 +21,13 @@ import * as collectorTypes from '../../types';
 
 import { ReadableSpan } from '@opentelemetry/tracing';
 import { CollectorTraceExporterBase } from '../../CollectorTraceExporterBase';
-import {
-  CollectorExporterError,
-  CollectorExporterConfigNode,
-} from '../../types';
+import { CollectorExporterError } from '../../types';
 import { toCollectorExportTraceServiceRequest } from '../../transform';
-import { GRPCSpanQueueItem, ServiceClient } from './types';
+import {
+  GRPCSpanQueueItem,
+  ServiceClient,
+  CollectorExporterConfigNode,
+} from './types';
 import { removeProtocol } from './util';
 
 const DEFAULT_COLLECTOR_URL = 'localhost:55680';

--- a/packages/opentelemetry-exporter-collector/src/platform/node/types.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/node/types.ts
@@ -16,7 +16,10 @@
 
 import * as grpc from 'grpc';
 import { ReadableSpan } from '@opentelemetry/tracing';
-import { CollectorExporterError } from '../../types';
+import {
+  CollectorExporterError,
+  CollectorExporterConfigBase,
+} from '../../types';
 
 /**
  * Queue item to be used to save temporary spans in case the GRPC service
@@ -37,4 +40,13 @@ export interface ServiceClient extends grpc.Client {
     metadata: grpc.Metadata | undefined,
     callback: Function
   ) => {};
+}
+
+/**
+ * Collector Exporter Config for Node
+ */
+export interface CollectorExporterConfigNode
+  extends CollectorExporterConfigBase {
+  credentials?: grpc.ChannelCredentials;
+  metadata?: grpc.Metadata;
 }

--- a/packages/opentelemetry-exporter-collector/src/types.ts
+++ b/packages/opentelemetry-exporter-collector/src/types.ts
@@ -16,7 +16,6 @@
 
 import { SpanKind, Logger, Attributes } from '@opentelemetry/api';
 import * as api from '@opentelemetry/api';
-import * as grpc from 'grpc';
 
 // header to prevent instrumentation on request
 export const OT_REQUEST_HEADER = 'x-opentelemetry-outgoing-request';
@@ -274,23 +273,6 @@ export interface CollectorExporterConfigBase {
   serviceName?: string;
   attributes?: Attributes;
   url?: string;
-}
-
-/**
- * Collector Exporter Config for Web
- */
-export interface CollectorExporterConfigBrowser
-  extends CollectorExporterConfigBase {
-  headers?: { [key: string]: string };
-}
-
-/**
- * Collector Exporter Config for Node
- */
-export interface CollectorExporterConfigNode
-  extends CollectorExporterConfigBase {
-  credentials?: grpc.ChannelCredentials;
-  metadata?: grpc.Metadata;
 }
 
 /**

--- a/packages/opentelemetry-exporter-collector/src/types.ts
+++ b/packages/opentelemetry-exporter-collector/src/types.ts
@@ -50,6 +50,100 @@ export namespace opentelemetryProto {
     }
   }
 
+  export namespace metrics.v1 {
+    export interface Metric {
+      metricDescriptor: opentelemetryProto.metrics.v1.MetricDescriptor;
+      int64DataPoints?: opentelemetryProto.metrics.v1.Int64DataPoint[];
+      doubleDataPoints?: opentelemetryProto.metrics.v1.DoubleDataPoint[];
+      histogramDataPoints?: opentelemetryProto.metrics.v1.HistogramDataPoint[];
+      summaryDataPoints?: opentelemetryProto.metrics.v1.SummaryDataPoint[];
+    }
+
+    export interface Int64DataPoint {
+      labels: opentelemetryProto.common.v1.StringKeyValue[];
+      startTimeUnixNano: number;
+      timeUnixNano: number;
+      value: number;
+    }
+
+    export interface DoubleDataPoint {
+      labels: opentelemetryProto.common.v1.StringKeyValue[];
+      startTimeUnixNano: number;
+      timeUnixNano: number;
+      value: number;
+    }
+
+    export interface HistogramDataPoint {
+      labels: opentelemetryProto.common.v1.StringKeyValue[];
+      startTimeUnixNano: number;
+      timeUnixNano: number;
+      count: number;
+      sum: number;
+      buckets?: opentelemetryProto.metrics.v1.HistogramDataPointBucket[];
+      explicitBounds?: number[];
+    }
+
+    export interface HistogramDataPointBucket {
+      count: number;
+      exemplar?: opentelemetryProto.metrics.v1.HistogramExemplar;
+    }
+
+    export interface HistogramExemplar {
+      value: number;
+      timeUnixNano: number;
+      attachments: opentelemetryProto.common.v1.StringKeyValue[];
+    }
+
+    export interface SummaryDataPoint {
+      labels: opentelemetryProto.common.v1.StringKeyValue[];
+      startTimeUnixNano: number;
+      timeUnixNano: number;
+      count?: number;
+      sum?: number;
+      percentileValues: opentelemetryProto.metrics.v1.SummaryDataPointValueAtPercentile[];
+    }
+
+    export interface SummaryDataPointValueAtPercentile {
+      percentile: number;
+      value: number;
+    }
+
+    export interface MetricDescriptor {
+      name: string;
+      description: string;
+      unit: string;
+      type: opentelemetryProto.metrics.v1.MetricDescriptorType;
+      temporality: opentelemetryProto.metrics.v1.MetricDescriptorTemporality;
+    }
+
+    export interface InstrumentationLibraryMetrics {
+      instrumentationLibrary?: opentelemetryProto.common.v1.InstrumentationLibrary;
+      metrics: opentelemetryProto.metrics.v1.Metric[];
+    }
+
+    export interface ResourceMetrics {
+      resource?: opentelemetryProto.resource.v1.Resource;
+      instrumentationLibraryMetrics: opentelemetryProto.metrics.v1.InstrumentationLibraryMetrics[];
+    }
+
+    export enum MetricDescriptorType {
+      INVALID_TYPE,
+      INT64,
+      MONOTONIC_INT64,
+      DOUBLE,
+      MONOTONIC_DOUBLE,
+      HISTOGRAM,
+      SUMMARY,
+    }
+
+    export enum MetricDescriptorTemporality {
+      INVALID_TEMPORALITY,
+      INSTANTANEOUS,
+      DELTA,
+      CUMULATIVE,
+    }
+  }
+
   export namespace trace.v1 {
     export namespace ConstantSampler {
       export enum ConstantDecision {

--- a/packages/opentelemetry-exporter-collector/test/browser/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/browser/CollectorTraceExporter.test.ts
@@ -20,6 +20,7 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { CollectorTraceExporter } from '../../src/platform/browser/index';
 import * as collectorTypes from '../../src/types';
+import { CollectorExporterConfigBrowser } from '../../src/platform/browser/types';
 
 import {
   ensureSpanIsCorrect,
@@ -32,7 +33,7 @@ const sendBeacon = navigator.sendBeacon;
 
 describe('CollectorExporter - web', () => {
   let collectorTraceExporter: CollectorTraceExporter;
-  let collectorExporterConfig: collectorTypes.CollectorExporterConfigBrowser;
+  let collectorExporterConfig: CollectorExporterConfigBrowser;
   let spyOpen: any;
   let spySend: any;
   let spyBeacon: any;


### PR DESCRIPTION
# Summary
This PR addresses Issue #1109.

Currently, the Collector Exporter only sends traces to the collector. In Python, Java, and Go, for example, metric exporting already exists for the collector. This PR adds that feature. I created two versions, one for Node and the other for browser. The node version uses gRPC, and the browser uses Beacon or XHR. It's up to date with all previous collector exporter commits.

# What this PR does

This is the 3rd part of this long [PR](https://github.com/open-telemetry/opentelemetry-js/pull/1248).

This PR just creates types based off the [OpenTelemetry Proto](https://github.com/open-telemetry/opentelemetry-proto/blob/master/opentelemetry/proto/metrics/v1/metrics.proto).

## Next Steps
The next diffs will be as follows 
1. Add transform functions and tests
2. E2E Metric exporter for Browser with tests
3. E2E Metric exporter for Node with tests