### PR TITLE
Add info that the project only works with Node.js

### DIFF
--- a/packages/opentelemetry-exporter-jaeger/README.md
+++ b/packages/opentelemetry-exporter-jaeger/README.md
@@ -18,6 +18,8 @@ OpenTelemetry Jaeger Trace Exporter allows the user to send collected traces to 
 
 ## Prerequisites
 
+This project relies on [jaeger-client](https://github.com/jaegertracing/jaeger-client-node) library and is thus only supported for **Node.js**.
+
 Get up and running with Jaeger in your local environment.
 
 [Jaeger](https://www.jaegertracing.io/docs/latest/) stores and queries traces exported by


### PR DESCRIPTION

## Which problem is this PR solving?
- Clearing up a misunderstanding someone might have in understanding the [opentelemetry-exporter-jaeger](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-exporter-jaeger/) package

## Short description of the changes
- Added info that the package is only supported in Node.js applications
