### PR TITLE
improv(instrumentation-http): supressInstrumentation when we get a request on ignoredPath [#1831]

### DIFF
--- a/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -26,6 +26,7 @@ import {
   TraceFlags,
   ROOT_CONTEXT,
   getSpan,
+  suppressInstrumentation,
 } from '@opentelemetry/api';
 import { NoRecordingSpan } from '@opentelemetry/core';
 import type * as http from 'http';
@@ -392,7 +393,9 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
             )
         )
       ) {
-        return original.apply(this, [event, ...args]);
+        return context.with(suppressInstrumentation(context.active()), () => {
+          return original.apply(this, [event, ...args]);
+        });
       }
 
       const headers = request.headers;

--- a/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -394,6 +394,8 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
         )
       ) {
         return context.with(suppressInstrumentation(context.active()), () => {
+          context.bind(request);
+          context.bind(response);
           return original.apply(this, [event, ...args]);
         });
       }

--- a/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
@@ -209,6 +209,9 @@ describe('HttpInstrumentation', () => {
         });
         instrumentation.enable();
         server = http.createServer((request, response) => {
+          if (request.url?.includes('/ignored')) {
+            provider.getTracer('test').startSpan('some-span').end();
+          }
           response.end('Test Server Response');
         });
 

--- a/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
@@ -200,6 +200,9 @@ describe('HttpsInstrumentation', () => {
             cert: fs.readFileSync('test/fixtures/server-cert.pem'),
           },
           (request, response) => {
+            if (request.url?.includes('/ignored')) {
+              tracer.startSpan('some-span').end();
+            }
             response.end('Test Server Response');
           }
         );

--- a/packages/opentelemetry-plugin-http/src/http.ts
+++ b/packages/opentelemetry-plugin-http/src/http.ts
@@ -297,6 +297,8 @@ export class HttpPlugin extends BasePlugin<Http> {
         )
       ) {
         return context.with(suppressInstrumentation(context.active()), () => {
+          context.bind(request);
+          context.bind(response);
           return original.apply(this, [event, ...args]);
         });
       }

--- a/packages/opentelemetry-plugin-http/src/http.ts
+++ b/packages/opentelemetry-plugin-http/src/http.ts
@@ -26,6 +26,7 @@ import {
   setSpan,
   ROOT_CONTEXT,
   getSpan,
+  suppressInstrumentation,
 } from '@opentelemetry/api';
 import { BasePlugin, NoRecordingSpan } from '@opentelemetry/core';
 import type {
@@ -295,7 +296,9 @@ export class HttpPlugin extends BasePlugin<Http> {
             plugin._logger.error('caught ignoreIncomingPaths error: ', e)
         )
       ) {
-        return original.apply(this, [event, ...args]);
+        return context.with(suppressInstrumentation(context.active()), () => {
+          return original.apply(this, [event, ...args]);
+        });
       }
 
       const headers = request.headers;

--- a/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
@@ -211,6 +211,9 @@ describe('HttpPlugin', () => {
         };
         plugin.enable(http, provider, provider.logger, config);
         server = http.createServer((request, response) => {
+          if (request.url?.includes('/ignored')) {
+            provider.getTracer('test').startSpan('some-span').end();
+          }
           response.end('Test Server Response');
         });
 

--- a/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
@@ -216,6 +216,9 @@ describe('HttpsPlugin', () => {
             cert: fs.readFileSync('test/fixtures/server-cert.pem'),
           },
           (request, response) => {
+            if (request.url?.includes('/ignored')) {
+              tracer.startSpan('some-span').end();
+            }
             response.end('Test Server Response');
           }
         );


### PR DESCRIPTION

Fixes #1831