### PR TITLE
chore: no verify access on publish

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -53,7 +53,7 @@ jobs:
           npm run compile
 
       - name: Publish
-        run: npx lerna publish --canary --yes
+        run: npx lerna publish --canary --yes --no-verify-access
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
https://github.com/lerna/lerna/issues/2788

The automation tokens we were using do not support the verification step in lerna. I switched to a more permissive token to fix the canary release automation for now but as a longer-term fix I would like to go back to using a regular automation token.