### PR TITLE
Aggregation Temporality Support

### DIFF
--- a/packages/opentelemetry-exporter-collector/test/common/transformMetrics.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/common/transformMetrics.test.ts
@@ -123,7 +123,7 @@ describe('transformMetrics', () => {
       ensureSumObserverIsCorrect(
         transform.toCollectorMetric(sumObserverMetric, 1592602232694000000),
         hrTimeToNanoseconds(sumObserverMetric.aggregator.toPoint().timestamp),
-        3
+        -1
       );
 
       // collect 3 times

--- a/packages/opentelemetry-exporter-prometheus/test/ExactProcessor.ts
+++ b/packages/opentelemetry-exporter-prometheus/test/ExactProcessor.ts
@@ -40,10 +40,18 @@ export class ExactProcessor<T, R extends Aggregator> extends Processor {
     return aggregator;
   }
 
+  start() {
+    /** Nothing to do with ExactProcessor on start */
+  }
+
   process(record: MetricRecord): void {
     const labels = Object.keys(record.labels)
       .map(k => `${k}=${record.labels[k]}`)
       .join(',');
     this._batchMap.set(record.descriptor.name + labels, record);
+  }
+
+  finish() {
+    /** Nothing to do with ExactProcessor on finish */
   }
 }

--- a/packages/opentelemetry-exporter-prometheus/test/ExactProcessor.ts
+++ b/packages/opentelemetry-exporter-prometheus/test/ExactProcessor.ts
@@ -15,14 +15,13 @@
  */
 import {
   Aggregator,
+  BasicProcessor,
   MetricDescriptor,
-  MetricRecord,
-  Processor,
 } from '@opentelemetry/metrics';
 
 type Constructor<T, R extends Aggregator> = new (...args: T[]) => R;
 
-export class ExactProcessor<T, R extends Aggregator> extends Processor {
+export class ExactProcessor<T, R extends Aggregator> extends BasicProcessor {
   private readonly args: ConstructorParameters<Constructor<T, R>>;
   public aggregators: R[] = [];
 
@@ -38,20 +37,5 @@ export class ExactProcessor<T, R extends Aggregator> extends Processor {
     const aggregator = new this.aggregator(...this.args);
     this.aggregators.push(aggregator);
     return aggregator;
-  }
-
-  start() {
-    /** Nothing to do with ExactProcessor on start */
-  }
-
-  process(record: MetricRecord): void {
-    const labels = Object.keys(record.labels)
-      .map(k => `${k}=${record.labels[k]}`)
-      .join(',');
-    this._batchMap.set(record.descriptor.name + labels, record);
-  }
-
-  finish() {
-    /** Nothing to do with ExactProcessor on finish */
   }
 }

--- a/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -203,35 +203,28 @@ describe('PrometheusExporter', () => {
       boundCounter.add(10);
       meter.collect().then(() => {
         exporter.export(meter.getProcessor().checkPointSet(), () => {
-          // TODO: Remove this special case once the PR is ready.
-          // This is to test the special case where counters are destroyed
-          // and recreated in the exporter in order to get around prom-client's
-          // aggregation and use ours.
-          boundCounter.add(10);
-          exporter.export(meter.getProcessor().checkPointSet(), () => {
-            http
-              .get('http://localhost:9464/metrics', res => {
-                res.on('data', chunk => {
-                  const body = chunk.toString();
-                  const lines = body.split('\n');
+          http
+            .get('http://localhost:9464/metrics', res => {
+              res.on('data', chunk => {
+                const body = chunk.toString();
+                const lines = body.split('\n');
 
-                  assert.strictEqual(
-                    lines[0],
-                    '# HELP counter a test description'
-                  );
+                assert.strictEqual(
+                  lines[0],
+                  '# HELP counter a test description'
+                );
 
-                  assert.deepStrictEqual(lines, [
-                    '# HELP counter a test description',
-                    '# TYPE counter counter',
-                    `counter{key1="labelValue1"} 20 ${mockedHrTimeMs}`,
-                    '',
-                  ]);
+                assert.deepStrictEqual(lines, [
+                  '# HELP counter a test description',
+                  '# TYPE counter counter',
+                  `counter{key1="labelValue1"} 10 ${mockedHrTimeMs}`,
+                  '',
+                ]);
 
-                  done();
-                });
-              })
-              .on('error', errorHandler(done));
-          });
+                done();
+              });
+            })
+            .on('error', errorHandler(done));
         });
       });
     });

--- a/packages/opentelemetry-metrics/src/Accumulator.ts
+++ b/packages/opentelemetry-metrics/src/Accumulator.ts
@@ -13,18 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Labels } from '@opentelemetry/api';
 
-export * from './BoundInstrument';
-export * from './CounterMetric';
-export * from './ValueRecorderMetric';
-export * from './Meter';
-export * from './MeterProvider';
-export * from './Metric';
-export * from './ValueObserverMetric';
-export * from './export/aggregators';
-export * from './export/ConsoleMetricExporter';
-export * from './export/Processor';
-export * from './export/BasicProcessor';
-export * from './export/types';
-export * from './UpDownCounterMetric';
-export { MeterConfig } from './types';
+export interface Accumulator {
+  update(accumulationKey: string, labels: Labels, value: number): void;
+}

--- a/packages/opentelemetry-metrics/src/CounterMetric.ts
+++ b/packages/opentelemetry-metrics/src/CounterMetric.ts
@@ -17,6 +17,7 @@
 import * as api from '@opentelemetry/api';
 import { InstrumentationLibrary } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
+import { Accumulator } from './Accumulator';
 import { BoundCounter } from './BoundInstrument';
 import { Processor } from './export/Processor';
 import { MetricKind } from './export/types';
@@ -27,19 +28,31 @@ export class CounterMetric extends Metric<BoundCounter> implements api.Counter {
   constructor(
     name: string,
     options: api.MetricOptions,
-    private readonly _processor: Processor,
+    processor: Processor,
     resource: Resource,
     instrumentationLibrary: InstrumentationLibrary
   ) {
-    super(name, options, MetricKind.COUNTER, resource, instrumentationLibrary);
+    super(
+      name,
+      options,
+      MetricKind.COUNTER,
+      processor,
+      resource,
+      instrumentationLibrary
+    );
   }
-  protected _makeInstrument(labels: api.Labels): BoundCounter {
+  protected _makeInstrument(
+    accumulationKey: string,
+    labels: api.Labels,
+    accumulator: Accumulator
+  ): BoundCounter {
     return new BoundCounter(
+      accumulationKey,
       labels,
-      this._disabled,
-      this._valueType,
+      accumulator,
       this._logger,
-      this._processor.aggregatorFor(this._descriptor)
+      this._disabled,
+      this._valueType
     );
   }
 

--- a/packages/opentelemetry-metrics/src/Meter.ts
+++ b/packages/opentelemetry-metrics/src/Meter.ts
@@ -320,6 +320,7 @@ export class Meter implements api.Meter {
       })
       .map(async metric => {
         const records = await metric.getMetricRecord();
+        // process the records in place to reduce required memory footprints.
         for (const record of records) {
           this._processor.process(record);
         }

--- a/packages/opentelemetry-metrics/src/SumObserverMetric.ts
+++ b/packages/opentelemetry-metrics/src/SumObserverMetric.ts
@@ -19,12 +19,11 @@ import { InstrumentationLibrary } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
 import { BaseObserverMetric } from './BaseObserverMetric';
 import { Processor } from './export/Processor';
-import { LastValue, MetricKind } from './export/types';
+import { MetricKind } from './export/types';
 import { ObserverResult } from './ObserverResult';
 
 /** This is a SDK implementation of SumObserver Metric. */
-export class SumObserverMetric
-  extends BaseObserverMetric
+export class SumObserverMetric extends BaseObserverMetric
   implements api.SumObserver {
   constructor(
     name: string,
@@ -49,15 +48,11 @@ export class SumObserverMetric
     observerResult.values.forEach((value, labels) => {
       const instrument = this.bind(labels);
       // SumObserver is monotonic which means it should only accept values
-      // greater or equal then previous value
-      const previous = instrument.getAggregator().toPoint();
-      let previousValue = -Infinity;
-      if (previous.timestamp[0] !== 0 || previous.timestamp[1] !== 0) {
-        previousValue = previous.value as LastValue;
-      }
-      if (value >= previousValue) {
-        instrument.update(value);
-      }
+      // greater or equal then previous value.
+      // However it is impractical for the stateless accumulator to remember
+      // last recorded value. Some practice may recognize the value drop as a
+      // reset and correctly reflect true trend.
+      instrument.update(value);
     });
   }
 }

--- a/packages/opentelemetry-metrics/src/UpDownCounterMetric.ts
+++ b/packages/opentelemetry-metrics/src/UpDownCounterMetric.ts
@@ -21,15 +21,15 @@ import { BoundUpDownCounter } from './BoundInstrument';
 import { MetricKind } from './export/types';
 import { Processor } from './export/Processor';
 import { Metric } from './Metric';
+import { Accumulator } from './Accumulator';
 
 /** This is a SDK implementation of UpDownCounter Metric. */
-export class UpDownCounterMetric
-  extends Metric<BoundUpDownCounter>
+export class UpDownCounterMetric extends Metric<BoundUpDownCounter>
   implements api.UpDownCounter {
   constructor(
     name: string,
     options: api.MetricOptions,
-    private readonly _processor: Processor,
+    processor: Processor,
     resource: Resource,
     instrumentationLibrary: InstrumentationLibrary
   ) {
@@ -37,17 +37,23 @@ export class UpDownCounterMetric
       name,
       options,
       MetricKind.UP_DOWN_COUNTER,
+      processor,
       resource,
       instrumentationLibrary
     );
   }
-  protected _makeInstrument(labels: api.Labels): BoundUpDownCounter {
+  protected _makeInstrument(
+    accumulationKey: string,
+    labels: api.Labels,
+    accumulator: Accumulator
+  ): BoundUpDownCounter {
     return new BoundUpDownCounter(
+      accumulationKey,
       labels,
-      this._disabled,
-      this._valueType,
+      accumulator,
       this._logger,
-      this._processor.aggregatorFor(this._descriptor)
+      this._disabled,
+      this._valueType
     );
   }
 

--- a/packages/opentelemetry-metrics/src/UpDownSumObserverMetric.ts
+++ b/packages/opentelemetry-metrics/src/UpDownSumObserverMetric.ts
@@ -22,8 +22,7 @@ import { Processor } from './export/Processor';
 import { MetricKind } from './export/types';
 
 /** This is a SDK implementation of UpDownSumObserver Metric. */
-export class UpDownSumObserverMetric
-  extends BaseObserverMetric
+export class UpDownSumObserverMetric extends BaseObserverMetric
   implements api.UpDownSumObserver {
   constructor(
     name: string,

--- a/packages/opentelemetry-metrics/src/ValueObserverMetric.ts
+++ b/packages/opentelemetry-metrics/src/ValueObserverMetric.ts
@@ -21,8 +21,7 @@ import { Processor } from './export/Processor';
 import { MetricKind } from './export/types';
 
 /** This is a SDK implementation of Value Observer Metric. */
-export class ValueObserverMetric
-  extends BaseObserverMetric
+export class ValueObserverMetric extends BaseObserverMetric
   implements api.ValueObserver {
   constructor(
     name: string,

--- a/packages/opentelemetry-metrics/src/ValueRecorderMetric.ts
+++ b/packages/opentelemetry-metrics/src/ValueRecorderMetric.ts
@@ -17,19 +17,19 @@
 import * as api from '@opentelemetry/api';
 import { InstrumentationLibrary } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
+import { Accumulator } from './Accumulator';
 import { BoundValueRecorder } from './BoundInstrument';
 import { Processor } from './export/Processor';
 import { MetricKind } from './export/types';
 import { Metric } from './Metric';
 
 /** This is a SDK implementation of Value Recorder Metric. */
-export class ValueRecorderMetric
-  extends Metric<BoundValueRecorder>
+export class ValueRecorderMetric extends Metric<BoundValueRecorder>
   implements api.ValueRecorder {
   constructor(
     name: string,
     options: api.MetricOptions,
-    private readonly _processor: Processor,
+    processor: Processor,
     resource: Resource,
     instrumentationLibrary: InstrumentationLibrary
   ) {
@@ -37,18 +37,24 @@ export class ValueRecorderMetric
       name,
       options,
       MetricKind.VALUE_RECORDER,
+      processor,
       resource,
       instrumentationLibrary
     );
   }
 
-  protected _makeInstrument(labels: api.Labels): BoundValueRecorder {
+  protected _makeInstrument(
+    accumulationKey: string,
+    labels: api.Labels,
+    accumulator: Accumulator
+  ): BoundValueRecorder {
     return new BoundValueRecorder(
+      accumulationKey,
       labels,
-      this._disabled,
-      this._valueType,
+      accumulator,
       this._logger,
-      this._processor.aggregatorFor(this._descriptor)
+      this._disabled,
+      this._valueType
     );
   }
 

--- a/packages/opentelemetry-metrics/src/export/Controller.ts
+++ b/packages/opentelemetry-metrics/src/export/Controller.ts
@@ -53,18 +53,15 @@ export class PushController extends Controller {
     await this._meter.collect();
     processor.finish();
     return new Promise(resolve => {
-      this._exporter.export(
-        this._meter.getProcessor().checkPointSet(),
-        result => {
-          if (result.code !== ExportResultCode.SUCCESS) {
-            globalErrorHandler(
-              result.error ??
-                new Error('PushController: export failed in _collect')
-            );
-          }
-          resolve();
+      this._exporter.export(processor.checkPointSet(), result => {
+        if (result.code !== ExportResultCode.SUCCESS) {
+          globalErrorHandler(
+            result.error ??
+              new Error('PushController: export failed in _collect')
+          );
         }
-      );
+        resolve();
+      });
     });
   }
 }

--- a/packages/opentelemetry-metrics/src/export/Controller.ts
+++ b/packages/opentelemetry-metrics/src/export/Controller.ts
@@ -48,7 +48,10 @@ export class PushController extends Controller {
   }
 
   private async _collect(): Promise<void> {
+    const processor = this._meter.getProcessor();
+    processor.start();
     await this._meter.collect();
+    processor.finish();
     return new Promise(resolve => {
       this._exporter.export(
         this._meter.getProcessor().checkPointSet(),

--- a/packages/opentelemetry-metrics/src/export/UngroupedProcessor.ts
+++ b/packages/opentelemetry-metrics/src/export/UngroupedProcessor.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Processor } from './Processor';
+import * as aggregators from './aggregators';
+import {
+  MetricRecord,
+  MetricKind,
+  Aggregator,
+  MetricDescriptor,
+} from './types';
+
+/**
+ * Processor which retains all dimensions/labels. It accepts all records and
+ * passes them for exporting.
+ */
+export class UngroupedProcessor extends Processor {
+  aggregatorFor(metricDescriptor: MetricDescriptor): Aggregator {
+    switch (metricDescriptor.metricKind) {
+      case MetricKind.COUNTER:
+      case MetricKind.UP_DOWN_COUNTER:
+        return new aggregators.SumAggregator();
+
+      case MetricKind.SUM_OBSERVER:
+      case MetricKind.UP_DOWN_SUM_OBSERVER:
+      case MetricKind.VALUE_OBSERVER:
+        return new aggregators.LastValueAggregator();
+
+      case MetricKind.VALUE_RECORDER:
+        return new aggregators.HistogramAggregator(
+          metricDescriptor.boundaries || [Infinity]
+        );
+
+      default:
+        return new aggregators.LastValueAggregator();
+    }
+  }
+
+  start() {
+    /** Nothing to do with UngroupedProcessor on start */
+  }
+
+  process(record: MetricRecord): void {
+    const labels = Object.keys(record.labels)
+      .map(k => `${k}=${record.labels[k]}`)
+      .join(',');
+    this._batchMap.set(record.descriptor.name + labels, record);
+  }
+
+  finish() {
+    /** Nothing to do with UngroupedProcessor on finish */
+  }
+}

--- a/packages/opentelemetry-metrics/src/export/aggregators/LastValue.ts
+++ b/packages/opentelemetry-metrics/src/export/aggregators/LastValue.ts
@@ -22,6 +22,7 @@ import {
 } from '../types';
 import { HrTime } from '@opentelemetry/api';
 import { hrTime } from '@opentelemetry/core';
+import { hrTimeCompare } from '../../Utils';
 
 /** Basic aggregator for LastValue which keeps the last recorded value. */
 export class LastValueAggregator implements LastValueAggregatorType {
@@ -39,5 +40,22 @@ export class LastValueAggregator implements LastValueAggregatorType {
       value: this._current,
       timestamp: this._lastUpdateTime,
     };
+  }
+
+  move(): LastValueAggregator {
+    const other = new LastValueAggregator();
+    other._current = this._current;
+    other._lastUpdateTime = this._lastUpdateTime;
+    this._current = 0;
+    this._lastUpdateTime = [0, 0];
+    return other;
+  }
+
+  merge(other: LastValueAggregator): void {
+    const cmx = hrTimeCompare(this._lastUpdateTime, other._lastUpdateTime);
+    if (cmx < 0) {
+      this._current = other._current;
+      this._lastUpdateTime = other._lastUpdateTime;
+    }
   }
 }

--- a/packages/opentelemetry-metrics/src/export/aggregators/Sum.ts
+++ b/packages/opentelemetry-metrics/src/export/aggregators/Sum.ts
@@ -17,6 +17,7 @@
 import { Point, Sum, AggregatorKind, SumAggregatorType } from '../types';
 import { HrTime } from '@opentelemetry/api';
 import { hrTime } from '@opentelemetry/core';
+import { hrTimeCompare } from '../../Utils';
 
 /** Basic aggregator which calculates a Sum from individual measurements. */
 export class SumAggregator implements SumAggregatorType {
@@ -34,5 +35,22 @@ export class SumAggregator implements SumAggregatorType {
       value: this._current,
       timestamp: this._lastUpdateTime,
     };
+  }
+
+  move(): SumAggregator {
+    const other = new SumAggregator();
+    other._current = this._current;
+    other._lastUpdateTime = this._lastUpdateTime;
+    this._current = 0;
+    this._lastUpdateTime = [0, 0];
+    return other;
+  }
+
+  merge(other: SumAggregator): void {
+    this._current += other._current;
+    this._lastUpdateTime =
+      hrTimeCompare(this._lastUpdateTime, other._lastUpdateTime) >= 0
+        ? this._lastUpdateTime
+        : other._lastUpdateTime;
   }
 }

--- a/packages/opentelemetry-metrics/src/index.ts
+++ b/packages/opentelemetry-metrics/src/index.ts
@@ -24,6 +24,7 @@ export * from './ValueObserverMetric';
 export * from './export/aggregators';
 export * from './export/ConsoleMetricExporter';
 export * from './export/Processor';
+export * from './export/UngroupedProcessor';
 export * from './export/types';
 export * from './UpDownCounterMetric';
 export { MeterConfig } from './types';

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -1372,8 +1372,16 @@ describe('Meter', () => {
 });
 
 class CustomProcessor extends Processor {
+  start(): void {
+    throw new Error('start method not implemented.');
+  }
+
   process(record: MetricRecord): void {
     throw new Error('process method not implemented.');
+  }
+
+  finish(): void {
+    throw new Error('finish method not implemented.');
   }
 
   aggregatorFor(metricKind: MetricDescriptor): Aggregator {

--- a/packages/opentelemetry-metrics/test/export/Controller.test.ts
+++ b/packages/opentelemetry-metrics/test/export/Controller.test.ts
@@ -20,7 +20,7 @@ import {
   MeterProvider,
   MetricExporter,
   MetricRecord,
-  UngroupedProcessor,
+  BasicProcessor,
 } from '../../src';
 import {
   ExportResult,
@@ -28,7 +28,7 @@ import {
   setGlobalErrorHandler,
 } from '@opentelemetry/core';
 
-class MockProcessor extends UngroupedProcessor {
+class MockProcessor extends BasicProcessor {
   private _started = false;
   private _finished = false;
 

--- a/packages/opentelemetry-metrics/test/export/aggregators/Histogram.test.ts
+++ b/packages/opentelemetry-metrics/test/export/aggregators/Histogram.test.ts
@@ -178,7 +178,7 @@ describe('HistogramAggregator', () => {
       const aggregator = new HistogramAggregator([100]);
       const point = aggregator.toPoint().value as Histogram;
       assert.deepEqual(aggregator.toPoint().value, point);
-      assert(aggregator.toPoint().timestamp.every(nbr => nbr > 0));
+      assert(aggregator.toPoint().timestamp.every(nbr => nbr >= 0));
     });
 
     it('should return last checkpoint if updated', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

- Refs: https://github.com/open-telemetry/opentelemetry-js/issues/1528
- Add stateless accumulations support.

## Short description of the changes

- Make metrics and bound metrics state ephemera, so that a label set will not be kept in store throughout the process lifetime without manual `unbind`.
- Rename UngroupedProcessor to BasicProcessor and supports cumulative processing to aggregate `AggregationTemporality.DELTA` aggregator snapshots to `AggregationTemporality.CUMULATIVE` accumulations.
- Add `move` and `merge` to Aggregator interfaces.

This PR depends on previous minor type introductions: 
- https://github.com/open-telemetry/opentelemetry-js/pull/1717
- https://github.com/open-telemetry/opentelemetry-js/pull/1712
