### PR TITLE
fix: include missing proto files in npm distribution

### DIFF
--- a/packages/opentelemetry-exporter-collector-grpc/package.json
+++ b/packages/opentelemetry-exporter-collector-grpc/package.json
@@ -38,7 +38,7 @@
     "build/src/**/*.js",
     "build/src/**/*.js.map",
     "build/src/**/*.d.ts",
-    "build/src/**/*.proto",
+    "build/protos/**/*.proto",
     "doc",
     "LICENSE",
     "README.md"

--- a/packages/opentelemetry-exporter-collector-proto/package.json
+++ b/packages/opentelemetry-exporter-collector-proto/package.json
@@ -38,7 +38,7 @@
     "build/src/**/*.js",
     "build/src/**/*.js.map",
     "build/src/**/*.d.ts",
-    "build/src/**/*.proto",
+    "build/protos/**/*.proto",
     "doc",
     "LICENSE",
     "README.md"


### PR DESCRIPTION
## Which problem is this PR solving?
#1538 
#1524
proto files from build directory of `@opentelemetry/exporter-collector-proto` and `@opentelemetry/exporter-collector-grpc` are not published to npm in v0.11.0, causing error message about missing files to be logged when package is used, and exporter to not work.

## Short description of the changes
Added the protos folder to the `"files"` section of `package.json`.
Validated the fix with `npm publish --dry-run`:
```
npm notice 304B   build/protos/opentelemetry/proto/collector/README.md                       
npm notice 2.9kB  build/protos/opentelemetry/proto/common/v1/common.proto                    
npm notice 1.9kB  build/protos/opentelemetry/proto/collector/metrics/v1/metrics_service.proto
npm notice 19.2kB build/protos/opentelemetry/proto/metrics/v1/metrics.proto                  
npm notice 1.3kB  build/protos/opentelemetry/proto/resource/v1/resource.proto                
npm notice 2.6kB  build/protos/opentelemetry/proto/trace/v1/trace_config.proto               
npm notice 2.0kB  build/protos/opentelemetry/proto/collector/trace/v1/trace_service.proto    
npm notice 11.1kB build/protos/opentelemetry/proto/trace/v1/trace.proto      
```

those files where missing before the change, and appear after the fix is applied.