### PR TITLE
chore: exporting grpc instrumentation config

### DIFF
--- a/packages/opentelemetry-instrumentation-grpc/src/index.ts
+++ b/packages/opentelemetry-instrumentation-grpc/src/index.ts
@@ -15,3 +15,4 @@
  */
 
 export * from './instrumentation';
+export { GrpcInstrumentationConfig } from './types';


### PR DESCRIPTION
missing export for grpc instrumentation config