### PR TITLE
fix(node): allow passing in plugin loader instead of a module path

### DIFF
--- a/packages/opentelemetry-core/src/trace/Plugin.ts
+++ b/packages/opentelemetry-core/src/trace/Plugin.ts
@@ -64,6 +64,15 @@ export interface PluginConfig {
   path?: string;
 
   /**
+   * Function to load the plugin.  Needed in environments like Yarn PnP
+   * where modules cannot use require() to load modules not listed in their
+   * own dependencies.
+   *
+   * Example: `loader: () => require('@opentelemetry/plugin-xxx').plugin`
+   */
+  loader?: () => Plugin;
+
+  /**
    * Request methods that match any string in ignoreMethods will not be traced.
    */
   ignoreMethods?: string[];

--- a/packages/opentelemetry-node/src/instrumentation/PluginLoader.ts
+++ b/packages/opentelemetry-node/src/instrumentation/PluginLoader.ts
@@ -150,7 +150,9 @@ export class PluginLoader {
 
         // Expecting a plugin from module;
         try {
-          const plugin: Plugin = require(modulePath).plugin;
+          const plugin: Plugin = config.loader
+            ? config.loader()
+            : require(modulePath).plugin;
           if (!utils.isSupportedVersion(version, plugin.supportedVersions)) {
             this.logger.warn(
               `PluginLoader#load: Plugin ${name} only supports module ${plugin.moduleName} with the versions: ${plugin.supportedVersions}`


### PR DESCRIPTION
In environments like Yarn PnP you cannot call `require` to load arbitrary modules,
you can only load modules that your module explicitly lists in its dependencies.

This change allows developers in these environments to pass in a function that does
the require operation within the context of a module that does declare the
appropriate dependency.

Note: this is a bit of a proposal at this point.  If you think it's not a good idea, we
can discard it.  If it's good but in need of tests, some tips on how you would test
this would be great.