### PR TITLE
chore: fixing released version in main package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentelemetry-base",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "OpenTelemetry is a distributed tracing and stats collection framework.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",


### PR DESCRIPTION
Seems like the main package.json version was missed when I released the latest version