### PR TITLE
chore: bump metapackage dependencies

### DIFF
--- a/metapackages/plugins-node-all/package.json
+++ b/metapackages/plugins-node-all/package.json
@@ -16,13 +16,13 @@
         "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
     },
     "dependencies": {
-        "@opentelemetry/plugin-express": "0.8.0",
-        "@opentelemetry/plugin-ioredis": "0.8.0",
-        "@opentelemetry/plugin-mongodb": "0.8.0",
-        "@opentelemetry/plugin-mysql": "0.8.0",
-        "@opentelemetry/plugin-pg": "0.8.0",
-        "@opentelemetry/plugin-pg-pool": "0.8.0",
-        "@opentelemetry/plugin-redis": "0.8.0",
+        "@opentelemetry/plugin-express": "0.9.0",
+        "@opentelemetry/plugin-ioredis": "0.9.0",
+        "@opentelemetry/plugin-mongodb": "0.9.0",
+        "@opentelemetry/plugin-mysql": "0.9.0",
+        "@opentelemetry/plugin-pg": "0.9.0",
+        "@opentelemetry/plugin-pg-pool": "0.9.0",
+        "@opentelemetry/plugin-redis": "0.9.0",
         "@opentelemetry/plugins-node-core": "^0.10.1"
     }
 }


### PR DESCRIPTION
Holding https://github.com/open-telemetry/opentelemetry-js/pull/1382 release for this.