### PR TITLE
docs(exporter-collector): document breaking change in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ To request automatic tracing support for a module not on this list, please [file
 
 ## Upgrade guidelines
 
+### 0.15.0 to 0.16.0
+[PR-1863](https://github.com/open-telemetry/opentelemetry-js/pull/1863) removed public attributes `keepAlive` and `httpAgentOptions` from nodejs `CollectorTraceExporter` and `CollectorMetricExporter`
+
 ### 0.14.0 to 0.15.0
 
 [PR-1764](https://github.com/open-telemetry/opentelemetry-js/pull/1764) removed some APIs from `Tracer`:

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ To request automatic tracing support for a module not on this list, please [file
 ## Upgrade guidelines
 
 ### 0.15.0 to 0.16.0
+
 [PR-1863](https://github.com/open-telemetry/opentelemetry-js/pull/1863) removed public attributes `keepAlive` and `httpAgentOptions` from nodejs `CollectorTraceExporter` and `CollectorMetricExporter`
 
 ### 0.14.0 to 0.15.0


### PR DESCRIPTION
## Which problem is this PR solving?

- Following #1863, and due to the fact that two public attributes were removed from the node's collector exporter implementation

## Short description of the changes

- Added a new section `0.15.0 to 0.16.0` under `Upgrade guidelines` in general README, which mentions this breaking change.
