### PR TITLE
grpc->grpc-js

### DIFF
--- a/packages/opentelemetry-exporter-collector-grpc/package.json
+++ b/packages/opentelemetry-exporter-collector-grpc/package.json
@@ -62,13 +62,13 @@
     "typescript": "3.9.7"
   },
   "dependencies": {
+    "@grpc/grpc-js": "^1.2.2",
     "@grpc/proto-loader": "^0.5.4",
     "@opentelemetry/api": "^0.14.0",
     "@opentelemetry/core": "^0.14.0",
     "@opentelemetry/exporter-collector": "^0.14.0",
     "@opentelemetry/metrics": "^0.14.0",
     "@opentelemetry/resources": "^0.14.0",
-    "@opentelemetry/tracing": "^0.14.0",
-    "grpc": "^1.24.2"
+    "@opentelemetry/tracing": "^0.14.0"
   }
 }

--- a/packages/opentelemetry-exporter-collector-grpc/src/CollectorExporterNodeBase.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/src/CollectorExporterNodeBase.ts
@@ -18,7 +18,7 @@ import {
   CollectorExporterBase,
   collectorTypes,
 } from '@opentelemetry/exporter-collector';
-import type { Metadata } from 'grpc';
+import type { Metadata } from '@grpc/grpc-js';
 import {
   CollectorExporterConfigNode,
   GRPCQueueItem,

--- a/packages/opentelemetry-exporter-collector-grpc/src/types.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/src/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { collectorTypes } from '@opentelemetry/exporter-collector';
-import * as grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
 
 /**
  * Queue item to be used to save temporary spans/metrics in case the GRPC service

--- a/packages/opentelemetry-exporter-collector-grpc/src/util.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/src/util.ts
@@ -16,7 +16,7 @@
 
 import * as protoLoader from '@grpc/proto-loader';
 import { collectorTypes } from '@opentelemetry/exporter-collector';
-import * as grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
 import * as path from 'path';
 
 import {

--- a/packages/opentelemetry-exporter-collector-grpc/test/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/test/CollectorMetricExporter.test.ts
@@ -106,9 +106,10 @@ const testCollectorMetricExporter = (params: TestParams) =>
                 ]
               )
             : grpc.ServerCredentials.createInsecure();
-          server.bind(address, credentials);
-          server.start();
-          done();
+          server.bindAsync(address, credentials, () => {
+            server.start();
+            done();
+          });
         });
     });
 

--- a/packages/opentelemetry-exporter-collector-grpc/test/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/test/CollectorMetricExporter.test.ts
@@ -15,7 +15,7 @@
  */
 
 import * as protoLoader from '@grpc/proto-loader';
-import * as grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
 import * as path from 'path';
 import * as fs from 'fs';
 

--- a/packages/opentelemetry-exporter-collector-grpc/test/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/test/CollectorTraceExporter.test.ts
@@ -104,9 +104,10 @@ const testCollectorExporter = (params: TestParams) =>
                 ]
               )
             : grpc.ServerCredentials.createInsecure();
-          server.bind(address, credentials);
-          server.start();
-          done();
+          server.bindAsync(address, credentials, () => {
+            server.start();
+            done();
+          });
         });
     });
 

