### PR TITLE
fix(http-instrumentation): crash fix

### DIFF
--- a/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -226,7 +226,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
         if (
           component === 'https' &&
           typeof options === 'object' &&
-          options?.constructor.name !== 'URL'
+          options?.constructor?.name !== 'URL'
         ) {
           options = Object.assign({}, options);
           instrumentation._setDefaultOptions(options);

--- a/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
@@ -527,15 +527,12 @@ describe('HttpsInstrumentation', () => {
         doNock(hostname, testPath, 200, 'Ok');
 
         const promiseRequest = new Promise((resolve, _reject) => {
-          const req = https.request(
-            options,
-            (resp: http.IncomingMessage) => {
-              resp.on('data', () => {});
-              resp.on('end', () => {
-                resolve({});
-              });
-            }
-          );
+          const req = https.request(options, (resp: http.IncomingMessage) => {
+            resp.on('data', () => {});
+            resp.on('end', () => {
+              resolve({});
+            });
+          });
           return req.end();
         });
 

--- a/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
@@ -515,6 +515,35 @@ describe('HttpsInstrumentation', () => {
         }
       });
 
+      it('should have 2 ended spans when provided "options" are an object without a constructor', async () => {
+        // Related issue: https://github.com/open-telemetry/opentelemetry-js/issues/2008
+        const testPath = '/outgoing/test';
+        const options = Object.create(null);
+        options.hostname = hostname;
+        options.port = serverPort;
+        options.path = pathname;
+        options.method = 'GET';
+
+        doNock(hostname, testPath, 200, 'Ok');
+
+        const promiseRequest = new Promise((resolve, _reject) => {
+          const req = https.request(
+            options,
+            (resp: http.IncomingMessage) => {
+              resp.on('data', () => {});
+              resp.on('end', () => {
+                resolve({});
+              });
+            }
+          );
+          return req.end();
+        });
+
+        await promiseRequest;
+        const spans = memoryExporter.getFinishedSpans();
+        assert.strictEqual(spans.length, 2);
+      });
+
       it('should have 1 ended span when response.end throw an exception', async () => {
         const testPath = '/outgoing/rootSpan/childs/1';
         doNock(hostname, testPath, 400, 'Not Ok');


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes https://github.com/open-telemetry/opentelemetry-js/issues/2008

## Short description of the changes

- Safely access `constructor.name`, in case object doesn't have a custructor.
