### PR TITLE
Fix flaky sdk test

### DIFF
--- a/packages/opentelemetry-sdk-node/package.json
+++ b/packages/opentelemetry-sdk-node/package.json
@@ -54,11 +54,13 @@
     "@opentelemetry/context-async-hooks": "^0.10.2",
     "@types/mocha": "7.0.2",
     "@types/node": "14.0.27",
+    "@types/sinon": "9.0.4",
     "codecov": "3.7.2",
     "gts": "2.0.2",
     "istanbul-instrumenter-loader": "3.0.1",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
+    "sinon": "9.0.2",
     "ts-loader": "7.0.5",
     "ts-mocha": "7.0.0",
     "typescript": "3.9.7"

--- a/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -35,13 +35,13 @@ import {
 import * as assert from 'assert';
 import { NodeSDK } from '../src';
 import * as NodeConfig from '@opentelemetry/node/build/src/config';
-import * as Sinon from "sinon";
+import * as Sinon from 'sinon';
 
 describe('Node SDK', () => {
   before(() => {
     // Disable attempted load of default plugins
-    Sinon.replace(NodeConfig, "DEFAULT_INSTRUMENTATION_PLUGINS", {})
-  })
+    Sinon.replace(NodeConfig, 'DEFAULT_INSTRUMENTATION_PLUGINS', {});
+  });
 
   beforeEach(() => {
     context.disable();

--- a/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -34,8 +34,15 @@ import {
 } from '@opentelemetry/tracing';
 import * as assert from 'assert';
 import { NodeSDK } from '../src';
+import * as NodeConfig from '@opentelemetry/node/build/src/config';
+import * as Sinon from "sinon";
 
 describe('Node SDK', () => {
+  before(() => {
+    // Disable attempted load of default plugins
+    Sinon.replace(NodeConfig, "DEFAULT_INSTRUMENTATION_PLUGINS", {})
+  })
+
   beforeEach(() => {
     context.disable();
     trace.disable();


### PR DESCRIPTION
Disable loading of plugins during sdk tests, which was the cause of the flaky test.