### PR TITLE
refactor: new interface for ExportResult #1569

### DIFF
--- a/packages/opentelemetry-core/src/ExportResult.ts
+++ b/packages/opentelemetry-core/src/ExportResult.ts
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-export enum ExportResult {
+export interface ExportResult {
+  code: ExportResultCode;
+  error?: Error;
+}
+
+export enum ExportResultCode {
   SUCCESS,
-  FAILED_NOT_RETRYABLE,
-  FAILED_RETRYABLE,
+  FAILED,
 }

--- a/packages/opentelemetry-exporter-collector-proto/test/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-proto/test/CollectorTraceExporter.test.ts
@@ -29,6 +29,7 @@ import {
   ensureProtoSpanIsCorrect,
   mockedReadableSpan,
 } from './helper';
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
 
 const fakeRequest = {
   end: function () {},
@@ -123,7 +124,6 @@ describe('CollectorTraceExporter - node with proto over http', () => {
     });
 
     it('should log the successful message', done => {
-      const spyLoggerDebug = sinon.stub(collectorExporter.logger, 'debug');
       const spyLoggerError = sinon.stub(collectorExporter.logger, 'error');
 
       const responseSpy = sinon.spy();
@@ -134,25 +134,15 @@ describe('CollectorTraceExporter - node with proto over http', () => {
         const callback = args[1];
         callback(mockRes);
         setTimeout(() => {
-          const response: any = spyLoggerDebug.args[1][0];
-          assert.strictEqual(response, 'statusCode: 200');
+          const result = responseSpy.args[0][0] as ExportResult;
+          assert.strictEqual(result.code, ExportResultCode.SUCCESS);
           assert.strictEqual(spyLoggerError.args.length, 0);
-          assert.strictEqual(responseSpy.args[0][0], 0);
           done();
         });
       }, waitTimeMS);
     });
 
     it('should log the error message', done => {
-      const spyLoggerError = sinon.spy();
-      const handler = core.loggingErrorHandler({
-        debug: sinon.fake(),
-        info: sinon.fake(),
-        warn: sinon.fake(),
-        error: spyLoggerError,
-      });
-      core.setGlobalErrorHandler(handler);
-
       const responseSpy = sinon.spy();
       collectorExporter.export(spans, responseSpy);
 
@@ -161,10 +151,10 @@ describe('CollectorTraceExporter - node with proto over http', () => {
         const callback = args[1];
         callback(mockResError);
         setTimeout(() => {
-          const response = spyLoggerError.args[0][0] as string;
-
-          assert.ok(response.includes('"code":"400"'));
-          assert.strictEqual(responseSpy.args[0][0], 1);
+          const result = responseSpy.args[0][0] as ExportResult;
+          assert.strictEqual(result.code, ExportResultCode.FAILED);
+          // @ts-expect-error
+          assert.strictEqual(result.error.code, 400);
           done();
         });
       }, waitTimeMS);

--- a/packages/opentelemetry-exporter-collector/src/platform/browser/util.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/browser/util.ts
@@ -72,7 +72,7 @@ export function sendWithXhr(
         onSuccess();
       } else {
         const error = new collectorTypes.CollectorExporterError(
-          xhr.responseText,
+          `Failed to export with XHR (status: ${xhr.status})`,
           xhr.status
         );
 

--- a/packages/opentelemetry-exporter-collector/test/common/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/common/CollectorMetricExporter.test.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  ExportResult,
-  ExportResultCode,
-  NoopLogger,
-} from '@opentelemetry/core';
+import { ExportResultCode, NoopLogger } from '@opentelemetry/core';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { CollectorExporterBase } from '../../src/CollectorExporterBase';

--- a/packages/opentelemetry-exporter-collector/test/common/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/common/CollectorMetricExporter.test.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { ExportResult, NoopLogger } from '@opentelemetry/core';
+import {
+  ExportResult,
+  ExportResultCode,
+  NoopLogger,
+} from '@opentelemetry/core';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { CollectorExporterBase } from '../../src/CollectorExporterBase';
@@ -149,8 +153,8 @@ describe('CollectorMetricExporter - common', () => {
           collectorExporter.export(metrics, callbackSpy);
           const returnCode = callbackSpy.args[0][0];
           assert.strictEqual(
-            returnCode,
-            ExportResult.FAILED_NOT_RETRYABLE,
+            returnCode.code,
+            ExportResultCode.FAILED,
             'return value is wrong'
           );
           assert.strictEqual(spySend.callCount, 0, 'should not call send');
@@ -158,34 +162,12 @@ describe('CollectorMetricExporter - common', () => {
       );
     });
     describe('when an error occurs', () => {
-      it('should return a Not Retryable Error', done => {
-        spySend.throws({
-          code: 100,
-          details: 'Test error',
-          metadata: {},
-          message: 'Non-retryable',
-          stack: 'Stack',
-        });
-        const callbackSpy = sinon.spy();
-        collectorExporter.export(metrics, callbackSpy);
-        setTimeout(() => {
-          const returnCode = callbackSpy.args[0][0];
-          assert.strictEqual(
-            returnCode,
-            ExportResult.FAILED_NOT_RETRYABLE,
-            'return value is wrong'
-          );
-          assert.strictEqual(spySend.callCount, 1, 'should call send');
-          done();
-        });
-      });
-
-      it('should return a Retryable Error', done => {
+      it('should return failed export result', done => {
         spySend.throws({
           code: 600,
           details: 'Test error',
           metadata: {},
-          message: 'Retryable',
+          message: 'Non-Retryable',
           stack: 'Stack',
         });
         const callbackSpy = sinon.spy();
@@ -193,9 +175,14 @@ describe('CollectorMetricExporter - common', () => {
         setTimeout(() => {
           const returnCode = callbackSpy.args[0][0];
           assert.strictEqual(
-            returnCode,
-            ExportResult.FAILED_RETRYABLE,
+            returnCode.code,
+            ExportResultCode.FAILED,
             'return value is wrong'
+          );
+          assert.strictEqual(
+            returnCode.error.message,
+            'Non-Retryable',
+            'return error message is wrong'
           );
           assert.strictEqual(spySend.callCount, 1, 'should call send');
           done();

--- a/packages/opentelemetry-exporter-collector/test/node/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/node/CollectorMetricExporter.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ConsoleLogger, LogLevel } from '@opentelemetry/core';
+import { ConsoleLogger, ExportResultCode, LogLevel } from '@opentelemetry/core';
 import * as core from '@opentelemetry/core';
 import * as http from 'http';
 import * as assert from 'assert';
@@ -42,10 +42,6 @@ const fakeRequest = {
 
 const mockRes = {
   statusCode: 200,
-};
-
-const mockResError = {
-  statusCode: 400,
 };
 
 const address = 'localhost:1501';
@@ -185,33 +181,10 @@ describe('CollectorMetricExporter - node with json over http', () => {
           const response: any = spyLoggerDebug.args[1][0];
           assert.strictEqual(response, 'statusCode: 200');
           assert.strictEqual(spyLoggerError.args.length, 0);
-          assert.strictEqual(responseSpy.args[0][0], 0);
-          done();
-        });
-      });
-    });
-
-    it('should log the error message', done => {
-      const spyLoggerError = sinon.spy();
-      const handler = core.loggingErrorHandler({
-        debug: sinon.fake(),
-        info: sinon.fake(),
-        warn: sinon.fake(),
-        error: spyLoggerError,
-      });
-      core.setGlobalErrorHandler(handler);
-
-      const responseSpy = sinon.spy();
-      collectorExporter.export(metrics, responseSpy);
-
-      setTimeout(() => {
-        const args = spyRequest.args[0];
-        const callback = args[1];
-        callback(mockResError);
-        setTimeout(() => {
-          const response = spyLoggerError.args[0][0] as string;
-          assert.ok(response.includes('"code":"400"'));
-          assert.strictEqual(responseSpy.args[0][0], 1);
+          assert.strictEqual(
+            responseSpy.args[0][0].code,
+            ExportResultCode.SUCCESS
+          );
           done();
         });
       });

--- a/packages/opentelemetry-exporter-collector/test/node/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/node/CollectorTraceExporter.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ConsoleLogger, LogLevel } from '@opentelemetry/core';
+import { ConsoleLogger, ExportResultCode, LogLevel } from '@opentelemetry/core';
 import * as core from '@opentelemetry/core';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import * as http from 'http';
@@ -40,9 +40,6 @@ const mockRes = {
   statusCode: 200,
 };
 
-const mockResError = {
-  statusCode: 400,
-};
 const address = 'localhost:1501';
 
 describe('CollectorTraceExporter - node with json over http', () => {
@@ -151,34 +148,10 @@ describe('CollectorTraceExporter - node with json over http', () => {
           const response: any = spyLoggerDebug.args[1][0];
           assert.strictEqual(response, 'statusCode: 200');
           assert.strictEqual(spyLoggerError.args.length, 0);
-          assert.strictEqual(responseSpy.args[0][0], 0);
-          done();
-        });
-      });
-    });
-
-    it('should log the error message', done => {
-      const spyLoggerError = sinon.spy();
-      const handler = core.loggingErrorHandler({
-        debug: sinon.fake(),
-        info: sinon.fake(),
-        warn: sinon.fake(),
-        error: spyLoggerError,
-      });
-      core.setGlobalErrorHandler(handler);
-
-      const responseSpy = sinon.spy();
-      collectorExporter.export(spans, responseSpy);
-
-      setTimeout(() => {
-        const args = spyRequest.args[0];
-        const callback = args[1];
-        callback(mockResError);
-        setTimeout(() => {
-          const response = spyLoggerError.args[0][0] as string;
-
-          assert.ok(response.includes('"code":"400"'));
-          assert.strictEqual(responseSpy.args[0][0], 1);
+          assert.strictEqual(
+            responseSpy.args[0][0].code,
+            ExportResultCode.SUCCESS
+          );
           done();
         });
       });

--- a/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -19,6 +19,7 @@ import {
   ExportResult,
   NoopLogger,
   globalErrorHandler,
+  ExportResultCode,
 } from '@opentelemetry/core';
 import { MetricExporter, MetricRecord } from '@opentelemetry/metrics';
 import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
@@ -86,7 +87,7 @@ export class PrometheusExporter implements MetricExporter {
     if (!this._server) {
       // It is conceivable that the _server may not be started as it is an async startup
       // However unlikely, if this happens the caller may retry the export
-      cb(ExportResult.FAILED_RETRYABLE);
+      cb({ code: ExportResultCode.FAILED });
       return;
     }
 
@@ -96,7 +97,7 @@ export class PrometheusExporter implements MetricExporter {
       this._batcher.process(record);
     }
 
-    cb(ExportResult.SUCCESS);
+    cb({ code: ExportResultCode.SUCCESS });
   }
 
   /**

--- a/packages/opentelemetry-exporter-zipkin/src/zipkin.ts
+++ b/packages/opentelemetry-exporter-zipkin/src/zipkin.ts
@@ -15,7 +15,11 @@
  */
 
 import * as api from '@opentelemetry/api';
-import { ExportResult, NoopLogger } from '@opentelemetry/core';
+import {
+  ExportResult,
+  ExportResultCode,
+  NoopLogger,
+} from '@opentelemetry/core';
 import { SpanExporter, ReadableSpan } from '@opentelemetry/tracing';
 import { prepareSend } from './platform/index';
 import * as zipkinTypes from './types';
@@ -66,7 +70,12 @@ export class ZipkinExporter implements SpanExporter {
     }
     this._logger.debug('Zipkin exporter export');
     if (this._isShutdown) {
-      setTimeout(() => resultCallback(ExportResult.FAILED_NOT_RETRYABLE));
+      setTimeout(() =>
+        resultCallback({
+          code: ExportResultCode.FAILED,
+          error: new Error('Exporter has been shutdown'),
+        })
+      );
       return;
     }
     const promise = new Promise(resolve => {

--- a/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
@@ -16,7 +16,6 @@
 
 import * as assert from 'assert';
 import * as nock from 'nock';
-import * as sinon from 'sinon';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import {
   ExportResult,

--- a/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
@@ -22,8 +22,7 @@ import {
   ExportResult,
   NoopLogger,
   hrTimeToMicroseconds,
-  setGlobalErrorHandler,
-  loggingErrorHandler,
+  ExportResultCode,
 } from '@opentelemetry/core';
 import * as api from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
@@ -118,7 +117,7 @@ describe('Zipkin Exporter - node', () => {
       });
 
       exporter.export([], (result: ExportResult) => {
-        assert.strictEqual(result, ExportResult.SUCCESS);
+        assert.strictEqual(result.code, ExportResultCode.SUCCESS);
       });
     });
 
@@ -195,7 +194,7 @@ describe('Zipkin Exporter - node', () => {
 
       exporter.export([span1, span2], (result: ExportResult) => {
         scope.done();
-        assert.strictEqual(result, ExportResult.SUCCESS);
+        assert.strictEqual(result.code, ExportResultCode.SUCCESS);
         assert.deepStrictEqual(requestBody, [
           // Span 1
           {
@@ -252,11 +251,11 @@ describe('Zipkin Exporter - node', () => {
 
       exporter.export([getReadableSpan()], (result: ExportResult) => {
         scope.done();
-        assert.strictEqual(result, ExportResult.SUCCESS);
+        assert.strictEqual(result.code, ExportResultCode.SUCCESS);
       });
     });
 
-    it('should return FailedNonRetryable with 4xx', () => {
+    it('should return Failed result with 4xx', () => {
       const scope = nock('http://localhost:9411')
         .post('/api/v2/spans')
         .reply(400);
@@ -268,11 +267,11 @@ describe('Zipkin Exporter - node', () => {
 
       exporter.export([getReadableSpan()], (result: ExportResult) => {
         scope.done();
-        assert.strictEqual(result, ExportResult.FAILED_NOT_RETRYABLE);
+        assert.strictEqual(result.code, ExportResultCode.FAILED);
       });
     });
 
-    it('should return FailedRetryable with 5xx', () => {
+    it('should return failed result with 5xx', () => {
       const scope = nock('http://localhost:9411')
         .post('/api/v2/spans')
         .reply(500);
@@ -284,11 +283,11 @@ describe('Zipkin Exporter - node', () => {
 
       exporter.export([getReadableSpan()], (result: ExportResult) => {
         scope.done();
-        assert.strictEqual(result, ExportResult.FAILED_RETRYABLE);
+        assert.strictEqual(result.code, ExportResultCode.FAILED);
       });
     });
 
-    it('should return FailedRetryable with socket error', () => {
+    it('should return failed result with socket error', () => {
       const scope = nock('http://localhost:9411')
         .post('/api/v2/spans')
         .replyWithError(new Error('My Socket Error'));
@@ -300,11 +299,11 @@ describe('Zipkin Exporter - node', () => {
 
       exporter.export([getReadableSpan()], (result: ExportResult) => {
         scope.done();
-        assert.strictEqual(result, ExportResult.FAILED_RETRYABLE);
+        assert.strictEqual(result.code, ExportResultCode.FAILED);
       });
     });
 
-    it('should return FailedNonRetryable after shutdown', done => {
+    it('should return failed result after shutdown', done => {
       const exporter = new ZipkinExporter({
         serviceName: 'my-service',
         logger: new NoopLogger(),
@@ -313,7 +312,7 @@ describe('Zipkin Exporter - node', () => {
       exporter.shutdown();
 
       exporter.export([getReadableSpan()], (result: ExportResult) => {
-        assert.strictEqual(result, ExportResult.FAILED_NOT_RETRYABLE);
+        assert.strictEqual(result.code, ExportResultCode.FAILED);
         done();
       });
     });
@@ -468,8 +467,6 @@ describe('Zipkin Exporter - node', () => {
       });
 
       it('should call globalErrorHandler on error', () => {
-        const errorHandlerSpy = sinon.spy();
-        setGlobalErrorHandler(errorHandlerSpy);
         const expectedError = new Error('Whoops');
         const scope = nock('http://localhost:9411')
           .post('/api/v2/spans')
@@ -481,14 +478,10 @@ describe('Zipkin Exporter - node', () => {
         });
 
         exporter.export([getReadableSpan()], (result: ExportResult) => {
+          assert.deepStrictEqual(result.code, ExportResultCode.FAILED);
+          assert.deepStrictEqual(result.error, expectedError);
           scope.done();
         });
-
-        const [[error]] = errorHandlerSpy.args;
-
-        assert.strictEqual(errorHandlerSpy.callCount, 1);
-        assert.strictEqual(error, expectedError);
-        setGlobalErrorHandler(loggingErrorHandler());
       });
     });
   });

--- a/packages/opentelemetry-metrics/src/export/ConsoleMetricExporter.ts
+++ b/packages/opentelemetry-metrics/src/export/ConsoleMetricExporter.ts
@@ -15,7 +15,7 @@
  */
 
 import { MetricExporter, MetricRecord, Histogram } from './types';
-import { ExportResult } from '@opentelemetry/core';
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
 
 /**
  * This is implementation of {@link MetricExporter} that prints metrics data to
@@ -41,7 +41,7 @@ export class ConsoleMetricExporter implements MetricExporter {
         console.log(point.value);
       }
     }
-    return resultCallback(ExportResult.SUCCESS);
+    return resultCallback({ code: ExportResultCode.SUCCESS });
   }
 
   shutdown(): Promise<void> {

--- a/packages/opentelemetry-metrics/src/export/Controller.ts
+++ b/packages/opentelemetry-metrics/src/export/Controller.ts
@@ -15,7 +15,7 @@
  */
 
 import {
-  ExportResult,
+  ExportResultCode,
   unrefTimer,
   globalErrorHandler,
 } from '@opentelemetry/core';
@@ -53,9 +53,10 @@ export class PushController extends Controller {
       this._exporter.export(
         this._meter.getBatcher().checkPointSet(),
         result => {
-          if (result !== ExportResult.SUCCESS) {
+          if (result.code !== ExportResultCode.SUCCESS) {
             globalErrorHandler(
-              new Error('PushController: export failed in _collect')
+              result.error ??
+                new Error('PushController: export failed in _collect')
             );
           }
           resolve();

--- a/packages/opentelemetry-metrics/test/export/Controller.test.ts
+++ b/packages/opentelemetry-metrics/test/export/Controller.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { MeterProvider, MetricExporter, MetricRecord } from '../../src';
+import {
+  ExportResult,
+  ExportResultCode,
+  setGlobalErrorHandler,
+} from '@opentelemetry/core';
+
+class MockExporter implements MetricExporter {
+  constructor(private _result: ExportResult) {}
+
+  export(
+    metrics: MetricRecord[],
+    resultCallback: (result: ExportResult) => void
+  ): void {
+    return resultCallback(this._result);
+  }
+
+  shutdown() {
+    return Promise.resolve();
+  }
+}
+
+describe('Controller', () => {
+  describe('._collect()', () => {
+    it('should use globalErrorHandler in case of error', done => {
+      const errorHandlerSpy = sinon.spy();
+      setGlobalErrorHandler(errorHandlerSpy);
+      const expectedError = new Error('Failed to export');
+      const meter = new MeterProvider({
+        exporter: new MockExporter({
+          code: ExportResultCode.FAILED,
+          error: expectedError,
+        }),
+      }).getMeter('test-console-metric-exporter');
+      const counter = meter
+        .createCounter('counter', {
+          description: 'a test description',
+        })
+        .bind({});
+      counter.add(10);
+
+      // @ts-expect-error trigger the collection from the controller
+      meter._controller._collect();
+      // wait for result
+      setTimeout(() => {
+        assert.deepStrictEqual(
+          errorHandlerSpy.args[0][0].message,
+          expectedError.message
+        );
+        setGlobalErrorHandler(() => {});
+        return done();
+      }, 0);
+    });
+  });
+});

--- a/packages/opentelemetry-tracing/src/export/BatchSpanProcessor.ts
+++ b/packages/opentelemetry-tracing/src/export/BatchSpanProcessor.ts
@@ -16,7 +16,7 @@
 
 import { context, suppressInstrumentation } from '@opentelemetry/api';
 import {
-  ExportResult,
+  ExportResultCode,
   globalErrorHandler,
   unrefTimer,
 } from '@opentelemetry/core';
@@ -111,13 +111,12 @@ export class BatchSpanProcessor implements SpanProcessor {
       context.with(suppressInstrumentation(context.active()), () => {
         this._exporter.export(this._finishedSpans, result => {
           this._finishedSpans = [];
-          if (result === ExportResult.SUCCESS) {
+          if (result.code === ExportResultCode.SUCCESS) {
             resolve();
           } else {
             reject(
-              new Error(
-                `BatchSpanProcessor: span export failed (status ${result})`
-              )
+              result.error ??
+                new Error('BatchSpanProcessor: span export failed')
             );
           }
         });

--- a/packages/opentelemetry-tracing/src/export/ConsoleSpanExporter.ts
+++ b/packages/opentelemetry-tracing/src/export/ConsoleSpanExporter.ts
@@ -16,7 +16,11 @@
 
 import { SpanExporter } from './SpanExporter';
 import { ReadableSpan } from './ReadableSpan';
-import { ExportResult, hrTimeToMicroseconds } from '@opentelemetry/core';
+import {
+  ExportResult,
+  ExportResultCode,
+  hrTimeToMicroseconds,
+} from '@opentelemetry/core';
 
 /**
  * This is implementation of {@link SpanExporter} that prints spans to the
@@ -75,7 +79,7 @@ export class ConsoleSpanExporter implements SpanExporter {
       console.log(this._exportInfo(span));
     }
     if (done) {
-      return done(ExportResult.SUCCESS);
+      return done({ code: ExportResultCode.SUCCESS });
     }
   }
 }

--- a/packages/opentelemetry-tracing/src/export/InMemorySpanExporter.ts
+++ b/packages/opentelemetry-tracing/src/export/InMemorySpanExporter.ts
@@ -16,7 +16,7 @@
 
 import { SpanExporter } from './SpanExporter';
 import { ReadableSpan } from './ReadableSpan';
-import { ExportResult } from '@opentelemetry/core';
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
 
 /**
  * This class can be used for testing purposes. It stores the exported spans
@@ -35,10 +35,14 @@ export class InMemorySpanExporter implements SpanExporter {
     spans: ReadableSpan[],
     resultCallback: (result: ExportResult) => void
   ): void {
-    if (this._stopped) return resultCallback(ExportResult.FAILED_NOT_RETRYABLE);
+    if (this._stopped)
+      return resultCallback({
+        code: ExportResultCode.FAILED,
+        error: new Error('Exporter has been stopped'),
+      });
     this._finishedSpans.push(...spans);
 
-    setTimeout(() => resultCallback(ExportResult.SUCCESS), 0);
+    setTimeout(() => resultCallback({ code: ExportResultCode.SUCCESS }), 0);
   }
 
   shutdown(): Promise<void> {

--- a/packages/opentelemetry-tracing/src/export/SimpleSpanProcessor.ts
+++ b/packages/opentelemetry-tracing/src/export/SimpleSpanProcessor.ts
@@ -15,7 +15,7 @@
  */
 
 import { context, suppressInstrumentation } from '@opentelemetry/api';
-import { ExportResult, globalErrorHandler } from '@opentelemetry/core';
+import { ExportResultCode, globalErrorHandler } from '@opentelemetry/core';
 import { Span } from '../Span';
 import { SpanExporter } from './SpanExporter';
 import { SpanProcessor } from '../SpanProcessor';
@@ -49,11 +49,12 @@ export class SimpleSpanProcessor implements SpanProcessor {
     // prevent downstream exporter calls from generating spans
     context.with(suppressInstrumentation(context.active()), () => {
       this._exporter.export([span], result => {
-        if (result !== ExportResult.SUCCESS) {
+        if (result.code !== ExportResultCode.SUCCESS) {
           globalErrorHandler(
-            new Error(
-              `SimpleSpanProcessor: span export failed (status ${result})`
-            )
+            result.error ??
+              new Error(
+                `SimpleSpanProcessor: span export failed (status ${result})`
+              )
           );
         }
       });

--- a/packages/opentelemetry-tracing/test/export/BatchSpanProcessor.test.ts
+++ b/packages/opentelemetry-tracing/test/export/BatchSpanProcessor.test.ts
@@ -16,7 +16,7 @@
 
 import {
   AlwaysOnSampler,
-  ExportResult,
+  ExportResultCode,
   loggingErrorHandler,
   setGlobalErrorHandler,
 } from '@opentelemetry/core';
@@ -224,7 +224,7 @@ describe('BatchSpanProcessor', () => {
         sinon.stub(exporter, 'export').callsFake((spans, callback) => {
           setTimeout(() => {
             exportedSpans = exportedSpans + spans.length;
-            callback(ExportResult.SUCCESS);
+            callback({ code: ExportResultCode.SUCCESS });
           }, 0);
         });
 
@@ -235,12 +235,10 @@ describe('BatchSpanProcessor', () => {
       });
 
       it('should call globalErrorHandler when exporting fails', async () => {
-        const expectedError = new Error(
-          'BatchSpanProcessor: span export failed (status 1)'
-        );
+        const expectedError = new Error('Exporter failed');
         sinon.stub(exporter, 'export').callsFake((_, callback) => {
           setTimeout(() => {
-            callback(ExportResult.FAILED_NOT_RETRYABLE);
+            callback({ code: ExportResultCode.FAILED, error: expectedError });
           }, 0);
         });
 

--- a/packages/opentelemetry-tracing/test/export/InMemorySpanExporter.test.ts
+++ b/packages/opentelemetry-tracing/test/export/InMemorySpanExporter.test.ts
@@ -21,7 +21,7 @@ import {
   BasicTracerProvider,
 } from '../../src';
 import { context, setActiveSpan } from '@opentelemetry/api';
-import { ExportResult } from '@opentelemetry/core';
+import { ExportResult, ExportResultCode } from '@opentelemetry/core';
 
 describe('InMemorySpanExporter', () => {
   let memoryExporter: InMemorySpanExporter;
@@ -83,7 +83,7 @@ describe('InMemorySpanExporter', () => {
   it('should return the success result', () => {
     const exorter = new InMemorySpanExporter();
     exorter.export([], (result: ExportResult) => {
-      assert.strictEqual(result, ExportResult.SUCCESS);
+      assert.strictEqual(result.code, ExportResultCode.SUCCESS);
     });
   });
 
@@ -93,7 +93,7 @@ describe('InMemorySpanExporter', () => {
 
     // after shutdown export should fail
     exorter.export([], (result: ExportResult) => {
-      assert.strictEqual(result, ExportResult.FAILED_NOT_RETRYABLE);
+      assert.strictEqual(result.code, ExportResultCode.FAILED);
     });
   });
 });

--- a/packages/opentelemetry-tracing/test/export/SimpleSpanProcessor.test.ts
+++ b/packages/opentelemetry-tracing/test/export/SimpleSpanProcessor.test.ts
@@ -22,7 +22,7 @@ import {
   TraceFlags,
 } from '@opentelemetry/api';
 import {
-  ExportResult,
+  ExportResultCode,
   loggingErrorHandler,
   setGlobalErrorHandler,
 } from '@opentelemetry/core';
@@ -98,9 +98,7 @@ describe('SimpleSpanProcessor', () => {
     });
 
     it('should call globalErrorHandler when exporting fails', async () => {
-      const expectedError = new Error(
-        'SimpleSpanProcessor: span export failed (status 1)'
-      );
+      const expectedError = new Error('Exporter failed');
       const processor = new SimpleSpanProcessor(exporter);
       const spanContext: SpanContext = {
         traceId: 'a3cda95b652f4a1592b449d5929fda1b',
@@ -117,7 +115,7 @@ describe('SimpleSpanProcessor', () => {
 
       sinon.stub(exporter, 'export').callsFake((_, callback) => {
         setTimeout(() => {
-          callback(ExportResult.FAILED_NOT_RETRYABLE);
+          callback({ code: ExportResultCode.FAILED, error: expectedError });
         }, 0);
       });
 


### PR DESCRIPTION
There is 2 goals for this PR:
- Remove `FAILED_RETRYABLE` result since it has been removed from the spec and we expect exporter to handle this.
- Add an optional `error` inside the result so the error is correctly handled at one place (on the `Controller` for metrics and `SpanProcessor` for spans). Previously every exporter had to use the `globalErrorHandler` to report the error which made multiple errors appears (one from the exporter and one for the upstream component that called it)

The design is the same as the Golang implementation: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#go-spanexporter-interface

Fixes #1569