### PR TITLE
feat: simplify active span logic

### DIFF
--- a/packages/opentelemetry-api/src/context/context.ts
+++ b/packages/opentelemetry-api/src/context/context.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Span, SpanContext } from '../';
+import { NoopSpan, Span, SpanContext } from '../';
 import { Context, createContextKey } from '@opentelemetry/context-base';
 
 /**
@@ -23,9 +23,7 @@ import { Context, createContextKey } from '@opentelemetry/context-base';
 const ACTIVE_SPAN_KEY = createContextKey(
   'OpenTelemetry Context Key ACTIVE_SPAN'
 );
-const EXTRACTED_SPAN_CONTEXT_KEY = createContextKey(
-  'OpenTelemetry Context Key EXTRACTED_SPAN_CONTEXT'
-);
+
 /**
  * Shared key for indicating if instrumentation should be suppressed beyond
  * this current scope.
@@ -61,22 +59,21 @@ export function setActiveSpan(context: Context, span: Span): Context {
 export function getExtractedSpanContext(
   context: Context
 ): SpanContext | undefined {
-  return (
-    (context.getValue(EXTRACTED_SPAN_CONTEXT_KEY) as SpanContext) || undefined
-  );
+  return getActiveSpan(context)?.context();
 }
 
 /**
- * Set the extracted span context on a context
+ * Wrap extracted span context in a NoopSpan as set as active span in a new
+ * context
  *
- * @param context context to set span context on
- * @param spanContext span context to set
+ * @param context context to set active span on
+ * @param spanContext span context to be wrapped
  */
 export function setExtractedSpanContext(
   context: Context,
   spanContext: SpanContext
 ): Context {
-  return context.setValue(EXTRACTED_SPAN_CONTEXT_KEY, spanContext);
+  return setActiveSpan(context, new NoopSpan(spanContext));
 }
 
 /**
@@ -89,7 +86,7 @@ export function setExtractedSpanContext(
 export function getParentSpanContext(
   context: Context
 ): SpanContext | undefined {
-  return getActiveSpan(context)?.context() || getExtractedSpanContext(context);
+  return getActiveSpan(context)?.context();
 }
 
 /**

--- a/packages/opentelemetry-api/src/context/context.ts
+++ b/packages/opentelemetry-api/src/context/context.ts
@@ -52,7 +52,7 @@ export function setActiveSpan(context: Context, span: Span): Context {
 }
 
 /**
- * Wrap extracted span context in a NoopSpan as set as active span in a new
+ * Wrap extracted span context in a NoopSpan and set as active span in a new
  * context
  *
  * @param context context to set active span on

--- a/packages/opentelemetry-api/src/context/context.ts
+++ b/packages/opentelemetry-api/src/context/context.ts
@@ -52,17 +52,6 @@ export function setActiveSpan(context: Context, span: Span): Context {
 }
 
 /**
- * Get the extracted span context from a context
- *
- * @param context context to get span context from
- */
-export function getExtractedSpanContext(
-  context: Context
-): SpanContext | undefined {
-  return getActiveSpan(context)?.context();
-}
-
-/**
  * Wrap extracted span context in a NoopSpan as set as active span in a new
  * context
  *

--- a/packages/opentelemetry-api/src/trace/NoopTracer.ts
+++ b/packages/opentelemetry-api/src/trace/NoopTracer.ts
@@ -18,7 +18,7 @@ import { Span, SpanOptions, Tracer, SpanContext } from '..';
 import { Context } from '@opentelemetry/context-base';
 import { NoopSpan, NOOP_SPAN } from './NoopSpan';
 import { isSpanContextValid } from './spancontext-utils';
-import { getExtractedSpanContext } from '../context/context';
+import { getActiveSpan } from '../context/context';
 
 /**
  * No-op implementations of {@link Tracer}.
@@ -31,7 +31,7 @@ export class NoopTracer implements Tracer {
   // startSpan starts a noop span.
   startSpan(name: string, options?: SpanOptions, context?: Context): Span {
     const parent = options?.parent;
-    const parentFromContext = context && getExtractedSpanContext(context);
+    const parentFromContext = context && getActiveSpan(context)?.context();
     if (isSpanContext(parent) && isSpanContextValid(parent)) {
       return new NoopSpan(parent);
     } else if (

--- a/packages/opentelemetry-core/test/context/B3MultiPropagator.test.ts
+++ b/packages/opentelemetry-core/test/context/B3MultiPropagator.test.ts
@@ -19,7 +19,7 @@ import {
   defaultSetter,
   SpanContext,
   TraceFlags,
-  getExtractedSpanContext,
+  getActiveSpan,
   setExtractedSpanContext,
 } from '@opentelemetry/api';
 import { ROOT_CONTEXT } from '@opentelemetry/context-base';
@@ -137,7 +137,7 @@ describe('B3MultiPropagator', () => {
         carrier,
         defaultGetter
       );
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'b7ad6b7169203331',
         traceId: '0af7651916cd43dd8448eb211c80319c',
@@ -158,7 +158,7 @@ describe('B3MultiPropagator', () => {
             carrier,
             defaultGetter
           );
-          const extractedSpanContext = getExtractedSpanContext(context);
+          const extractedSpanContext = getActiveSpan(context)?.context();
 
           assert.deepStrictEqual(extractedSpanContext, {
             spanId: 'b7ad6b7169203331',
@@ -180,7 +180,7 @@ describe('B3MultiPropagator', () => {
             carrier,
             defaultGetter
           );
-          const extractedSpanContext = getExtractedSpanContext(context);
+          const extractedSpanContext = getActiveSpan(context)?.context();
 
           assert.deepStrictEqual(extractedSpanContext, {
             spanId: 'b7ad6b7169203331',
@@ -202,7 +202,7 @@ describe('B3MultiPropagator', () => {
             carrier,
             defaultGetter
           );
-          const extractedSpanContext = getExtractedSpanContext(context);
+          const extractedSpanContext = getActiveSpan(context)?.context();
 
           assert.deepStrictEqual(extractedSpanContext, {
             spanId: 'b7ad6b7169203331',
@@ -226,7 +226,7 @@ describe('B3MultiPropagator', () => {
             carrier,
             defaultGetter
           );
-          const extractedSpanContext = getExtractedSpanContext(context);
+          const extractedSpanContext = getActiveSpan(context)?.context();
 
           assert.deepStrictEqual(extractedSpanContext, {
             spanId: 'b7ad6b7169203331',
@@ -251,7 +251,7 @@ describe('B3MultiPropagator', () => {
             carrier,
             defaultGetter
           );
-          const extractedSpanContext = getExtractedSpanContext(context);
+          const extractedSpanContext = getActiveSpan(context)?.context();
 
           assert.deepStrictEqual(extractedSpanContext, {
             spanId: 'b7ad6b7169203331',
@@ -274,7 +274,7 @@ describe('B3MultiPropagator', () => {
             carrier,
             defaultGetter
           );
-          const extractedSpanContext = getExtractedSpanContext(context);
+          const extractedSpanContext = getActiveSpan(context)?.context();
 
           assert.deepStrictEqual(extractedSpanContext, {
             spanId: 'b7ad6b7169203331',
@@ -297,7 +297,7 @@ describe('B3MultiPropagator', () => {
             carrier,
             defaultGetter
           );
-          const extractedSpanContext = getExtractedSpanContext(context);
+          const extractedSpanContext = getActiveSpan(context)?.context();
 
           assert.deepStrictEqual(extractedSpanContext, {
             spanId: 'b7ad6b7169203331',
@@ -320,7 +320,7 @@ describe('B3MultiPropagator', () => {
             carrier,
             defaultGetter
           );
-          const extractedSpanContext = getExtractedSpanContext(context);
+          const extractedSpanContext = getActiveSpan(context)?.context();
 
           assert.deepStrictEqual(extractedSpanContext, {
             spanId: 'b7ad6b7169203331',
@@ -338,9 +338,9 @@ describe('B3MultiPropagator', () => {
         it('should return undefined', () => {
           carrier[X_B3_TRACE_ID] = undefined;
           carrier[X_B3_SPAN_ID] = 'b7ad6b7169203331';
-          const context = getExtractedSpanContext(
+          const context = getActiveSpan(
             b3Propagator.extract(ROOT_CONTEXT, carrier, defaultGetter)
-          );
+          )?.context();
           assert.deepStrictEqual(context, undefined);
         });
       });
@@ -349,9 +349,9 @@ describe('B3MultiPropagator', () => {
         it('should return undefined', () => {
           carrier[X_B3_TRACE_ID] = '0af7651916cd43dd8448eb211c80319c';
           carrier[X_B3_SPAN_ID] = undefined;
-          const context = getExtractedSpanContext(
+          const context = getActiveSpan(
             b3Propagator.extract(ROOT_CONTEXT, carrier, defaultGetter)
-          );
+          )?.context();
           assert.deepStrictEqual(context, undefined);
         });
       });
@@ -361,18 +361,18 @@ describe('B3MultiPropagator', () => {
           carrier[X_B3_TRACE_ID] = '0af7651916cd43dd8448eb211c80319c';
           carrier[X_B3_SPAN_ID] = 'b7ad6b7169203331';
           carrier[X_B3_SAMPLED] = '2';
-          const context = getExtractedSpanContext(
+          const context = getActiveSpan(
             b3Propagator.extract(ROOT_CONTEXT, carrier, defaultGetter)
-          );
+          )?.context();
           assert.deepStrictEqual(context, undefined);
         });
       });
 
       describe('AND b3 header is missing', () => {
         it('should return undefined', () => {
-          const context = getExtractedSpanContext(
+          const context = getActiveSpan(
             b3Propagator.extract(ROOT_CONTEXT, carrier, defaultGetter)
-          );
+          )?.context();
           assert.deepStrictEqual(context, undefined);
         });
       });
@@ -381,9 +381,9 @@ describe('B3MultiPropagator', () => {
         it('should return undefined', () => {
           carrier[X_B3_TRACE_ID] = 'invalid!';
           carrier[X_B3_SPAN_ID] = 'b7ad6b7169203331';
-          const context = getExtractedSpanContext(
+          const context = getActiveSpan(
             b3Propagator.extract(ROOT_CONTEXT, carrier, defaultGetter)
-          );
+          )?.context();
           assert.deepStrictEqual(context, undefined);
         });
       });
@@ -398,7 +398,7 @@ describe('B3MultiPropagator', () => {
         carrier,
         defaultGetter
       );
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'b7ad6b7169203331',
         traceId: '0af7651916cd43dd8448eb211c80319c',
@@ -447,9 +447,9 @@ describe('B3MultiPropagator', () => {
 
       Object.getOwnPropertyNames(testCases).forEach(testCase => {
         carrier[X_B3_TRACE_ID] = testCases[testCase];
-        const extractedSpanContext = getExtractedSpanContext(
+        const extractedSpanContext = getActiveSpan(
           b3Propagator.extract(ROOT_CONTEXT, carrier, defaultGetter)
-        );
+        )?.context();
         assert.deepStrictEqual(extractedSpanContext, undefined, testCase);
       });
     });
@@ -485,7 +485,7 @@ describe('B3MultiPropagator', () => {
         carrier,
         defaultGetter
       );
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
 
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'b7ad6b7169203331',

--- a/packages/opentelemetry-core/test/context/B3Propagator.test.ts
+++ b/packages/opentelemetry-core/test/context/B3Propagator.test.ts
@@ -20,7 +20,7 @@ import {
   defaultSetter,
   SpanContext,
   TraceFlags,
-  getExtractedSpanContext,
+  getActiveSpan,
   setExtractedSpanContext,
 } from '@opentelemetry/api';
 import { ROOT_CONTEXT } from '@opentelemetry/context-base';
@@ -109,7 +109,7 @@ describe('B3Propagator', () => {
         defaultGetter
       );
 
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'e457b5a2e4d86bd1',
         traceId: '80f198ee56343ba864fe8b2a57d3eff7',
@@ -125,7 +125,7 @@ describe('B3Propagator', () => {
         defaultGetter
       );
 
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: '6e0c63257de34c92',
         traceId: 'd4cda95b652f4a1592b449d5929fda1b',
@@ -141,7 +141,7 @@ describe('B3Propagator', () => {
         defaultGetter
       );
 
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'e457b5a2e4d86bd1',
         traceId: '80f198ee56343ba864fe8b2a57d3eff7',

--- a/packages/opentelemetry-core/test/context/B3SinglePropagator.test.ts
+++ b/packages/opentelemetry-core/test/context/B3SinglePropagator.test.ts
@@ -22,7 +22,7 @@ import {
   TraceFlags,
   INVALID_SPANID,
   INVALID_TRACEID,
-  getExtractedSpanContext,
+  getActiveSpan,
   setExtractedSpanContext,
 } from '@opentelemetry/api';
 import { ROOT_CONTEXT } from '@opentelemetry/context-base';
@@ -136,7 +136,7 @@ describe('B3SinglePropagator', () => {
 
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultGetter);
 
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'e457b5a2e4d86bd1',
         traceId: '80f198ee56343ba864fe8b2a57d3eff7',
@@ -153,7 +153,7 @@ describe('B3SinglePropagator', () => {
 
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultGetter);
 
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'e457b5a2e4d86bd1',
         traceId: '80f198ee56343ba864fe8b2a57d3eff7',
@@ -170,7 +170,7 @@ describe('B3SinglePropagator', () => {
 
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultGetter);
 
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'e457b5a2e4d86bd1',
         traceId: '80f198ee56343ba864fe8b2a57d3eff7',
@@ -186,7 +186,7 @@ describe('B3SinglePropagator', () => {
 
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultGetter);
 
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'e457b5a2e4d86bd1',
         traceId: '00000000000000004aaba1a52cf8ee09',
@@ -203,7 +203,7 @@ describe('B3SinglePropagator', () => {
 
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultGetter);
 
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: 'e457b5a2e4d86bd1',
         traceId: '80f198ee56343ba864fe8b2a57d3eff7',
@@ -220,7 +220,7 @@ describe('B3SinglePropagator', () => {
 
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultGetter);
 
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(undefined, extractedSpanContext);
     });
 
@@ -231,7 +231,7 @@ describe('B3SinglePropagator', () => {
 
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultGetter);
 
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(undefined, extractedSpanContext);
     });
 
@@ -242,7 +242,7 @@ describe('B3SinglePropagator', () => {
 
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultGetter);
 
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(undefined, extractedSpanContext);
     });
 
@@ -253,7 +253,7 @@ describe('B3SinglePropagator', () => {
 
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultGetter);
 
-      const extractedSpanContext = getExtractedSpanContext(context);
+      const extractedSpanContext = getActiveSpan(context)?.context();
       assert.deepStrictEqual(undefined, extractedSpanContext);
     });
   });

--- a/packages/opentelemetry-core/test/context/composite.test.ts
+++ b/packages/opentelemetry-core/test/context/composite.test.ts
@@ -19,7 +19,7 @@ import {
   defaultSetter,
   TextMapPropagator,
   SpanContext,
-  getExtractedSpanContext,
+  getActiveSpan,
   setExtractedSpanContext,
 } from '@opentelemetry/api';
 import { Context, ROOT_CONTEXT } from '@opentelemetry/context-base';
@@ -113,9 +113,9 @@ describe('Composite Propagator', () => {
       const composite = new CompositePropagator({
         propagators: [new B3MultiPropagator(), new HttpTraceContext()],
       });
-      const spanContext = getExtractedSpanContext(
+      const spanContext = getActiveSpan(
         composite.extract(ROOT_CONTEXT, carrier, defaultGetter)
-      );
+      )?.context();
 
       if (!spanContext) {
         throw new Error('no extracted context');
@@ -132,9 +132,9 @@ describe('Composite Propagator', () => {
       const composite = new CompositePropagator({
         propagators: [new ThrowingPropagator(), new HttpTraceContext()],
       });
-      const spanContext = getExtractedSpanContext(
+      const spanContext = getActiveSpan(
         composite.extract(ROOT_CONTEXT, carrier, defaultGetter)
-      );
+      )?.context();
 
       if (!spanContext) {
         throw new Error('no extracted context');

--- a/packages/opentelemetry-plugin-http/test/utils/DummyPropagation.ts
+++ b/packages/opentelemetry-plugin-http/test/utils/DummyPropagation.ts
@@ -30,6 +30,7 @@ export class DummyPropagation implements TextMapPropagator {
       traceId: carrier[DummyPropagation.TRACE_CONTEXT_KEY] as string,
       spanId: DummyPropagation.SPAN_CONTEXT_KEY,
       traceFlags: TraceFlags.SAMPLED,
+      isRemote: true,
     };
     if (extractedSpanContext.traceId && extractedSpanContext.spanId) {
       return setExtractedSpanContext(context, extractedSpanContext);

--- a/packages/opentelemetry-plugin-https/test/utils/DummyPropagation.ts
+++ b/packages/opentelemetry-plugin-https/test/utils/DummyPropagation.ts
@@ -30,6 +30,7 @@ export class DummyPropagation implements TextMapPropagator {
       traceId: carrier[DummyPropagation.TRACE_CONTEXT_KEY] as string,
       spanId: DummyPropagation.SPAN_CONTEXT_KEY,
       traceFlags: TraceFlags.SAMPLED,
+      isRemote: true,
     };
     if (extractedSpanContext.traceId && extractedSpanContext.spanId) {
       return setExtractedSpanContext(context, extractedSpanContext);

--- a/packages/opentelemetry-shim-opentracing/src/shim.ts
+++ b/packages/opentelemetry-shim-opentracing/src/shim.ts
@@ -200,7 +200,7 @@ export class TracerShim extends opentracing.Tracer {
       case opentracing.FORMAT_HTTP_HEADERS:
       case opentracing.FORMAT_TEXT_MAP: {
         const context: api.Context = api.propagation.extract(carrier);
-        const spanContext = api.getExtractedSpanContext(context);
+        const spanContext = api.getActiveSpan(context)?.context();
         const correlationContext = getCorrelationContext(context);
 
         if (!spanContext) {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes #1558

## Short description of the changes

This PR simplifies the active span logic by only storing a span in the active context. Instead of storing plain span contexts in a context, they are wrapped in a NoopSpan on extract.

- The `setExtractedSpanContext` API method was updated to wrap the extracted span context in a NoopSpan before storing it in a context.
- The `getExtractedSpanContext` method was removed, as this should now be done by accessing the context of the current span.
- Logic in the http plugin had to be adjusted to preserve the require parent behavior.

cc: @vmarchaud - This work might be a prerequisite for #1552.
