### PR TITLE
feat(prometheus): add `getMetricsRequestHandler`-method to Prometheus…

### DIFF
--- a/packages/opentelemetry-exporter-prometheus/package.json
+++ b/packages/opentelemetry-exporter-prometheus/package.json
@@ -41,11 +41,13 @@
   "devDependencies": {
     "@types/mocha": "8.2.0",
     "@types/node": "14.14.20",
+    "@types/sinon": "9.0.10",
     "codecov": "3.8.1",
     "gts": "2.0.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
+    "sinon": "9.2.3",
     "ts-mocha": "8.0.0",
     "ts-node": "9.1.1",
     "typescript": "3.9.7"

--- a/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -158,6 +158,18 @@ export class PrometheusExporter implements MetricExporter {
   }
 
   /**
+   * Request handler that responds with the current state of metrics
+   * @param request Incoming HTTP request of server instance
+   * @param response HTTP response objet used to response to request
+   */
+  public getMetricsRequestHandler(
+    _request: IncomingMessage,
+    response: ServerResponse
+  ) {
+    this._exportMetrics(response);
+  }
+
+  /**
    * Request handler used by http library to respond to incoming requests
    * for the current state of metrics by the Prometheus backend.
    *

--- a/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -24,9 +24,11 @@ import {
   HistogramAggregator,
 } from '@opentelemetry/metrics';
 import * as assert from 'assert';
+import * as sinon from 'sinon';
 import * as http from 'http';
 import { PrometheusExporter } from '../src';
 import { mockAggregator, mockedHrTimeMs } from './util';
+import { SinonStubbedInstance } from 'sinon';
 
 describe('PrometheusExporter', () => {
   mockAggregator(SumAggregator);
@@ -170,6 +172,16 @@ describe('PrometheusExporter', () => {
       exporter.shutdown().then(() => {
         return done();
       });
+    });
+
+    it('should able to call getMetricsRequestHandler function to generate response with metrics', () => {
+      const exporter = new PrometheusExporter({ preventServerStart: true });
+      const mockRequest: SinonStubbedInstance<http.IncomingMessage> = sinon.createStubInstance(http.IncomingMessage)
+      const mockResponse: SinonStubbedInstance<http.ServerResponse> = sinon.createStubInstance(http.ServerResponse)
+      exporter.getMetricsRequestHandler(mockRequest as unknown as http.IncomingMessage, mockResponse as unknown as http.ServerResponse);
+      sinon.assert.calledOnce(mockResponse.setHeader)
+      sinon.assert.calledOnce(mockResponse.end)
+      assert.strictEqual(mockResponse.statusCode, 200)
     });
   });
 


### PR DESCRIPTION
… exporter

This commit introduces a new method on the `PrometheusExporter`-class that
allows users of server frameworks with an existing service instance to
call the `getMetricsRequestHandler`-method as part of a route to return
the collected metrics in Prometheus format.

Fixes #1872

## Which problem is this PR solving?

- Allows using an existing server instance to expose the Prometheus endpoint / metrics

## Short description of the changes

- Added a new `getMetricsRequestHandler`-method to the `PrometheusExporter`-class which calls the internal `_exportMetrics`-method
