### PR TITLE
chore: prepare for branch rename

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -2,8 +2,7 @@ name: Deploy Canary Release
 
 on:
   push:
-    branches:
-      - master
+    branches: [master, main]
 
 jobs:
   build-and-test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   push:
-    branches: [master]
+    branches: [master, main]
   pull_request:
 
 jobs:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,7 +1,7 @@
 name: Unit Tests
 on:
   push:
-    branches: [master]
+    branches: [master, main]
   pull_request:
 
 jobs:

--- a/.github/workflows/w3c-integration-test.yml
+++ b/.github/workflows/w3c-integration-test.yml
@@ -2,7 +2,7 @@ name: Run w3c tests on push
 
 on:
   push:
-    branches: [master]
+    branches: [master, main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Prepare to rename `master` branch to `main` by adding `main` to the github action triggers. After the branch is renamed, `master` will be removed from the list.

See [this post](https://github.com/github/renaming) for more information