### PR TITLE
fix: timeInputToHrTime Date handling

### DIFF
--- a/packages/opentelemetry-core/src/common/time.ts
+++ b/packages/opentelemetry-core/src/common/time.ts
@@ -85,7 +85,7 @@ export function timeInputToHrTime(time: api.TimeInput): api.HrTime {
       return numberToHrtime(time);
     }
   } else if (time instanceof Date) {
-    return [time.getTime(), 0];
+    return numberToHrtime(time.getTime());
   } else {
     throw TypeError('Invalid input type');
   }

--- a/packages/opentelemetry-core/test/common/time.test.ts
+++ b/packages/opentelemetry-core/test/common/time.test.ts
@@ -111,13 +111,18 @@ describe('time', () => {
     it('should convert Date hrTime', () => {
       const timeInput = new Date();
       const output = timeInputToHrTime(timeInput);
-      assert.deepStrictEqual(output, [timeInput.getTime(), 0]);
+      // Should exactly match the epoch millis conversion
+      assert.deepStrictEqual(output, timeInputToHrTime(timeInput.getTime()));
     });
 
     it('should convert epoch milliseconds hrTime', () => {
       const timeInput = Date.now();
+      const epochSecs = timeInput / 1000;
       const output = timeInputToHrTime(timeInput);
-      assert.deepStrictEqual(output[0], Math.trunc(timeInput / 1000));
+      assert.deepStrictEqual(output, [
+        Math.trunc(epochSecs),
+        Number((epochSecs - Math.trunc(epochSecs)).toFixed(9)) * 1000000000,
+      ]);
     });
 
     it('should convert performance.now() hrTime', () => {


### PR DESCRIPTION
> The getTime() method returns the number of milliseconds* since the Unix Epoch.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime

