### PR TITLE
chore: export API singleton types

### DIFF
--- a/packages/opentelemetry-api/src/index.ts
+++ b/packages/opentelemetry-api/src/index.ts
@@ -62,14 +62,17 @@ export {
 } from '@opentelemetry/context-base';
 
 import { ContextAPI } from './api/context';
+export type { ContextAPI } from './api/context';
 /** Entrypoint for context API */
 export const context = ContextAPI.getInstance();
 
 import { TraceAPI } from './api/trace';
+export type { TraceAPI } from './api/trace';
 /** Entrypoint for trace API */
 export const trace = TraceAPI.getInstance();
 
 import { PropagationAPI } from './api/propagation';
+export type { PropagationAPI } from './api/propagation';
 /** Entrypoint for propagation API */
 export const propagation = PropagationAPI.getInstance();
 


### PR DESCRIPTION
This will fix the currently-failing lint workflow.

An update to typedoc means that only classes which are exported are included in the documentation. Here, the API singletons are exported as type only. This means they can't be used directly, but are included in the typedoc documentation and the following code will compile successfully:

```typescript
import { context, ContextAPI } from "@opentelemetry/api";

let ctx: ContextAPI = context;
```

The following code will still fail:

```typescript
import { ContextAPI } from "@opentelemetry/api";

const ctx = new ContextAPI() // this will fail
const ctx2 = ContextAPI.getInstance() // this will also fail
```