### PR TITLE
chore: remove duplicate hostname resource attribute

### DIFF
--- a/packages/opentelemetry-resource-detector-aws/src/detectors/AwsEc2Detector.ts
+++ b/packages/opentelemetry-resource-detector-aws/src/detectors/AwsEc2Detector.ts
@@ -71,7 +71,6 @@ class AwsEc2Detector implements Detector {
       [HOST_RESOURCE.ID]: instanceId,
       [HOST_RESOURCE.TYPE]: instanceType,
       [HOST_RESOURCE.NAME]: hostname,
-      [HOST_RESOURCE.HOSTNAME]: hostname,
     });
   }
 

--- a/packages/opentelemetry-resources/src/constants.ts
+++ b/packages/opentelemetry-resources/src/constants.ts
@@ -48,12 +48,6 @@ export const CONTAINER_RESOURCE = {
 /** Attributes defining a computing instance (e.g. host). */
 export const HOST_RESOURCE = {
   /**
-   * Hostname of the host. It contains what the hostname command returns on the
-   * host machine.
-   */
-  HOSTNAME: 'host.hostname',
-
-  /**
    * Unique host id. For Cloud this must be the instance_id assigned by the
    * cloud provider
    */

--- a/packages/opentelemetry-resources/test/resource-assertions.test.ts
+++ b/packages/opentelemetry-resources/test/resource-assertions.test.ts
@@ -89,7 +89,6 @@ describe('assertHostResource', () => {
 
   it('validates optional attributes', () => {
     const resource = new Resource({
-      [HOST_RESOURCE.HOSTNAME]: 'opentelemetry-test-hostname',
       [HOST_RESOURCE.ID]: 'opentelemetry-test-id',
       [HOST_RESOURCE.NAME]: 'opentelemetry-test-name',
       [HOST_RESOURCE.TYPE]: 'n1-standard-1',

--- a/packages/opentelemetry-resources/test/util/resource-assertions.ts
+++ b/packages/opentelemetry-resources/test/util/resource-assertions.ts
@@ -122,11 +122,6 @@ export const assertHostResource = (
   }
 ) => {
   assertHasOneLabel(HOST_RESOURCE, resource);
-  if (validations.hostName)
-    assert.strictEqual(
-      resource.attributes[HOST_RESOURCE.HOSTNAME],
-      validations.hostName
-    );
   if (validations.id)
     assert.strictEqual(resource.attributes[HOST_RESOURCE.ID], validations.id);
   if (validations.name)


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes #1580 

## Short description of the changes

- There were two host name attributes: `host.name` and `host.hostname`. This PR removes the latter as per: https://github.com/open-telemetry/opentelemetry-specification/pull/838.
