### PR TITLE
fix: do not access promise before resolve

### DIFF
--- a/examples/tracer-web/examples/user-interaction/index.js
+++ b/examples/tracer-web/examples/user-interaction/index.js
@@ -4,7 +4,7 @@ import { XMLHttpRequestPlugin } from '@opentelemetry/plugin-xml-http-request';
 import { UserInteractionPlugin } from '@opentelemetry/plugin-user-interaction';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { CollectorTraceExporter } from '@opentelemetry/exporter-collector';
-import { B3Propagator } from '@opentelemetry/core';
+import { B3Propagator } from '@opentelemetry/propagator-b3';
 
 const providerWithZone = new WebTracerProvider({
   plugins: [
@@ -12,10 +12,10 @@ const providerWithZone = new WebTracerProvider({
     new XMLHttpRequestPlugin({
       ignoreUrls: [/localhost/],
       propagateTraceHeaderCorsUrls: [
-        'http://localhost:8090'
-      ]
-    })
-  ]
+        'http://localhost:8090',
+      ],
+    }),
+  ],
 });
 
 providerWithZone.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));

--- a/packages/opentelemetry-exporter-collector-grpc/src/CollectorExporterNodeBase.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/src/CollectorExporterNodeBase.ts
@@ -64,9 +64,9 @@ export abstract class CollectorExporterNodeBase<
         _onFinish();
       };
       const _onFinish = () => {
+        resolve();
         const index = this._sendingPromises.indexOf(promise);
         this._sendingPromises.splice(index, 1);
-        resolve();
       };
 
       this._send(this, objects, _onSuccess, _onError);

--- a/packages/opentelemetry-exporter-collector-proto/src/CollectorExporterNodeBase.ts
+++ b/packages/opentelemetry-exporter-collector-proto/src/CollectorExporterNodeBase.ts
@@ -44,9 +44,9 @@ export abstract class CollectorExporterNodeBase<
         _onFinish();
       };
       const _onFinish = () => {
+        resolve();
         const index = this._sendingPromises.indexOf(promise);
         this._sendingPromises.splice(index, 1);
-        resolve();
       };
 
       this._send(this, objects, _onSuccess, _onError);

--- a/packages/opentelemetry-exporter-collector/src/platform/browser/CollectorExporterBrowserBase.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/browser/CollectorExporterBrowserBase.ts
@@ -78,9 +78,9 @@ export abstract class CollectorExporterBrowserBase<
         _onFinish();
       };
       const _onFinish = () => {
+        resolve();
         const index = this._sendingPromises.indexOf(promise);
         this._sendingPromises.splice(index, 1);
-        resolve();
       };
 
       if (this._useXHR) {

--- a/packages/opentelemetry-exporter-collector/src/platform/node/CollectorExporterNodeBase.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/node/CollectorExporterNodeBase.ts
@@ -67,9 +67,9 @@ export abstract class CollectorExporterNodeBase<
         _onFinish();
       };
       const _onFinish = () => {
+        resolve();
         const index = this._sendingPromises.indexOf(promise);
         this._sendingPromises.splice(index, 1);
-        resolve();
       };
       sendWithHttp(
         this,


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #1601
- Fixes #1610

## Short description of the changes

- The problem was that the promise was not yet resolved before it has been already removed from the Promise.all. So after it is resolved now can be removed
- During testing it turn out that the example for web hasn't been updated with B3 Propagator
