### PR TITLE
feat(jaeger): read service name from JAEGER_SERVICE_NAME env var

### DIFF
--- a/packages/opentelemetry-exporter-jaeger/src/jaeger.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/jaeger.ts
@@ -51,6 +51,9 @@ export class JaegerExporter implements SpanExporter {
     localConfig.username = localConfig.username || process.env.JAEGER_USER;
     localConfig.password = localConfig.password || process.env.JAEGER_PASSWORD;
     localConfig.host = localConfig.host || process.env.JAEGER_AGENT_HOST;
+    if (process.env.JAEGER_SERVICE_NAME) {
+      localConfig.serviceName = process.env.JAEGER_SERVICE_NAME;
+    }
     if (localConfig.endpoint) {
       this._sender = new jaegerTypes.HTTPSender(localConfig);
     } else {

--- a/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
@@ -74,6 +74,25 @@ describe('JaegerExporter', () => {
       assert.strictEqual(exporter['_sender']._host, 'env-set-host');
     });
 
+    it('should respect jaeger service name env variable', () => {
+      process.env.JAEGER_SERVICE_NAME = 'env-set-service-name';
+      const exporter = new JaegerExporter({
+        serviceName: 'option-service',
+      });
+      assert.strictEqual(
+        exporter['_process'].serviceName,
+        'env-set-service-name'
+      );
+    });
+
+    it('should use the service name option if the env var is unset', () => {
+      process.env.JAEGER_SERVICE_NAME = '';
+      const exporter = new JaegerExporter({
+        serviceName: 'option-service',
+      });
+      assert.strictEqual(exporter['_process'].serviceName, 'option-service');
+    });
+
     it('should prioritize host option over env variable', () => {
       process.env.JAEGER_AGENT_HOST = 'env-set-host';
       const exporter = new JaegerExporter({


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- #1565 

## Short description of the changes

- if `JAEGER_SERVICE_NAME` is set as an env var, use it to configure the serviceName.

Note that this means the environment variable will override the local config, whereas for username, password or host the local options take precedence.
