### PR TITLE
chore: fix docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Dependencies
+        run: |
           npm install --ignore-scripts
           npx lerna bootstrap --no-ci --scope @opentelemetry/api --include-dependencies
 


### PR DESCRIPTION
During a previous PR the workflow `run` line was accidentally removed.