### PR TITLE
docs(instrumentation-http): fix typo in README

### DIFF
--- a/packages/opentelemetry-instrumentation-http/README.md
+++ b/packages/opentelemetry-instrumentation-http/README.md
@@ -23,7 +23,7 @@ OpenTelemetry HTTP Instrumentation allows the user to automatically collect trac
 To load a specific instrumentation (HTTP in this case), specify it in the Node Tracer's configuration.
 
 ```js
-const { HttpInstrumentation } = require('@opentelemetry/instrumentation-graphql');
+const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http');
 
 const { ConsoleSpanExporter, SimpleSpanProcessor } = require('@opentelemetry/tracing');
 const { NodeTracerProvider } = require('@opentelemetry/node');


### PR DESCRIPTION

## Which problem is this PR solving?

- Typo in `instrumentation-http` README example code.

## Short description of the changes

- current example: `require('@opentelemetry/instrumentation-graphql')`
- should be: `require('@opentelemetry/instrumentation-http')`
