### PR TITLE
chore: use local server for http integration tests

### DIFF
--- a/packages/opentelemetry-instrumentation-http/test/integrations/http-enable.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/integrations/http-enable.test.ts
@@ -60,7 +60,7 @@ describe('HttpInstrumentation Integration tests', () => {
   let mockServerPort = 0;
   let mockServer: http.Server;
   const sockets: Array<Socket> = [];
-  before(() => {
+  before(done => {
     mockServer = http.createServer((req, res) => {
       res.statusCode = 200;
       res.setHeader('content-type', 'application/json');
@@ -75,23 +75,27 @@ describe('HttpInstrumentation Integration tests', () => {
     mockServer.listen(0, () => {
       const addr = mockServer.address();
       if (addr == null) {
-        throw new Error('unexpected addr null');
+        done(new Error('unexpected addr null'));
+        return;
       }
 
       if (typeof addr === 'string') {
-        throw new Error(`unexpected addr ${addr}`);
+        done(new Error(`unexpected addr ${addr}`));
+        return;
       }
 
       if (addr.port <= 0) {
-        throw new Error('Could not get port');
+        done(new Error('Could not get port'));
+        return;
       }
       mockServerPort = addr.port;
+      done();
     });
   });
 
-  after(() => {
-    mockServer.close();
+  after(done => {
     sockets.forEach(s => s.destroy());
+    mockServer.close(done);
   });
 
   beforeEach(() => {

--- a/packages/opentelemetry-instrumentation-http/test/integrations/https-enable.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/integrations/https-enable.test.ts
@@ -63,7 +63,7 @@ describe('HttpsInstrumentation Integration tests', () => {
   let mockServerPort = 0;
   let mockServer: https.Server;
   const sockets: Array<Socket> = [];
-  before(() => {
+  before(done => {
     mockServer = https.createServer(
       {
         key: fs.readFileSync(
@@ -88,23 +88,27 @@ describe('HttpsInstrumentation Integration tests', () => {
     mockServer.listen(0, () => {
       const addr = mockServer.address();
       if (addr == null) {
-        throw new Error('unexpected addr null');
+        done(new Error('unexpected addr null'));
+        return;
       }
 
       if (typeof addr === 'string') {
-        throw new Error(`unexpected addr ${addr}`);
+        done(new Error(`unexpected addr ${addr}`));
+        return;
       }
 
       if (addr.port <= 0) {
-        throw new Error('Could not get port');
+        done(new Error('Could not get port'));
+        return;
       }
       mockServerPort = addr.port;
+      done();
     });
   });
 
-  after(() => {
-    mockServer.close();
+  after(done => {
     sockets.forEach(s => s.destroy());
+    mockServer.close(done);
   });
 
   beforeEach(() => {

--- a/packages/opentelemetry-instrumentation-http/test/integrations/https-enable.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/integrations/https-enable.test.ts
@@ -27,6 +27,9 @@ import {
 } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import * as http from 'http';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Socket } from 'net';
 import { assertSpan } from '../utils/assertSpan';
 import * as url from 'url';
 import * as utils from '../utils/utils';
@@ -57,6 +60,53 @@ export const customAttributeFunction = (span: Span): void => {
 };
 
 describe('HttpsInstrumentation Integration tests', () => {
+  let mockServerPort = 0;
+  let mockServer: https.Server;
+  const sockets: Array<Socket> = [];
+  before(() => {
+    mockServer = https.createServer(
+      {
+        key: fs.readFileSync(
+          path.join(__dirname, '..', 'fixtures', 'server-key.pem')
+        ),
+        cert: fs.readFileSync(
+          path.join(__dirname, '..', 'fixtures', 'server-cert.pem')
+        ),
+      },
+      (req, res) => {
+        res.statusCode = 200;
+        res.setHeader('content-type', 'application/json');
+        res.write(
+          JSON.stringify({
+            success: true,
+          })
+        );
+        res.end();
+      }
+    );
+
+    mockServer.listen(0, () => {
+      const addr = mockServer.address();
+      if (addr == null) {
+        throw new Error('unexpected addr null');
+      }
+
+      if (typeof addr === 'string') {
+        throw new Error(`unexpected addr ${addr}`);
+      }
+
+      if (addr.port <= 0) {
+        throw new Error('Could not get port');
+      }
+      mockServerPort = addr.port;
+    });
+  });
+
+  after(() => {
+    mockServer.close();
+    sockets.forEach(s => s.destroy());
+  });
+
   beforeEach(() => {
     memoryExporter.reset();
     context.setGlobalContextManager(new AsyncHooksContextManager().enable());
@@ -116,13 +166,14 @@ describe('HttpsInstrumentation Integration tests', () => {
       assert.strictEqual(spans.length, 0);
 
       const result = await httpsRequest.get(
-        `${protocol}://google.fr/?query=test`
+        `${protocol}://localhost:${mockServerPort}/?query=test`
       );
 
       spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
+        hostname: 'localhost',
         httpStatusCode: result.statusCode!,
         httpMethod: 'GET',
         pathname: '/',
@@ -132,7 +183,7 @@ describe('HttpsInstrumentation Integration tests', () => {
         component: 'https',
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTPS GET');
       assertSpan(span, SpanKind.CLIENT, validations);
     });
@@ -142,13 +193,14 @@ describe('HttpsInstrumentation Integration tests', () => {
       assert.strictEqual(spans.length, 0);
 
       const result = await httpsRequest.get(
-        new url.URL(`${protocol}://google.fr/?query=test`)
+        new url.URL(`${protocol}://localhost:${mockServerPort}/?query=test`)
       );
 
       spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
+        hostname: 'localhost',
         httpStatusCode: result.statusCode!,
         httpMethod: 'GET',
         pathname: '/',
@@ -158,7 +210,7 @@ describe('HttpsInstrumentation Integration tests', () => {
         component: 'https',
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTPS GET');
       assertSpan(span, SpanKind.CLIENT, validations);
     });
@@ -168,14 +220,17 @@ describe('HttpsInstrumentation Integration tests', () => {
       assert.strictEqual(spans.length, 0);
 
       const result = await httpsRequest.get(
-        new url.URL(`${protocol}://google.fr/?query=test`),
-        { headers: { 'x-foo': 'foo' } }
+        new url.URL(`${protocol}://localhost:${mockServerPort}/?query=test`),
+        {
+          headers: { 'x-foo': 'foo' },
+        }
       );
 
       spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
+        hostname: 'localhost',
         httpStatusCode: result.statusCode!,
         httpMethod: 'GET',
         pathname: '/',
@@ -185,7 +240,7 @@ describe('HttpsInstrumentation Integration tests', () => {
         component: 'https',
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTPS GET');
       assert.strictEqual(result.reqHeaders['x-foo'], 'foo');
       assert.strictEqual(span.attributes[HttpAttribute.HTTP_FLAVOR], '1.1');
@@ -197,11 +252,14 @@ describe('HttpsInstrumentation Integration tests', () => {
     });
 
     it('custom attributes should show up on client spans', async () => {
-      const result = await httpsRequest.get(`${protocol}://google.fr/`);
+      const result = await httpsRequest.get(
+        `${protocol}://localhost:${mockServerPort}/`
+      );
       const spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
+        hostname: 'localhost',
         httpStatusCode: result.statusCode!,
         httpMethod: 'GET',
         pathname: '/',
@@ -210,7 +268,7 @@ describe('HttpsInstrumentation Integration tests', () => {
         component: 'https',
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTPS GET');
       assert.strictEqual(span.attributes['span kind'], SpanKind.CLIENT);
       assertSpan(span, SpanKind.CLIENT, validations);
@@ -221,15 +279,16 @@ describe('HttpsInstrumentation Integration tests', () => {
       assert.strictEqual(spans.length, 0);
       const options = Object.assign(
         { headers: { Expect: '100-continue' } },
-        url.parse(`${protocol}://google.fr/`)
+        url.parse(`${protocol}://localhost:${mockServerPort}/`)
       );
 
       const result = await httpsRequest.get(options);
       spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
-        httpStatusCode: 301,
+        hostname: 'localhost',
+        httpStatusCode: 200,
         httpMethod: 'GET',
         pathname: '/',
         resHeaders: result.resHeaders,
@@ -237,20 +296,13 @@ describe('HttpsInstrumentation Integration tests', () => {
         component: 'https',
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTPS GET');
-
-      try {
-        assertSpan(span, SpanKind.CLIENT, validations);
-      } catch (error) {
-        // temporary redirect is also correct
-        validations.httpStatusCode = 307;
-        assertSpan(span, SpanKind.CLIENT, validations);
-      }
+      assertSpan(span, SpanKind.CLIENT, validations);
     });
     for (const headers of [
-      { Expect: '100-continue', 'user-agent': 'https-instrumentation-test' },
-      { 'user-agent': 'https-instrumentation-test' },
+      { Expect: '100-continue', 'user-agent': 'http-plugin-test' },
+      { 'user-agent': 'http-plugin-test' },
     ]) {
       it(`should create a span for GET requests and add propagation when using the following signature: get(url, options, callback) and following headers: ${JSON.stringify(
         headers
@@ -268,7 +320,7 @@ describe('HttpsInstrumentation Integration tests', () => {
         assert.strictEqual(spans.length, 0);
         const options = { headers };
         const req = https.get(
-          `${protocol}://google.fr/`,
+          `${protocol}://localhost:${mockServerPort}/`,
           options,
           (resp: http.IncomingMessage) => {
             const res = (resp as unknown) as http.IncomingMessage & {
@@ -280,7 +332,7 @@ describe('HttpsInstrumentation Integration tests', () => {
             });
             resp.on('end', () => {
               validations = {
-                hostname: 'google.fr',
+                hostname: 'localhost',
                 httpStatusCode: 301,
                 httpMethod: 'GET',
                 pathname: '/',
@@ -297,8 +349,10 @@ describe('HttpsInstrumentation Integration tests', () => {
 
         req.on('close', () => {
           const spans = memoryExporter.getFinishedSpans();
-          assert.strictEqual(spans.length, 1);
-          assert.strictEqual(spans[0].name, 'HTTPS GET');
+          const span = spans.find(s => s.kind === SpanKind.CLIENT);
+          assert.ok(span);
+          assert.strictEqual(spans.length, 2);
+          assert.strictEqual(span.name, 'HTTPS GET');
           assert.ok(data);
           assert.ok(validations.reqHeaders[DummyPropagation.TRACE_CONTEXT_KEY]);
           assert.ok(validations.reqHeaders[DummyPropagation.SPAN_CONTEXT_KEY]);

--- a/packages/opentelemetry-plugin-http/test/integrations/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/integrations/http-enable.test.ts
@@ -48,7 +48,7 @@ describe('HttpPlugin Integration tests', () => {
   let mockServerPort = 0;
   let mockServer: http.Server;
   const sockets: Array<Socket> = [];
-  before(() => {
+  before(done => {
     mockServer = http.createServer((req, res) => {
       res.statusCode = 200;
       res.setHeader('content-type', 'application/json');
@@ -63,23 +63,27 @@ describe('HttpPlugin Integration tests', () => {
     mockServer.listen(0, () => {
       const addr = mockServer.address();
       if (addr == null) {
-        throw new Error('unexpected addr null');
+        done(new Error('unexpected addr null'));
+        return;
       }
 
       if (typeof addr === 'string') {
-        throw new Error(`unexpected addr ${addr}`);
+        done(new Error(`unexpected addr ${addr}`));
+        return;
       }
 
       if (addr.port <= 0) {
-        throw new Error('Could not get port');
+        done(new Error('Could not get port'));
+        return;
       }
       mockServerPort = addr.port;
+      done();
     });
   });
 
-  after(() => {
-    mockServer.close();
+  after(done => {
     sockets.forEach(s => s.destroy());
+    mockServer.close(done);
   });
 
   beforeEach(() => {

--- a/packages/opentelemetry-plugin-http/test/integrations/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/integrations/http-enable.test.ts
@@ -34,6 +34,7 @@ import {
 } from '@opentelemetry/tracing';
 import { HttpPluginConfig } from '../../src/types';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { Socket } from 'net';
 const protocol = 'http';
 const serverPort = 32345;
 const hostname = 'localhost';
@@ -44,6 +45,43 @@ export const customAttributeFunction = (span: Span): void => {
 };
 
 describe('HttpPlugin Integration tests', () => {
+  let mockServerPort = 0;
+  let mockServer: http.Server;
+  const sockets: Array<Socket> = [];
+  before(() => {
+    mockServer = http.createServer((req, res) => {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.write(
+        JSON.stringify({
+          success: true,
+        })
+      );
+      res.end();
+    });
+
+    mockServer.listen(0, () => {
+      const addr = mockServer.address();
+      if (addr == null) {
+        throw new Error('unexpected addr null');
+      }
+
+      if (typeof addr === 'string') {
+        throw new Error(`unexpected addr ${addr}`);
+      }
+
+      if (addr.port <= 0) {
+        throw new Error('Could not get port');
+      }
+      mockServerPort = addr.port;
+    });
+  });
+
+  after(() => {
+    mockServer.close();
+    sockets.forEach(s => s.destroy());
+  });
+
   beforeEach(() => {
     memoryExporter.reset();
     context.setGlobalContextManager(new AsyncHooksContextManager().enable());
@@ -104,13 +142,14 @@ describe('HttpPlugin Integration tests', () => {
       assert.strictEqual(spans.length, 0);
 
       const result = await httpRequest.get(
-        `${protocol}://google.fr/?query=test`
+        `${protocol}://localhost:${mockServerPort}/?query=test`
       );
 
       spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
+        hostname: 'localhost',
         httpStatusCode: result.statusCode!,
         httpMethod: 'GET',
         pathname: '/',
@@ -120,7 +159,7 @@ describe('HttpPlugin Integration tests', () => {
         component: plugin.component,
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTP GET');
       assertSpan(span, SpanKind.CLIENT, validations);
     });
@@ -130,13 +169,14 @@ describe('HttpPlugin Integration tests', () => {
       assert.strictEqual(spans.length, 0);
 
       const result = await httpRequest.get(
-        new url.URL(`${protocol}://google.fr/?query=test`)
+        new url.URL(`${protocol}://localhost:${mockServerPort}/?query=test`)
       );
 
       spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
+        hostname: 'localhost',
         httpStatusCode: result.statusCode!,
         httpMethod: 'GET',
         pathname: '/',
@@ -146,7 +186,7 @@ describe('HttpPlugin Integration tests', () => {
         component: plugin.component,
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTP GET');
       assertSpan(span, SpanKind.CLIENT, validations);
     });
@@ -156,16 +196,17 @@ describe('HttpPlugin Integration tests', () => {
       assert.strictEqual(spans.length, 0);
 
       const result = await httpRequest.get(
-        new url.URL(`${protocol}://google.fr/?query=test`),
+        new url.URL(`${protocol}://localhost:${mockServerPort}/?query=test`),
         {
           headers: { 'x-foo': 'foo' },
         }
       );
 
       spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
+        hostname: 'localhost',
         httpStatusCode: result.statusCode!,
         httpMethod: 'GET',
         pathname: '/',
@@ -175,7 +216,7 @@ describe('HttpPlugin Integration tests', () => {
         component: plugin.component,
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTP GET');
       assert.strictEqual(result.reqHeaders['x-foo'], 'foo');
       assert.strictEqual(span.attributes[HttpAttribute.HTTP_FLAVOR], '1.1');
@@ -187,11 +228,14 @@ describe('HttpPlugin Integration tests', () => {
     });
 
     it('custom attributes should show up on client spans', async () => {
-      const result = await httpRequest.get(`${protocol}://google.fr/`);
+      const result = await httpRequest.get(
+        `${protocol}://localhost:${mockServerPort}/`
+      );
       const spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
+        hostname: 'localhost',
         httpStatusCode: result.statusCode!,
         httpMethod: 'GET',
         pathname: '/',
@@ -200,7 +244,7 @@ describe('HttpPlugin Integration tests', () => {
         component: plugin.component,
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTP GET');
       assert.strictEqual(span.attributes['span kind'], SpanKind.CLIENT);
       assertSpan(span, SpanKind.CLIENT, validations);
@@ -211,15 +255,16 @@ describe('HttpPlugin Integration tests', () => {
       assert.strictEqual(spans.length, 0);
       const options = Object.assign(
         { headers: { Expect: '100-continue' } },
-        url.parse(`${protocol}://google.fr/`)
+        url.parse(`${protocol}://localhost:${mockServerPort}/`)
       );
 
       const result = await httpRequest.get(options);
       spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
-        httpStatusCode: 301,
+        hostname: 'localhost',
+        httpStatusCode: 200,
         httpMethod: 'GET',
         pathname: '/',
         resHeaders: result.resHeaders,
@@ -227,16 +272,9 @@ describe('HttpPlugin Integration tests', () => {
         component: plugin.component,
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTP GET');
-
-      try {
-        assertSpan(span, SpanKind.CLIENT, validations);
-      } catch (error) {
-        // temporary redirect is also correct
-        validations.httpStatusCode = 307;
-        assertSpan(span, SpanKind.CLIENT, validations);
-      }
+      assertSpan(span, SpanKind.CLIENT, validations);
     });
     for (const headers of [
       { Expect: '100-continue', 'user-agent': 'http-plugin-test' },
@@ -258,7 +296,7 @@ describe('HttpPlugin Integration tests', () => {
         assert.strictEqual(spans.length, 0);
         const options = { headers };
         const req = http.get(
-          `${protocol}://google.fr/`,
+          `${protocol}://localhost:${mockServerPort}/`,
           options,
           (resp: http.IncomingMessage) => {
             const res = (resp as unknown) as http.IncomingMessage & {
@@ -270,7 +308,7 @@ describe('HttpPlugin Integration tests', () => {
             });
             resp.on('end', () => {
               validations = {
-                hostname: 'google.fr',
+                hostname: 'localhost',
                 httpStatusCode: 301,
                 httpMethod: 'GET',
                 pathname: '/',
@@ -287,8 +325,10 @@ describe('HttpPlugin Integration tests', () => {
 
         req.on('close', () => {
           const spans = memoryExporter.getFinishedSpans();
-          assert.strictEqual(spans.length, 1);
-          assert.strictEqual(spans[0].name, 'HTTP GET');
+          const span = spans.find(s => s.kind === SpanKind.CLIENT);
+          assert.ok(span);
+          assert.strictEqual(spans.length, 2);
+          assert.strictEqual(span.name, 'HTTP GET');
           assert.ok(data);
           assert.ok(validations.reqHeaders[DummyPropagation.TRACE_CONTEXT_KEY]);
           assert.ok(validations.reqHeaders[DummyPropagation.SPAN_CONTEXT_KEY]);

--- a/packages/opentelemetry-plugin-https/test/integrations/https-enable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/integrations/https-enable.test.ts
@@ -52,7 +52,7 @@ describe('HttpsPlugin Integration tests', () => {
   let mockServerPort = 0;
   let mockServer: https.Server;
   const sockets: Array<Socket> = [];
-  before(() => {
+  before(done => {
     mockServer = https.createServer(
       {
         key: fs.readFileSync(
@@ -77,23 +77,27 @@ describe('HttpsPlugin Integration tests', () => {
     mockServer.listen(0, () => {
       const addr = mockServer.address();
       if (addr == null) {
-        throw new Error('unexpected addr null');
+        done(new Error('unexpected addr null'));
+        return;
       }
 
       if (typeof addr === 'string') {
-        throw new Error(`unexpected addr ${addr}`);
+        done(new Error(`unexpected addr ${addr}`));
+        return;
       }
 
       if (addr.port <= 0) {
-        throw new Error('Could not get port');
+        done(new Error('Could not get port'));
+        return;
       }
       mockServerPort = addr.port;
+      done();
     });
   });
 
-  after(() => {
-    mockServer.close();
+  after(done => {
     sockets.forEach(s => s.destroy());
+    mockServer.close(done);
   });
 
   beforeEach(() => {

--- a/packages/opentelemetry-plugin-https/test/integrations/https-enable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/integrations/https-enable.test.ts
@@ -22,6 +22,8 @@ import {
 } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import * as http from 'http';
+import * as fs from 'fs';
+import * as path from 'path';
 import * as https from 'https';
 import { plugin } from '../../src/https';
 import { assertSpan } from '../utils/assertSpan';
@@ -35,6 +37,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/tracing';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { Socket } from 'net';
 
 const protocol = 'https';
 const serverPort = 42345;
@@ -46,6 +49,53 @@ export const customAttributeFunction = (span: Span): void => {
 };
 
 describe('HttpsPlugin Integration tests', () => {
+  let mockServerPort = 0;
+  let mockServer: https.Server;
+  const sockets: Array<Socket> = [];
+  before(() => {
+    mockServer = https.createServer(
+      {
+        key: fs.readFileSync(
+          path.join(__dirname, '..', 'fixtures', 'server-key.pem')
+        ),
+        cert: fs.readFileSync(
+          path.join(__dirname, '..', 'fixtures', 'server-cert.pem')
+        ),
+      },
+      (req, res) => {
+        res.statusCode = 200;
+        res.setHeader('content-type', 'application/json');
+        res.write(
+          JSON.stringify({
+            success: true,
+          })
+        );
+        res.end();
+      }
+    );
+
+    mockServer.listen(0, () => {
+      const addr = mockServer.address();
+      if (addr == null) {
+        throw new Error('unexpected addr null');
+      }
+
+      if (typeof addr === 'string') {
+        throw new Error(`unexpected addr ${addr}`);
+      }
+
+      if (addr.port <= 0) {
+        throw new Error('Could not get port');
+      }
+      mockServerPort = addr.port;
+    });
+  });
+
+  after(() => {
+    mockServer.close();
+    sockets.forEach(s => s.destroy());
+  });
+
   beforeEach(() => {
     memoryExporter.reset();
     context.setGlobalContextManager(new AsyncHooksContextManager().enable());
@@ -111,13 +161,14 @@ describe('HttpsPlugin Integration tests', () => {
       assert.strictEqual(spans.length, 0);
 
       const result = await httpsRequest.get(
-        `${protocol}://google.fr/?query=test`
+        `${protocol}://localhost:${mockServerPort}/?query=test`
       );
 
       spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
+        hostname: 'localhost',
         httpStatusCode: result.statusCode!,
         httpMethod: 'GET',
         pathname: '/',
@@ -127,7 +178,7 @@ describe('HttpsPlugin Integration tests', () => {
         component: plugin.component,
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTP GET');
       assertSpan(span, SpanKind.CLIENT, validations);
     });
@@ -137,13 +188,14 @@ describe('HttpsPlugin Integration tests', () => {
       assert.strictEqual(spans.length, 0);
 
       const result = await httpsRequest.get(
-        new url.URL(`${protocol}://google.fr/?query=test`)
+        new url.URL(`${protocol}://localhost:${mockServerPort}/?query=test`)
       );
 
       spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
+        hostname: 'localhost',
         httpStatusCode: result.statusCode!,
         httpMethod: 'GET',
         pathname: '/',
@@ -153,7 +205,7 @@ describe('HttpsPlugin Integration tests', () => {
         component: plugin.component,
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTP GET');
       assertSpan(span, SpanKind.CLIENT, validations);
     });
@@ -163,14 +215,17 @@ describe('HttpsPlugin Integration tests', () => {
       assert.strictEqual(spans.length, 0);
 
       const result = await httpsRequest.get(
-        new url.URL(`${protocol}://google.fr/?query=test`),
-        { headers: { 'x-foo': 'foo' } }
+        new url.URL(`${protocol}://localhost:${mockServerPort}/?query=test`),
+        {
+          headers: { 'x-foo': 'foo' },
+        }
       );
 
       spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
+        hostname: 'localhost',
         httpStatusCode: result.statusCode!,
         httpMethod: 'GET',
         pathname: '/',
@@ -180,7 +235,7 @@ describe('HttpsPlugin Integration tests', () => {
         component: plugin.component,
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTP GET');
       assert.strictEqual(result.reqHeaders['x-foo'], 'foo');
       assert.strictEqual(span.attributes[HttpAttribute.HTTP_FLAVOR], '1.1');
@@ -192,11 +247,14 @@ describe('HttpsPlugin Integration tests', () => {
     });
 
     it('custom attributes should show up on client spans', async () => {
-      const result = await httpsRequest.get(`${protocol}://google.fr/`);
+      const result = await httpsRequest.get(
+        `${protocol}://localhost:${mockServerPort}/`
+      );
       const spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
+        hostname: 'localhost',
         httpStatusCode: result.statusCode!,
         httpMethod: 'GET',
         pathname: '/',
@@ -205,7 +263,7 @@ describe('HttpsPlugin Integration tests', () => {
         component: plugin.component,
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTP GET');
       assert.strictEqual(span.attributes['span kind'], SpanKind.CLIENT);
       assertSpan(span, SpanKind.CLIENT, validations);
@@ -216,15 +274,16 @@ describe('HttpsPlugin Integration tests', () => {
       assert.strictEqual(spans.length, 0);
       const options = Object.assign(
         { headers: { Expect: '100-continue' } },
-        url.parse(`${protocol}://google.fr/`)
+        url.parse(`${protocol}://localhost:${mockServerPort}/`)
       );
 
       const result = await httpsRequest.get(options);
       spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
+      const span = spans.find(s => s.kind === SpanKind.CLIENT);
+      assert.ok(span);
       const validations = {
-        hostname: 'google.fr',
-        httpStatusCode: 301,
+        hostname: 'localhost',
+        httpStatusCode: 200,
         httpMethod: 'GET',
         pathname: '/',
         resHeaders: result.resHeaders,
@@ -232,20 +291,13 @@ describe('HttpsPlugin Integration tests', () => {
         component: plugin.component,
       };
 
-      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(spans.length, 2);
       assert.strictEqual(span.name, 'HTTP GET');
-
-      try {
-        assertSpan(span, SpanKind.CLIENT, validations);
-      } catch (error) {
-        // temporary redirect is also correct
-        validations.httpStatusCode = 307;
-        assertSpan(span, SpanKind.CLIENT, validations);
-      }
+      assertSpan(span, SpanKind.CLIENT, validations);
     });
     for (const headers of [
-      { Expect: '100-continue', 'user-agent': 'https-plugin-test' },
-      { 'user-agent': 'https-plugin-test' },
+      { Expect: '100-continue', 'user-agent': 'http-plugin-test' },
+      { 'user-agent': 'http-plugin-test' },
     ]) {
       it(`should create a span for GET requests and add propagation when using the following signature: get(url, options, callback) and following headers: ${JSON.stringify(
         headers
@@ -263,7 +315,7 @@ describe('HttpsPlugin Integration tests', () => {
         assert.strictEqual(spans.length, 0);
         const options = { headers };
         const req = https.get(
-          `${protocol}://google.fr/`,
+          `${protocol}://localhost:${mockServerPort}/`,
           options,
           (resp: http.IncomingMessage) => {
             const res = (resp as unknown) as http.IncomingMessage & {
@@ -275,7 +327,7 @@ describe('HttpsPlugin Integration tests', () => {
             });
             resp.on('end', () => {
               validations = {
-                hostname: 'google.fr',
+                hostname: 'localhost',
                 httpStatusCode: 301,
                 httpMethod: 'GET',
                 pathname: '/',
@@ -292,8 +344,10 @@ describe('HttpsPlugin Integration tests', () => {
 
         req.on('close', () => {
           const spans = memoryExporter.getFinishedSpans();
-          assert.strictEqual(spans.length, 1);
-          assert.strictEqual(spans[0].name, 'HTTP GET');
+          const span = spans.find(s => s.kind === SpanKind.CLIENT);
+          assert.ok(span);
+          assert.strictEqual(spans.length, 2);
+          assert.strictEqual(span.name, 'HTTP GET');
           assert.ok(data);
           assert.ok(validations.reqHeaders[DummyPropagation.TRACE_CONTEXT_KEY]);
           assert.ok(validations.reqHeaders[DummyPropagation.SPAN_CONTEXT_KEY]);


### PR DESCRIPTION
I believe the flakiness of the http test comes down to its dependence on making requests to google.fr. I have replaced this functionality in the tests with a local dev server. Making these requests locally means they are faster and more reliable.