### PR TITLE
chore: eslint - fix unused vars warnings, add precommit lint - part 1

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,7 @@ module.exports = {
           "leadingUnderscore": "require"
         }
     ],
+    "@typescript-eslint/no-unused-vars": ["error", {"argsIgnorePattern": "^_", "args": "after-used"}],
     "@typescript-eslint/no-inferrable-types": ["error", { ignoreProperties: true }],
     "arrow-parens": ["error", "as-needed"],
     "prettier/prettier": ["error", { "singleQuote": true, "arrowParens": "avoid" }],
@@ -41,8 +42,8 @@ module.exports = {
         "@typescript-eslint/ban-ts-ignore": "off",
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-unused-vars": "off",
-        "@typescript-eslint/no-var-requires": "off"
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/no-unused-vars": "off"
       }
     }
   ]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,8 +42,8 @@ module.exports = {
         "@typescript-eslint/ban-ts-ignore": "off",
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-var-requires": "off",
-        "@typescript-eslint/no-unused-vars": "off"
+        "@typescript-eslint/no-unused-vars": "off",
+        "@typescript-eslint/no-var-requires": "off"
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -56,11 +56,13 @@
     "husky": "4.2.5",
     "lerna": "3.22.1",
     "lerna-changelog": "1.0.1",
+    "lint-staged": "^10.5.0",
     "markdownlint-cli": "0.23.2",
     "typescript": "3.9.7"
   },
   "husky": {
     "hooks": {
+      "pre-commit": "lerna run --concurrency 1 --stream lint:fix --since HEAD --exclude-dependents",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "husky": "4.2.5",
     "lerna": "3.22.1",
     "lerna-changelog": "1.0.1",
-    "lint-staged": "^10.5.0",
     "markdownlint-cli": "0.23.2",
     "typescript": "3.9.7"
   },

--- a/packages/opentelemetry-api/src/context/propagation/NoopTextMapPropagator.ts
+++ b/packages/opentelemetry-api/src/context/propagation/NoopTextMapPropagator.ts
@@ -22,9 +22,9 @@ import { TextMapPropagator } from './TextMapPropagator';
  */
 export class NoopTextMapPropagator implements TextMapPropagator {
   /** Noop inject function does nothing */
-  inject(context: Context, carrier: unknown): void {}
+  inject(_context: Context, _carrier: unknown): void {}
   /** Noop extract function does nothing and returns the input context */
-  extract(context: Context, carrier: unknown): Context {
+  extract(context: Context, _carrier: unknown): Context {
     return context;
   }
   fields(): string[] {

--- a/packages/opentelemetry-api/src/metrics/NoopMeter.ts
+++ b/packages/opentelemetry-api/src/metrics/NoopMeter.ts
@@ -48,7 +48,7 @@ export class NoopMeter implements Meter {
    * @param name the name of the metric.
    * @param [options] the metric options.
    */
-  createValueRecorder(name: string, options?: MetricOptions): ValueRecorder {
+  createValueRecorder(_name: string, _options?: MetricOptions): ValueRecorder {
     return NOOP_VALUE_RECORDER_METRIC;
   }
 
@@ -57,7 +57,7 @@ export class NoopMeter implements Meter {
    * @param name the name of the metric.
    * @param [options] the metric options.
    */
-  createCounter(name: string, options?: MetricOptions): Counter {
+  createCounter(_name: string, _options?: MetricOptions): Counter {
     return NOOP_COUNTER_METRIC;
   }
 
@@ -66,7 +66,7 @@ export class NoopMeter implements Meter {
    * @param name the name of the metric.
    * @param [options] the metric options.
    */
-  createUpDownCounter(name: string, options?: MetricOptions): UpDownCounter {
+  createUpDownCounter(_name: string, _options?: MetricOptions): UpDownCounter {
     return NOOP_COUNTER_METRIC;
   }
 
@@ -77,9 +77,9 @@ export class NoopMeter implements Meter {
    * @param [callback] the value observer callback
    */
   createValueObserver(
-    name: string,
-    options?: MetricOptions,
-    callback?: (observerResult: ObserverResult) => void
+    _name: string,
+    _options?: MetricOptions,
+    _callback?: (observerResult: ObserverResult) => void
   ): ValueObserver {
     return NOOP_VALUE_OBSERVER_METRIC;
   }
@@ -90,8 +90,8 @@ export class NoopMeter implements Meter {
    * @param callback the batch observer callback
    */
   createBatchObserver(
-    name: string,
-    callback: (batchObserverResult: BatchObserverResult) => void
+    _name: string,
+    _callback: (batchObserverResult: BatchObserverResult) => void
   ): BatchObserver {
     return NOOP_BATCH_OBSERVER_METRIC;
   }
@@ -111,7 +111,7 @@ export class NoopMetric<T> implements UnboundMetric<T> {
    * @param labels key-values pairs that are associated with a specific metric
    *     that you want to record.
    */
-  bind(labels: Labels): T {
+  bind(_labels: Labels): T {
     return this._instrument;
   }
 
@@ -119,7 +119,7 @@ export class NoopMetric<T> implements UnboundMetric<T> {
    * Removes the Binding from the metric, if it is present.
    * @param labels key-values pairs that are associated with a specific metric.
    */
-  unbind(labels: Labels): void {
+  unbind(_labels: Labels): void {
     return;
   }
 
@@ -163,23 +163,23 @@ export class NoopBatchObserverMetric
   implements BatchObserver {}
 
 export class NoopBoundCounter implements BoundCounter {
-  add(value: number): void {
+  add(_value: number): void {
     return;
   }
 }
 
 export class NoopBoundValueRecorder implements BoundValueRecorder {
   record(
-    value: number,
-    correlationContext?: CorrelationContext,
-    spanContext?: SpanContext
+    _value: number,
+    _correlationContext?: CorrelationContext,
+    _spanContext?: SpanContext
   ): void {
     return;
   }
 }
 
 export class NoopBoundBaseObserver implements BoundBaseObserver {
-  update(value: number) {}
+  update(_value: number) {}
 }
 
 export const NOOP_METER = new NoopMeter();

--- a/packages/opentelemetry-api/src/trace/NoopLogger.ts
+++ b/packages/opentelemetry-api/src/trace/NoopLogger.ts
@@ -19,14 +19,14 @@ import { Logger } from '../common/Logger';
 /** No-op implementation of Logger */
 export class NoopLogger implements Logger {
   // By default does nothing
-  debug(message: string, ...args: unknown[]) {}
+  debug(_message: string, ..._args: unknown[]) {}
 
   // By default does nothing
-  error(message: string, ...args: unknown[]) {}
+  error(_message: string, ..._args: unknown[]) {}
 
   // By default does nothing
-  warn(message: string, ...args: unknown[]) {}
+  warn(_message: string, ..._args: unknown[]) {}
 
   // By default does nothing
-  info(message: string, ...args: unknown[]) {}
+  info(_message: string, ..._args: unknown[]) {}
 }

--- a/packages/opentelemetry-api/src/trace/NoopSpan.ts
+++ b/packages/opentelemetry-api/src/trace/NoopSpan.ts
@@ -38,32 +38,32 @@ export class NoopSpan implements Span {
   }
 
   // By default does nothing
-  setAttribute(key: string, value: unknown): this {
+  setAttribute(_key: string, _value: unknown): this {
     return this;
   }
 
   // By default does nothing
-  setAttributes(attributes: Attributes): this {
+  setAttributes(_attributes: Attributes): this {
     return this;
   }
 
   // By default does nothing
-  addEvent(name: string, attributes?: Attributes): this {
+  addEvent(_name: string, _attributes?: Attributes): this {
     return this;
   }
 
   // By default does nothing
-  setStatus(status: Status): this {
+  setStatus(_status: Status): this {
     return this;
   }
 
   // By default does nothing
-  updateName(name: string): this {
+  updateName(_name: string): this {
     return this;
   }
 
   // By default does nothing
-  end(endTime?: TimeInput): void {}
+  end(_endTime?: TimeInput): void {}
 
   // isRecording always returns false for noopSpan.
   isRecording(): boolean {
@@ -71,7 +71,7 @@ export class NoopSpan implements Span {
   }
 
   // By default does nothing
-  recordException(exception: Exception, time?: TimeInput): void {}
+  recordException(_exception: Exception, _time?: TimeInput): void {}
 }
 
 export const NOOP_SPAN = new NoopSpan();

--- a/packages/opentelemetry-api/src/trace/NoopTracer.ts
+++ b/packages/opentelemetry-api/src/trace/NoopTracer.ts
@@ -51,7 +51,7 @@ export class NoopTracer implements Tracer {
     return fn();
   }
 
-  bind<T>(target: T, span?: Span): T {
+  bind<T>(target: T, _span?: Span): T {
     return target;
   }
 }

--- a/packages/opentelemetry-context-base/src/NoopContextManager.ts
+++ b/packages/opentelemetry-context-base/src/NoopContextManager.ts
@@ -23,13 +23,13 @@ export class NoopContextManager implements types.ContextManager {
   }
 
   with<T extends (...args: unknown[]) => ReturnType<T>>(
-    context: types.Context,
+    _context: types.Context,
     fn: T
   ): ReturnType<T> {
     return fn();
   }
 
-  bind<T>(target: T, context?: types.Context): T {
+  bind<T>(target: T, _context?: types.Context): T {
     return target;
   }
 

--- a/packages/opentelemetry-core/src/common/ConsoleLogger.ts
+++ b/packages/opentelemetry-core/src/common/ConsoleLogger.ts
@@ -42,11 +42,11 @@ export class ConsoleLogger implements Logger {
     }
   }
 
-  debug(message: string, ...args: unknown[]) {}
+  debug(_message: string, ..._args: unknown[]) {}
 
-  error(message: string, ...args: unknown[]) {}
+  error(_message: string, ..._args: unknown[]) {}
 
-  warn(message: string, ...args: unknown[]) {}
+  warn(_message: string, ..._args: unknown[]) {}
 
-  info(message: string, ...args: unknown[]) {}
+  info(_message: string, ..._args: unknown[]) {}
 }

--- a/packages/opentelemetry-core/src/common/NoopLogger.ts
+++ b/packages/opentelemetry-core/src/common/NoopLogger.ts
@@ -19,14 +19,14 @@ import { Logger } from '@opentelemetry/api';
 /** No-op implementation of Logger */
 export class NoopLogger implements Logger {
   // By default does nothing
-  debug(message: string, ...args: unknown[]) {}
+  debug(_message: string, ..._args: unknown[]) {}
 
   // By default does nothing
-  error(message: string, ...args: unknown[]) {}
+  error(_message: string, ..._args: unknown[]) {}
 
   // By default does nothing
-  warn(message: string, ...args: unknown[]) {}
+  warn(_message: string, ..._args: unknown[]) {}
 
   // By default does nothing
-  info(message: string, ...args: unknown[]) {}
+  info(_message: string, ..._args: unknown[]) {}
 }

--- a/packages/opentelemetry-core/src/platform/browser/timer-util.ts
+++ b/packages/opentelemetry-core/src/platform/browser/timer-util.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export function unrefTimer(timer: number): void {}
+export function unrefTimer(_timer: number): void {}

--- a/packages/opentelemetry-core/src/trace/sampler/AlwaysOffSampler.ts
+++ b/packages/opentelemetry-core/src/trace/sampler/AlwaysOffSampler.ts
@@ -25,6 +25,6 @@ export class AlwaysOffSampler implements Sampler {
   }
 
   toString(): string {
-    return `AlwaysOffSampler`;
+    return 'AlwaysOffSampler';
   }
 }

--- a/packages/opentelemetry-core/src/trace/sampler/AlwaysOnSampler.ts
+++ b/packages/opentelemetry-core/src/trace/sampler/AlwaysOnSampler.ts
@@ -25,6 +25,6 @@ export class AlwaysOnSampler implements Sampler {
   }
 
   toString(): string {
-    return `AlwaysOnSampler`;
+    return 'AlwaysOnSampler';
   }
 }

--- a/packages/opentelemetry-exporter-collector/src/platform/node/CollectorExporterNodeBase.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/node/CollectorExporterNodeBase.ts
@@ -42,7 +42,7 @@ export abstract class CollectorExporterNodeBase<
       parseHeaders(config.headers, this.logger) || this.DEFAULT_HEADERS;
   }
 
-  onInit(config: CollectorExporterConfigBase): void {
+  onInit(_config: CollectorExporterConfigBase): void {
     this._isShutdown = false;
   }
 

--- a/packages/opentelemetry-metrics/src/export/Controller.ts
+++ b/packages/opentelemetry-metrics/src/export/Controller.ts
@@ -49,7 +49,7 @@ export class PushController extends Controller {
 
   private async _collect(): Promise<void> {
     await this._meter.collect();
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       this._exporter.export(
         this._meter.getBatcher().checkPointSet(),
         result => {

--- a/packages/opentelemetry-metrics/src/export/NoopExporter.ts
+++ b/packages/opentelemetry-metrics/src/export/NoopExporter.ts
@@ -20,8 +20,8 @@ import { ExportResult } from '@opentelemetry/core';
 export class NoopExporter implements MetricExporter {
   // By default does nothing
   export(
-    metrics: MetricRecord[],
-    resultCallback: (result: ExportResult) => void
+    _metrics: MetricRecord[],
+    _resultCallback: (result: ExportResult) => void
   ): void {}
 
   // By default does nothing

--- a/packages/opentelemetry-plugin-grpc/src/grpc.ts
+++ b/packages/opentelemetry-plugin-grpc/src/grpc.ts
@@ -342,8 +342,8 @@ export class GrpcPlugin extends BasePlugin<grpc> {
       return function makeClientConstructor(
         this: typeof grpcTypes.Client,
         methods: { [key: string]: { originalName?: string } },
-        serviceName: string,
-        options: grpcTypes.GenericClientOptions
+        _serviceName: string,
+        _options: grpcTypes.GenericClientOptions
       ) {
         const client = original.apply(this, arguments as any);
         shimmer.massWrap(
@@ -421,7 +421,7 @@ export class GrpcPlugin extends BasePlugin<grpc> {
     function patchedCallback(
       span: Span,
       callback: SendUnaryDataCallback,
-      metadata: grpcTypes.Metadata
+      _metadata: grpcTypes.Metadata
     ) {
       const wrappedFn = (err: grpcTypes.ServiceError, res: any) => {
         if (err) {

--- a/packages/opentelemetry-plugin-http/src/http.ts
+++ b/packages/opentelemetry-plugin-http/src/http.ts
@@ -155,7 +155,7 @@ export class HttpPlugin extends BasePlugin<Http> {
       ...args: HttpRequestArgs
     ) => ClientRequest
   ) {
-    return (original: Func<ClientRequest>): Func<ClientRequest> => {
+    return (_original: Func<ClientRequest>): Func<ClientRequest> => {
       // Re-implement http.get. This needs to be done (instead of using
       // getPatchOutgoingRequestFunction to patch it) because we need to
       // set the trace context header before the returned ClientRequest is
@@ -325,7 +325,7 @@ export class HttpPlugin extends BasePlugin<Http> {
           const originalEnd = response.end;
           response.end = function (
             this: ServerResponse,
-            ...args: ResponseEndArgs
+            ..._args: ResponseEndArgs
           ) {
             response.end = originalEnd;
             // Cannot pass args of type ResponseEndArgs,

--- a/packages/opentelemetry-shim-opentracing/src/shim.ts
+++ b/packages/opentelemetry-shim-opentracing/src/shim.ts
@@ -293,7 +293,7 @@ export class SpanShim extends opentracing.Span {
    * Logs a set of key value pairs. Since OpenTelemetry only supports events,
    * the KV pairs are used as attributes on an event named "log".
    */
-  log(keyValuePairs: Attributes, timestamp?: number): this {
+  log(keyValuePairs: Attributes, _timestamp?: number): this {
     // @todo: Handle timestamp
     this._span.addEvent('log', keyValuePairs);
     return this;

--- a/packages/opentelemetry-tracing/src/NoopSpanProcessor.ts
+++ b/packages/opentelemetry-tracing/src/NoopSpanProcessor.ts
@@ -20,8 +20,8 @@ import { SpanProcessor } from './SpanProcessor';
 
 /** No-op implementation of SpanProcessor */
 export class NoopSpanProcessor implements SpanProcessor {
-  onStart(span: Span): void {}
-  onEnd(span: ReadableSpan): void {}
+  onStart(_span: Span): void {}
+  onEnd(_span: ReadableSpan): void {}
   shutdown(): Promise<void> {
     return Promise.resolve();
   }

--- a/packages/opentelemetry-tracing/src/export/BatchSpanProcessor.ts
+++ b/packages/opentelemetry-tracing/src/export/BatchSpanProcessor.ts
@@ -55,7 +55,7 @@ export class BatchSpanProcessor implements SpanProcessor {
   }
 
   // does nothing.
-  onStart(span: Span): void {}
+  onStart(_span: Span): void {}
 
   onEnd(span: ReadableSpan): void {
     if (this._isShutdown) {

--- a/packages/opentelemetry-tracing/src/export/SimpleSpanProcessor.ts
+++ b/packages/opentelemetry-tracing/src/export/SimpleSpanProcessor.ts
@@ -38,7 +38,7 @@ export class SimpleSpanProcessor implements SpanProcessor {
   }
 
   // does nothing.
-  onStart(span: Span): void {}
+  onStart(_span: Span): void {}
 
   onEnd(span: ReadableSpan): void {
     if (this._isShutdown) {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- This PR removes warnings regarding  unused vars (https://github.com/open-telemetry/opentelemetry-js/issues/1093)

## Short description of the changes

- Stub classes methods arguments were prefixed with "_". Unused vars - deleted. Now this rule will throw error

Also, precommit lint hook introduced
