### PR TITLE
chore: only set one sigterm listener

### DIFF
--- a/packages/opentelemetry-core/src/platform/browser/ShutdownNotifier.ts
+++ b/packages/opentelemetry-core/src/platform/browser/ShutdownNotifier.ts
@@ -14,14 +14,26 @@
  * limitations under the License.
  */
 
+
+let shutDownListeners: Array<() => void> = [];
+window.addEventListener('unload', function () {
+  shutDownListeners.forEach(listener => listener());
+  shutDownListeners = [];
+});
+
 /**
  * Adds an event listener to trigger a callback when an unload event in the window is detected
  */
 export function notifyOnGlobalShutdown(cb: () => void): () => void {
-  window.addEventListener('unload', cb, { once: true });
-  return function removeCallbackFromGlobalShutdown() {
-    window.removeEventListener('unload', cb, false);
+  function removeCallbackFromGlobalShutdown() {
+    const i = shutDownListeners.findIndex((v) => v === cb);
+    if (i !== -1) {
+      shutDownListeners.splice(i, 1);
+    }
   };
+  removeCallbackFromGlobalShutdown();
+  shutDownListeners.push(cb);
+  return removeCallbackFromGlobalShutdown;
 }
 
 /**

--- a/packages/opentelemetry-core/src/platform/node/ShutdownNotifier.ts
+++ b/packages/opentelemetry-core/src/platform/node/ShutdownNotifier.ts
@@ -14,13 +14,22 @@
  * limitations under the License.
  */
 
+let shutDownListeners: Array<() => void> = [];
+process.once('SIGTERM', function () {
+  shutDownListeners.forEach(listener => listener());
+});
+
 /**
  * Adds an event listener to trigger a callback when a SIGTERM is detected in the process
  */
 export function notifyOnGlobalShutdown(cb: () => void): () => void {
-  process.once('SIGTERM', cb);
+  shutDownListeners.push(cb);
+
   return function removeCallbackFromGlobalShutdown() {
-    process.removeListener('SIGTERM', cb);
+    const i = shutDownListeners.findIndex((v) => v === cb);
+    if (i !== -1) {
+      shutDownListeners = shutDownListeners.slice(0, i).concat(shutDownListeners.slice(i + 1))
+    }
   };
 }
 

--- a/packages/opentelemetry-core/src/platform/node/ShutdownNotifier.ts
+++ b/packages/opentelemetry-core/src/platform/node/ShutdownNotifier.ts
@@ -17,6 +17,7 @@
 let shutDownListeners: Array<() => void> = [];
 process.on('SIGTERM', function () {
   shutDownListeners.forEach(listener => listener());
+  shutDownListeners = [];
 });
 
 /**

--- a/packages/opentelemetry-core/src/platform/node/ShutdownNotifier.ts
+++ b/packages/opentelemetry-core/src/platform/node/ShutdownNotifier.ts
@@ -15,7 +15,7 @@
  */
 
 let shutDownListeners: Array<() => void> = [];
-process.once('SIGTERM', function () {
+process.on('SIGTERM', function () {
   shutDownListeners.forEach(listener => listener());
 });
 

--- a/packages/opentelemetry-core/src/platform/node/ShutdownNotifier.ts
+++ b/packages/opentelemetry-core/src/platform/node/ShutdownNotifier.ts
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-let shutDownListenerReferences: Array<() => void> = [];
+let shutDownListeners: Array<() => void> = [];
 process.on('SIGTERM', function () {
-  shutDownListenerReferences.forEach(listener => listener());
-  shutDownListenerReferences = [];
+  shutDownListeners.forEach(listener => listener());
+  shutDownListeners = [];
 });
 
 /**
@@ -26,13 +26,13 @@ process.on('SIGTERM', function () {
  */
 export function notifyOnGlobalShutdown(cb: () => void): () => void {
   function removeCallbackFromGlobalShutdown() {
-    const i = shutDownListenerReferences.findIndex((v) => v === cb);
+    const i = shutDownListeners.findIndex((v) => v === cb);
     if (i !== -1) {
-      shutDownListenerReferences.splice(i, 1);
+      shutDownListeners.splice(i, 1);
     }
   };
   removeCallbackFromGlobalShutdown();
-  shutDownListenerReferences.push(cb);
+  shutDownListeners.push(cb);
   return removeCallbackFromGlobalShutdown;
 }
 


### PR DESCRIPTION
Currently, when tests are run the console logs many complaints that too many SIGTERM listeners are registered. This is because each callback that registers a listener for the global shutdown is added as a new listener. This PR fixes that by making a single global listener which calls all registered callbacks.