### PR TITLE
chore: remove unused tracer config gracefulShutdown

### DIFF
--- a/packages/opentelemetry-tracing/src/config.ts
+++ b/packages/opentelemetry-tracing/src/config.ts
@@ -30,5 +30,4 @@ export const DEFAULT_CONFIG = {
     numberOfLinksPerSpan: getEnv().OTEL_SPAN_LINK_COUNT_LIMIT,
     numberOfEventsPerSpan: getEnv().OTEL_SPAN_EVENT_COUNT_LIMIT,
   },
-  gracefulShutdown: true,
 };

--- a/packages/opentelemetry-tracing/src/types.ts
+++ b/packages/opentelemetry-tracing/src/types.ts
@@ -43,9 +43,6 @@ export interface TracerConfig {
   /** Resource associated with trace telemetry  */
   resource?: Resource;
 
-  /** Bool for whether or not graceful shutdown is enabled. If disabled spans will not be exported when SIGTERM is recieved */
-  gracefulShutdown?: boolean;
-
   /**
    * Generator of trace and span IDs
    * The default idGenerator generates random ids


### PR DESCRIPTION
## Which problem is this PR solving?

Remove obsolete code.

## Short description of the changes

Graceful shutdown support was removed via https://github.com/open-telemetry/opentelemetry-js/pull/1522

Remove the corresponding configuration because it is not used anymore.

Refs: https://github.com/open-telemetry/opentelemetry-js/pull/1321
