### PR TITLE
chore: fixing conversion of id to hex and base64

### DIFF
--- a/examples/collector-exporter-node/docker/docker-compose.yaml
+++ b/examples/collector-exporter-node/docker/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 services:
   # Collector
   collector:
-    image: otel/opentelemetry-collector:0.12.0
+    image: otel/opentelemetry-collector:0.13.0
 #    image: otel/opentelemetry-collector:latest
     command: ["--config=/conf/collector-config.yaml", "--log-level=DEBUG"]
     volumes:

--- a/packages/opentelemetry-exporter-collector-grpc/test/helper.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/test/helper.ts
@@ -34,33 +34,25 @@ const meterProvider = new MeterProvider({
 const meter = meterProvider.getMeter('default', '0.0.1');
 
 const traceIdArr = [
-  213,
-  253,
-  116,
-  211,
-  199,
-  92,
-  241,
-  237,
-  187,
-  209,
-  239,
-  57,
-  115,
-  141,
-  26,
-  209,
-  222,
+  31,
+  16,
+  8,
   220,
-  223,
-  221,
-  253,
-  111,
-  110,
-  252,
+  142,
+  39,
+  14,
+  133,
+  196,
+  10,
+  13,
+  124,
+  57,
+  57,
+  178,
+  120,
 ];
-const spanIdArr = [229, 237, 116, 239, 110, 181, 127, 174, 31, 107, 157, 222];
-const parentIdArr = [239, 198, 188, 247, 94, 116, 247, 207, 58, 227, 127, 60];
+const spanIdArr = [94, 16, 114, 97, 246, 79, 165, 62];
+const parentIdArr = [120, 168, 145, 80, 152, 134, 67, 136];
 
 export async function mockCounter(): Promise<MetricRecord> {
   const name = 'int-counter';

--- a/packages/opentelemetry-exporter-collector-proto/test/helper.ts
+++ b/packages/opentelemetry-exporter-collector-proto/test/helper.ts
@@ -15,6 +15,7 @@
  */
 
 import { TraceFlags, ValueType } from '@opentelemetry/api';
+import { hexToBase64 } from '@opentelemetry/core';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import { Resource } from '@opentelemetry/resources';
 import { collectorTypes } from '@opentelemetry/exporter-collector';
@@ -97,11 +98,11 @@ export const mockedReadableSpan: ReadableSpan = {
   name: 'documentFetch',
   kind: 0,
   spanContext: {
-    traceId: '1f1008dc8e270e85c40a0d7c3939b278',
-    spanId: '5e107261f64fa53e',
+    traceId: traceIdHex,
+    spanId: spanIdHex,
     traceFlags: TraceFlags.SAMPLED,
   },
-  parentSpanId: '78a8915098864388',
+  parentSpanId: parentIdHex,
   startTime: [1574120165, 429803070],
   endTime: [1574120165, 438688070],
   ended: true,
@@ -110,8 +111,8 @@ export const mockedReadableSpan: ReadableSpan = {
   links: [
     {
       context: {
-        traceId: '1f1008dc8e270e85c40a0d7c3939b278',
-        spanId: '78a8915098864388',
+        traceId: traceIdHex,
+        spanId: parentIdHex,
       },
       attributes: { component: 'document-load' },
     },
@@ -222,8 +223,8 @@ export function ensureProtoLinksAreCorrect(
     attributes,
     [
       {
-        traceId: traceIdHex,
-        spanId: parentIdHex,
+        traceId: hexToBase64(traceIdHex),
+        spanId: hexToBase64(parentIdHex),
         attributes: [
           {
             key: 'component',
@@ -251,11 +252,19 @@ export function ensureProtoSpanIsCorrect(
   if (span.links) {
     ensureProtoLinksAreCorrect(span.links);
   }
-  assert.deepStrictEqual(span.traceId, traceIdHex, 'traceId is wrong');
-  assert.deepStrictEqual(span.spanId, spanIdHex, 'spanId is wrong');
+  assert.deepStrictEqual(
+    span.traceId,
+    hexToBase64(traceIdHex),
+    'traceId is' + ' wrong'
+  );
+  assert.deepStrictEqual(
+    span.spanId,
+    hexToBase64(spanIdHex),
+    'spanId is' + ' wrong'
+  );
   assert.deepStrictEqual(
     span.parentSpanId,
-    parentIdHex,
+    hexToBase64(parentIdHex),
     'parentIdArr is wrong'
   );
   assert.strictEqual(span.name, 'documentFetch', 'name is wrong');

--- a/packages/opentelemetry-exporter-collector/src/platform/browser/CollectorTraceExporter.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/browser/CollectorTraceExporter.ts
@@ -35,7 +35,7 @@ export class CollectorTraceExporter
   convert(
     spans: ReadableSpan[]
   ): collectorTypes.opentelemetryProto.collector.trace.v1.ExportTraceServiceRequest {
-    return toCollectorExportTraceServiceRequest(spans, this);
+    return toCollectorExportTraceServiceRequest(spans, this, true);
   }
 
   getDefaultUrl(config: CollectorExporterConfigBase) {

--- a/packages/opentelemetry-exporter-collector/src/platform/node/CollectorTraceExporter.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/node/CollectorTraceExporter.ts
@@ -35,7 +35,7 @@ export class CollectorTraceExporter
   convert(
     spans: ReadableSpan[]
   ): collectorTypes.opentelemetryProto.collector.trace.v1.ExportTraceServiceRequest {
-    return toCollectorExportTraceServiceRequest(spans, this);
+    return toCollectorExportTraceServiceRequest(spans, this, true);
   }
 
   getDefaultUrl(config: CollectorExporterConfigBase): string {

--- a/packages/opentelemetry-exporter-collector/test/common/transform.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/common/transform.test.ts
@@ -93,8 +93,11 @@ describe('transform', () => {
   });
 
   describe('toCollectorSpan', () => {
-    it('should convert span', () => {
+    it('should convert span using hex', () => {
       ensureSpanIsCorrect(transform.toCollectorSpan(mockedReadableSpan, true));
+    });
+    it('should convert span using base64', () => {
+      ensureSpanIsCorrect(transform.toCollectorSpan(mockedReadableSpan), false);
     });
   });
 

--- a/packages/opentelemetry-exporter-collector/test/common/transform.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/common/transform.test.ts
@@ -94,7 +94,7 @@ describe('transform', () => {
 
   describe('toCollectorSpan', () => {
     it('should convert span', () => {
-      ensureSpanIsCorrect(transform.toCollectorSpan(mockedReadableSpan));
+      ensureSpanIsCorrect(transform.toCollectorSpan(mockedReadableSpan, true));
     });
   });
 

--- a/packages/opentelemetry-exporter-collector/test/helper.ts
+++ b/packages/opentelemetry-exporter-collector/test/helper.ts
@@ -18,7 +18,7 @@ import { TraceFlags, ValueType } from '@opentelemetry/api';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import { Resource } from '@opentelemetry/resources';
 import { MetricRecord, MeterProvider } from '@opentelemetry/metrics';
-import { InstrumentationLibrary } from '@opentelemetry/core';
+import { hexToBase64, InstrumentationLibrary } from '@opentelemetry/core';
 import * as assert from 'assert';
 import { opentelemetryProto } from '../src/types';
 import * as collectorTypes from '../src/types';
@@ -387,14 +387,15 @@ export function ensureAttributesAreCorrect(
 }
 
 export function ensureLinksAreCorrect(
-  attributes: opentelemetryProto.trace.v1.Span.Link[]
+  attributes: opentelemetryProto.trace.v1.Span.Link[],
+  useHex?: boolean
 ) {
   assert.deepStrictEqual(
     attributes,
     [
       {
-        traceId: traceIdHex,
-        spanId: parentIdHex,
+        traceId: useHex ? traceIdHex : hexToBase64(traceIdHex),
+        spanId: useHex ? parentIdHex : hexToBase64(parentIdHex),
         attributes: [
           {
             key: 'component',
@@ -411,7 +412,8 @@ export function ensureLinksAreCorrect(
 }
 
 export function ensureSpanIsCorrect(
-  span: collectorTypes.opentelemetryProto.trace.v1.Span
+  span: collectorTypes.opentelemetryProto.trace.v1.Span,
+  useHex = true
 ) {
   if (span.attributes) {
     ensureAttributesAreCorrect(span.attributes);
@@ -420,13 +422,21 @@ export function ensureSpanIsCorrect(
     ensureEventsAreCorrect(span.events);
   }
   if (span.links) {
-    ensureLinksAreCorrect(span.links);
+    ensureLinksAreCorrect(span.links, useHex);
   }
-  assert.deepStrictEqual(span.traceId, traceIdHex, 'traceId is wrong');
-  assert.deepStrictEqual(span.spanId, spanIdHex, 'spanId is wrong');
+  assert.deepStrictEqual(
+    span.traceId,
+    useHex ? traceIdHex : hexToBase64(traceIdHex),
+    'traceId is' + ' wrong'
+  );
+  assert.deepStrictEqual(
+    span.spanId,
+    useHex ? spanIdHex : hexToBase64(spanIdHex),
+    'spanId is' + ' wrong'
+  );
   assert.deepStrictEqual(
     span.parentSpanId,
-    parentIdHex,
+    useHex ? parentIdHex : hexToBase64(parentIdHex),
     'parentIdArr is wrong'
   );
   assert.strictEqual(span.name, 'documentFetch', 'name is wrong');


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #1623 

## Short description of the changes

- For proto and grpc the ids is converted from hex to base64
- For json the id are kept as hex
