### PR TITLE
chore: update API to 0.18.0

### DIFF
--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -11,7 +11,7 @@
     "compile": "tsc --build"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/context-async-hooks": "^0.17.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/tracing": "^0.17.0",

--- a/packages/opentelemetry-api-metrics/package.json
+++ b/packages/opentelemetry-api-metrics/package.json
@@ -48,7 +48,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0"
+    "@opentelemetry/api": "^0.18.0"
   },
   "devDependencies": {
     "@types/mocha": "8.2.0",

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -53,6 +53,6 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/context-base": "^0.17.0"
+    "@opentelemetry/api": "^0.18.0"
   }
 }

--- a/packages/opentelemetry-context-async-hooks/src/AbstractAsyncHooksContextManager.ts
+++ b/packages/opentelemetry-context-async-hooks/src/AbstractAsyncHooksContextManager.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ContextManager, Context } from '@opentelemetry/context-base';
+import { ContextManager, Context } from '@opentelemetry/api';
 import { EventEmitter } from 'events';
 
 type Func<T> = (...args: unknown[]) => T;

--- a/packages/opentelemetry-context-async-hooks/src/AsyncHooksContextManager.ts
+++ b/packages/opentelemetry-context-async-hooks/src/AsyncHooksContextManager.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Context, ROOT_CONTEXT } from '@opentelemetry/context-base';
+import { Context, ROOT_CONTEXT } from '@opentelemetry/api';
 import * as asyncHooks from 'async_hooks';
 import { AbstractAsyncHooksContextManager } from './AbstractAsyncHooksContextManager';
 

--- a/packages/opentelemetry-context-async-hooks/src/AsyncLocalStorageContextManager.ts
+++ b/packages/opentelemetry-context-async-hooks/src/AsyncLocalStorageContextManager.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Context, ROOT_CONTEXT } from '@opentelemetry/context-base';
+import { Context, ROOT_CONTEXT } from '@opentelemetry/api';
 import { AsyncLocalStorage } from 'async_hooks';
 import { AbstractAsyncHooksContextManager } from './AbstractAsyncHooksContextManager';
 

--- a/packages/opentelemetry-context-async-hooks/test/AsyncHooksContextManager.test.ts
+++ b/packages/opentelemetry-context-async-hooks/test/AsyncHooksContextManager.test.ts
@@ -20,7 +20,7 @@ import {
   AsyncLocalStorageContextManager,
 } from '../src';
 import { EventEmitter } from 'events';
-import { createContextKey, ROOT_CONTEXT } from '@opentelemetry/context-base';
+import { createContextKey, ROOT_CONTEXT } from '@opentelemetry/api';
 
 for (const contextManagerClass of [
   AsyncHooksContextManager,

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -70,7 +70,7 @@
     "zone.js": "0.11.3"
   },
   "dependencies": {
-    "@opentelemetry/context-base": "^0.17.0"
+    "@opentelemetry/api": "^0.18.0"
   },
   "peerDependencies": {
     "zone.js": "^0.10.2 || ^0.11.0"

--- a/packages/opentelemetry-context-zone-peer-dep/src/ZoneContextManager.ts
+++ b/packages/opentelemetry-context-zone-peer-dep/src/ZoneContextManager.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Context,
-  ContextManager,
-  ROOT_CONTEXT,
-} from '@opentelemetry/context-base';
+import { Context, ContextManager, ROOT_CONTEXT } from '@opentelemetry/api';
 import { Func, TargetWithEvents } from './types';
 import { isListenerObject } from './util';
 

--- a/packages/opentelemetry-context-zone-peer-dep/test/ZoneContextManager.test.ts
+++ b/packages/opentelemetry-context-zone-peer-dep/test/ZoneContextManager.test.ts
@@ -18,7 +18,7 @@ import 'zone.js';
 import * as sinon from 'sinon';
 import * as assert from 'assert';
 import { ZoneContextManager } from '../src';
-import { ROOT_CONTEXT, createContextKey } from '@opentelemetry/context-base';
+import { ROOT_CONTEXT, createContextKey } from '@opentelemetry/api';
 
 let clock: any;
 

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -76,8 +76,7 @@
     "webpack": "4.46.0"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
-    "@opentelemetry/context-base": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "semver": "^7.1.3"
   }
 }

--- a/packages/opentelemetry-core/test/baggage/HttpBaggage.test.ts
+++ b/packages/opentelemetry-core/test/baggage/HttpBaggage.test.ts
@@ -23,7 +23,7 @@ import {
   getBaggage,
   setBaggage,
 } from '@opentelemetry/api';
