### PR TITLE
fix: propagate the b3 parentspanid. fixes regression of (#1338)

### DIFF
--- a/packages/opentelemetry-core/src/context/propagation/b3-common.ts
+++ b/packages/opentelemetry-core/src/context/propagation/b3-common.ts
@@ -16,6 +16,11 @@
 
 import { createContextKey } from '@opentelemetry/api';
 
+/** shared context for storing an extracted b3 parent span id */
+export const B3_PARENT_SPAN_ID_KEY = createContextKey(
+  'OpenTelemetry Context Key B3 Parent Span Id'
+);
+
 /** shared context for storing an extracted b3 debug flag */
 export const B3_DEBUG_FLAG_KEY = createContextKey(
   'OpenTelemetry Context Key B3 Debug Flag'


### PR DESCRIPTION
Signed-off-by: dblackhall-tyro <39076155+dblackhall-tyro@users.noreply.github.com>

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

There is a regression in 0.12 with the B3Propagator not propagating the parent span id.

## Short description of the changes

Created a B3_PARENT_SPAN_ID_KEY which is used to inject and extract the parent span id.
