### PR TITLE
fix(type): TracerConfig plugins

### DIFF
--- a/packages/opentelemetry-node/src/config.ts
+++ b/packages/opentelemetry-node/src/config.ts
@@ -21,5 +21,5 @@ import { TracerConfig } from '@opentelemetry/tracing';
  */
 export interface NodeTracerConfig extends TracerConfig {
   /** Plugins options deprecated */
-  plugins?: unknown[];
+  plugins?: Record<string, unknown>;
 }

--- a/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
+++ b/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
@@ -91,7 +91,7 @@ describe('NodeTracerProvider', () => {
       const dummyPlugin1 = {};
       const spyWarn = sinon.spy(diag.getLogger(), 'warn');
 
-      const plugins = [dummyPlugin1];
+      const plugins = { dummy: dummyPlugin1 };
       const options = { plugins };
       provider = new NodeTracerProvider(options);
 

--- a/packages/opentelemetry-web/src/WebTracerProvider.ts
+++ b/packages/opentelemetry-web/src/WebTracerProvider.ts
@@ -28,7 +28,7 @@ export interface WebTracerConfig extends TracerConfig {
   /**
    * plugins to be used with tracer, they will be enabled automatically
    */
-  plugins?: unknown[];
+  plugins?: Record<string, unknown>;
 }
 
 /**

--- a/packages/opentelemetry-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-web/test/WebTracerProvider.test.ts
@@ -52,7 +52,7 @@ describe('WebTracerProvider', () => {
       const dummyPlugin1 = {};
       const spyWarn = sinon.spy(window.console, 'warn');
 
-      const plugins = [dummyPlugin1];
+      const plugins = { dummy: dummyPlugin1 };
 
       const options = { plugins };
       new WebTracerProvider(options);


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

When we use plugins, it is like

```js
const tracerProvider = new NodeTracerProvider({
  plugins: {
    express: {
      enabled: true,
      path: '@opentelemetry/plugin-express',
    },
  },
});
```

`plugins` is an object instead of array. This change fixes the type error:

> Type '{ express: { enabled: true; path: string; }; }' is not assignable to type 'unknown[]'.
>   Object literal may only specify known properties, and 'express' does not exist in type 'unknown[]'.

## Short description of the changes

Correct `plugins` the type.
