### PR TITLE
feat(prometheus): make the prometheus exporter http handler public

### DIFF
--- a/packages/opentelemetry-exporter-prometheus/README.md
+++ b/packages/opentelemetry-exporter-prometheus/README.md
@@ -25,17 +25,17 @@ Create & register the exporter on your application.
 const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
 const { MeterProvider }  = require('@opentelemetry/metrics');
 
-// Add your port and startServer to the Prometheus options
-const options = {port: 9464, startServer: true};
+// Add your port to the Prometheus options.
+const options = {port: 9464};
 const exporter = new PrometheusExporter(options);
 
-// Register the exporter
+// Register the exporter.
 const meter = new MeterProvider({
   exporter,
   interval: 1000,
 }).getMeter('example-prometheus');
 
-// Now, start recording data
+// Now, start recording data.
 const counter = meter.createCounter('metric_name', {
   description: 'Example of a counter'
 });
@@ -47,6 +47,44 @@ const boundCounter = counter.bind({ pid: process.pid });
 boundCounter.add(10);
 
 // .. some other work
+```
+
+Use with an existing http server.
+
+```js
+const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
+const { MeterProvider }  = require('@opentelemetry/metrics');
+
+// Add preventServerStart and endpoint to the Prometheus options.
+const options = {preventServerStart: true, endpoint: '/metrics'};
+const exporter = new PrometheusExporter(options);
+
+// Register the exporter.
+const meter = new MeterProvider({
+  exporter,
+  interval: 1000,
+}).getMeter('example-prometheus');
+
+// Create a counter.
+const counter = meter.createCounter('metric_name', {
+  description: 'Example of a counter'
+});
+
+
+// Create the http server.
+const app = require('express')();
+
+// Register a router.
+app.get('/', (request, response) => {
+  counter.add(1);
+  response.end('index');
+});
+
+// Register the Prometheus endpoint.
+app.get(options.endpoint, exporter.requestHandler);
+
+// Start the http server.
+app.listen(9464);
 ```
 
 ## Viewing your metrics

--- a/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -56,7 +56,7 @@ export class PrometheusExporter implements MetricExporter {
     this._logger = config.logger || new NoopLogger();
     this._port = config.port || PrometheusExporter.DEFAULT_OPTIONS.port;
     this._prefix = config.prefix || PrometheusExporter.DEFAULT_OPTIONS.prefix;
-    this._server = createServer(this._requestHandler);
+    this._server = createServer(this.requestHandler);
     this._serializer = new PrometheusSerializer(this._prefix);
 
     this._endpoint = (
@@ -156,10 +156,7 @@ export class PrometheusExporter implements MetricExporter {
    * @param request Incoming HTTP request to export server
    * @param response HTTP response object used to respond to request
    */
-  private _requestHandler = (
-    request: IncomingMessage,
-    response: ServerResponse
-  ) => {
+  requestHandler = (request: IncomingMessage, response: ServerResponse) => {
     if (url.parse(request.url!).pathname === this._endpoint) {
       this._exportMetrics(response);
     } else {

--- a/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -38,6 +38,7 @@ describe('PrometheusExporter', () => {
       const exporter = new PrometheusExporter();
       assert.ok(typeof exporter.startServer === 'function');
       assert.ok(typeof exporter.shutdown === 'function');
+      assert.ok(typeof exporter.requestHandler === 'function');
       exporter.shutdown().then(done);
     });
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Serve Prometheus metrics with an existing http server.

I am very new to javascript so I might be missing something obvious, but I didn't find a different way to use the exporter without starting a new http server on a different port.

Being in a context where I don't have control over the http ingress, I can't listen to a new port but still would like to expose the Prometheus metrics.


## Short description of the changes

- remove the `private` keyword for the function and rename from `_requestHandler` to `requetsHandler`.