--- a/packages/opentelemetry-exporter-collector-grpc/test/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/test/CollectorTraceExporter.test.ts
@@ -24,7 +24,7 @@ import {
 
 import * as assert from 'assert';
 import * as fs from 'fs';
-import * as grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
 import * as path from 'path';
 import * as sinon from 'sinon';
 import { CollectorTraceExporter } from '../src';

--- a/packages/opentelemetry-exporter-collector-grpc/test/fake.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/test/fake.ts
@@ -1,0 +1,122 @@
+import * as protoLoader from '@grpc/proto-loader';
+import { collectorTypes } from '@opentelemetry/exporter-collector';
+import { ConsoleLogger, LogLevel } from '@opentelemetry/core';
+import {
+  BasicTracerProvider,
+  SimpleSpanProcessor,
+} from '@opentelemetry/tracing';
+
+// import * as assert from 'assert';
+import * as fs from 'fs';
+import * as grpc from '@grpc/grpc-js';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import { CollectorTraceExporter } from '../src';
+
+import {
+  // ensureExportedSpanIsCorrect,
+  // ensureMetadataIsCorrect,
+  // ensureResourceIsCorrect,
+  mockedReadableSpan,
+} from './helper';
+
+const traceServiceProtoPath =
+  'opentelemetry/proto/collector/trace/v1/trace_service.proto';
+const includeDirs = [path.resolve(__dirname, '../protos')];
+
+const address = 'localhost:1501';
+
+const metadata = new grpc.Metadata();
+metadata.set('k', 'v');
+
+let collectorExporter: CollectorTraceExporter;
+let server: grpc.Server;
+let exportedData:
+  | collectorTypes.opentelemetryProto.trace.v1.ResourceSpans
+  | undefined;
+let reqMetadata: grpc.Metadata | undefined;
+
+const setup = async () => {
+  const params = {
+    useTLS: false,
+    metadata
+  }
+  server = new grpc.Server();
+  const packageDefinition = await protoLoader.load(traceServiceProtoPath, {
+    keepCase: false,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true,
+    includeDirs,
+  })
+  const packageObject: any = grpc.loadPackageDefinition(
+    packageDefinition
+  );
+  server.addService(
+    packageObject.opentelemetry.proto.collector.trace.v1.TraceService
+      .service,
+    {
+        Export: (data: {
+          request: collectorTypes.opentelemetryProto.collector.trace.v1.ExportTraceServiceRequest;
+          metadata: grpc.Metadata;
+        }) => {
+          try {
+            console.log('try')
+            exportedData = data.request.resourceSpans[0];
+            reqMetadata = data.metadata;
+            console.log('try ok')
+          } catch (e) {
+            console.log('catch')
+            exportedData = undefined;
+          }
+        },
+      }
+  );
+  const credentials = params.useTLS
+    ? grpc.ServerCredentials.createSsl(
+      fs.readFileSync('./test/certs/ca.crt'),
+      [
+        {
+          cert_chain: fs.readFileSync('./test/certs/server.crt'),
+          private_key: fs.readFileSync('./test/certs/server.key'),
+        },
+      ]
+    )
+    : grpc.ServerCredentials.createInsecure();
+  await server.bindAsync(address, credentials, (err) => {
+    if (err) {
+      console.log('XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX')
+      throw err
+    }
+    server.start();
+  });
+
+  // const credentials = params.useTLS
+  //   ? grpc.credentials.createSsl(
+  //     fs.readFileSync('./test/certs/ca.crt'),
+  //     fs.readFileSync('./test/certs/client.key'),
+  //     fs.readFileSync('./test/certs/client.crt')
+  //   )
+  //   : undefined;
+  collectorExporter = new CollectorTraceExporter({
+    serviceName: 'basic-service',
+    url: address,
+    // credentials,
+    credentials: undefined,
+    metadata: params.metadata,
+  });
+
+  const provider = new BasicTracerProvider();
+  provider.addSpanProcessor(new SimpleSpanProcessor(collectorExporter));
+}
+
+const main =  async () => {
+  await setup()
+  const responseSpy = sinon.spy();
+  const spans = [Object.assign({}, mockedReadableSpan)];
+  await collectorExporter.export(spans, responseSpy);
+  console.log('ok')
+}
+
+main()

--- a/packages/opentelemetry-exporter-collector-grpc/test/helper.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/test/helper.ts
@@ -20,7 +20,7 @@ import { ReadableSpan } from '@opentelemetry/tracing';
 import { Resource } from '@opentelemetry/resources';
 import { collectorTypes } from '@opentelemetry/exporter-collector';
 import * as assert from 'assert';
-import * as grpc from 'grpc';
+import * as grpc from '@grpc/grpc-js';
 
 const meterProvider = new metrics.MeterProvider({
   interval: 30000,

--- a/packages/opentelemetry-exporter-collector-grpc/tsconfig.json
+++ b/packages/opentelemetry-exporter-collector-grpc/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "noUnusedLocals": false,
     "rootDir": ".",
     "outDir": "build"
   },


### PR DESCRIPTION
NOTE: this is a draft just so it's easier to have a discussion about the issue. I know I'm not doing the commits properly.

## Which problem is this PR solving?

- opentelemetry-js uses grpc, even though this has been deprecated in favor of grpc-js
- i'm personally seeing build times for my services instrumented with otel going WAY up as we compile all this C++ (eww). this is bad enough now, and going to get worse as we apply otel instrumentation to all our other microservices.
- previously , we wanted to upgrade to nodejs 15.x.x, but ran into bugs with node-gyp during build & couldn't do so. I know technically you guys don't concern yourself with non-lts node versions, and we were able to fix this by using node 14.x.x which is fine for us, but wouldn't you rather not have these kinds of dependency issues?

## Short description of the changes

- replacing grpc with grpc-js
- modifying the tests so they still work with grpc-js (this is where the difficulty comes in)

As you can see, despite the claims, grpc-js is not really a drop-in replacement for grpc. I'm sure the client is a drop-in replacement, but the server isn't, and I don't know enough about this test framework & how the server is supposed to work normally to fix it.

For reference: https://www.npmjs.com/package/@grpc/grpc-js