### PR TITLE
chore: adding johnbley to js approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Approvers ([@open-telemetry/js-approvers](https://github.com/orgs/open-telemetry
 
 - [Chengzhong Wu](https://github.com/legendecas), Alibaba
 - [Gerhard Stöbich](https://github.com/Flarna), Dynatrace
+- [John Bley](https://github.com/johnbley), Splunk
 - [Mark Wolff](https://github.com/markwolff), Microsoft
 - [Matthew Wear](https://github.com/mwear), LightStep
 - [Naseem K. Ullah](https://github.com/naseemkullah), Transit


### PR DESCRIPTION
I wanted to propose @johnbley as js approver. He is contributing to this project with web related stuff and I believe it would be great to have him as an approver too.

https://github.com/open-telemetry/opentelemetry-js-contrib/commits?author=johnbley
https://github.com/open-telemetry/opentelemetry-js/commits?author=johnbley

