### PR TITLE
feat: processor export phases interface

### DIFF
--- a/packages/opentelemetry-exporter-prometheus/test/ExactProcessor.ts
+++ b/packages/opentelemetry-exporter-prometheus/test/ExactProcessor.ts
@@ -40,10 +40,18 @@ export class ExactProcessor<T, R extends Aggregator> extends Processor {
     return aggregator;
   }
 
+  start() {
+    /** Nothing to do with ExactProcessor on start */
+  }
+
   process(record: MetricRecord): void {
     const labels = Object.keys(record.labels)
       .map(k => `${k}=${record.labels[k]}`)
       .join(',');
     this._batchMap.set(record.descriptor.name + labels, record);
+  }
+
+  finish() {
+    /** Nothing to do with ExactProcessor on finish */
   }
 }

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -320,6 +320,7 @@ export class Meter implements api.Meter {
       })
       .map(async metric => {
         const records = await metric.getMetricRecord();
+        // process the records in place to reduce required memory footprints.
         for (const record of records) {
           this._processor.process(record);
         }

--- a/packages/opentelemetry-metrics/src/export/Controller.ts
+++ b/packages/opentelemetry-metrics/src/export/Controller.ts
@@ -53,18 +53,15 @@ export class PushController extends Controller {
     await this._meter.collect();
     processor.finish();
     return new Promise(resolve => {
-      this._exporter.export(
-        this._meter.getProcessor().checkPointSet(),
-        result => {
-          if (result.code !== ExportResultCode.SUCCESS) {
-            globalErrorHandler(
-              result.error ??
-                new Error('PushController: export failed in _collect')
-            );
-          }
-          resolve();
+      this._exporter.export(processor.checkPointSet(), result => {
+        if (result.code !== ExportResultCode.SUCCESS) {
+          globalErrorHandler(
+            result.error ??
+              new Error('PushController: export failed in _collect')
+          );
         }
-      );
+        resolve();
+      });
     });
   }
 }

--- a/packages/opentelemetry-metrics/src/export/Controller.ts
+++ b/packages/opentelemetry-metrics/src/export/Controller.ts
@@ -48,7 +48,10 @@ export class PushController extends Controller {
   }
 
   private async _collect(): Promise<void> {
+    const processor = this._meter.getProcessor();
+    processor.start();
     await this._meter.collect();
+    processor.finish();
     return new Promise(resolve => {
       this._exporter.export(
         this._meter.getProcessor().checkPointSet(),

--- a/packages/opentelemetry-metrics/src/export/UngroupedProcessor.ts
+++ b/packages/opentelemetry-metrics/src/export/UngroupedProcessor.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Processor } from './Processor';
+import * as aggregators from './aggregators';
+import {
+  MetricRecord,
+  MetricKind,
+  Aggregator,
+  MetricDescriptor,
+} from './types';
+
+/**
+ * Processor which retains all dimensions/labels. It accepts all records and
+ * passes them for exporting.
+ */
+export class UngroupedProcessor extends Processor {
+  aggregatorFor(metricDescriptor: MetricDescriptor): Aggregator {
+    switch (metricDescriptor.metricKind) {
+      case MetricKind.COUNTER:
+      case MetricKind.UP_DOWN_COUNTER:
+        return new aggregators.SumAggregator();
+
+      case MetricKind.SUM_OBSERVER:
+      case MetricKind.UP_DOWN_SUM_OBSERVER:
+      case MetricKind.VALUE_OBSERVER:
+        return new aggregators.LastValueAggregator();
+
+      case MetricKind.VALUE_RECORDER:
+        return new aggregators.HistogramAggregator(
+          metricDescriptor.boundaries || [Infinity]
+        );
+
+      default:
+        return new aggregators.LastValueAggregator();
+    }
+  }
+
+  start() {
+    /** Nothing to do with UngroupedProcessor on start */
+  }
+
+  process(record: MetricRecord): void {
+    const labels = Object.keys(record.labels)
+      .map(k => `${k}=${record.labels[k]}`)
+      .join(',');
+    this._batchMap.set(record.descriptor.name + labels, record);
+  }
+
+  finish() {
+    /** Nothing to do with UngroupedProcessor on finish */
+  }
+}

--- a/packages/opentelemetry-metrics/src/index.ts
+++ b/packages/opentelemetry-metrics/src/index.ts
@@ -24,6 +24,7 @@ export * from './ValueObserverMetric';
 export * from './export/aggregators';
 export * from './export/ConsoleMetricExporter';
 export * from './export/Processor';
+export * from './export/UngroupedProcessor';
 export * from './export/types';
 export * from './UpDownCounterMetric';
 export { MeterConfig } from './types';

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -1372,8 +1372,16 @@ describe('Meter', () => {
 });
 
 class CustomProcessor extends Processor {
+  start(): void {
+    throw new Error('start method not implemented.');
+  }
+
   process(record: MetricRecord): void {
     throw new Error('process method not implemented.');
+  }
+
+  finish(): void {
+    throw new Error('finish method not implemented.');
   }
 
   aggregatorFor(metricKind: MetricDescriptor): Aggregator {


### PR DESCRIPTION
## Which problem is this PR solving?

- https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/sdk.md#dataflow-diagram
- To reduce penalties on delta export kind, the processors are responsible to handle delta aggregation snapshot to cumulative aggregation, and export cumulative aggregation to exporters. In this case, processors have to be notified when a new series of `collect` starts and finishes.

## Short description of the changes

- Add start/finish method to processor interface.
