### PR TITLE
feat(semantic-conventions): add missing RpcAttributes from spec

### DIFF
--- a/packages/opentelemetry-semantic-conventions/src/trace/rpc.ts
+++ b/packages/opentelemetry-semantic-conventions/src/trace/rpc.ts
@@ -14,7 +14,29 @@
  * limitations under the License.
  */
 export const RpcAttribute = {
+  /**
+   * 	A string identifying the remoting system.
+   *
+   * @remarks
+   * Required
+   */
+  RPC_SYSTEM: 'rpc.system',
+
+  /**
+   * The full name of the service being called, including its package name, if applicable.
+   *
+   * @remarks
+   * Not required, but recommended
+   */
   RPC_SERVICE: 'rpc.service',
+
+  /**
+   * The name of the method being called, must be equal to the $method part in the span name.
+   *
+   * @remarks
+   * Not required, but recommended
+   */
+  RPC_METHOD: 'rpc.method',
 
   // GRPC (no spec)
   GRPC_KIND: 'grpc.kind', // SERVER or CLIENT


### PR DESCRIPTION

## Which problem is this PR solving?

- Adding 2 missing attributes to `rpc` semantic conventions, according to the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/rpc.md). I need them to update the aws-sdk instrumentation according to [these](https://github.com/open-telemetry/opentelemetry-specification/pull/1422/files) conventions

## Short description of the changes

-
