### PR TITLE
chore: set registry and scope for canary publish

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/setup-node@master
         with:
           node-version: 14.x
+          registry-url: https://registry.npmjs.org
+          scope: '@opentelemetry'
 
       - name: restore lerna
         uses: actions/cache@master # must use unreleased master to cache multiple paths


### PR DESCRIPTION
The publish action failed because by default the setup-node github action uses the github registry. Set to npmjs specifically.