-import { ROOT_CONTEXT } from '@opentelemetry/context-base';
+import { ROOT_CONTEXT } from '@opentelemetry/api';
 import * as assert from 'assert';
 import {
   BAGGAGE_HEADER,

--- a/packages/opentelemetry-core/test/common/time.test.ts
+++ b/packages/opentelemetry-core/test/common/time.test.ts
@@ -30,27 +30,21 @@ import {
 } from '../../src/common/time';
 
 describe('time', () => {
-  let sandbox: sinon.SinonSandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
   afterEach(() => {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('#hrTime', () => {
     it('should return hrtime now', () => {
-      sandbox.stub(performance, 'timeOrigin').value(11.5);
-      sandbox.stub(performance, 'now').callsFake(() => 11.3);
+      sinon.stub(performance, 'timeOrigin').value(11.5);
+      sinon.stub(performance, 'now').callsFake(() => 11.3);
 
       const output = hrTime();
       assert.deepStrictEqual(output, [0, 22800000]);
     });
 
     it('should convert performance now', () => {
-      sandbox.stub(performance, 'timeOrigin').value(11.5);
+      sinon.stub(performance, 'timeOrigin').value(11.5);
       const performanceNow = 11.3;
 
       const output = hrTime(performanceNow);
@@ -58,7 +52,7 @@ describe('time', () => {
     });
 
     it('should handle nanosecond overflow', () => {
-      sandbox.stub(performance, 'timeOrigin').value(11.5);
+      sinon.stub(performance, 'timeOrigin').value(11.5);
       const performanceNow = 11.6;
 
       const output = hrTime(performanceNow);
@@ -66,24 +60,24 @@ describe('time', () => {
     });
 
     it('should allow passed "performanceNow" equal to 0', () => {
-      sandbox.stub(performance, 'timeOrigin').value(11.5);
-      sandbox.stub(performance, 'now').callsFake(() => 11.3);
+      sinon.stub(performance, 'timeOrigin').value(11.5);
+      sinon.stub(performance, 'now').callsFake(() => 11.3);
 
       const output = hrTime(0);
       assert.deepStrictEqual(output, [0, 11500000]);
     });
 
     it('should use performance.now() when "performanceNow" is equal to undefined', () => {
-      sandbox.stub(performance, 'timeOrigin').value(11.5);
-      sandbox.stub(performance, 'now').callsFake(() => 11.3);
+      sinon.stub(performance, 'timeOrigin').value(11.5);
+      sinon.stub(performance, 'now').callsFake(() => 11.3);
 
       const output = hrTime(undefined);
       assert.deepStrictEqual(output, [0, 22800000]);
     });
 
     it('should use performance.now() when "performanceNow" is equal to null', () => {
-      sandbox.stub(performance, 'timeOrigin').value(11.5);
-      sandbox.stub(performance, 'now').callsFake(() => 11.3);
+      sinon.stub(performance, 'timeOrigin').value(11.5);
+      sinon.stub(performance, 'now').callsFake(() => 11.3);
 
       const output = hrTime(null as any);
       assert.deepStrictEqual(output, [0, 22800000]);
@@ -98,8 +92,8 @@ describe('time', () => {
           },
         });
 
-        sandbox.stub(performance, 'timeOrigin').value(undefined);
-        sandbox.stub(performance, 'now').callsFake(() => 11.3);
+        sinon.stub(performance, 'timeOrigin').value(undefined);
+        sinon.stub(performance, 'now').callsFake(() => 11.3);
 
         const output = hrTime();
         assert.deepStrictEqual(output, [0, 22800000]);
@@ -121,7 +115,7 @@ describe('time', () => {
     });
 
     it('should convert performance.now() hrTime', () => {
-      sandbox.stub(performance, 'timeOrigin').value(111.5);
+      sinon.stub(performance, 'timeOrigin').value(111.5);
 
       const timeInput = 11.9;
       const output = timeInputToHrTime(timeInput);
@@ -130,7 +124,7 @@ describe('time', () => {
     });
 
     it('should not convert hrtime hrTime', () => {
-      sandbox.stub(performance, 'timeOrigin').value(111.5);
+      sinon.stub(performance, 'timeOrigin').value(111.5);
 
       const timeInput: [number, number] = [3138971, 245466222];
       const output = timeInputToHrTime(timeInput);

--- a/packages/opentelemetry-core/test/context/HttpTraceContext.test.ts
+++ b/packages/opentelemetry-core/test/context/HttpTraceContext.test.ts
@@ -22,7 +22,7 @@ import {
   getSpanContext,
   setSpanContext,
 } from '@opentelemetry/api';
-import { ROOT_CONTEXT } from '@opentelemetry/context-base';
+import { ROOT_CONTEXT } from '@opentelemetry/api';
 import * as assert from 'assert';
 import {
   HttpTraceContext,

--- a/packages/opentelemetry-core/test/context/composite.test.ts
+++ b/packages/opentelemetry-core/test/context/composite.test.ts
@@ -22,7 +22,7 @@ import {
   getSpanContext,
   setSpanContext,
 } from '@opentelemetry/api';
-import { Context, ROOT_CONTEXT } from '@opentelemetry/context-base';
+import { Context, ROOT_CONTEXT } from '@opentelemetry/api';
 import * as assert from 'assert';
 import {
   CompositePropagator,

--- a/packages/opentelemetry-core/test/utils/environment.test.ts
+++ b/packages/opentelemetry-core/test/utils/environment.test.ts
@@ -59,15 +59,9 @@ export function removeMockEnvironment() {
 }
 
 describe('environment', () => {
-  let sandbox: sinon.SinonSandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
   afterEach(() => {
     removeMockEnvironment();
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('parseEnvironment', () => {

--- a/packages/opentelemetry-exporter-collector-grpc/package.json
+++ b/packages/opentelemetry-exporter-collector-grpc/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.5.4",
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/exporter-collector": "^0.17.0",
     "@opentelemetry/metrics": "^0.17.0",

--- a/packages/opentelemetry-exporter-collector-grpc/test/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/test/CollectorMetricExporter.test.ts
@@ -120,8 +120,6 @@ const testCollectorMetricExporter = (params: TestParams) =>
     });
 
     beforeEach(async () => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
       const credentials = params.useTLS
         ? grpc.credentials.createSsl(
             fs.readFileSync('./test/certs/ca.crt'),
@@ -162,12 +160,13 @@ const testCollectorMetricExporter = (params: TestParams) =>
     afterEach(() => {
       exportedData = undefined;
       reqMetadata = undefined;
+      sinon.restore();
     });
 
     describe('instance', () => {
       it('should warn about headers', () => {
         // Need to stub/spy on the underlying logger as the "diag" instance is global
-        const spyLoggerWarn = sinon.stub(diag.getLogger(), 'warn');
+        const spyLoggerWarn = sinon.stub(diag, 'warn');
         collectorExporter = new CollectorMetricExporter({
           serviceName: 'basic-service',
           url: address,

--- a/packages/opentelemetry-exporter-collector-grpc/test/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/test/CollectorTraceExporter.test.ts
@@ -115,8 +115,6 @@ const testCollectorExporter = (params: TestParams) =>
     });
 
     beforeEach(done => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
       const credentials = params.useTLS
         ? grpc.credentials.createSsl(
             fs.readFileSync('./test/certs/ca.crt'),
@@ -139,12 +137,13 @@ const testCollectorExporter = (params: TestParams) =>
     afterEach(() => {
       exportedData = undefined;
       reqMetadata = undefined;
+      sinon.restore();
     });
 
     describe('instance', () => {
       it('should warn about headers when using grpc', () => {
         // Need to stub/spy on the underlying logger as the "diag" instance is global
-        const spyLoggerWarn = sinon.stub(diag.getLogger(), 'warn');
+        const spyLoggerWarn = sinon.stub(diag, 'warn');
         collectorExporter = new CollectorTraceExporter({
           serviceName: 'basic-service',
           url: address,

--- a/packages/opentelemetry-exporter-collector-proto/package.json
+++ b/packages/opentelemetry-exporter-collector-proto/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.5.4",
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/exporter-collector": "^0.17.0",
     "@opentelemetry/metrics": "^0.17.0",

--- a/packages/opentelemetry-exporter-collector-proto/test/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-proto/test/CollectorMetricExporter.test.ts
@@ -55,8 +55,6 @@ describe('CollectorMetricExporter - node with proto over http', () => {
 
   describe('export', () => {
     beforeEach(async () => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
       collectorExporterConfig = {
         headers: {
           foo: 'bar',
@@ -177,7 +175,7 @@ describe('CollectorMetricExporter - node with proto over http', () => {
 
     it('should log the successful message', done => {
       // Need to stub/spy on the underlying logger as the "diag" instance is global
-      const spyLoggerError = sinon.stub(diag.getLogger(), 'error');
+      const spyLoggerError = sinon.stub(diag, 'error');
 
       collectorExporter.export(metrics, result => {
         assert.strictEqual(result.code, ExportResultCode.SUCCESS);

--- a/packages/opentelemetry-exporter-collector-proto/test/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-proto/test/CollectorTraceExporter.test.ts
@@ -46,8 +46,6 @@ describe('CollectorTraceExporter - node with proto over http', () => {
 
   describe('export', () => {
     beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
       collectorExporterConfig = {
         headers: {
           foo: 'bar',
@@ -126,7 +124,7 @@ describe('CollectorTraceExporter - node with proto over http', () => {
 
     it('should log the successful message', done => {
       // Need to stub/spy on the underlying logger as the "diag" instance is global
-      const spyLoggerError = sinon.stub(diag.getLogger(), 'error');
+      const spyLoggerError = sinon.stub(diag, 'error');
 
       collectorExporter.export(spans, result => {
         assert.strictEqual(result.code, ExportResultCode.SUCCESS);

--- a/packages/opentelemetry-exporter-collector/package.json
+++ b/packages/opentelemetry-exporter-collector/package.json
@@ -77,7 +77,7 @@
     "webpack-merge": "5.7.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/api-metrics": "^0.17.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/metrics": "^0.17.0",

--- a/packages/opentelemetry-exporter-collector/test/browser/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/browser/CollectorMetricExporter.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { diag, DiagLogLevel } from '@opentelemetry/api';
+import { diag } from '@opentelemetry/api';
 import {
   Counter,
   ValueObserver,
@@ -50,13 +50,12 @@ const sendBeacon = navigator.sendBeacon;
 describe('CollectorMetricExporter - web', () => {
   let collectorExporter: CollectorMetricExporter;
   let spyOpen: any;
-  let spySend: any;
   let spyBeacon: any;
   let metrics: MetricRecord[];
 
   beforeEach(async () => {
     spyOpen = sinon.stub(XMLHttpRequest.prototype, 'open');
-    spySend = sinon.stub(XMLHttpRequest.prototype, 'send');
+    sinon.stub(XMLHttpRequest.prototype, 'send');
     spyBeacon = sinon.stub(navigator, 'sendBeacon');
     metrics = [];
     const counter: Metric<BoundCounter> & Counter = mockCounter();
@@ -80,17 +79,12 @@ describe('CollectorMetricExporter - web', () => {
 
   afterEach(() => {
     navigator.sendBeacon = sendBeacon;
-    spyOpen.restore();
-    spySend.restore();
-    spyBeacon.restore();
+    sinon.restore();
   });
 
   describe('export', () => {
     describe('when "sendBeacon" is available', () => {
       beforeEach(() => {
-        // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-        diag.setLogger();
-        diag.setLogLevel(DiagLogLevel.VERBOSE);
         collectorExporter = new CollectorMetricExporter({
           url: 'http://foo.bar.com',
           serviceName: 'bar',
@@ -170,9 +164,8 @@ describe('CollectorMetricExporter - web', () => {
 
       it('should log the successful message', done => {
         // Need to stub/spy on the underlying logger as the "diag" instance is global
-        const spyLoggerDebug = sinon.stub(diag.getLogger(), 'debug');
-        const spyLoggerError = sinon.stub(diag.getLogger(), 'error');
-        spyBeacon.restore();
+        const spyLoggerDebug = sinon.stub(diag, 'debug');
+        const spyLoggerError = sinon.stub(diag, 'error');
         spyBeacon = sinon.stub(window.navigator, 'sendBeacon').returns(true);
 
         collectorExporter.export(metrics, () => {});
@@ -187,7 +180,6 @@ describe('CollectorMetricExporter - web', () => {
       });
 
       it('should log the error message', done => {
-        spyBeacon.restore();
         spyBeacon = sinon.stub(window.navigator, 'sendBeacon').returns(false);
 
         collectorExporter.export(metrics, result => {
@@ -201,9 +193,6 @@ describe('CollectorMetricExporter - web', () => {
     describe('when "sendBeacon" is NOT available', () => {
       let server: any;
       beforeEach(() => {
-        // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-        diag.setLogger();
-        diag.setLogLevel(DiagLogLevel.VERBOSE);
         (window.navigator as any).sendBeacon = false;
         collectorExporter = new CollectorMetricExporter({
           url: 'http://foo.bar.com',
@@ -285,8 +274,8 @@ describe('CollectorMetricExporter - web', () => {
 
       it('should log the successful message', done => {
         // Need to stub/spy on the underlying logger as the "diag" instance is global
-        const spyLoggerDebug = sinon.stub(diag.getLogger(), 'debug');
-        const spyLoggerError = sinon.stub(diag.getLogger(), 'error');
+        const spyLoggerDebug = sinon.stub(diag, 'debug');
+        const spyLoggerError = sinon.stub(diag, 'error');
 
         collectorExporter.export(metrics, () => {});
 
@@ -339,9 +328,6 @@ describe('CollectorMetricExporter - web', () => {
     let collectorExporterConfig: CollectorExporterConfigBase;
 
     beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
-      diag.setLogLevel(DiagLogLevel.VERBOSE);
       collectorExporterConfig = {
         headers: customHeaders,
       };

--- a/packages/opentelemetry-exporter-collector/test/browser/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/browser/CollectorTraceExporter.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { diag, DiagLogLevel } from '@opentelemetry/api';
+import { diag } from '@opentelemetry/api';
 import { ExportResultCode } from '@opentelemetry/core';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import * as assert from 'assert';
@@ -36,13 +36,12 @@ describe('CollectorTraceExporter - web', () => {
   let collectorTraceExporter: CollectorTraceExporter;
   let collectorExporterConfig: CollectorExporterConfigBase;
   let spyOpen: sinon.SinonSpy;
-  let spySend: sinon.SinonSpy;
   let spyBeacon: sinon.SinonSpy;
   let spans: ReadableSpan[];
 
   beforeEach(() => {
     spyOpen = sinon.stub(XMLHttpRequest.prototype, 'open');
-    spySend = sinon.stub(XMLHttpRequest.prototype, 'send');
+    sinon.stub(XMLHttpRequest.prototype, 'send');
     spyBeacon = sinon.stub(navigator, 'sendBeacon');
     spans = [];
     spans.push(Object.assign({}, mockedReadableSpan));
@@ -50,16 +49,11 @@ describe('CollectorTraceExporter - web', () => {
 
   afterEach(() => {
     navigator.sendBeacon = sendBeacon;
-    spyOpen.restore();
-    spySend.restore();
-    spyBeacon.restore();
+    sinon.restore();
   });
 
   describe('export', () => {
     beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
-      diag.setLogLevel(DiagLogLevel.VERBOSE);
       collectorExporterConfig = {
         hostname: 'foo',
         serviceName: 'bar',
@@ -112,9 +106,8 @@ describe('CollectorTraceExporter - web', () => {
 
       it('should log the successful message', done => {
         // Need to stub/spy on the underlying logger as the "diag" instance is global
-        const spyLoggerDebug = sinon.stub(diag.getLogger(), 'debug');
-        const spyLoggerError = sinon.stub(diag.getLogger(), 'error');
-        spyBeacon.restore();
+        const spyLoggerDebug = sinon.stub(diag, 'debug');
+        const spyLoggerError = sinon.stub(diag, 'error');
         spyBeacon = sinon.stub(window.navigator, 'sendBeacon').returns(true);
 
         collectorTraceExporter.export(spans, () => {});
@@ -129,7 +122,6 @@ describe('CollectorTraceExporter - web', () => {
       });
 
       it('should log the error message', done => {
-        spyBeacon.restore();
         spyBeacon = sinon.stub(window.navigator, 'sendBeacon').returns(false);
 
         collectorTraceExporter.export(spans, result => {
@@ -189,8 +181,8 @@ describe('CollectorTraceExporter - web', () => {
 
       it('should log the successful message', done => {
         // Need to stub/spy on the underlying logger as the "diag" instance is global
-        const spyLoggerDebug = sinon.stub(diag.getLogger(), 'debug');
-        const spyLoggerError = sinon.stub(diag.getLogger(), 'error');
+        const spyLoggerDebug = sinon.stub(diag, 'debug');
+        const spyLoggerError = sinon.stub(diag, 'error');
 
         collectorTraceExporter.export(spans, () => {});
 
@@ -242,9 +234,6 @@ describe('CollectorTraceExporter - web', () => {
     };
 
     beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
-      diag.setLogLevel(DiagLogLevel.VERBOSE);
       collectorExporterConfig = {
         headers: customHeaders,
       };

--- a/packages/opentelemetry-exporter-collector/test/browser/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/browser/CollectorTraceExporter.test.ts
@@ -30,25 +30,23 @@ import {
   ensureHeadersContain,
   mockedReadableSpan,
 } from '../helper';
-const sendBeacon = navigator.sendBeacon;
 
 describe('CollectorTraceExporter - web', () => {
   let collectorTraceExporter: CollectorTraceExporter;
   let collectorExporterConfig: CollectorExporterConfigBase;
-  let spyOpen: sinon.SinonSpy;
-  let spyBeacon: sinon.SinonSpy;
+  let stubOpen: sinon.SinonStub;
+  let stubBeacon: sinon.SinonStub;
   let spans: ReadableSpan[];
 
   beforeEach(() => {
-    spyOpen = sinon.stub(XMLHttpRequest.prototype, 'open');
+    stubOpen = sinon.stub(XMLHttpRequest.prototype, 'open');
     sinon.stub(XMLHttpRequest.prototype, 'send');
-    spyBeacon = sinon.stub(navigator, 'sendBeacon');
+    stubBeacon = sinon.stub(navigator, 'sendBeacon');
     spans = [];
     spans.push(Object.assign({}, mockedReadableSpan));
   });
 
   afterEach(() => {
-    navigator.sendBeacon = sendBeacon;
     sinon.restore();
   });
 
@@ -73,7 +71,7 @@ describe('CollectorTraceExporter - web', () => {
         collectorTraceExporter.export(spans, () => {});
 
         setTimeout(() => {
-          const args = spyBeacon.args[0];
+          const args = stubBeacon.args[0];
           const url = args[0];
           const body = args[1];
           const json = JSON.parse(
@@ -94,9 +92,9 @@ describe('CollectorTraceExporter - web', () => {
           }
 
           assert.strictEqual(url, 'http://foo.bar.com');
-          assert.strictEqual(spyBeacon.callCount, 1);
+          assert.strictEqual(stubBeacon.callCount, 1);
 
-          assert.strictEqual(spyOpen.callCount, 0);
+          assert.strictEqual(stubOpen.callCount, 0);
 
           ensureExportTraceServiceRequestIsSet(json);
 
@@ -108,7 +106,7 @@ describe('CollectorTraceExporter - web', () => {
         // Need to stub/spy on the underlying logger as the "diag" instance is global
         const spyLoggerDebug = sinon.stub(diag, 'debug');
         const spyLoggerError = sinon.stub(diag, 'error');
-        spyBeacon = sinon.stub(window.navigator, 'sendBeacon').returns(true);
+        stubBeacon.returns(true);
 
         collectorTraceExporter.export(spans, () => {});
 
@@ -122,7 +120,7 @@ describe('CollectorTraceExporter - web', () => {
       });
 
       it('should log the error message', done => {
-        spyBeacon = sinon.stub(window.navigator, 'sendBeacon').returns(false);
+        stubBeacon.returns(false);
 
         collectorTraceExporter.export(spans, result => {
           assert.deepStrictEqual(result.code, ExportResultCode.FAILED);
@@ -171,7 +169,7 @@ describe('CollectorTraceExporter - web', () => {
             ensureWebResourceIsCorrect(resource);
           }
 
-          assert.strictEqual(spyBeacon.callCount, 0);
+          assert.strictEqual(stubBeacon.callCount, 0);
 
           ensureExportTraceServiceRequestIsSet(json);
 
@@ -194,7 +192,7 @@ describe('CollectorTraceExporter - web', () => {
           assert.strictEqual(response, 'xhr success');
           assert.strictEqual(spyLoggerError.args.length, 0);
 
-          assert.strictEqual(spyBeacon.callCount, 0);
+          assert.strictEqual(stubBeacon.callCount, 0);
           done();
         });
       });
@@ -219,7 +217,7 @@ describe('CollectorTraceExporter - web', () => {
           const request = server.requests[0];
           request.respond(200);
 
-          assert.strictEqual(spyBeacon.callCount, 0);
+          assert.strictEqual(stubBeacon.callCount, 0);
           done();
         });
       });
@@ -257,8 +255,8 @@ describe('CollectorTraceExporter - web', () => {
           const [{ requestHeaders }] = server.requests;
 
           ensureHeadersContain(requestHeaders, customHeaders);
-          assert.strictEqual(spyBeacon.callCount, 0);
-          assert.strictEqual(spyOpen.callCount, 0);
+          assert.strictEqual(stubBeacon.callCount, 0);
+          assert.strictEqual(stubOpen.callCount, 0);
 
           done();
         });
@@ -280,8 +278,8 @@ describe('CollectorTraceExporter - web', () => {
           const [{ requestHeaders }] = server.requests;
 
           ensureHeadersContain(requestHeaders, customHeaders);
-          assert.strictEqual(spyBeacon.callCount, 0);
-          assert.strictEqual(spyOpen.callCount, 0);
+          assert.strictEqual(stubBeacon.callCount, 0);
+          assert.strictEqual(stubOpen.callCount, 0);
 
           done();
         });

--- a/packages/opentelemetry-exporter-collector/test/common/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/common/CollectorMetricExporter.test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { diag } from '@opentelemetry/api';
 import { Counter, ValueObserver } from '@opentelemetry/api-metrics';
 import { ExportResultCode } from '@opentelemetry/core';
 import {
@@ -56,12 +55,15 @@ describe('CollectorMetricExporter - common', () => {
   let collectorExporter: CollectorMetricExporter;
   let collectorExporterConfig: CollectorExporterConfig;
   let metrics: MetricRecord[];
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
   describe('constructor', () => {
     let onInitSpy: any;
 
     beforeEach(async () => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
       onInitSpy = sinon.stub(CollectorMetricExporter.prototype, 'onInit');
       collectorExporterConfig = {
         hostname: 'foo',
@@ -83,10 +85,6 @@ describe('CollectorMetricExporter - common', () => {
 
       metrics.push((await counter.getMetricRecord())[0]);
       metrics.push((await observer.getMetricRecord())[0]);
-    });
-
-    afterEach(() => {
-      onInitSpy.restore();
     });
 
     it('should create an instance', () => {
@@ -130,9 +128,6 @@ describe('CollectorMetricExporter - common', () => {
     beforeEach(() => {
       spySend = sinon.stub(CollectorMetricExporter.prototype, 'send');
       collectorExporter = new CollectorMetricExporter(collectorExporterConfig);
-    });
-    afterEach(() => {
-      spySend.restore();
     });
 
     it('should export metrics as collectorTypes.Metrics', done => {
@@ -200,8 +195,6 @@ describe('CollectorMetricExporter - common', () => {
   describe('shutdown', () => {
     let onShutdownSpy: any;
     beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
       onShutdownSpy = sinon.stub(
         CollectorMetricExporter.prototype,
         'onShutdown'
@@ -213,9 +206,6 @@ describe('CollectorMetricExporter - common', () => {
         url: 'http://foo.bar.com',
       };
       collectorExporter = new CollectorMetricExporter(collectorExporterConfig);
-    });
-    afterEach(() => {
-      onShutdownSpy.restore();
     });
 
     it('should call onShutdown', async () => {

--- a/packages/opentelemetry-exporter-collector/test/common/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/common/CollectorTraceExporter.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { diag } from '@opentelemetry/api';
+
 import { ExportResultCode } from '@opentelemetry/core';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import * as assert from 'assert';
@@ -61,12 +61,14 @@ describe('CollectorTraceExporter - common', () => {
   let collectorExporter: CollectorTraceExporter;
   let collectorExporterConfig: CollectorExporterConfig;
 
+  afterEach(() => {
+    sinon.restore();
+  });
+
   describe('constructor', () => {
     let onInitSpy: any;
 
     beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
       onInitSpy = sinon.stub(CollectorTraceExporter.prototype, 'onInit');
       collectorExporterConfig = {
         hostname: 'foo',
@@ -75,10 +77,6 @@ describe('CollectorTraceExporter - common', () => {
         url: 'http://foo.bar.com',
       };
       collectorExporter = new CollectorTraceExporter(collectorExporterConfig);
-    });
-
-    afterEach(() => {
-      onInitSpy.restore();
     });
 
     it('should create an instance', () => {
@@ -119,9 +117,6 @@ describe('CollectorTraceExporter - common', () => {
     beforeEach(() => {
       spySend = sinon.stub(CollectorTraceExporter.prototype, 'send');
       collectorExporter = new CollectorTraceExporter(collectorExporterConfig);
-    });
-    afterEach(() => {
-      spySend.restore();
     });
 
     it('should export spans as collectorTypes.Spans', done => {
@@ -220,8 +215,6 @@ describe('CollectorTraceExporter - common', () => {
   describe('shutdown', () => {
     let onShutdownSpy: any;
     beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
       onShutdownSpy = sinon.stub(
         CollectorTraceExporter.prototype,
         'onShutdown'
@@ -233,9 +226,6 @@ describe('CollectorTraceExporter - common', () => {
         url: 'http://foo.bar.com',
       };
       collectorExporter = new CollectorTraceExporter(collectorExporterConfig);
-    });
-    afterEach(() => {
-      onShutdownSpy.restore();
     });
 
     it('should call onShutdown', async () => {

--- a/packages/opentelemetry-exporter-collector/test/common/utils.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/common/utils.test.ts
@@ -20,15 +20,14 @@ import { diag } from '@opentelemetry/api';
 import { parseHeaders } from '../../src/util';
 
 describe('utils', () => {
-  describe('parseHeaders', () => {
-    beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
-    });
+  afterEach(() => {
+    sinon.restore();
+  });
 
+  describe('parseHeaders', () => {
     it('should ignore undefined headers', () => {
       // Need to stub/spy on the underlying logger as the "diag" instance is global
-      const spyWarn = sinon.stub(diag.getLogger(), 'warn');
+      const spyWarn = sinon.stub(diag, 'warn');
       const headers: Partial<Record<string, unknown>> = {
         foo1: undefined,
         foo2: 'bar',
@@ -45,6 +44,7 @@ describe('utils', () => {
         'Header "foo1" has wrong value and will be ignored'
       );
     });
+
     it('should parse undefined', () => {
       const result = parseHeaders(undefined);
       assert.deepStrictEqual(result, {});

--- a/packages/opentelemetry-exporter-collector/test/node/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/node/CollectorMetricExporter.test.ts
@@ -61,11 +61,16 @@ describe('CollectorMetricExporter - node with json over http', () => {
   let spyRequest: sinon.SinonSpy;
   let spyWrite: sinon.SinonSpy;
   let metrics: MetricRecord[];
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
   describe('instance', () => {
     it('should warn about metadata when using json', () => {
       const metadata = 'foo';
       // Need to stub/spy on the underlying logger as the "diag" instance is global
-      const spyLoggerWarn = sinon.stub(diag.getLogger(), 'warn');
+      const spyLoggerWarn = sinon.stub(diag, 'warn');
       collectorExporter = new CollectorMetricExporter({
         serviceName: 'basic-service',
         url: address,
@@ -78,8 +83,6 @@ describe('CollectorMetricExporter - node with json over http', () => {
 
   describe('export', () => {
     beforeEach(async () => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
       spyRequest = sinon.stub(http, 'request').returns(fakeRequest as any);
       spyWrite = sinon.stub(fakeRequest, 'write');
       collectorExporterConfig = {
@@ -115,11 +118,6 @@ describe('CollectorMetricExporter - node with json over http', () => {
       metrics.push((await counter.getMetricRecord())[0]);
       metrics.push((await observer.getMetricRecord())[0]);
       metrics.push((await recorder.getMetricRecord())[0]);
-    });
-
-    afterEach(() => {
-      spyRequest.restore();
-      spyWrite.restore();
     });
 
     it('should open the connection', done => {
@@ -203,7 +201,7 @@ describe('CollectorMetricExporter - node with json over http', () => {
 
     it('should log the successful message', done => {
       // Need to stub/spy on the underlying logger as the "diag" instance is global
-      const spyLoggerError = sinon.stub(diag.getLogger(), 'error');
+      const spyLoggerError = sinon.stub(diag, 'error');
 
       const responseSpy = sinon.spy();
       collectorExporter.export(metrics, responseSpy);
@@ -226,8 +224,6 @@ describe('CollectorMetricExporter - node with json over http', () => {
     });
 
     it('should log the error message', done => {
-      const spyLoggerError = sinon.spy();
-      diag.error = spyLoggerError;
       const handler = core.loggingErrorHandler();
       core.setGlobalErrorHandler(handler);
 

--- a/packages/opentelemetry-exporter-collector/test/node/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/node/CollectorMetricExporter.test.ts
@@ -58,8 +58,8 @@ const address = 'localhost:1501';
 describe('CollectorMetricExporter - node with json over http', () => {
   let collectorExporter: CollectorMetricExporter;
   let collectorExporterConfig: CollectorExporterNodeConfigBase;
-  let spyRequest: sinon.SinonSpy;
-  let spyWrite: sinon.SinonSpy;
+  let stubRequest: sinon.SinonStub;
+  let stubWrite: sinon.SinonStub;
   let metrics: MetricRecord[];
 
   afterEach(() => {
@@ -83,8 +83,8 @@ describe('CollectorMetricExporter - node with json over http', () => {
 
   describe('export', () => {
     beforeEach(async () => {
-      spyRequest = sinon.stub(http, 'request').returns(fakeRequest as any);
-      spyWrite = sinon.stub(fakeRequest, 'write');
+      stubRequest = sinon.stub(http, 'request').returns(fakeRequest as any);
+      stubWrite = sinon.stub(fakeRequest, 'write');
       collectorExporterConfig = {
         headers: {
           foo: 'bar',
@@ -124,7 +124,7 @@ describe('CollectorMetricExporter - node with json over http', () => {
       collectorExporter.export(metrics, () => {});
 
       setTimeout(() => {
-        const args = spyRequest.args[0];
+        const args = stubRequest.args[0];
         const options = args[0];
 
         assert.strictEqual(options.hostname, 'foo.bar.com');
@@ -138,7 +138,7 @@ describe('CollectorMetricExporter - node with json over http', () => {
       collectorExporter.export(metrics, () => {});
 
       setTimeout(() => {
-        const args = spyRequest.args[0];
+        const args = stubRequest.args[0];
         const options = args[0];
         assert.strictEqual(options.headers['foo'], 'bar');
         done();
@@ -149,7 +149,7 @@ describe('CollectorMetricExporter - node with json over http', () => {
       collectorExporter.export(metrics, () => {});
 
       setTimeout(() => {
-        const args = spyRequest.args[0];
+        const args = stubRequest.args[0];
         const options = args[0];
         const agent = options.agent;
         assert.strictEqual(agent.keepAlive, true);
@@ -162,7 +162,7 @@ describe('CollectorMetricExporter - node with json over http', () => {
       collectorExporter.export(metrics, () => {});
 
       setTimeout(() => {
-        const writeArgs = spyWrite.args[0];
+        const writeArgs = stubWrite.args[0];
         const json = JSON.parse(
           writeArgs[0]
         ) as collectorTypes.opentelemetryProto.collector.metrics.v1.ExportMetricsServiceRequest;
@@ -201,19 +201,19 @@ describe('CollectorMetricExporter - node with json over http', () => {
 
     it('should log the successful message', done => {
       // Need to stub/spy on the underlying logger as the "diag" instance is global
-      const spyLoggerError = sinon.stub(diag, 'error');
+      const stubLoggerError = sinon.stub(diag, 'error');
 
       const responseSpy = sinon.spy();
       collectorExporter.export(metrics, responseSpy);
 
       setTimeout(() => {
         const mockRes = new MockedResponse(200);
-        const args = spyRequest.args[0];
+        const args = stubRequest.args[0];
         const callback = args[1];
         callback(mockRes);
         mockRes.send('success');
         setTimeout(() => {
-          assert.strictEqual(spyLoggerError.args.length, 0);
+          assert.strictEqual(stubLoggerError.args.length, 0);
           assert.strictEqual(
             responseSpy.args[0][0].code,
             core.ExportResultCode.SUCCESS
@@ -232,7 +232,7 @@ describe('CollectorMetricExporter - node with json over http', () => {
 
       setTimeout(() => {
         const mockRes = new MockedResponse(400);
-        const args = spyRequest.args[0];
+        const args = stubRequest.args[0];
         const callback = args[1];
         callback(mockRes);
         mockRes.send('failed');

--- a/packages/opentelemetry-exporter-collector/test/node/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/node/CollectorTraceExporter.test.ts
@@ -47,15 +47,16 @@ describe('CollectorTraceExporter - node with json over http', () => {
   let spyRequest: sinon.SinonSpy;
   let spyWrite: sinon.SinonSpy;
   let spans: ReadableSpan[];
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
   describe('instance', () => {
-    beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
-    });
     it('should warn about metadata when using json', () => {
       const metadata = 'foo';
       // Need to stub/spy on the underlying logger as the "diag" instance is global
-      const spyLoggerWarn = sinon.stub(diag.getLogger(), 'warn');
+      const spyLoggerWarn = sinon.stub(diag, 'warn');
       collectorExporter = new CollectorTraceExporter({
         serviceName: 'basic-service',
         metadata,
@@ -68,8 +69,6 @@ describe('CollectorTraceExporter - node with json over http', () => {
 
   describe('export', () => {
     beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
       spyRequest = sinon.stub(http, 'request').returns(fakeRequest as any);
       spyWrite = sinon.stub(fakeRequest, 'write');
       collectorExporterConfig = {
@@ -86,10 +85,6 @@ describe('CollectorTraceExporter - node with json over http', () => {
       collectorExporter = new CollectorTraceExporter(collectorExporterConfig);
       spans = [];
       spans.push(Object.assign({}, mockedReadableSpan));
-    });
-    afterEach(() => {
-      spyRequest.restore();
-      spyWrite.restore();
     });
 
     it('should open the connection', done => {
@@ -166,7 +161,7 @@ describe('CollectorTraceExporter - node with json over http', () => {
 
     it('should log the successful message', done => {
       // Need to stub/spy on the underlying logger as the "diag" instance is global
-      const spyLoggerError = sinon.stub(diag.getLogger(), 'error');
+      const spyLoggerError = sinon.stub(diag, 'error');
       const responseSpy = sinon.spy();
       collectorExporter.export(spans, responseSpy);
 

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/tracing": "^0.17.0",
     "jaeger-client": "^3.15.0"

--- a/packages/opentelemetry-exporter-prometheus/package.json
+++ b/packages/opentelemetry-exporter-prometheus/package.json
@@ -53,7 +53,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/api-metrics": "^0.17.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/metrics": "^0.17.0"

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -75,7 +75,7 @@
     "webpack-merge": "5.7.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/resources": "^0.17.0",
     "@opentelemetry/tracing": "^0.17.0"

--- a/packages/opentelemetry-exporter-zipkin/test/browser/zipkin.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/browser/zipkin.test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { diag } from '@opentelemetry/api';
 import {
   setGlobalErrorHandler,
   loggingErrorHandler,
@@ -38,18 +37,16 @@ describe('Zipkin Exporter - web', () => {
   let spySend: sinon.SinonSpy;
   let spyBeacon: sinon.SinonSpy;
   let spans: ReadableSpan[];
-  let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
-    spySend = sandbox.stub(XMLHttpRequest.prototype, 'send');
-    spyBeacon = sandbox.stub(navigator, 'sendBeacon');
+    spySend = sinon.stub(XMLHttpRequest.prototype, 'send');
+    spyBeacon = sinon.stub(navigator, 'sendBeacon');
     spans = [];
     spans.push(Object.assign({}, mockedReadableSpan));
   });
 
   afterEach(() => {
-    sandbox.restore();
+    sinon.restore();
     navigator.sendBeacon = sendBeacon;
   });
 
@@ -109,8 +106,6 @@ describe('Zipkin Exporter - web', () => {
     };
 
     beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
       zipkinConfig = {
         headers: customHeaders,
       };

--- a/packages/opentelemetry-grpc-utils/package.json
+++ b/packages/opentelemetry-grpc-utils/package.json
@@ -43,7 +43,6 @@
     "@grpc/grpc-js": "1.2.3",
     "@grpc/proto-loader": "0.5.5",
     "@opentelemetry/context-async-hooks": "^0.17.0",
-    "@opentelemetry/context-base": "^0.17.0",
     "@opentelemetry/node": "^0.17.0",
     "@opentelemetry/tracing": "^0.17.0",
     "@types/mocha": "8.2.0",
@@ -65,7 +64,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/semantic-conventions": "^0.17.0",
     "shimmer": "1.2.1"

--- a/packages/opentelemetry-grpc-utils/test/grpcUtils.test.ts
+++ b/packages/opentelemetry-grpc-utils/test/grpcUtils.test.ts
@@ -29,7 +29,7 @@ import {
 } from '@opentelemetry/core';
 import { NodeTracerProvider } from '@opentelemetry/node';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
-import { ContextManager } from '@opentelemetry/context-base';
+import { ContextManager } from '@opentelemetry/api';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,

--- a/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/packages/opentelemetry-instrumentation-fetch/package.json
@@ -74,7 +74,7 @@
     "webpack-merge": "5.7.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/instrumentation": "^0.17.0",
     "@opentelemetry/semantic-conventions": "^0.17.0",

--- a/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -130,7 +130,6 @@ function createFakePerformanceObs(url: string) {
 }
 
 describe('fetch', () => {
-  let sandbox: sinon.SinonSandbox;
   let contextManager: ZoneContextManager;
   let lastResponse: any | undefined;
   let webTracerWithZone: api.Tracer;
@@ -146,7 +145,7 @@ describe('fetch', () => {
   const badUrl = 'http://foo.bar.com/get';
 
   const clearData = () => {
-    sandbox.restore();
+    sinon.restore();
     lastResponse = undefined;
   };
 
@@ -158,11 +157,10 @@ describe('fetch', () => {
     disablePerfObserver?: boolean,
     disableGetEntries?: boolean
   ) => {
-    sandbox = sinon.createSandbox();
-    sandbox.useFakeTimers();
+    sinon.useFakeTimers();
 
-    sandbox.stub(core.otperformance, 'timeOrigin').value(0);
-    sandbox.stub(core.otperformance, 'now').callsFake(() => fakeNow);
+    sinon.stub(core.otperformance, 'timeOrigin').value(0);
+    sinon.stub(core.otperformance, 'now').callsFake(() => fakeNow);
 
     function fakeFetch(input: RequestInfo | Request, init: RequestInit = {}) {
       return new Promise((resolve, reject) => {
@@ -188,7 +186,7 @@ describe('fetch', () => {
       });
     }
 
-    sandbox.stub(window, 'fetch').callsFake(fakeFetch as any);
+    sinon.stub(window, 'fetch').callsFake(fakeFetch as any);
 
     const resources: PerformanceResourceTiming[] = [];
     resources.push(
@@ -201,17 +199,17 @@ describe('fetch', () => {
     );
 
     if (disablePerfObserver) {
-      sandbox.stub(window, 'PerformanceObserver').value(undefined);
+      sinon.stub(window, 'PerformanceObserver').value(undefined);
     } else {
-      sandbox
+      sinon
         .stub(window, 'PerformanceObserver')
         .value(createFakePerformanceObs(fileUrl));
     }
 
     if (disableGetEntries) {
-      sandbox.stub(performance, 'getEntriesByType').value(undefined);
+      sinon.stub(performance, 'getEntriesByType').value(undefined);
     } else {
-      const spyEntries = sandbox.stub(performance, 'getEntriesByType');
+      const spyEntries = sinon.stub(performance, 'getEntriesByType');
       spyEntries.withArgs('resource').returns(resources);
     }
 
@@ -223,8 +221,8 @@ describe('fetch', () => {
     });
     webTracerWithZone = webTracerProviderWithZone.getTracer('fetch-test');
     dummySpanExporter = new DummySpanExporter();
-    exportSpy = sandbox.stub(dummySpanExporter, 'export');
-    clearResourceTimingsSpy = sandbox.stub(performance, 'clearResourceTimings');
+    exportSpy = sinon.stub(dummySpanExporter, 'export');
+    clearResourceTimingsSpy = sinon.stub(performance, 'clearResourceTimings');
     webTracerProviderWithZone.addSpanProcessor(
       new tracing.SimpleSpanProcessor(dummySpanExporter)
     );
@@ -245,13 +243,13 @@ describe('fetch', () => {
               });
               lastResponse.headers = headers;
               // OBSERVER_WAIT_TIME_MS
-              sandbox.clock.tick(300);
+              sinon.clock.tick(300);
               done();
             },
             () => {
               lastResponse = undefined;
               // OBSERVER_WAIT_TIME_MS
-              sandbox.clock.tick(300);
+              sinon.clock.tick(300);
               done();
             }
           );
@@ -259,7 +257,7 @@ describe('fetch', () => {
         () => {
           lastResponse = undefined;
           // OBSERVER_WAIT_TIME_MS
-          sandbox.clock.tick(300);
+          sinon.clock.tick(300);
           done();
         }
       );

--- a/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/packages/opentelemetry-instrumentation-grpc/package.json
@@ -44,7 +44,6 @@
     "@grpc/grpc-js": "1.2.3",
     "@grpc/proto-loader": "0.5.5",
     "@opentelemetry/context-async-hooks": "^0.17.0",
-    "@opentelemetry/context-base": "^0.17.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/node": "^0.17.0",
     "@opentelemetry/tracing": "^0.17.0",
@@ -67,7 +66,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/api-metrics": "^0.17.0",
     "@opentelemetry/instrumentation": "^0.17.0",
     "@opentelemetry/semantic-conventions": "^0.17.0"

--- a/packages/opentelemetry-instrumentation-grpc/test/helper.ts
+++ b/packages/opentelemetry-instrumentation-grpc/test/helper.ts
@@ -24,7 +24,7 @@ import {
 import { HttpTraceContext } from '@opentelemetry/core';
 import { NodeTracerProvider } from '@opentelemetry/node';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
-import { ContextManager } from '@opentelemetry/context-base';
+import { ContextManager } from '@opentelemetry/api';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,

--- a/packages/opentelemetry-instrumentation-http/package.json
+++ b/packages/opentelemetry-instrumentation-http/package.json
@@ -42,7 +42,6 @@
   },
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^0.17.0",
-    "@opentelemetry/context-base": "^0.17.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/node": "^0.17.0",
     "@opentelemetry/tracing": "^0.17.0",
@@ -70,7 +69,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/instrumentation": "^0.17.0",
     "@opentelemetry/semantic-conventions": "^0.17.0",
     "semver": "^7.1.3"

--- a/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
@@ -39,7 +39,7 @@ import { HttpInstrumentationConfig } from '../../src/types';
 import { assertSpan } from '../utils/assertSpan';
 import { DummyPropagation } from '../utils/DummyPropagation';
 import { httpRequest } from '../utils/httpRequest';
-import { ContextManager } from '@opentelemetry/context-base';
+import { ContextManager } from '@opentelemetry/api';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import type { ClientRequest, IncomingMessage, ServerResponse } from 'http';
 import { isWrapped } from '@opentelemetry/instrumentation';

--- a/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
@@ -23,7 +23,7 @@ import {
   setSpan,
 } from '@opentelemetry/api';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
-import { ContextManager } from '@opentelemetry/context-base';
+import { ContextManager } from '@opentelemetry/api';
 import {
   BasicTracerProvider,
   InMemorySpanExporter,

--- a/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -141,13 +141,12 @@ describe('Utility', () => {
   });
 
   describe('isIgnored()', () => {
-    let satisfiesPatternStub: sinon.SinonSpy<[string, IgnoreMatcher], boolean>;
     beforeEach(() => {
-      satisfiesPatternStub = sinon.spy(utils, 'satisfiesPattern');
+      sinon.spy(utils, 'satisfiesPattern');
     });
 
     afterEach(() => {
-      satisfiesPatternStub.restore();
+      sinon.restore();
     });
 
     it('should call isSatisfyPattern, n match', () => {
@@ -160,7 +159,6 @@ describe('Utility', () => {
     });
 
     it('should call isSatisfyPattern, match for function', () => {
-      satisfiesPatternStub.restore();
       const answer1 = utils.isIgnored('/test/1', [
         url => url.endsWith('/test/1'),
       ]);
@@ -168,7 +166,6 @@ describe('Utility', () => {
     });
 
     it('should not re-throw when function throws an exception', () => {
-      satisfiesPatternStub.restore();
       const onException = (e: Error) => {
         // Do nothing
       };
@@ -188,7 +185,6 @@ describe('Utility', () => {
     });
 
     it('should call onException when function throws an exception', () => {
-      satisfiesPatternStub.restore();
       const onException = sinon.spy();
       assert.doesNotThrow(() =>
         utils.isIgnored(

--- a/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -73,7 +73,7 @@
     "webpack-merge": "5.7.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/instrumentation": "^0.17.0",
     "@opentelemetry/semantic-conventions": "^0.17.0",

--- a/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -126,7 +126,6 @@ describe('xhr', () => {
   asyncTests.forEach(test => {
     const testAsync = test.async;
     describe(`when async='${testAsync}'`, () => {
-      let sandbox: sinon.SinonSandbox;
       let requests: any[] = [];
       let prepareData: any;
       let clearData: any;
@@ -165,20 +164,18 @@ describe('xhr', () => {
 
         clearData = () => {
           requests = [];
-          sandbox.restore();
-          spyEntries.restore();
+          sinon.restore();
         };
 
         prepareData = (done: any, fileUrl: string, config?: any) => {
-          sandbox = sinon.createSandbox();
-          const fakeXhr = sandbox.useFakeXMLHttpRequest();
+          const fakeXhr = sinon.useFakeXMLHttpRequest();
           fakeXhr.onCreate = function (xhr: any) {
             requests.push(xhr);
           };
-          sandbox.useFakeTimers();
+          sinon.useFakeTimers();
 
-          sandbox.stub(performance, 'timeOrigin').value(0);
-          sandbox.stub(performance, 'now').callsFake(() => fakeNow);
+          sinon.stub(performance, 'timeOrigin').value(0);
+          sinon.stub(performance, 'now').callsFake(() => fakeNow);
 
           const resources: PerformanceResourceTiming[] = [];
           resources.push(
@@ -190,7 +187,7 @@ describe('xhr', () => {
             })
           );
 
-          spyEntries = sandbox.stub(
+          spyEntries = sinon.stub(
             (performance as unknown) as Performance,
             'getEntriesByType'
           );
@@ -206,7 +203,7 @@ describe('xhr', () => {
           webTracerWithZone = webTracerProviderWithZone.getTracer('xhr-test');
           dummySpanExporter = new DummySpanExporter();
           exportSpy = sinon.stub(dummySpanExporter, 'export');
-          clearResourceTimingsSpy = sandbox.stub(
+          clearResourceTimingsSpy = sinon.stub(
             (performance as unknown) as Performance,
             'clearResourceTimings'
           );
@@ -225,7 +222,7 @@ describe('xhr', () => {
               testAsync
             ).then(() => {
               fakeNow = 0;
-              sandbox.clock.tick(1000);
+              sinon.clock.tick(1000);
               done();
             });
             assert.strictEqual(requests.length, 1, 'request not called');
@@ -640,7 +637,7 @@ describe('xhr', () => {
                   testAsync
                 ).then(() => {
                   fakeNow = 0;
-                  sandbox.clock.tick(1000);
+                  sinon.clock.tick(1000);
                 });
               }
             );
@@ -657,7 +654,7 @@ describe('xhr', () => {
                   testAsync
                 ).then(() => {
                   fakeNow = 0;
-                  sandbox.clock.tick(1000);
+                  sinon.clock.tick(1000);
                   done();
                 });
 
@@ -702,16 +699,15 @@ describe('xhr', () => {
         let fakeNow = 0;
 
         beforeEach(() => {
-          sandbox = sinon.createSandbox();
-          const fakeXhr = sandbox.useFakeXMLHttpRequest();
+          const fakeXhr = sinon.useFakeXMLHttpRequest();
           fakeXhr.onCreate = function (xhr: any) {
             requests.push(xhr);
           };
 
-          sandbox.useFakeTimers();
+          sinon.useFakeTimers();
 
-          sandbox.stub(performance, 'timeOrigin').value(0);
-          sandbox.stub(performance, 'now').callsFake(() => fakeNow);
+          sinon.stub(performance, 'timeOrigin').value(0);
+          sinon.stub(performance, 'now').callsFake(() => fakeNow);
 
           const resources: PerformanceResourceTiming[] = [];
           resources.push(
@@ -720,7 +716,7 @@ describe('xhr', () => {
             })
           );
 
-          spyEntries = sandbox.stub(
+          spyEntries = sinon.stub(
             (performance as unknown) as Performance,
             'getEntriesByType'
           );
@@ -761,7 +757,7 @@ describe('xhr', () => {
                   testAsync
                 ).then(() => {
                   fakeNow = 0;
-                  sandbox.clock.tick(1000);
+                  sinon.clock.tick(1000);
                   done();
                 });
                 assert.strictEqual(requests.length, 1, 'request not called');
@@ -897,7 +893,7 @@ describe('xhr', () => {
                 getData(new XMLHttpRequest(), url, () => {}, testAsync).then(
                   () => {
                     fakeNow = 0;
-                    sandbox.clock.tick(1000);
+                    sinon.clock.tick(1000);
                     done();
                   }
                 );
@@ -989,7 +985,7 @@ describe('xhr', () => {
                 getData(new XMLHttpRequest(), url, () => {}, testAsync).then(
                   () => {
                     fakeNow = 0;
-                    sandbox.clock.tick(1000);
+                    sinon.clock.tick(1000);
                     done();
                   }
                 );
@@ -1082,12 +1078,12 @@ describe('xhr', () => {
                   new XMLHttpRequest(),
                   url,
                   () => {
-                    sandbox.clock.tick(XHR_TIMEOUT);
+                    sinon.clock.tick(XHR_TIMEOUT);
                   },
                   testAsync
                 ).then(() => {
                   fakeNow = 0;
-                  sandbox.clock.tick(1000);
+                  sinon.clock.tick(1000);
                   done();
                 });
               }

--- a/packages/opentelemetry-instrumentation/package.json
+++ b/packages/opentelemetry-instrumentation/package.json
@@ -54,7 +54,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/api-metrics": "^0.17.0",
     "require-in-the-middle": "^5.0.3",
     "semver": "^7.3.2",

--- a/packages/opentelemetry-instrumentation/test/browser/autoLoader.test.ts
+++ b/packages/opentelemetry-instrumentation/test/browser/autoLoader.test.ts
@@ -28,13 +28,9 @@ class WebPlugin implements OldClassPlugin {
 }
 
 describe('autoLoader', () => {
-  let sandbox: sinon.SinonSandbox;
   let unload: Function | undefined;
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
   afterEach(() => {
-    sandbox.restore();
+    sinon.restore();
     if (typeof unload === 'function') {
       unload();
       unload = undefined;
@@ -49,7 +45,7 @@ describe('autoLoader', () => {
       let webPlugin: WebPlugin;
       beforeEach(() => {
         webPlugin = new WebPlugin();
-        enableSpy = sandbox.spy(webPlugin, 'enable');
+        enableSpy = sinon.spy(webPlugin, 'enable');
         unload = registerInstrumentations({
           instrumentations: [webPlugin],
           tracerProvider,

--- a/packages/opentelemetry-instrumentation/test/common/autoLoader.test.ts
+++ b/packages/opentelemetry-instrumentation/test/common/autoLoader.test.ts
@@ -29,13 +29,10 @@ class FooInstrumentation extends InstrumentationBase {
 }
 
 describe('autoLoader', () => {
-  let sandbox: sinon.SinonSandbox;
   let unload: Function | undefined;
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
+
   afterEach(() => {
-    sandbox.restore();
+    sinon.restore();
     if (typeof unload === 'function') {
       unload();
       unload = undefined;
@@ -52,12 +49,9 @@ describe('autoLoader', () => {
       const meterProvider = NOOP_METER_PROVIDER;
       beforeEach(() => {
         instrumentation = new FooInstrumentation('foo', '1', {});
-        enableSpy = sandbox.spy(instrumentation, 'enable');
-        setTracerProviderSpy = sandbox.stub(
-          instrumentation,
-          'setTracerProvider'
-        );
-        setsetMeterProvider = sandbox.stub(instrumentation, 'setMeterProvider');
+        enableSpy = sinon.spy(instrumentation, 'enable');
+        setTracerProviderSpy = sinon.stub(instrumentation, 'setTracerProvider');
+        setsetMeterProvider = sinon.stub(instrumentation, 'setMeterProvider');
         unload = registerInstrumentations({
           instrumentations: [instrumentation],
           tracerProvider,

--- a/packages/opentelemetry-instrumentation/test/common/autoLoaderUtils.test.ts
+++ b/packages/opentelemetry-instrumentation/test/common/autoLoaderUtils.test.ts
@@ -15,7 +15,6 @@
  */
 
 import * as assert from 'assert';
-import * as sinon from 'sinon';
 import { InstrumentationBase } from '../../src';
 import { parseInstrumentationOptions } from '../../src/autoLoaderUtils';
 import { InstrumentationOption } from '../../src/types_internal';
@@ -46,14 +45,6 @@ class FooWebPlugin implements OldClassPlugin {
 // const fooInstrumentation = new FooInstrumentation();
 
 describe('autoLoaderUtils', () => {
-  let sandbox: sinon.SinonSandbox;
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-  afterEach(() => {
-    sandbox.restore();
-  });
-
   describe('parseInstrumentationOptions', () => {
     it('should create a new instrumentation from class', () => {
       const { instrumentations } = parseInstrumentationOptions([

--- a/packages/opentelemetry-instrumentation/test/common/utils.test.ts
+++ b/packages/opentelemetry-instrumentation/test/common/utils.test.ts
@@ -101,10 +101,10 @@ describe('safeExecuteInTheMiddleAsync', () => {
       true
     );
   });
-  it('should throw error', () => {
+  it('should throw error', async () => {
     const error = new Error('test');
     try {
-      safeExecuteInTheMiddleAsync(
+      await safeExecuteInTheMiddleAsync(
         async () => {
           await setTimeout(() => {}, 1);
           throw error;

--- a/packages/opentelemetry-instrumentation/test/node/autoLoader.test.ts
+++ b/packages/opentelemetry-instrumentation/test/node/autoLoader.test.ts
@@ -37,18 +37,14 @@ const httpPlugin: Plugins = {
 };
 
 describe('autoLoader', () => {
-  let sandbox: sinon.SinonSandbox;
   let unload: Function | undefined;
   before(() => {
     module.paths.push(INSTALLED_PLUGINS_PATH);
     searchPathForTest(INSTALLED_PLUGINS_PATH);
   });
 
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
   afterEach(() => {
-    sandbox.restore();
+    sinon.restore();
     Object.keys(require.cache).forEach(key => delete require.cache[key]);
     if (typeof unload === 'function') {
       unload();
@@ -65,7 +61,7 @@ describe('autoLoader', () => {
         // eslint-disable-next-line node/no-extraneous-require
         const simpleModule = require('@opentelemetry/plugin-simple-module')
           .plugin;
-        enableSpy = sandbox.spy(simpleModule, 'enable');
+        enableSpy = sinon.spy(simpleModule, 'enable');
         unload = registerInstrumentations({
           instrumentations: [
             {

--- a/packages/opentelemetry-metrics/package.json
+++ b/packages/opentelemetry-metrics/package.json
@@ -55,7 +55,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/api-metrics": "^0.17.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/resources": "^0.17.0",

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -79,9 +79,11 @@ describe('Meter', () => {
   const labels: api.Labels = { [keyb]: 'value2', [keya]: 'value1' };
 
   beforeEach(() => {
-    // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap warn which is already wrapped
-    diag.setLogger();
     meter = new MeterProvider().getMeter('test-meter');
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   describe('#counter', () => {
@@ -772,11 +774,6 @@ describe('Meter', () => {
   });
 
   describe('#SumObserverMetric', () => {
-    beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
-    });
-
     it('should create an Sum observer', () => {
       const sumObserver = meter.createSumObserver('name') as SumObserverMetric;
       assert.ok(sumObserver instanceof Metric);
@@ -784,7 +781,7 @@ describe('Meter', () => {
 
     it('should return noop observer when name is invalid', () => {
       // Need to stub/spy on the underlying logger as the "diag" instance is global
-      const spy = sinon.stub(diag.getLogger(), 'warn');
+      const spy = sinon.stub(diag, 'warn');
       const sumObserver = meter.createSumObserver('na me');
       assert.ok(sumObserver === api.NOOP_SUM_OBSERVER_METRIC);
       const args = spy.args[0];
@@ -917,11 +914,6 @@ describe('Meter', () => {
   });
 
   describe('#ValueObserver', () => {
-    beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
-    });
-
     it('should create a value observer', () => {
       const valueObserver = meter.createValueObserver(
         'name'
@@ -931,7 +923,7 @@ describe('Meter', () => {
 
     it('should return noop observer when name is invalid', () => {
       // Need to stub/spy on the underlying logger as the "diag" instance is global
-      const spy = sinon.stub(diag.getLogger(), 'warn');
+      const spy = sinon.stub(diag, 'warn');
       const valueObserver = meter.createValueObserver('na me');
       assert.ok(valueObserver === api.NOOP_VALUE_OBSERVER_METRIC);
       const args = spy.args[0];
@@ -1004,11 +996,6 @@ describe('Meter', () => {
   });
 
   describe('#UpDownSumObserverMetric', () => {
-    beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap xxxx which is already wrapped
-      diag.setLogger();
-    });
-
     it('should create an UpDownSum observer', () => {
       const upDownSumObserver = meter.createUpDownSumObserver(
         'name'
@@ -1018,7 +1005,7 @@ describe('Meter', () => {
 
     it('should return noop observer when name is invalid', () => {
       // Need to stub/spy on the underlying logger as the "diag" instance is global
-      const spy = sinon.stub(diag.getLogger(), 'warn');
+      const spy = sinon.stub(diag, 'warn');
       const upDownSumObserver = meter.createUpDownSumObserver('na me');
       assert.ok(upDownSumObserver === api.NOOP_UP_DOWN_SUM_OBSERVER_METRIC);
       const args = spy.args[0];

--- a/packages/opentelemetry-metrics/test/MeterProvider.test.ts
+++ b/packages/opentelemetry-metrics/test/MeterProvider.test.ts
@@ -19,6 +19,10 @@ import * as sinon from 'sinon';
 import { MeterProvider, Meter, CounterMetric } from '../src';
 
 describe('MeterProvider', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   describe('constructor', () => {
     it('should construct an instance without any options', () => {
       const provider = new MeterProvider();
@@ -77,12 +81,11 @@ describe('MeterProvider', () => {
       const meterProvider = new MeterProvider({
         interval: Math.pow(2, 31) - 1,
       });
-      const sandbox = sinon.createSandbox();
-      const shutdownStub1 = sandbox.stub(
+      const shutdownStub1 = sinon.stub(
         meterProvider.getMeter('meter1'),
         'shutdown'
       );
-      const shutdownStub2 = sandbox.stub(
+      const shutdownStub2 = sinon.stub(
         meterProvider.getMeter('meter2'),
         'shutdown'
       );

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -41,7 +41,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/context-base": "^0.17.0",
     "@opentelemetry/resources": "^0.17.0",
     "@types/mocha": "8.2.0",
     "@types/node": "14.14.20",
@@ -60,7 +59,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/context-async-hooks": "^0.17.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/tracing": "^0.17.0",

--- a/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
+++ b/packages/opentelemetry-node/test/NodeTracerProvider.test.ts
@@ -29,7 +29,7 @@ import { Resource, TELEMETRY_SDK_RESOURCE } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as path from 'path';
-import { ContextManager, ROOT_CONTEXT } from '@opentelemetry/context-base';
+import { ContextManager, ROOT_CONTEXT } from '@opentelemetry/api';
 import { NodeTracerProvider } from '../src/NodeTracerProvider';
 
 const sleep = (time: number) =>
@@ -53,8 +53,6 @@ describe('NodeTracerProvider', () => {
   beforeEach(() => {
     contextManager = new AsyncHooksContextManager();
     context.setGlobalContextManager(contextManager.enable());
-    // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap warn which is already wrapped
-    diag.setLogger();
   });
 
   afterEach(() => {
@@ -65,11 +63,6 @@ describe('NodeTracerProvider', () => {
   });
 
   describe('constructor', () => {
-    beforeEach(() => {
-      // Set no logger so that sinon doesn't complain about TypeError: Attempted to wrap warn which is already wrapped
-      diag.setLogger();
-    });
-
     it('should construct an instance with required only options', () => {
       provider = new NodeTracerProvider();
       assert.ok(provider instanceof NodeTracerProvider);
@@ -89,7 +82,7 @@ describe('NodeTracerProvider', () => {
 
     it('should show warning when plugins are defined', () => {
       const dummyPlugin1 = {};
-      const spyWarn = sinon.spy(diag.getLogger(), 'warn');
+      const spyWarn = sinon.spy(diag, 'warn');
 
       const plugins = [dummyPlugin1];
       const options = { plugins };

--- a/packages/opentelemetry-node/test/registration.test.ts
+++ b/packages/opentelemetry-node/test/registration.test.ts
@@ -25,7 +25,7 @@ import {
   AsyncHooksContextManager,
   AsyncLocalStorageContextManager,
 } from '@opentelemetry/context-async-hooks';
-import { NoopContextManager } from '@opentelemetry/context-base';
+import { NoopContextManager } from '@opentelemetry/api';
 import { CompositePropagator } from '@opentelemetry/core';
 import * as assert from 'assert';
 import { NodeTracerProvider } from '../src';

--- a/packages/opentelemetry-plugin-grpc-js/package.json
+++ b/packages/opentelemetry-plugin-grpc-js/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@grpc/grpc-js": "1.2.3",
     "@opentelemetry/context-async-hooks": "^0.17.0",
-    "@opentelemetry/context-base": "^0.17.0",
     "@opentelemetry/grpc-utils": "^0.17.0",
     "@opentelemetry/node": "^0.17.0",
     "@opentelemetry/tracing": "^0.17.0",
@@ -65,7 +64,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/semantic-conventions": "^0.17.0",
     "shimmer": "1.2.1"

--- a/packages/opentelemetry-plugin-grpc/package.json
+++ b/packages/opentelemetry-plugin-grpc/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^0.17.0",
-    "@opentelemetry/context-base": "^0.17.0",
     "@opentelemetry/grpc-utils": "^0.17.0",
     "@opentelemetry/node": "^0.17.0",
     "@opentelemetry/tracing": "^0.17.0",
@@ -64,7 +63,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/semantic-conventions": "^0.17.0",
     "shimmer": "^1.2.1"

--- a/packages/opentelemetry-plugin-http/package.json
+++ b/packages/opentelemetry-plugin-http/package.json
@@ -42,7 +42,6 @@
   },
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^0.17.0",
-    "@opentelemetry/context-base": "^0.17.0",
     "@opentelemetry/node": "^0.17.0",
     "@opentelemetry/tracing": "^0.17.0",
     "@types/got": "9.6.11",
@@ -70,7 +69,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/semantic-conventions": "^0.17.0",
     "semver": "^7.1.3",

--- a/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/http-enable.test.ts
@@ -40,7 +40,7 @@ import { Http, HttpPluginConfig } from '../../src/types';
 import { assertSpan } from '../utils/assertSpan';
 import { DummyPropagation } from '../utils/DummyPropagation';
 import { httpRequest } from '../utils/httpRequest';
-import { ContextManager } from '@opentelemetry/context-base';
+import { ContextManager } from '@opentelemetry/api';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { ClientRequest, IncomingMessage, ServerResponse } from 'http';
 

--- a/packages/opentelemetry-plugin-http/test/functionals/utils.test.ts
+++ b/packages/opentelemetry-plugin-http/test/functionals/utils.test.ts
@@ -140,13 +140,12 @@ describe('Utility', () => {
   });
 
   describe('isIgnored()', () => {
-    let satisfiesPatternStub: sinon.SinonSpy<[string, IgnoreMatcher], boolean>;
     beforeEach(() => {
-      satisfiesPatternStub = sinon.spy(utils, 'satisfiesPattern');
+      sinon.spy(utils, 'satisfiesPattern');
     });
 
     afterEach(() => {
-      satisfiesPatternStub.restore();
+      sinon.restore();
     });
 
     it('should call isSatisfyPattern, n match', () => {
@@ -159,7 +158,6 @@ describe('Utility', () => {
     });
 
     it('should call isSatisfyPattern, match for function', () => {
-      satisfiesPatternStub.restore();
       const answer1 = utils.isIgnored('/test/1', [
         url => url.endsWith('/test/1'),
       ]);
@@ -167,7 +165,6 @@ describe('Utility', () => {
     });
 
     it('should not re-throw when function throws an exception', () => {
-      satisfiesPatternStub.restore();
       const onException = (e: Error) => {
         // Do Nothing
       };
@@ -187,7 +184,6 @@ describe('Utility', () => {
     });
 
     it('should call onException when function throws an exception', () => {
-      satisfiesPatternStub.restore();
       const onException = sinon.spy();
       assert.doesNotThrow(() =>
         utils.isIgnored(

--- a/packages/opentelemetry-plugin-https/package.json
+++ b/packages/opentelemetry-plugin-https/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^0.17.0",
-    "@opentelemetry/context-base": "^0.17.0",
     "@opentelemetry/node": "^0.17.0",
     "@opentelemetry/tracing": "^0.17.0",
     "@types/got": "9.6.11",
@@ -69,7 +68,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/plugin-http": "^0.17.0",
     "@opentelemetry/semantic-conventions": "^0.17.0",

--- a/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
+++ b/packages/opentelemetry-plugin-https/test/functionals/https-enable.test.ts
@@ -25,7 +25,7 @@ import {
 import { NodeTracerProvider } from '@opentelemetry/node';
 import { Http, HttpPluginConfig } from '@opentelemetry/plugin-http';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
-import { ContextManager } from '@opentelemetry/context-base';
+import { ContextManager } from '@opentelemetry/api';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -39,10 +39,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0"
+    "@opentelemetry/api": "^0.18.0"
   },
   "devDependencies": {
-    "@opentelemetry/context-base": "^0.17.0",
     "@types/mocha": "8.2.0",
     "@types/node": "14.14.20",
     "codecov": "3.8.1",

--- a/packages/opentelemetry-propagator-b3/test/B3MultiPropagator.test.ts
+++ b/packages/opentelemetry-propagator-b3/test/B3MultiPropagator.test.ts
@@ -22,7 +22,7 @@ import {
   SpanContext,
   TraceFlags,
 } from '@opentelemetry/api';
-import { ROOT_CONTEXT } from '@opentelemetry/context-base';
+import { ROOT_CONTEXT } from '@opentelemetry/api';
 import * as assert from 'assert';
 import {
   B3MultiPropagator,

--- a/packages/opentelemetry-propagator-b3/test/B3Propagator.test.ts
+++ b/packages/opentelemetry-propagator-b3/test/B3Propagator.test.ts
@@ -22,8 +22,8 @@ import {
   TraceFlags,
   getSpanContext,
   setSpanContext,
+  ROOT_CONTEXT,
 } from '@opentelemetry/api';
-import { ROOT_CONTEXT } from '@opentelemetry/context-base';
 import { B3Propagator } from '../src/B3Propagator';
 import { B3InjectEncoding } from '../src/types';
 import { B3_CONTEXT_HEADER } from '../src/B3SinglePropagator';

--- a/packages/opentelemetry-propagator-b3/test/B3SinglePropagator.test.ts
+++ b/packages/opentelemetry-propagator-b3/test/B3SinglePropagator.test.ts
@@ -24,7 +24,7 @@ import {
   SpanContext,
   TraceFlags,
 } from '@opentelemetry/api';
-import { ROOT_CONTEXT } from '@opentelemetry/context-base';
+import { ROOT_CONTEXT } from '@opentelemetry/api';
 import * as assert from 'assert';
 import {
   B3SinglePropagator,

--- a/packages/opentelemetry-resource-detector-aws/package.json
+++ b/packages/opentelemetry-resource-detector-aws/package.json
@@ -54,7 +54,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/resources": "^0.17.0"
   }

--- a/packages/opentelemetry-resource-detector-aws/test/detectors/AwsBeanstalkDetector.test.ts
+++ b/packages/opentelemetry-resource-detector-aws/test/detectors/AwsBeanstalkDetector.test.ts
@@ -37,29 +37,24 @@ describe('BeanstalkResourceDetector', () => {
   };
 
   let readStub, fileStub;
-  let sandbox: sinon.SinonSandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
 
   afterEach(() => {
-    sandbox.restore();
+    sinon.restore();
   });
 
   it('should successfully return resource data', async () => {
-    fileStub = sandbox
+    fileStub = sinon
       .stub(AwsBeanstalkDetector, 'fileAccessAsync' as any)
       .resolves();
-    readStub = sandbox
+    readStub = sinon
       .stub(AwsBeanstalkDetector, 'readFileAsync' as any)
       .resolves(JSON.stringify(data));
-    sandbox.stub(JSON, 'parse').returns(data);
+    sinon.stub(JSON, 'parse').returns(data);
 
     const resource = await awsBeanstalkDetector.detect();
 
-    sandbox.assert.calledOnce(fileStub);
-    sandbox.assert.calledOnce(readStub);
+    sinon.assert.calledOnce(fileStub);
+    sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertServiceResource(resource, {
       name: 'elastic_beanstalk',
@@ -70,18 +65,18 @@ describe('BeanstalkResourceDetector', () => {
   });
 
   it('should successfully return resource data with noise', async () => {
-    fileStub = sandbox
+    fileStub = sinon
       .stub(AwsBeanstalkDetector, 'fileAccessAsync' as any)
       .resolves();
-    readStub = sandbox
+    readStub = sinon
       .stub(AwsBeanstalkDetector, 'readFileAsync' as any)
       .resolves(JSON.stringify(noisyData));
-    sandbox.stub(JSON, 'parse').returns(noisyData);
+    sinon.stub(JSON, 'parse').returns(noisyData);
 
     const resource = await awsBeanstalkDetector.detect();
 
-    sandbox.assert.calledOnce(fileStub);
-    sandbox.assert.calledOnce(readStub);
+    sinon.assert.calledOnce(fileStub);
+    sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertServiceResource(resource, {
       name: 'elastic_beanstalk',
@@ -92,33 +87,33 @@ describe('BeanstalkResourceDetector', () => {
   });
 
   it('should return empty resource when failing to read file', async () => {
-    fileStub = sandbox
+    fileStub = sinon
       .stub(AwsBeanstalkDetector, 'fileAccessAsync' as any)
       .resolves();
-    readStub = sandbox
+    readStub = sinon
       .stub(AwsBeanstalkDetector, 'readFileAsync' as any)
       .rejects(err);
 
     const resource = await awsBeanstalkDetector.detect();
 
-    sandbox.assert.calledOnce(fileStub);
-    sandbox.assert.calledOnce(readStub);
+    sinon.assert.calledOnce(fileStub);
+    sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertEmptyResource(resource);
   });
 
   it('should return empty resource when config file does not exist', async () => {
-    fileStub = sandbox
+    fileStub = sinon
       .stub(AwsBeanstalkDetector, 'fileAccessAsync' as any)
       .rejects(err);
-    readStub = sandbox
+    readStub = sinon
       .stub(AwsBeanstalkDetector, 'readFileAsync' as any)
       .resolves(JSON.stringify(data));
 
     const resource = await awsBeanstalkDetector.detect();
 
-    sandbox.assert.calledOnce(fileStub);
-    sandbox.assert.notCalled(readStub);
+    sinon.assert.calledOnce(fileStub);
+    sinon.assert.notCalled(readStub);
     assert.ok(resource);
     assertEmptyResource(resource);
   });

--- a/packages/opentelemetry-resource-detector-aws/test/detectors/AwsEcsDetector.test.ts
+++ b/packages/opentelemetry-resource-detector-aws/test/detectors/AwsEcsDetector.test.ts
@@ -40,28 +40,26 @@ describe('BeanstalkResourceDetector', () => {
   const hostNameData = 'abcd.test.testing.com';
 
   let readStub;
-  let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
     process.env.ECS_CONTAINER_METADATA_URI_V4 = '';
     process.env.ECS_CONTAINER_METADATA_URI = '';
   });
 
   afterEach(() => {
-    sandbox.restore();
+    sinon.restore();
   });
 
   it('should successfully return resource data', async () => {
     process.env.ECS_CONTAINER_METADATA_URI_V4 = 'ecs_metadata_v4_uri';
-    sandbox.stub(os, 'hostname').returns(hostNameData);
-    readStub = sandbox
+    sinon.stub(os, 'hostname').returns(hostNameData);
+    readStub = sinon
       .stub(AwsEcsDetector, 'readFileAsync' as any)
       .resolves(correctCgroupData);
 
     const resource = await awsEcsDetector.detect();
 
-    sandbox.assert.calledOnce(readStub);
+    sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertContainerResource(resource, {
       name: 'abcd.test.testing.com',
@@ -71,14 +69,14 @@ describe('BeanstalkResourceDetector', () => {
 
   it('should successfully return resource data with noisy cgroup file', async () => {
     process.env.ECS_CONTAINER_METADATA_URI = 'ecs_metadata_v3_uri';
-    sandbox.stub(os, 'hostname').returns(hostNameData);
-    readStub = sandbox
+    sinon.stub(os, 'hostname').returns(hostNameData);
+    readStub = sinon
       .stub(AwsEcsDetector, 'readFileAsync' as any)
       .resolves(noisyCgroupData);
 
     const resource = await awsEcsDetector.detect();
 
-    sandbox.assert.calledOnce(readStub);
+    sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertContainerResource(resource, {
       name: 'abcd.test.testing.com',
@@ -88,14 +86,14 @@ describe('BeanstalkResourceDetector', () => {
 
   it('should always return first valid line of data', async () => {
     process.env.ECS_CONTAINER_METADATA_URI = 'ecs_metadata_v3_uri';
-    sandbox.stub(os, 'hostname').returns(hostNameData);
-    readStub = sandbox
+    sinon.stub(os, 'hostname').returns(hostNameData);
+    readStub = sinon
       .stub(AwsEcsDetector, 'readFileAsync' as any)
       .resolves(multiValidCgroupData);
 
     const resource = await awsEcsDetector.detect();
 
-    sandbox.assert.calledOnce(readStub);
+    sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertContainerResource(resource, {
       name: 'abcd.test.testing.com',
@@ -104,28 +102,28 @@ describe('BeanstalkResourceDetector', () => {
   });
 
   it('should empty resource without accessing files', async () => {
-    sandbox.stub(os, 'hostname').returns(hostNameData);
-    readStub = sandbox
+    sinon.stub(os, 'hostname').returns(hostNameData);
+    readStub = sinon
       .stub(AwsEcsDetector, 'readFileAsync' as any)
       .resolves(correctCgroupData);
 
     const resource = await awsEcsDetector.detect();
 
-    sandbox.assert.notCalled(readStub);
+    sinon.assert.notCalled(readStub);
     assert.ok(resource);
     assertEmptyResource(resource);
   });
 
   it('should return resource only with hostname attribute without cgroup file', async () => {
     process.env.ECS_CONTAINER_METADATA_URI_V4 = 'ecs_metadata_v4_uri';
-    sandbox.stub(os, 'hostname').returns(hostNameData);
-    readStub = sandbox
+    sinon.stub(os, 'hostname').returns(hostNameData);
+    readStub = sinon
       .stub(AwsEcsDetector, 'readFileAsync' as any)
       .rejects(errorMsg.fileNotFoundError);
 
     const resource = await awsEcsDetector.detect();
 
-    sandbox.assert.calledOnce(readStub);
+    sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertContainerResource(resource, {
       name: 'abcd.test.testing.com',
@@ -134,14 +132,12 @@ describe('BeanstalkResourceDetector', () => {
 
   it('should return resource only with hostname attribute when cgroup file does not contain valid container ID', async () => {
     process.env.ECS_CONTAINER_METADATA_URI_V4 = 'ecs_metadata_v4_uri';
-    sandbox.stub(os, 'hostname').returns(hostNameData);
-    readStub = sandbox
-      .stub(AwsEcsDetector, 'readFileAsync' as any)
-      .resolves('');
+    sinon.stub(os, 'hostname').returns(hostNameData);
+    readStub = sinon.stub(AwsEcsDetector, 'readFileAsync' as any).resolves('');
 
     const resource = await awsEcsDetector.detect();
 
-    sandbox.assert.calledOnce(readStub);
+    sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertContainerResource(resource, {
       name: 'abcd.test.testing.com',
@@ -150,14 +146,14 @@ describe('BeanstalkResourceDetector', () => {
 
   it('should return resource only with container ID attribute without hostname', async () => {
     process.env.ECS_CONTAINER_METADATA_URI_V4 = 'ecs_metadata_v4_uri';
-    sandbox.stub(os, 'hostname').returns('');
-    readStub = sandbox
+    sinon.stub(os, 'hostname').returns('');
+    readStub = sinon
       .stub(AwsEcsDetector, 'readFileAsync' as any)
       .resolves(correctCgroupData);
 
     const resource = await awsEcsDetector.detect();
 
-    sandbox.assert.calledOnce(readStub);
+    sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertContainerResource(resource, {
       id: 'bcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklm',
@@ -166,14 +162,14 @@ describe('BeanstalkResourceDetector', () => {
 
   it('should return empty resource when both hostname and container ID are invalid', async () => {
     process.env.ECS_CONTAINER_METADATA_URI_V4 = 'ecs_metadata_v4_uri';
-    sandbox.stub(os, 'hostname').returns('');
-    readStub = sandbox
+    sinon.stub(os, 'hostname').returns('');
+    readStub = sinon
       .stub(AwsEcsDetector, 'readFileAsync' as any)
       .rejects(errorMsg.fileNotFoundError);
 
     const resource = await awsEcsDetector.detect();
 
-    sandbox.assert.calledOnce(readStub);
+    sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertEmptyResource(resource);
   });

--- a/packages/opentelemetry-resource-detector-aws/test/detectors/AwsEksDetector.test.ts
+++ b/packages/opentelemetry-resource-detector-aws/test/detectors/AwsEksDetector.test.ts
@@ -39,29 +39,27 @@ describe('awsEksDetector', () => {
   const mockedClusterResponse = '{"data":{"cluster.name":"my-cluster"}}';
   const mockedAwsAuth = 'my-auth';
   const k8s_token = 'Bearer 31ada4fd-adec-460c-809a-9e56ceb75269';
-  let sandbox: sinon.SinonSandbox;
   let readStub, fileStub, getCredStub;
 
   beforeEach(() => {
-    sandbox = sinon.createSandbox();
     nock.disableNetConnect();
     nock.cleanAll();
   });
 
   afterEach(() => {
-    sandbox.restore();
+    sinon.restore();
     nock.enableNetConnect();
   });
 
   describe('on successful request', () => {
     it('should return an aws_eks_instance_resource', async () => {
-      fileStub = sandbox
+      fileStub = sinon
         .stub(AwsEksDetector, 'fileAccessAsync' as any)
         .resolves();
-      readStub = sandbox
+      readStub = sinon
         .stub(AwsEksDetector, 'readFileAsync' as any)
         .resolves(correctCgroupData);
-      getCredStub = sandbox
+      getCredStub = sinon
         .stub(awsEksDetector, '_getK8sCredHeader' as any)
         .resolves(k8s_token);
       const scope = nock('https://' + K8S_SVC_URL)
@@ -77,9 +75,9 @@ describe('awsEksDetector', () => {
 
       scope.done();
 
-      sandbox.assert.calledOnce(fileStub);
-      sandbox.assert.calledTwice(readStub);
-      sandbox.assert.calledTwice(getCredStub);
+      sinon.assert.calledOnce(fileStub);
+      sinon.assert.calledTwice(readStub);
+      sinon.assert.calledTwice(getCredStub);
 
       assert.ok(resource);
       assertK8sResource(resource, {
@@ -91,14 +89,14 @@ describe('awsEksDetector', () => {
     });
 
     it('should return a resource with clusterName attribute without cgroup file', async () => {
-      fileStub = sandbox
+      fileStub = sinon
         .stub(AwsEksDetector, 'fileAccessAsync' as any)
         .resolves();
-      readStub = sandbox
+      readStub = sinon
         .stub(AwsEksDetector, 'readFileAsync' as any)
         .onSecondCall()
         .rejects(errorMsg.fileNotFoundError);
-      getCredStub = sandbox
+      getCredStub = sinon
         .stub(awsEksDetector, '_getK8sCredHeader' as any)
         .resolves(k8s_token);
       const scope = nock('https://' + K8S_SVC_URL)
@@ -121,13 +119,13 @@ describe('awsEksDetector', () => {
     });
 
     it('should return a resource with container ID attribute without a clusterName', async () => {
-      fileStub = sandbox
+      fileStub = sinon
         .stub(AwsEksDetector, 'fileAccessAsync' as any)
         .resolves();
-      readStub = sandbox
+      readStub = sinon
         .stub(AwsEksDetector, 'readFileAsync' as any)
         .resolves(correctCgroupData);
-      getCredStub = sandbox
+      getCredStub = sinon
         .stub(awsEksDetector, '_getK8sCredHeader' as any)
         .resolves(k8s_token);
       const scope = nock('https://' + K8S_SVC_URL)
@@ -150,14 +148,14 @@ describe('awsEksDetector', () => {
     });
 
     it('should return a resource with clusterName attribute when cgroup file does not contain valid Container ID', async () => {
-      fileStub = sandbox
+      fileStub = sinon
         .stub(AwsEksDetector, 'fileAccessAsync' as any)
         .resolves();
-      readStub = sandbox
+      readStub = sinon
         .stub(AwsEksDetector, 'readFileAsync' as any)
         .onSecondCall()
         .resolves('');
-      getCredStub = sandbox
+      getCredStub = sinon
         .stub(awsEksDetector, '_getK8sCredHeader' as any)
         .resolves(k8s_token);
       const scope = nock('https://' + K8S_SVC_URL)
@@ -181,13 +179,13 @@ describe('awsEksDetector', () => {
     });
 
     it('should return an empty resource when not running on Eks', async () => {
-      fileStub = sandbox
+      fileStub = sinon
         .stub(AwsEksDetector, 'fileAccessAsync' as any)
         .resolves('');
-      readStub = sandbox
+      readStub = sinon
         .stub(AwsEksDetector, 'readFileAsync' as any)
         .resolves(correctCgroupData);
-      getCredStub = sandbox
+      getCredStub = sinon
         .stub(awsEksDetector, '_getK8sCredHeader' as any)
         .resolves(k8s_token);
       const scope = nock('https://' + K8S_SVC_URL)
@@ -208,7 +206,7 @@ describe('awsEksDetector', () => {
       const errorMsg = {
         fileNotFoundError: new Error('cannot file k8s token file'),
       };
-      fileStub = sandbox
+      fileStub = sinon
         .stub(AwsEksDetector, 'fileAccessAsync' as any)
         .rejects(errorMsg.fileNotFoundError);
 
@@ -219,15 +217,15 @@ describe('awsEksDetector', () => {
     });
 
     it('should return an empty resource when containerId and clusterName are invalid', async () => {
-      fileStub = sandbox
+      fileStub = sinon
         .stub(AwsEksDetector, 'fileAccessAsync' as any)
         .resolves('');
-      readStub = sandbox
+      readStub = sinon
         .stub(AwsEksDetector, 'readFileAsync' as any)
         .onSecondCall()
         .rejects(errorMsg.fileNotFoundError);
 
-      getCredStub = sandbox
+      getCredStub = sinon
         .stub(awsEksDetector, '_getK8sCredHeader' as any)
         .resolves(k8s_token);
       const scope = nock('https://' + K8S_SVC_URL)
@@ -251,13 +249,13 @@ describe('awsEksDetector', () => {
   describe('on unsuccesful request', () => {
     it('should throw when receiving error response code', async () => {
       const expectedError = new Error('EKS metadata api request timed out.');
-      fileStub = sandbox
+      fileStub = sinon
         .stub(AwsEksDetector, 'fileAccessAsync' as any)
         .resolves();
-      readStub = sandbox
+      readStub = sinon
         .stub(AwsEksDetector, 'readFileAsync' as any)
         .resolves(correctCgroupData);
-      getCredStub = sandbox
+      getCredStub = sinon
         .stub(awsEksDetector, '_getK8sCredHeader' as any)
         .resolves(k8s_token);
       const scope = nock('https://' + K8S_SVC_URL)
@@ -278,13 +276,13 @@ describe('awsEksDetector', () => {
 
     it('should return an empty resource when timed out', async () => {
       const expectedError = new Error('Failed to load page, status code: 404');
-      fileStub = sandbox
+      fileStub = sinon
         .stub(AwsEksDetector, 'fileAccessAsync' as any)
         .resolves();
-      readStub = sandbox
+      readStub = sinon
         .stub(AwsEksDetector, 'readFileAsync' as any)
         .resolves(correctCgroupData);
-      getCredStub = sandbox
+      getCredStub = sinon
         .stub(awsEksDetector, '_getK8sCredHeader' as any)
         .resolves(k8s_token);
       const scope = nock('https://' + K8S_SVC_URL)

--- a/packages/opentelemetry-resource-detector-gcp/package.json
+++ b/packages/opentelemetry-resource-detector-gcp/package.json
@@ -54,7 +54,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/resources": "^0.17.0",
     "gcp-metadata": "^4.1.4",
     "semver": "7.3.4"

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -58,7 +58,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0"
   }
 }

--- a/packages/opentelemetry-resources/test/detectors/ProcessDetector.test.ts
+++ b/packages/opentelemetry-resources/test/detectors/ProcessDetector.test.ts
@@ -21,20 +21,14 @@ import {
 } from '../util/resource-assertions';
 
 describe('processDetector()', () => {
-  let sandbox: sinon.SinonSandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
   afterEach(() => {
-    sandbox.restore();
+    sinon.restore();
   });
 
   it('should return resource information from process', async () => {
-    sandbox.stub(process, 'pid').value(1234);
-    sandbox.stub(process, 'title').value('otProcess');
-    sandbox
+    sinon.stub(process, 'pid').value(1234);
+    sinon.stub(process, 'title').value('otProcess');
+    sinon
       .stub(process, 'argv')
       .value(['/tmp/node', '/home/ot/test.js', 'arg1', 'arg2']);
 
@@ -47,9 +41,9 @@ describe('processDetector()', () => {
     });
   });
   it('should return empty resources if title, command and commondLine is missing', async () => {
-    sandbox.stub(process, 'pid').value(1234);
-    sandbox.stub(process, 'title').value(undefined);
-    sandbox.stub(process, 'argv').value([]);
+    sinon.stub(process, 'pid').value(1234);
+    sinon.stub(process, 'title').value(undefined);
+    sinon.stub(process, 'argv').value([]);
     const resource: Resource = await processDetector.detect();
     assertEmptyResource(resource);
   });

--- a/packages/opentelemetry-sdk-node/package.json
+++ b/packages/opentelemetry-sdk-node/package.json
@@ -40,9 +40,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/api-metrics": "^0.17.0",
-    "@opentelemetry/context-base": "^0.17.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/instrumentation": "^0.17.0",
     "@opentelemetry/metrics": "^0.17.0",

--- a/packages/opentelemetry-sdk-node/src/index.ts
+++ b/packages/opentelemetry-sdk-node/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 export * as api from '@opentelemetry/api';
-export * as contextBase from '@opentelemetry/context-base';
+export * as contextBase from '@opentelemetry/api';
 export * as core from '@opentelemetry/core';
 export * as metrics from '@opentelemetry/metrics';
 export * as node from '@opentelemetry/node';

--- a/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -16,7 +16,7 @@
 
 import { TextMapPropagator } from '@opentelemetry/api';
 import { metrics } from '@opentelemetry/api-metrics';
-import { ContextManager } from '@opentelemetry/context-base';
+import { ContextManager } from '@opentelemetry/api';
 import { MeterConfig, MeterProvider } from '@opentelemetry/metrics';
 import {
   InstrumentationOption,

--- a/packages/opentelemetry-sdk-node/src/types.ts
+++ b/packages/opentelemetry-sdk-node/src/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { SpanAttributes, TextMapPropagator, Sampler } from '@opentelemetry/api';
-import type { ContextManager } from '@opentelemetry/context-base';
+import type { ContextManager } from '@opentelemetry/api';
 import { InstrumentationOption } from '@opentelemetry/instrumentation';
 import { MetricExporter, Processor } from '@opentelemetry/metrics';
 import { Resource } from '@opentelemetry/resources';

--- a/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -29,7 +29,7 @@ import {
   AsyncHooksContextManager,
   AsyncLocalStorageContextManager,
 } from '@opentelemetry/context-async-hooks';
-import { NoopContextManager } from '@opentelemetry/context-base';
+import { NoopContextManager } from '@opentelemetry/api';
 import { CompositePropagator } from '@opentelemetry/core';
 import { ConsoleMetricExporter, MeterProvider } from '@opentelemetry/metrics';
 import { NodeTracerProvider } from '@opentelemetry/node';
@@ -41,7 +41,7 @@ import {
   assertCloudResource,
   assertHostResource,
   assertServiceResource,
-} from '@opentelemetry/resources/test/util/resource-assertions';
+} from '@opentelemetry/resources/build/test/util/resource-assertions';
 import {
   ConsoleSpanExporter,
   SimpleSpanProcessor,
@@ -354,11 +354,6 @@ describe('Node SDK', () => {
         });
       };
 
-      beforeEach(() => {
-        diag.setLogLevel(DiagLogLevel.VERBOSE);
-        diag.setLogger();
-      });
-
       it('prints detected resources and debug messages to the logger', async () => {
         const sdk = new NodeSDK({
           autoDetectResources: true,
@@ -367,10 +362,13 @@ describe('Node SDK', () => {
         // This test depends on the env detector to be functioning as intended
         const mockedLoggerMethod = Sinon.fake();
         const mockedVerboseLoggerMethod = Sinon.fake();
-        diag.setLogger({
-          debug: mockedLoggerMethod,
-          verbose: mockedVerboseLoggerMethod,
-        } as any);
+        diag.setLogger(
+          {
+            debug: mockedLoggerMethod,
+            verbose: mockedVerboseLoggerMethod,
+          } as any,
+          DiagLogLevel.VERBOSE
+        );
 
         await sdk.detectResources();
 
@@ -403,8 +401,6 @@ describe('Node SDK', () => {
       describe('with missing environment variable', () => {
         beforeEach(() => {
           delete process.env.OTEL_RESOURCE_ATTRIBUTES;
-          diag.setLogLevel(DiagLogLevel.DEBUG);
-          diag.setLogger();
         });
 
         it('prints correct error messages when EnvDetector has no env variable', async () => {
@@ -412,9 +408,12 @@ describe('Node SDK', () => {
             autoDetectResources: true,
           });
           const mockedLoggerMethod = Sinon.fake();
-          diag.setLogger({
-            debug: mockedLoggerMethod,
-          } as any);
+          diag.setLogger(
+            {
+              debug: mockedLoggerMethod,
+            } as any,
+            DiagLogLevel.DEBUG
+          );
 
           await sdk.detectResources();
 
@@ -430,8 +429,6 @@ describe('Node SDK', () => {
       describe('with a faulty environment variable', () => {
         beforeEach(() => {
           process.env.OTEL_RESOURCE_ATTRIBUTES = 'bad=~attribute';
-          diag.setLogLevel(DiagLogLevel.DEBUG);
-          diag.setLogger();
         });
 
         it('prints correct error messages when EnvDetector has an invalid variable', async () => {
@@ -439,9 +436,12 @@ describe('Node SDK', () => {
             autoDetectResources: true,
           });
           const mockedLoggerMethod = Sinon.fake();
-          diag.setLogger({
-            debug: mockedLoggerMethod,
-          } as any);
+          diag.setLogger(
+            {
+              debug: mockedLoggerMethod,
+            } as any,
+            DiagLogLevel.DEBUG
+          );
 
           await sdk.detectResources();
 

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -53,7 +53,7 @@
     "typescript": "4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "opentracing": "^0.14.4"
   }

--- a/packages/opentelemetry-tracing/package.json
+++ b/packages/opentelemetry-tracing/package.json
@@ -73,8 +73,7 @@
     "webpack": "4.46.0"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
-    "@opentelemetry/context-base": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/resources": "^0.17.0",
     "@opentelemetry/semantic-conventions": "^0.17.0",

--- a/packages/opentelemetry-tracing/src/types.ts
+++ b/packages/opentelemetry-tracing/src/types.ts
@@ -17,7 +17,7 @@
 import { TextMapPropagator, Sampler } from '@opentelemetry/api';
 import { IdGenerator } from '@opentelemetry/core';
 
-import { ContextManager } from '@opentelemetry/context-base';
+import { ContextManager } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
 
 /**

--- a/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-tracing/test/BasicTracerProvider.test.ts
@@ -34,16 +34,14 @@ import * as sinon from 'sinon';
 import { BasicTracerProvider, Span } from '../src';
 
 describe('BasicTracerProvider', () => {
-  let sandbox: sinon.SinonSandbox;
   let removeEvent: Function | undefined;
 
   beforeEach(() => {
     context.disable();
-    sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {
-    sandbox.restore();
+    sinon.restore();
     if (removeEvent) {
       removeEvent();
       removeEvent = undefined;
@@ -315,7 +313,7 @@ describe('BasicTracerProvider', () => {
   describe('.shutdown()', () => {
     it('should trigger shutdown when manually invoked', () => {
       const tracerProvider = new BasicTracerProvider();
-      const shutdownStub = sandbox.stub(
+      const shutdownStub = sinon.stub(
         tracerProvider.getActiveSpanProcessor(),
         'shutdown'
       );

--- a/packages/opentelemetry-tracing/test/export/TestStackContextManager.ts
+++ b/packages/opentelemetry-tracing/test/export/TestStackContextManager.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  ContextManager,
-  Context,
-  ROOT_CONTEXT,
-} from '@opentelemetry/context-base';
+import { ContextManager, Context, ROOT_CONTEXT } from '@opentelemetry/api';
 
 /**
  * A test-only ContextManager that uses an in-memory stack to keep track of

--- a/packages/opentelemetry-web/package.json
+++ b/packages/opentelemetry-web/package.json
@@ -74,8 +74,7 @@
     "webpack-merge": "5.7.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.17.0",
-    "@opentelemetry/context-base": "^0.17.0",
+    "@opentelemetry/api": "^0.18.0",
     "@opentelemetry/core": "^0.17.0",
     "@opentelemetry/semantic-conventions": "^0.17.0",
     "@opentelemetry/tracing": "^0.17.0"

--- a/packages/opentelemetry-web/src/StackContextManager.ts
+++ b/packages/opentelemetry-web/src/StackContextManager.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Context } from '@opentelemetry/api';
-import { ContextManager, ROOT_CONTEXT } from '@opentelemetry/context-base';
+import { Context, ContextManager, ROOT_CONTEXT } from '@opentelemetry/api';
 
 /**
  * Stack Context Manager for managing the state in web

--- a/packages/opentelemetry-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-web/test/WebTracerProvider.test.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { context, getSpan, setSpan } from '@opentelemetry/api';
-import { ContextManager } from '@opentelemetry/context-base';
+import { context, getSpan, setSpan, ContextManager } from '@opentelemetry/api';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { Resource, TELEMETRY_SDK_RESOURCE } from '@opentelemetry/resources';

--- a/packages/opentelemetry-web/test/registration.test.ts
+++ b/packages/opentelemetry-web/test/registration.test.ts
@@ -16,12 +16,12 @@
 
 import {
   context,
+  NoopContextManager,
   NoopTextMapPropagator,
   propagation,
   trace,
   ProxyTracerProvider,
 } from '@opentelemetry/api';
-import { NoopContextManager } from '@opentelemetry/context-base';
 import { CompositePropagator } from '@opentelemetry/core';
 import * as assert from 'assert';
 import { StackContextManager, WebTracerProvider } from '../src';

--- a/packages/opentelemetry-web/test/utils.test.ts
+++ b/packages/opentelemetry-web/test/utils.test.ts
@@ -124,14 +124,8 @@ function createResource(
 }
 
 describe('utils', () => {
-  let sandbox: sinon.SinonSandbox;
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox();
-  });
-
   afterEach(() => {
-    sandbox.restore();
+    sinon.restore();
   });
 
   describe('addSpanNetworkEvents', () => {
@@ -232,18 +226,12 @@ describe('utils', () => {
   });
   describe('getResource', () => {
     const startTime = [0, 123123123] as HrTime;
-    let spyHrTime: any;
     beforeEach(() => {
       const time = createHrTime(startTime, 500);
-      sandbox.stub(performance, 'timeOrigin').value(0);
-      sandbox
-        .stub(performance, 'now')
-        .callsFake(() => hrTimeToNanoseconds(time));
+      sinon.stub(performance, 'timeOrigin').value(0);
+      sinon.stub(performance, 'now').callsFake(() => hrTimeToNanoseconds(time));
 
-      spyHrTime = sinon.stub(core, 'hrTime').returns(time);
-    });
-    afterEach(() => {
-      spyHrTime.restore();
+      sinon.stub(core, 'hrTime').returns(time);
     });
 
     describe('when resources are empty', () => {


### PR DESCRIPTION
Update dependencies to @opentelemetry/api 0.18.0.

Removed dependencies to @opentelemetry/context-base because it has been included in api.
