### PR TITLE
Request setup code in template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,13 @@ Please answer these questions before submitting a bug report.
 
 ### What version of Node are you using?
 
+### What code are you using to set up your tracing?
+
+```typescript
+// Please provide the code used to set up your MeterProvider/TracerProvider
+// and register it for use with the API
+```
+
 ### What did you do?
 
 If possible, provide a recipe for reproducing the error.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,12 +10,7 @@ Please answer these questions before submitting a bug report.
 
 ### What version of Node are you using?
 
-### What code are you using to set up your tracing?
-
-```typescript
-// Please provide the code used to set up your MeterProvider/TracerProvider
-// and register it for use with the API
-```
+### Please provide the code you used to setup the OpenTelemetry SDK
 
 ### What did you do?
 


### PR DESCRIPTION
We have found that many issues are a result of improper setup. This adds a section to the issue template which asks users to provide their setup code.