### PR TITLE
feat(tracing): support for truncatation of span attribute values

### DIFF
--- a/packages/opentelemetry-core/src/utils/environment.ts
+++ b/packages/opentelemetry-core/src/utils/environment.ts
@@ -25,10 +25,12 @@ export interface ENVIRONMENT {
   OTEL_LOG_LEVEL?: LogLevel;
   OTEL_NO_PATCH_MODULES?: string;
   OTEL_SAMPLING_PROBABILITY?: number;
+  OTEL_SPAN_ATTRIBUTE_VALUE_SIZE_LIMIT?: number | null;
 }
 
 const ENVIRONMENT_NUMBERS: Partial<keyof ENVIRONMENT>[] = [
   'OTEL_SAMPLING_PROBABILITY',
+  'OTEL_SPAN_ATTRIBUTE_VALUE_SIZE_LIMIT',
 ];
 
 /**
@@ -38,6 +40,7 @@ export const DEFAULT_ENVIRONMENT: Required<ENVIRONMENT> = {
   OTEL_NO_PATCH_MODULES: '',
   OTEL_LOG_LEVEL: LogLevel.INFO,
   OTEL_SAMPLING_PROBABILITY: 1,
+  OTEL_SPAN_ATTRIBUTE_VALUE_SIZE_LIMIT: null,
 };
 
 /**
@@ -114,6 +117,10 @@ export function parseEnvironment(values: ENVIRONMENT_MAP): ENVIRONMENT {
 
       case 'OTEL_LOG_LEVEL':
         setLogLevelFromEnv(key, environment, values);
+        break;
+
+      case 'OTEL_SPAN_ATTRIBUTE_VALUE_SIZE_LIMIT':
+        parseNumber(key, environment, values, 32, Number.MAX_SAFE_INTEGER);
         break;
 
       default:

--- a/packages/opentelemetry-core/test/utils/environment.test.ts
+++ b/packages/opentelemetry-core/test/utils/environment.test.ts
@@ -77,11 +77,13 @@ describe('environment', () => {
         OTEL_NO_PATCH_MODULES: 'a,b,c',
         OTEL_LOG_LEVEL: 'ERROR',
         OTEL_SAMPLING_PROBABILITY: '0.5',
+        OTEL_SPAN_ATTRIBUTE_VALUE_SIZE_LIMIT: '32',
       });
       const env = getEnv();
       assert.strictEqual(env.OTEL_NO_PATCH_MODULES, 'a,b,c');
       assert.strictEqual(env.OTEL_LOG_LEVEL, LogLevel.ERROR);
       assert.strictEqual(env.OTEL_SAMPLING_PROBABILITY, 0.5);
+      assert.strictEqual(env.OTEL_SPAN_ATTRIBUTE_VALUE_SIZE_LIMIT, 32);
     });
 
     it('should parse OTEL_LOG_LEVEL despite casing', () => {

--- a/packages/opentelemetry-tracing/src/Tracer.ts
+++ b/packages/opentelemetry-tracing/src/Tracer.ts
@@ -55,6 +55,15 @@ export class Tracer implements api.Tracer {
     this.resource = _tracerProvider.resource;
     this.instrumentationLibrary = instrumentationLibrary;
     this.logger = config.logger || new ConsoleLogger(config.logLevel);
+
+    const configuredAttributeLimit =
+      this._traceParams.spanAttributeValueSizeLimit || null;
+    if (configuredAttributeLimit !== null && configuredAttributeLimit < 32) {
+      this.logger.warn(
+        'OTEL_SPAN_ATTRIBUTE_VALUE_SIZE_LIMIT was set to a value lower than 32, which is not allowed, limit of 32 will be applied.'
+      );
+      this._traceParams.spanAttributeValueSizeLimit = 32;
+    }
   }
 
   /**

--- a/packages/opentelemetry-tracing/src/config.ts
+++ b/packages/opentelemetry-tracing/src/config.ts
@@ -36,6 +36,7 @@ export const DEFAULT_CONFIG = {
     numberOfAttributesPerSpan: DEFAULT_MAX_ATTRIBUTES_PER_SPAN,
     numberOfLinksPerSpan: DEFAULT_MAX_LINKS_PER_SPAN,
     numberOfEventsPerSpan: DEFAULT_MAX_EVENTS_PER_SPAN,
+    spanAttributeValueSizeLimit: getEnv().OTEL_SPAN_ATTRIBUTE_VALUE_SIZE_LIMIT,
   },
   gracefulShutdown: true,
 };

--- a/packages/opentelemetry-tracing/src/types.ts
+++ b/packages/opentelemetry-tracing/src/types.ts
@@ -74,6 +74,8 @@ export interface TraceParams {
   numberOfLinksPerSpan?: number;
   /** numberOfEventsPerSpan is number of message events per span */
   numberOfEventsPerSpan?: number;
