### PR TITLE
feat: fixing failing test

### DIFF
--- a/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
@@ -55,7 +55,7 @@ const applyCustomAttributesOnSpanErrorMessage =
   'bad applyCustomAttributesOnSpan function';
 
 let server: http.Server;
-const serverPort = 22345;
+const serverPort = 22346;
 const protocol = 'http';
 const hostname = 'localhost';
 const pathname = '/test';

--- a/packages/opentelemetry-instrumentation-http/test/functionals/http-package.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/http-package.test.ts
@@ -102,13 +102,7 @@ describe('Packages', () => {
         }
 
         const urlparsed = url.parse(
-          name === 'got' && process.versions.node.startsWith('12')
-            ? // there is an issue with got 9.6 version and node 12 when redirecting so url above will not work
-              // https://github.com/nock/nock/pull/1551
-              // https://github.com/sindresorhus/got/commit/bf1aa5492ae2bc78cbbec6b7d764906fb156e6c2#diff-707a4781d57c42085155dcb27edb9ccbR258
-              // TODO: check if this is still the case when new version
-              `${protocol}://info.cern.ch/`
-            : `${protocol}://www.google.com/search?q=axios&oq=axios&aqs=chrome.0.69i59l2j0l3j69i60.811j0j7&sourceid=chrome&ie=UTF-8`
+          `${protocol}://www.google.com/search?q=axios&oq=axios&aqs=chrome.0.69i59l2j0l3j69i60.811j0j7&sourceid=chrome&ie=UTF-8`
         );
         const result = await httpPackage.get(urlparsed.href!);
         if (!resHeaders) {

--- a/packages/opentelemetry-plugin-http/test/functionals/http-package.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-package.test.ts
@@ -93,13 +93,7 @@ describe('Packages', () => {
         }
 
         const urlparsed = url.parse(
-          name === 'got' && process.versions.node.startsWith('12')
-            ? // there is an issue with got 9.6 version and node 12 when redirecting so url above will not work
-              // https://github.com/nock/nock/pull/1551
-              // https://github.com/sindresorhus/got/commit/bf1aa5492ae2bc78cbbec6b7d764906fb156e6c2#diff-707a4781d57c42085155dcb27edb9ccbR258
-              // TODO: check if this is still the case when new version
-              `${protocol}://info.cern.ch/`
-            : `${protocol}://www.google.com/search?q=axios&oq=axios&aqs=chrome.0.69i59l2j0l3j69i60.811j0j7&sourceid=chrome&ie=UTF-8`
+          `${protocol}://www.google.com/search?q=axios&oq=axios&aqs=chrome.0.69i59l2j0l3j69i60.811j0j7&sourceid=chrome&ie=UTF-8`
         );
         const result = await httpPackage.get(urlparsed.href!);
         if (!resHeaders) {


### PR DESCRIPTION
Fixes #1745 

Update:
the 2nd link (info.cern.ch) used in test is not valid anymore
http instrumentation and http plugin was using the same port