### PR TITLE
fix(@opentelemetry/exporter-jaeger): fixed issue #1757

### DIFF
--- a/packages/opentelemetry-exporter-jaeger/src/transform.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/transform.ts
@@ -55,9 +55,9 @@ export function spanToThrift(span: ReadableSpan): ThriftSpan {
   if (span.status.message) {
     tags.push({ key: 'status.message', value: span.status.message });
   }
-  // Ensure that if Status.Code is not OK, that we set the "error" tag on the
+  // Ensure that if Status.Code is ERROR, that we set the "error" tag on the
   // Jaeger span.
-  if (span.status.code !== StatusCode.OK) {
+  if (span.status.code === StatusCode.ERROR) {
     tags.push({ key: 'error', value: true });
   }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Jaeger exporter set error tag when span status is Unset as discribed in issue #1757 


## Short description of the changes

Changed error flag setting logic
Added test for this
