### PR TITLE
fix: proper histogram boundaries sort

### DIFF
--- a/packages/opentelemetry-metrics/src/export/aggregators/Histogram.ts
+++ b/packages/opentelemetry-metrics/src/export/aggregators/Histogram.ts
@@ -39,7 +39,7 @@ export class HistogramAggregator implements HistogramAggregatorType {
     }
     // we need to an ordered set to be able to correctly compute count for each
     // boundary since we'll iterate on each in order.
-    this._boundaries = boundaries.sort();
+    this._boundaries = boundaries.sort((a, b) => a - b);
     this._current = this._newEmptyCheckpoint();
     this._lastUpdateTime = hrTime();
   }

--- a/packages/opentelemetry-metrics/test/export/aggregators/Histogram.test.ts
+++ b/packages/opentelemetry-metrics/test/export/aggregators/Histogram.test.ts
@@ -27,9 +27,23 @@ describe('HistogramAggregator', () => {
     });
 
     it('should sort boundaries', () => {
-      const aggregator = new HistogramAggregator([200, 500, 300, 700, 1000, 1500]);
+      const aggregator = new HistogramAggregator([
+        200,
+        500,
+        300,
+        700,
+        1000,
+        1500,
+      ]);
       const point = aggregator.toPoint().value as Histogram;
-      assert.deepEqual(point.buckets.boundaries, [200, 300, 500, 700, 1000, 1500]);
+      assert.deepEqual(point.buckets.boundaries, [
+        200,
+        300,
+        500,
+        700,
+        1000,
+        1500,
+      ]);
     });
 
     it('should throw if no boundaries are defined', () => {

--- a/packages/opentelemetry-metrics/test/export/aggregators/Histogram.test.ts
+++ b/packages/opentelemetry-metrics/test/export/aggregators/Histogram.test.ts
@@ -27,9 +27,9 @@ describe('HistogramAggregator', () => {
     });
 
     it('should sort boundaries', () => {
-      const aggregator = new HistogramAggregator([500, 300, 700]);
+      const aggregator = new HistogramAggregator([200, 500, 300, 700, 1000, 1500]);
       const point = aggregator.toPoint().value as Histogram;
-      assert.deepEqual(point.buckets.boundaries, [300, 500, 700]);
+      assert.deepEqual(point.buckets.boundaries, [200, 300, 500, 700, 1000, 1500]);
     });
 
     it('should throw if no boundaries are defined', () => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Proper sort of histogram boundaries

## Short description of the changes

- Well known javascript behaviour, when array sort is being implemented by lexicographical order, not number,
so [200, 1000, 300, 1500] instead of [200, 300, 1000, 1500] becomes [1000, 1500, 200, 300]