+  /** this field defines maximum length of attribute value before it is truncated */
+  spanAttributeValueSizeLimit?: number | null;
 }
 
 /** Interface configuration for a buffer. */

--- a/packages/opentelemetry-tracing/src/utility.ts
+++ b/packages/opentelemetry-tracing/src/utility.ts
@@ -56,6 +56,9 @@ export function mergeConfig(userConfig: TracerConfig) {
       traceParams.numberOfEventsPerSpan || DEFAULT_MAX_EVENTS_PER_SPAN;
     target.traceParams.numberOfLinksPerSpan =
       traceParams.numberOfLinksPerSpan || DEFAULT_MAX_LINKS_PER_SPAN;
+    target.traceParams.spanAttributeValueSizeLimit =
+      target.traceParams.spanAttributeValueSizeLimit ||
+      getEnv().OTEL_SPAN_ATTRIBUTE_VALUE_SIZE_LIMIT;
   }
   return target;
 }

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -78,6 +78,7 @@ describe('BasicTracerProvider', () => {
         numberOfAttributesPerSpan: 32,
         numberOfEventsPerSpan: 128,
         numberOfLinksPerSpan: 32,
+        spanAttributeValueSizeLimit: null,
       });
     });
 
@@ -91,6 +92,7 @@ describe('BasicTracerProvider', () => {
         numberOfAttributesPerSpan: 100,
         numberOfEventsPerSpan: 128,
         numberOfLinksPerSpan: 32,
+        spanAttributeValueSizeLimit: null,
       });
     });
 
@@ -104,6 +106,7 @@ describe('BasicTracerProvider', () => {
         numberOfAttributesPerSpan: 32,
         numberOfEventsPerSpan: 300,
         numberOfLinksPerSpan: 32,
+        spanAttributeValueSizeLimit: null,
       });
     });
 
@@ -117,6 +120,21 @@ describe('BasicTracerProvider', () => {
         numberOfAttributesPerSpan: 32,
         numberOfEventsPerSpan: 128,
         numberOfLinksPerSpan: 10,
+        spanAttributeValueSizeLimit: null,
+      });
+    });
+
+    it('should construct an instance with customized spanAttributeValueSizeLimit trace params', () => {
+      const tracer = new BasicTracerProvider({
+        traceParams: {
+          spanAttributeValueSizeLimit: 100,
+        },
+      }).getTracer('default');
+      assert.deepStrictEqual(tracer.getActiveTraceParams(), {
+        numberOfAttributesPerSpan: 32,
+        numberOfEventsPerSpan: 128,
+        numberOfLinksPerSpan: 32,
+        spanAttributeValueSizeLimit: 100,
       });
     });
 


### PR DESCRIPTION
## Which problem is this PR solving?
- implementation for Span attribute value truncatation as per incoming spec update https://github.com/open-telemetry/opentelemetry-specification/pull/1130

## Short description of the changes
- new utility function for truncating attribute values
- truncating function applied when setting attributes on Span
