### PR TITLE
fix: specification compliant resource collision precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,11 @@ To request automatic tracing support for a module not on this list, please [file
 
 ## Upgrade guidelines
 
+### 0.17.0 to 0.18.0
+
+[PR-1975](https://github.com/open-telemetry/opentelemetry-js/pull/1975)
+- Breaking change - Update resource key collision precedence
+
 ### 0.16.0 to 0.17.0
 
 [PR-1880](https://github.com/open-telemetry/opentelemetry-js/pull/1880) feat(diag-logger): introduce a new global level api.diag for internal diagnostic logging

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ To request automatic tracing support for a module not on this list, please [file
 
 [PR-1975](https://github.com/open-telemetry/opentelemetry-js/pull/1975)
 
-- Breaking change - Update resource key collision precedence
+- Breaking change - The resulting resource MUST have all attributes that are on any of the two input resources. If a key exists on both the old and updating resource, the value of the updating resource MUST be picked - previously it was opposite.
 
 ### 0.16.0 to 0.17.0
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ To request automatic tracing support for a module not on this list, please [file
 ### 0.17.0 to 0.18.0
 
 [PR-1975](https://github.com/open-telemetry/opentelemetry-js/pull/1975)
+
 - Breaking change - Update resource key collision precedence
 
 ### 0.16.0 to 0.17.0

--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -54,7 +54,7 @@ export class Resource {
 
   /**
    * Returns a new, merged {@link Resource} by merging the current Resource
-   * with the other Resource. In case of a collision, current Resource takes
+   * with the other Resource. In case of a collision, other Resource takes
    * precedence.
    *
    * @param other the Resource that will be merged with this.
@@ -66,8 +66,8 @@ export class Resource {
     // SpanAttributes from resource overwrite attributes from other resource.
     const mergedAttributes = Object.assign(
       {},
-      other.attributes,
-      this.attributes
+      this.attributes,
+      other.attributes
     );
     return new Resource(mergedAttributes);
   }

--- a/packages/opentelemetry-resources/test/Resource.test.ts
+++ b/packages/opentelemetry-resources/test/Resource.test.ts
@@ -50,7 +50,7 @@ describe('Resource', () => {
 
   it('should return merged resource when collision in attributes', () => {
     const expectedResource = new Resource({
-      'k8s.io/container/name': 'c1',
+      'k8s.io/container/name': 'c2',
       'k8s.io/namespace/name': 'default',
       'k8s.io/pod/name': 'pod-xyz-123',
       'k8s.io/location': 'location1',


### PR DESCRIPTION
[Resource Merge Spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#merge)

> The resulting resource MUST have all attributes that are on any of the two input resources. If a key exists on both the old and updating resource, the value of the updating resource MUST be picked (even if the updated value is empty).

This commit updates the resource collision precedence.