### PR TITLE
chore(eslint): no-console error rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ module.exports = {
           "leadingUnderscore": "require"
         }
     ],
+    "no-console": "error",
     "no-shadow": "off",
     "@typescript-eslint/no-shadow": ["warn"],
     "@typescript-eslint/no-unused-vars": ["error", {"argsIgnorePattern": "^_", "args": "after-used"}],

--- a/packages/opentelemetry-tracing/src/export/ConsoleSpanExporter.ts
+++ b/packages/opentelemetry-tracing/src/export/ConsoleSpanExporter.ts
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+import {
+  diag,
+  SpanAttributes,
+  SpanKind,
+  SpanStatus,
+  TimedEvent,
+} from '@opentelemetry/api';
 import { SpanExporter } from './SpanExporter';
 import { ReadableSpan } from './ReadableSpan';
 import {
@@ -51,7 +58,7 @@ export class ConsoleSpanExporter implements SpanExporter {
    * converts span info into more readable format
    * @param span
    */
-  private _exportInfo(span: ReadableSpan) {
+  private _exportInfo(span: ReadableSpan): LoggedSpan {
     return {
       traceId: span.spanContext.traceId,
       parentId: span.parentSpanId,
@@ -76,10 +83,23 @@ export class ConsoleSpanExporter implements SpanExporter {
     done?: (result: ExportResult) => void
   ): void {
     for (const span of spans) {
-      console.log(this._exportInfo(span));
+      diag.info('span', this._exportInfo(span));
     }
     if (done) {
       return done({ code: ExportResultCode.SUCCESS });
     }
   }
+}
+
+export interface LoggedSpan {
+  traceId: string;
+  parentId: string | undefined;
+  name: string;
+  id: string;
+  kind: SpanKind;
+  timestamp: number;
+  duration: number;
+  attributes: SpanAttributes;
+  status: SpanStatus;
+  events: TimedEvent[];
 }

--- a/packages/opentelemetry-tracing/test/export/BatchSpanProcessor.test.ts
+++ b/packages/opentelemetry-tracing/test/export/BatchSpanProcessor.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { diag } from '@opentelemetry/api';
 import {
   AlwaysOnSampler,
   ExportResultCode,
@@ -237,7 +238,10 @@ describe('BatchSpanProcessor', () => {
             clock.tick(defaultBufferConfig.scheduledDelayMillis + 10);
             clock.restore();
 
-            console.log(exporter.getFinishedSpans().length);
+            diag.info(
+              'finished spans count',
+              exporter.getFinishedSpans().length
+            );
             assert.strictEqual(
               exporter.getFinishedSpans().length,
               totalSpans + 1


### PR DESCRIPTION
## Which problem is this PR solving?

Adds ESLint rule for avoiding any console log statements in the codebase
Fixes https://github.com/open-telemetry/opentelemetry-js/issues/2007 and https://github.com/open-telemetry/opentelemetry-js/issues/1861


