### PR TITLE
chore: use WebTracerProvider instead of WebTracer in docs

### DIFF
--- a/packages/opentelemetry-context-zone-peer-dep/README.md
+++ b/packages/opentelemetry-context-zone-peer-dep/README.md
@@ -23,15 +23,17 @@ npm install --save @opentelemetry/context-zone-peer-dep
 
 ```js
 import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/tracing';
-import { WebTracer } from '@opentelemetry/web';
+import { WebTracerProvider } from '@opentelemetry/web';
 import { ZoneContextManager } from '@opentelemetry/context-zone-peer-dep';
 
-const webTracerWithZone = new WebTracer({
+const providerWithZone = new WebTracerProvider();
+providerWithZone.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+providerWithZone.register({
   contextManager: new ZoneContextManager()
 });
-webTracerWithZone.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
 
 // Example how the ZoneContextManager keeps the reference to the correct context during async operations
+const webTracerWithZone = providerWithZone.getTracer('default');
 const span1 = webTracerWithZone.startSpan('foo1');
 webTracerWithZone.withSpan(span1, () => {
   console.log('Current span is span1', webTracerWithZone.getCurrentSpan() === span1);

--- a/packages/opentelemetry-context-zone/README.md
+++ b/packages/opentelemetry-context-zone/README.md
@@ -20,15 +20,17 @@ npm install --save @opentelemetry/context-zone
 
 ```js
 import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/tracing';
-import { WebTracer } from '@opentelemetry/web';
+import { WebTracerProvider } from '@opentelemetry/web';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 
-const webTracerWithZone = new WebTracer({
+const providerWithZone = new WebTracerProvider();
+providerWithZone.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+provider.register({
   contextManager: new ZoneContextManager()
 });
-webTracerWithZone.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
 
 // Example how the ZoneContextManager keeps the reference to the correct context during async operations
+const webTracerWithZone = providerWithZone.getTracer('default');
 const span1 = webTracerWithZone.startSpan('foo1');
 webTracerWithZone.withSpan(span1, () => {
   console.log('Current span is span1', webTracerWithZone.getCurrentSpan() === span1);

--- a/packages/opentelemetry-instrumentation-xml-http-request/README.md
+++ b/packages/opentelemetry-instrumentation-xml-http-request/README.md
@@ -18,32 +18,36 @@ npm install --save @opentelemetry/instrumentation-xml-http-request
 
 ```js
 import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/tracing';
-import { WebTracer } from '@opentelemetry/web';
+import { WebTracerProvider } from '@opentelemetry/web';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 
 // this is still possible
-const webTracerWithZone = new WebTracer({
-  contextManager: new ZoneContextManager(),
+const providerWithZone = new WebTracerProvider({
   plugins: [
     new XMLHttpRequestInstrumentation({
       propagateTraceHeaderCorsUrls: ['http://localhost:8090']
     })
   ]
 });
+providerWithZone.register({
+  contextManager: new ZoneContextManager(),
+});
+const webTracerWithZone = providerWithZone.getTracer('default');
 /////////////////////////////////////////
 
 // or plugin can be also initialised separately and then set the tracer provider or meter provider
 const xmlHttpRequestInstrumentation = new XMLHttpRequestInstrumentation({
   propagateTraceHeaderCorsUrls: ['http://localhost:8090']
 });
-const webTracerWithZone = new WebTracer({
+const providerWithZone = new WebTracerProvider();
+providerWithZone.register({
   contextManager: new ZoneContextManager(),
 });
-xmlHttpRequestInstrumentation.setTracerProvider(webTracerWithZone);
+xmlHttpRequestInstrumentation.setTracerProvider(providerWithZone);
 /////////////////////////////////////////
 
-webTracerWithZone.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+providerWithZone.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
 
 // and some test
 const req = new XMLHttpRequest();


### PR DESCRIPTION


## Which problem is this PR solving?

I didn't make an issue, as it seemed simple enough. A few packages were using `WebTracer` as opposed to `WebTracerProvider` in their examples. It seems like this may have been removed from the exports in `@opentelemetry/web` (please correct me if wrong), so these examples are out of date. Regardless, there is some inconsistency.

## Short description of the changes

Update examples to use `WebTracerProvider` and specify `contextManager` in the `register()` method as opposed to on instantiation of provider.

