### PR TITLE
fix(propagator-jaeger): zero pad extracted trace id to 32 characters

### DIFF
--- a/packages/opentelemetry-propagator-jaeger/src/JaegerHttpTracePropagator.ts
+++ b/packages/opentelemetry-propagator-jaeger/src/JaegerHttpTracePropagator.ts
@@ -95,8 +95,10 @@ function deserializeSpanContext(serializedString: string): SpanContext | null {
   if (headers.length !== 4) {
     return null;
   }
-  const [traceId, spanId, , flags] = headers;
 
+  const [_traceId, spanId, , flags] = headers;
+
+  const traceId = _traceId.padStart(32, '0');
   const traceFlags = flags.match(/^[0-9a-f]{2}$/i) ? parseInt(flags) & 1 : 1;
 
   return { traceId, spanId, isRemote: true, traceFlags };

--- a/packages/opentelemetry-propagator-jaeger/test/JaegerHttpTracePropagator.test.ts
+++ b/packages/opentelemetry-propagator-jaeger/test/JaegerHttpTracePropagator.test.ts
@@ -113,7 +113,7 @@ describe('JaegerHttpTracePropagator', () => {
 
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: '45fd2a9709dadcf1',
-        traceId: '9c41e35aeb6d1272',
+        traceId: '00000000000000009c41e35aeb6d1272',
         isRemote: true,
         traceFlags: TraceFlags.SAMPLED,
       });
@@ -132,7 +132,7 @@ describe('JaegerHttpTracePropagator', () => {
 
       assert.deepStrictEqual(extractedSpanContext, {
         spanId: '5ac292c4a11a163e',
-        traceId: 'ac1f3dc3c2c0b06e',
+        traceId: '0000000000000000ac1f3dc3c2c0b06e',
         isRemote: true,
         traceFlags: TraceFlags.SAMPLED,
       });


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #1983

## Short description of the changes
Ensures the Jaeger propagator context extraction conforms to the [Jaeger trace context specification](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format). Specifically, when received trace id shorter that 32 characters, it will now be zero-padded to 32 characters.