### PR TITLE
chore: remove race from tests

### DIFF
--- a/packages/opentelemetry-exporter-collector-proto/test/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-proto/test/CollectorMetricExporter.test.ts
@@ -48,8 +48,6 @@ describe('CollectorMetricExporter - node with proto over http', () => {
   let collectorExporterConfig: CollectorExporterNodeConfigBase;
   let metrics: metrics.MetricRecord[];
 
-  const sandbox = sinon.createSandbox();
-
   describe('export', () => {
     beforeEach(async () => {
       collectorExporterConfig = {
@@ -89,13 +87,13 @@ describe('CollectorMetricExporter - node with proto over http', () => {
       metrics.push((await recorder.getMetricRecord())[0]);
     });
     afterEach(() => {
-      sandbox.restore();
+      sinon.restore();
     });
 
     it('should open the connection', done => {
       collectorExporter.export(metrics, () => {});
 
-      sandbox.stub(http, 'request').callsFake((options: any) => {
+      sinon.stub(http, 'request').callsFake((options: any) => {
         assert.strictEqual(options.hostname, 'foo.bar.com');
         assert.strictEqual(options.method, 'POST');
         assert.strictEqual(options.path, '/');
@@ -107,7 +105,7 @@ describe('CollectorMetricExporter - node with proto over http', () => {
     it('should set custom headers', done => {
       collectorExporter.export(metrics, () => {});
 
-      sandbox.stub(http, 'request').callsFake((options: any) => {
+      sinon.stub(http, 'request').callsFake((options: any) => {
         assert.strictEqual(options.headers['foo'], 'bar');
         done();
         return fakeRequest as any;
@@ -117,7 +115,7 @@ describe('CollectorMetricExporter - node with proto over http', () => {
     it('should have keep alive and keepAliveMsecs option set', done => {
       collectorExporter.export(metrics, () => {});
 
-      sandbox.stub(http, 'request').callsFake((options: any) => {
+      sinon.stub(http, 'request').callsFake((options: any) => {
         assert.strictEqual(options.agent.keepAlive, true);
         assert.strictEqual(options.agent.options.keepAliveMsecs, 2000);
         done();
@@ -128,7 +126,7 @@ describe('CollectorMetricExporter - node with proto over http', () => {
     it('should successfully send metrics', done => {
       collectorExporter.export(metrics, () => {});
 
-      sandbox.stub(http, 'request').returns({
+      sinon.stub(http, 'request').returns({
         end: () => {},
         on: () => {},
         write: (...writeArgs: any[]) => {
@@ -180,7 +178,7 @@ describe('CollectorMetricExporter - node with proto over http', () => {
         done();
       });
 
-      sandbox.stub(http, 'request').callsFake((options: any, cb: any) => {
+      sinon.stub(http, 'request').callsFake((options: any, cb: any) => {
         const mockRes = new MockedResponse(200);
         cb(mockRes);
         mockRes.send('success');
@@ -196,7 +194,7 @@ describe('CollectorMetricExporter - node with proto over http', () => {
         done();
       });
 
-      sandbox.stub(http, 'request').callsFake((options: any, cb: any) => {
+      sinon.stub(http, 'request').callsFake((options: any, cb: any) => {
         const mockResError = new MockedResponse(400);
         cb(mockResError);
         mockResError.send('failed');

--- a/packages/opentelemetry-exporter-collector-proto/test/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-proto/test/CollectorMetricExporter.test.ts
@@ -14,30 +14,28 @@
  * limitations under the License.
  */
 
-import {
-  collectorTypes,
-  CollectorExporterNodeConfigBase,
-} from '@opentelemetry/exporter-collector';
 import * as api from '@opentelemetry/api';
+import { ExportResultCode } from '@opentelemetry/core';
+import {
+  CollectorExporterNodeConfigBase,
+  collectorTypes,
+} from '@opentelemetry/exporter-collector';
 import * as metrics from '@opentelemetry/metrics';
-import * as http from 'http';
 import * as assert from 'assert';
+import * as http from 'http';
 import * as sinon from 'sinon';
 import { CollectorMetricExporter } from '../src';
 import { getExportRequestProto } from '../src/util';
-
 import {
-  mockCounter,
-  mockObserver,
-  ensureExportMetricsServiceRequestIsSet,
-  mockValueRecorder,
   ensureExportedCounterIsCorrect,
   ensureExportedObserverIsCorrect,
   ensureExportedValueRecorderIsCorrect,
+  ensureExportMetricsServiceRequestIsSet,
+  mockCounter,
   MockedResponse,
+  mockObserver,
+  mockValueRecorder,
 } from './helper';
-import { ExportResult, ExportResultCode } from '@opentelemetry/core';
-import { CollectorExporterError } from '@opentelemetry/exporter-collector/build/src/types';
 
 const fakeRequest = {
   end: function () {},
@@ -45,19 +43,15 @@ const fakeRequest = {
   write: function () {},
 };
 
-// send is lazy loading file so need to wait a bit
-const waitTimeMS = 20;
-
 describe('CollectorMetricExporter - node with proto over http', () => {
   let collectorExporter: CollectorMetricExporter;
   let collectorExporterConfig: CollectorExporterNodeConfigBase;
-  let spyRequest: sinon.SinonSpy;
-  let spyWrite: sinon.SinonSpy;
   let metrics: metrics.MetricRecord[];
+
+  const sandbox = sinon.createSandbox();
+
   describe('export', () => {
     beforeEach(async () => {
-      spyRequest = sinon.stub(http, 'request').returns(fakeRequest as any);
-      spyWrite = sinon.stub(fakeRequest, 'write');
       collectorExporterConfig = {
         headers: {
           foo: 'bar',
@@ -95,131 +89,120 @@ describe('CollectorMetricExporter - node with proto over http', () => {
       metrics.push((await recorder.getMetricRecord())[0]);
     });
     afterEach(() => {
-      spyRequest.restore();
-      spyWrite.restore();
+      sandbox.restore();
     });
 
     it('should open the connection', done => {
       collectorExporter.export(metrics, () => {});
 
-      setTimeout(() => {
-        const args = spyRequest.args[0];
-        const options = args[0];
-
+      sandbox.stub(http, 'request').callsFake((options: any) => {
         assert.strictEqual(options.hostname, 'foo.bar.com');
         assert.strictEqual(options.method, 'POST');
         assert.strictEqual(options.path, '/');
         done();
-      }, waitTimeMS);
+        return fakeRequest as any;
+      });
     });
 
     it('should set custom headers', done => {
       collectorExporter.export(metrics, () => {});
 
-      setTimeout(() => {
-        const args = spyRequest.args[0];
-        const options = args[0];
+      sandbox.stub(http, 'request').callsFake((options: any) => {
         assert.strictEqual(options.headers['foo'], 'bar');
         done();
-      }, waitTimeMS);
+        return fakeRequest as any;
+      });
     });
 
     it('should have keep alive and keepAliveMsecs option set', done => {
       collectorExporter.export(metrics, () => {});
 
-      setTimeout(() => {
-        const args = spyRequest.args[0];
-        const options = args[0];
-        const agent = options.agent;
-        assert.strictEqual(agent.keepAlive, true);
-        assert.strictEqual(agent.options.keepAliveMsecs, 2000);
+      sandbox.stub(http, 'request').callsFake((options: any) => {
+        assert.strictEqual(options.agent.keepAlive, true);
+        assert.strictEqual(options.agent.options.keepAliveMsecs, 2000);
         done();
+        return fakeRequest as any;
       });
     });
 
     it('should successfully send metrics', done => {
       collectorExporter.export(metrics, () => {});
 
-      setTimeout(() => {
-        const writeArgs = spyWrite.args[0];
-        const ExportTraceServiceRequestProto = getExportRequestProto();
-        const data = ExportTraceServiceRequestProto?.decode(writeArgs[0]);
-        const json = data?.toJSON() as collectorTypes.opentelemetryProto.collector.metrics.v1.ExportMetricsServiceRequest;
+      sandbox.stub(http, 'request').returns({
+        end: () => {},
+        on: () => {},
+        write: (...writeArgs: any[]) => {
+          const ExportTraceServiceRequestProto = getExportRequestProto();
+          const data = ExportTraceServiceRequestProto?.decode(writeArgs[0]);
+          const json = data?.toJSON() as collectorTypes.opentelemetryProto.collector.metrics.v1.ExportMetricsServiceRequest;
 
-        const metric1 =
-          json.resourceMetrics[0].instrumentationLibraryMetrics[0].metrics[0];
-        const metric2 =
-          json.resourceMetrics[0].instrumentationLibraryMetrics[0].metrics[1];
-        const metric3 =
-          json.resourceMetrics[0].instrumentationLibraryMetrics[0].metrics[2];
+          const metric1 =
+            json.resourceMetrics[0].instrumentationLibraryMetrics[0].metrics[0];
+          const metric2 =
+            json.resourceMetrics[0].instrumentationLibraryMetrics[0].metrics[1];
+          const metric3 =
+            json.resourceMetrics[0].instrumentationLibraryMetrics[0].metrics[2];
 
-        assert.ok(typeof metric1 !== 'undefined', "counter doesn't exist");
-        ensureExportedCounterIsCorrect(
-          metric1,
-          metric1.intSum?.dataPoints[0].timeUnixNano
-        );
-        assert.ok(typeof metric2 !== 'undefined', "observer doesn't exist");
-        ensureExportedObserverIsCorrect(
-          metric2,
-          metric2.doubleGauge?.dataPoints[0].timeUnixNano
-        );
-        assert.ok(
-          typeof metric3 !== 'undefined',
-          "value recorder doesn't exist"
-        );
-        ensureExportedValueRecorderIsCorrect(
-          metric3,
-          metric3.intHistogram?.dataPoints[0].timeUnixNano,
-          [0, 100],
-          ['0', '2', '0']
-        );
+          assert.ok(typeof metric1 !== 'undefined', "counter doesn't exist");
+          ensureExportedCounterIsCorrect(
+            metric1,
+            metric1.intSum?.dataPoints[0].timeUnixNano
+          );
+          assert.ok(typeof metric2 !== 'undefined', "observer doesn't exist");
+          ensureExportedObserverIsCorrect(
+            metric2,
+            metric2.doubleGauge?.dataPoints[0].timeUnixNano
+          );
+          assert.ok(
+            typeof metric3 !== 'undefined',
+            "value recorder doesn't exist"
+          );
+          ensureExportedValueRecorderIsCorrect(
+            metric3,
+            metric3.intHistogram?.dataPoints[0].timeUnixNano,
+            [0, 100],
+            ['0', '2', '0']
+          );
 
-        ensureExportMetricsServiceRequestIsSet(json);
+          ensureExportMetricsServiceRequestIsSet(json);
 
-        done();
-      }, waitTimeMS);
+          done();
+        },
+      } as any);
     });
 
     it('should log the successful message', done => {
       const spyLoggerError = sinon.stub(collectorExporter.logger, 'error');
 
-      const responseSpy = sinon.spy();
-      collectorExporter.export(metrics, responseSpy);
+      collectorExporter.export(metrics, result => {
+        assert.strictEqual(result.code, ExportResultCode.SUCCESS);
+        assert.strictEqual(spyLoggerError.args.length, 0);
+        done();
+      });
 
-      setTimeout(() => {
+      sandbox.stub(http, 'request').callsFake((options: any, cb: any) => {
         const mockRes = new MockedResponse(200);
-        const args = spyRequest.args[0];
-        const callback = args[1];
-        callback(mockRes);
+        cb(mockRes);
         mockRes.send('success');
-        setTimeout(() => {
-          const result = responseSpy.args[0][0] as ExportResult;
-          assert.strictEqual(result.code, ExportResultCode.SUCCESS);
-          assert.strictEqual(spyLoggerError.args.length, 0);
-          done();
-        });
-      }, waitTimeMS);
+        return fakeRequest as any;
+      });
     });
 
     it('should log the error message', done => {
-      const responseSpy = sinon.spy();
-      collectorExporter.export(metrics, responseSpy);
+      collectorExporter.export(metrics, result => {
+        assert.strictEqual(result.code, ExportResultCode.FAILED);
+        // @ts-expect-error
+        assert.strictEqual(result.error.code, 400);
+        done();
+      });
 
-      setTimeout(() => {
-        const mockRes = new MockedResponse(400);
-        const args = spyRequest.args[0];
-        const callback = args[1];
-        callback(mockRes);
-        mockRes.send('failed');
-        setTimeout(() => {
-          const result = responseSpy.args[0][0] as ExportResult;
-          assert.strictEqual(result.code, ExportResultCode.FAILED);
-          const error = result.error as CollectorExporterError;
-          assert.strictEqual(error.code, 400);
-          assert.strictEqual(error.data, 'failed');
-          done();
-        });
-      }, waitTimeMS);
+      sandbox.stub(http, 'request').callsFake((options: any, cb: any) => {
+        const mockResError = new MockedResponse(400);
+        cb(mockResError);
+        mockResError.send('failed');
+
+        return fakeRequest as any;
+      });
     });
   });
 });

--- a/packages/opentelemetry-exporter-collector-proto/test/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-proto/test/CollectorTraceExporter.test.ts
@@ -14,26 +14,24 @@
  * limitations under the License.
  */
 
-import {
-  collectorTypes,
-  CollectorExporterNodeConfigBase,
-} from '@opentelemetry/exporter-collector';
-
 import { NoopLogger } from '@opentelemetry/api';
+import { ExportResultCode } from '@opentelemetry/core';
+import {
+  CollectorExporterNodeConfigBase,
+  collectorTypes,
+} from '@opentelemetry/exporter-collector';
 import { ReadableSpan } from '@opentelemetry/tracing';
-import * as http from 'http';
 import * as assert from 'assert';
+import * as http from 'http';
 import * as sinon from 'sinon';
 import { CollectorTraceExporter } from '../src';
 import { getExportRequestProto } from '../src/util';
-
 import {
   ensureExportTraceServiceRequestIsSet,
   ensureProtoSpanIsCorrect,
   mockedReadableSpan,
   MockedResponse,
 } from './helper';
-import { ExportResult, ExportResultCode } from '@opentelemetry/core';
 
 const fakeRequest = {
   end: function () {},
@@ -41,19 +39,15 @@ const fakeRequest = {
   write: function () {},
 };
 
-// send is lazy loading file so need to wait a bit
-const waitTimeMS = 20;
-
 describe('CollectorTraceExporter - node with proto over http', () => {
   let collectorExporter: CollectorTraceExporter;
   let collectorExporterConfig: CollectorExporterNodeConfigBase;
-  let spyRequest: sinon.SinonSpy;
-  let spyWrite: sinon.SinonSpy;
   let spans: ReadableSpan[];
+
+  const sandbox = sinon.createSandbox();
+
   describe('export', () => {
     beforeEach(() => {
-      spyRequest = sinon.stub(http, 'request').returns(fakeRequest as any);
-      spyWrite = sinon.stub(fakeRequest, 'write');
       collectorExporterConfig = {
         headers: {
           foo: 'bar',
@@ -71,108 +65,98 @@ describe('CollectorTraceExporter - node with proto over http', () => {
       spans.push(Object.assign({}, mockedReadableSpan));
     });
     afterEach(() => {
-      spyRequest.restore();
-      spyWrite.restore();
+      sandbox.restore();
     });
 
     it('should open the connection', done => {
       collectorExporter.export(spans, () => {});
 
-      setTimeout(() => {
-        const args = spyRequest.args[0];
-        const options = args[0];
-
+      sandbox.stub(http, 'request').callsFake((options: any) => {
         assert.strictEqual(options.hostname, 'foo.bar.com');
         assert.strictEqual(options.method, 'POST');
         assert.strictEqual(options.path, '/');
         done();
-      }, waitTimeMS);
+        return fakeRequest as any;
+      });
     });
 
     it('should set custom headers', done => {
       collectorExporter.export(spans, () => {});
 
-      setTimeout(() => {
-        const args = spyRequest.args[0];
-        const options = args[0];
+      sandbox.stub(http, 'request').callsFake((options: any) => {
         assert.strictEqual(options.headers['foo'], 'bar');
         done();
-      }, waitTimeMS);
+        return fakeRequest as any;
+      });
     });
 
     it('should have keep alive and keepAliveMsecs option set', done => {
       collectorExporter.export(spans, () => {});
 
-      setTimeout(() => {
-        const args = spyRequest.args[0];
-        const options = args[0];
-        const agent = options.agent;
-        assert.strictEqual(agent.keepAlive, true);
-        assert.strictEqual(agent.options.keepAliveMsecs, 2000);
+      sandbox.stub(http, 'request').callsFake((options: any) => {
+        assert.strictEqual(options.agent.keepAlive, true);
+        assert.strictEqual(options.agent.options.keepAliveMsecs, 2000);
         done();
+        return fakeRequest as any;
       });
     });
 
     it('should successfully send the spans', done => {
       collectorExporter.export(spans, () => {});
 
-      setTimeout(() => {
-        const writeArgs = spyWrite.args[0];
-        const ExportTraceServiceRequestProto = getExportRequestProto();
-        const data = ExportTraceServiceRequestProto?.decode(writeArgs[0]);
-        const json = data?.toJSON() as collectorTypes.opentelemetryProto.collector.trace.v1.ExportTraceServiceRequest;
-        const span1 =
-          json.resourceSpans[0].instrumentationLibrarySpans[0].spans[0];
-        assert.ok(typeof span1 !== 'undefined', "span doesn't exist");
-        if (span1) {
-          ensureProtoSpanIsCorrect(span1);
-        }
+      sandbox.stub(http, 'request').returns({
+        end: () => {},
+        on: () => {},
+        write: (...args: any[]) => {
+          const ExportTraceServiceRequestProto = getExportRequestProto();
+          const data = ExportTraceServiceRequestProto?.decode(args[0]);
+          const json = data?.toJSON() as collectorTypes.opentelemetryProto.collector.trace.v1.ExportTraceServiceRequest;
+          const span1 =
+            json.resourceSpans[0].instrumentationLibrarySpans[0].spans[0];
+          assert.ok(typeof span1 !== 'undefined', "span doesn't exist");
+          if (span1) {
+            ensureProtoSpanIsCorrect(span1);
+          }
 
-        ensureExportTraceServiceRequestIsSet(json);
+          ensureExportTraceServiceRequestIsSet(json);
 
-        done();
-      }, waitTimeMS);
+          done();
+        },
+      } as any);
     });
 
     it('should log the successful message', done => {
-      const spyLoggerError = sinon.stub(collectorExporter.logger, 'error');
+      const spyLoggerError = sandbox.stub(collectorExporter.logger, 'error');
 
-      const responseSpy = sinon.spy();
-      collectorExporter.export(spans, responseSpy);
+      collectorExporter.export(spans, result => {
+        assert.strictEqual(result.code, ExportResultCode.SUCCESS);
+        assert.strictEqual(spyLoggerError.args.length, 0);
+        done();
+      });
 
-      setTimeout(() => {
+      sandbox.stub(http, 'request').callsFake((options: any, cb: any) => {
         const mockRes = new MockedResponse(200);
-        const args = spyRequest.args[0];
-        const callback = args[1];
-        callback(mockRes);
+        cb(mockRes);
         mockRes.send('success');
-        setTimeout(() => {
-          const result = responseSpy.args[0][0] as ExportResult;
-          assert.strictEqual(result.code, ExportResultCode.SUCCESS);
-          assert.strictEqual(spyLoggerError.args.length, 0);
-          done();
-        });
-      }, waitTimeMS);
+        return fakeRequest as any;
+      });
     });
 
     it('should log the error message', done => {
-      const responseSpy = sinon.spy();
-      collectorExporter.export(spans, responseSpy);
+      collectorExporter.export(spans, result => {
+        assert.strictEqual(result.code, ExportResultCode.FAILED);
+        // @ts-expect-error
+        assert.strictEqual(result.error.code, 400);
+        done();
+      });
 
-      setTimeout(() => {
+      sandbox.stub(http, 'request').callsFake((options: any, cb: any) => {
         const mockResError = new MockedResponse(400);
-        const args = spyRequest.args[0];
-        const callback = args[1];
-        callback(mockResError);
+        cb(mockResError);
         mockResError.send('failed');
-        setTimeout(() => {
-          const result = responseSpy.args[0][0] as ExportResult;
-          assert.strictEqual(result.code, ExportResultCode.FAILED);
-          // @ts-expect-error
-          assert.strictEqual(result.error.code, 400);
-          done();
-        });
-      }, waitTimeMS);
+
+        return fakeRequest as any;
+      });
     });
   });
 });

--- a/packages/opentelemetry-exporter-collector-proto/test/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-proto/test/CollectorTraceExporter.test.ts
@@ -44,8 +44,6 @@ describe('CollectorTraceExporter - node with proto over http', () => {
   let collectorExporterConfig: CollectorExporterNodeConfigBase;
   let spans: ReadableSpan[];
 
-  const sandbox = sinon.createSandbox();
-
   describe('export', () => {
     beforeEach(() => {
       collectorExporterConfig = {
@@ -65,13 +63,13 @@ describe('CollectorTraceExporter - node with proto over http', () => {
       spans.push(Object.assign({}, mockedReadableSpan));
     });
     afterEach(() => {
-      sandbox.restore();
+      sinon.restore();
     });
 
     it('should open the connection', done => {
       collectorExporter.export(spans, () => {});
 
-      sandbox.stub(http, 'request').callsFake((options: any) => {
+      sinon.stub(http, 'request').callsFake((options: any) => {
         assert.strictEqual(options.hostname, 'foo.bar.com');
         assert.strictEqual(options.method, 'POST');
         assert.strictEqual(options.path, '/');
@@ -83,7 +81,7 @@ describe('CollectorTraceExporter - node with proto over http', () => {
     it('should set custom headers', done => {
       collectorExporter.export(spans, () => {});
 
-      sandbox.stub(http, 'request').callsFake((options: any) => {
+      sinon.stub(http, 'request').callsFake((options: any) => {
         assert.strictEqual(options.headers['foo'], 'bar');
         done();
         return fakeRequest as any;
@@ -93,7 +91,7 @@ describe('CollectorTraceExporter - node with proto over http', () => {
     it('should have keep alive and keepAliveMsecs option set', done => {
       collectorExporter.export(spans, () => {});
 
-      sandbox.stub(http, 'request').callsFake((options: any) => {
+      sinon.stub(http, 'request').callsFake((options: any) => {
         assert.strictEqual(options.agent.keepAlive, true);
         assert.strictEqual(options.agent.options.keepAliveMsecs, 2000);
         done();
@@ -104,7 +102,7 @@ describe('CollectorTraceExporter - node with proto over http', () => {
     it('should successfully send the spans', done => {
       collectorExporter.export(spans, () => {});
 
-      sandbox.stub(http, 'request').returns({
+      sinon.stub(http, 'request').returns({
         end: () => {},
         on: () => {},
         write: (...args: any[]) => {
@@ -126,7 +124,7 @@ describe('CollectorTraceExporter - node with proto over http', () => {
     });
 
     it('should log the successful message', done => {
-      const spyLoggerError = sandbox.stub(collectorExporter.logger, 'error');
+      const spyLoggerError = sinon.stub(collectorExporter.logger, 'error');
 
       collectorExporter.export(spans, result => {
         assert.strictEqual(result.code, ExportResultCode.SUCCESS);
@@ -134,7 +132,7 @@ describe('CollectorTraceExporter - node with proto over http', () => {
         done();
       });
 
-      sandbox.stub(http, 'request').callsFake((options: any, cb: any) => {
+      sinon.stub(http, 'request').callsFake((options: any, cb: any) => {
         const mockRes = new MockedResponse(200);
         cb(mockRes);
         mockRes.send('success');
@@ -150,7 +148,7 @@ describe('CollectorTraceExporter - node with proto over http', () => {
         done();
       });
 
-      sandbox.stub(http, 'request').callsFake((options: any, cb: any) => {
+      sinon.stub(http, 'request').callsFake((options: any, cb: any) => {
         const mockResError = new MockedResponse(400);
         cb(mockResError);
         mockResError.send('failed');


### PR DESCRIPTION
Fixes #1811 

The collector exporter proto tests had a race condition. They were waiting 20ms for the exporter to lazy-load the proto files. If it took longer than 20ms, the tests failed. This removes the race. 