### PR TITLE
fix: version compatibility check

### DIFF
--- a/packages/opentelemetry-api/package.json
+++ b/packages/opentelemetry-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Public API for OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-api/src/api/context.ts
+++ b/packages/opentelemetry-api/src/api/context.ts
@@ -59,8 +59,7 @@ export class ContextAPI {
 
     _global[GLOBAL_CONTEXT_MANAGER_API_KEY] = makeGetter(
       API_BACKWARDS_COMPATIBILITY_VERSION,
-      contextManager,
-      NOOP_CONTEXT_MANAGER
+      contextManager
     );
 
     return contextManager;
@@ -99,7 +98,8 @@ export class ContextAPI {
   private _getContextManager(): ContextManager {
     return (
       _global[GLOBAL_CONTEXT_MANAGER_API_KEY]?.(
-        API_BACKWARDS_COMPATIBILITY_VERSION
+        API_BACKWARDS_COMPATIBILITY_VERSION,
+        NOOP_CONTEXT_MANAGER
       ) ?? NOOP_CONTEXT_MANAGER
     );
   }

--- a/packages/opentelemetry-api/src/api/global-utils.ts
+++ b/packages/opentelemetry-api/src/api/global-utils.ts
@@ -31,7 +31,7 @@ export const GLOBAL_PROPAGATION_API_KEY = Symbol.for(
 );
 export const GLOBAL_TRACE_API_KEY = Symbol.for('io.opentelemetry.js.api.trace');
 
-type Get<T> = (version: number) => T;
+type Get<T> = (version: number, fallback: T) => T;
 type OtelGlobal = Partial<{
   [GLOBAL_CONTEXT_MANAGER_API_KEY]: Get<ContextManager>;
   [GLOBAL_METRICS_API_KEY]: Get<MeterProvider>;
@@ -51,10 +51,9 @@ export const _global = _globalThis as OtelGlobal;
  */
 export function makeGetter<T>(
   requiredVersion: number,
-  instance: T,
-  fallback: T
+  instance: T
 ): Get<T> {
-  return (version: number): T =>
+  return (version: number, fallback: T): T => 
     version === requiredVersion ? instance : fallback;
 }
 

--- a/packages/opentelemetry-api/src/api/metrics.ts
+++ b/packages/opentelemetry-api/src/api/metrics.ts
@@ -31,7 +31,7 @@ export class MetricsAPI {
   private static _instance?: MetricsAPI;
 
   /** Empty private constructor prevents end users from constructing a new instance of the API */
-  private constructor() {}
+  private constructor() { }
 
   /** Get the singleton instance of the Metrics API */
   public static getInstance(): MetricsAPI {
@@ -53,8 +53,7 @@ export class MetricsAPI {
 
     _global[GLOBAL_METRICS_API_KEY] = makeGetter(
       API_BACKWARDS_COMPATIBILITY_VERSION,
-      provider,
-      NOOP_METER_PROVIDER
+      provider
     );
 
     return provider;
@@ -65,8 +64,10 @@ export class MetricsAPI {
    */
   public getMeterProvider(): MeterProvider {
     return (
-      _global[GLOBAL_METRICS_API_KEY]?.(API_BACKWARDS_COMPATIBILITY_VERSION) ??
-      NOOP_METER_PROVIDER
+      _global[GLOBAL_METRICS_API_KEY]?.(
+        API_BACKWARDS_COMPATIBILITY_VERSION,
+        NOOP_METER_PROVIDER
+      ) ?? NOOP_METER_PROVIDER
     );
   }
 

--- a/packages/opentelemetry-api/src/api/propagation.ts
+++ b/packages/opentelemetry-api/src/api/propagation.ts
@@ -60,8 +60,7 @@ export class PropagationAPI {
 
     _global[GLOBAL_PROPAGATION_API_KEY] = makeGetter(
       API_BACKWARDS_COMPATIBILITY_VERSION,
-      propagator,
-      NOOP_HTTP_TEXT_PROPAGATOR
+      propagator
     );
 
     return propagator;
@@ -105,7 +104,8 @@ export class PropagationAPI {
   private _getGlobalPropagator(): HttpTextPropagator {
     return (
       _global[GLOBAL_PROPAGATION_API_KEY]?.(
-        API_BACKWARDS_COMPATIBILITY_VERSION
+        API_BACKWARDS_COMPATIBILITY_VERSION,
+        NOOP_HTTP_TEXT_PROPAGATOR
       ) ?? NOOP_HTTP_TEXT_PROPAGATOR
     );
   }

--- a/packages/opentelemetry-api/src/api/trace.ts
+++ b/packages/opentelemetry-api/src/api/trace.ts
@@ -31,7 +31,7 @@ export class TraceAPI {
   private static _instance?: TraceAPI;
 
   /** Empty private constructor prevents end users from constructing a new instance of the API */
-  private constructor() {}
+  private constructor() { }
 
   /** Get the singleton instance of the Trace API */
   public static getInstance(): TraceAPI {
@@ -53,8 +53,7 @@ export class TraceAPI {
 
     _global[GLOBAL_TRACE_API_KEY] = makeGetter(
       API_BACKWARDS_COMPATIBILITY_VERSION,
-      provider,
-      NOOP_TRACER_PROVIDER
+      provider
     );
 
     return this.getTracerProvider();
@@ -65,8 +64,10 @@ export class TraceAPI {
    */
   public getTracerProvider(): TracerProvider {
     return (
-      _global[GLOBAL_TRACE_API_KEY]?.(API_BACKWARDS_COMPATIBILITY_VERSION) ??
-      NOOP_TRACER_PROVIDER
+      _global[GLOBAL_TRACE_API_KEY]?.(
+        API_BACKWARDS_COMPATIBILITY_VERSION,
+        NOOP_TRACER_PROVIDER
+      ) ?? NOOP_TRACER_PROVIDER
     );
   }
 

--- a/packages/opentelemetry-api/test/api/global.test.ts
+++ b/packages/opentelemetry-api/test/api/global.test.ts
@@ -72,10 +72,10 @@ describe('Global Utils', () => {
   });
 
   it('should return the module NoOp implementation if the version is a mismatch', () => {
-    const original = api1.context['_getContextManager']();
+    const fallback = new NoopContextManager();
     api1.context.setGlobalContextManager(new NoopContextManager());
-    const afterSet = _global[GLOBAL_CONTEXT_MANAGER_API_KEY]!(-1);
+    const afterSet = _global[GLOBAL_CONTEXT_MANAGER_API_KEY]!(-1, fallback);
 
-    assert.strictEqual(original, afterSet);
+    assert.strictEqual(fallback, afterSet);
   });
 });


### PR DESCRIPTION
Fixes a bug in the version compatibility check

- version x registers a global
	- a getter is created which takes a version and returns either the instance or noop if the version doesn't match
- version y gets the global
- fallback is returned. This fallback is the version X noop though, not the version y noop
- y api calls some method y expects to be there, but x noop doesn't have it
- throw/failure

The fix is to make the getter take the fallback as the second parameter. The fallback needs to be set by the caller, not the version that creates the global getter.

After this merges I will release a hotfix of only the API version