### PR TITLE
chore: make examples work on the repo-local versions of packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This is the JavaScript version of [OpenTelemetry](https://opentelemetry.io/), a 
 
 | API Version | Core version | Contrib Version         |
 | ----------- |--------------|-------------------------|
+| v1.0.0-rc.0 | ------       | ------                  |
 | 0.18.x      | 0.18.x       | 0.14.x                  |
 |             | 0.17.x       | ------                  |
 |             | 0.16.x       | ------                  |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ module.exports = {
           "leadingUnderscore": "require"
         }
     ],
+    "no-console": "error",
     "no-shadow": "off",
     "@typescript-eslint/no-shadow": ["warn"],
     "@typescript-eslint/no-unused-vars": ["error", {"argsIgnorePattern": "^_", "args": "after-used"}],

--- a/examples/grpc-js/package.json
+++ b/examples/grpc-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "grpc-js-example",
+  "name": "example-grpc-js",
   "private": true,
   "version": "0.18.0",
   "description": "Example of @grpc/grpc-js integration with OpenTelemetry",

--- a/examples/grpc/package.json
+++ b/examples/grpc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "grpc-example",
+  "name": "example-grpc",
   "private": true,
   "version": "0.18.0",
   "description": "Example of gRPC integration with OpenTelemetry",

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "http-example",
+  "name": "example-http",
   "private": true,
   "version": "0.18.0",
   "description": "Example of HTTP integration with OpenTelemetry",

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "https-example",
+  "name": "example-https",
   "private": true,
   "version": "0.18.0",
   "description": "Example of HTTPs integration with OpenTelemetry",

--- a/examples/opentracing-shim/package.json
+++ b/examples/opentracing-shim/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opentracing-shim",
+  "name": "example-opentracing-shim",
   "private": true,
   "version": "0.18.0",
   "description": "Example of using @opentelemetry/shim-opentracing in Node.js",

--- a/examples/prometheus/package.json
+++ b/examples/prometheus/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "prometheus-example",
+  "name": "example-prometheus",
+  "private": true,
   "version": "0.18.0",
   "description": "Example of using @opentelemetry/metrics and  @opentelemetry/exporter-prometheus",
   "main": "index.js",

--- a/examples/tracer-web/package.json
+++ b/examples/tracer-web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "web-tracer-example",
+  "name": "example-web-tracer",
   "private": true,
   "version": "0.18.0",
   "description": "Example of using @opentelemetry/web in browser",

--- a/lerna.json
+++ b/lerna.json
@@ -6,8 +6,16 @@
     "backwards-compatability/*",
     "metapackages/*",
     "packages/*",
+    "examples/*",
     "integration-tests/*"
   ],
+  "command": {
+    "publish": {
+      "ignoreChanges": [
+        "example-*"
+      ]
+    }
+  },
   "version": "0.18.0",
   "changelog": {
     "repo": "open-telemetry/opentelemetry-js",

--- a/packages/opentelemetry-metrics/src/export/ConsoleMetricExporter.ts
+++ b/packages/opentelemetry-metrics/src/export/ConsoleMetricExporter.ts
@@ -21,6 +21,8 @@ import { ExportResult, ExportResultCode } from '@opentelemetry/core';
  * This is implementation of {@link MetricExporter} that prints metrics data to
  * the console. This class can be used for diagnostic purposes.
  */
+
+/* eslint-disable no-console */
 export class ConsoleMetricExporter implements MetricExporter {
   export(
     metrics: MetricRecord[],

--- a/packages/opentelemetry-metrics/test/Meter.test.ts
+++ b/packages/opentelemetry-metrics/test/Meter.test.ts
@@ -804,7 +804,7 @@ describe('Meter', () => {
       let counter = 0;
 
       function getValue() {
-        console.log('getting value, counter:', counter);
+        diag.info('getting value, counter:', counter);
         if (++counter % 2 === 0) {
           return 3;
         }

--- a/packages/opentelemetry-metrics/test/export/ConsoleMetricExporter.test.ts
+++ b/packages/opentelemetry-metrics/test/export/ConsoleMetricExporter.test.ts
@@ -19,6 +19,7 @@ import * as sinon from 'sinon';
 import { ConsoleMetricExporter, MeterProvider, MetricKind } from '../../src';
 import { ValueType } from '@opentelemetry/api-metrics';
 
+/* eslint-disable no-console */
 describe('ConsoleMetricExporter', () => {
   let consoleExporter: ConsoleMetricExporter;
   let previousConsoleLog: any;

--- a/packages/opentelemetry-resource-detector-aws/README.md
+++ b/packages/opentelemetry-resource-detector-aws/README.md
@@ -17,7 +17,17 @@ npm install --save @opentelemetry/resource-detector-aws
 
 ## Usage
 
-> TODO
+```typescript
+import { detectResources } from '@opentelemetry/resources';
+import { awsBeanstalkDetector } from '@opentelemetry/resource-detector-aws'
+const resource = await detectResources({
+   detectors: [awsEc2Detector],
+})
+
+const tracerProvider = new NodeTracerProvider({ resource });
+```
+
+**Note**: Besides `awsEc2Detector` there are also the following detectors available: `awsBeanstalkDetector`, `awsEksDetector` and `awsEcsDetector`
 
 ## Useful links
 

--- a/packages/opentelemetry-semantic-conventions/src/trace/general.ts
+++ b/packages/opentelemetry-semantic-conventions/src/trace/general.ts
@@ -36,4 +36,6 @@ export const GeneralAttribute = {
   IP_TCP: 'IP.TCP',
   IP_UDP: 'IP.UDP',
   INPROC: 'inproc',
+  PIPE: 'pipe',
+  UNIX: 'Unix',
 };

--- a/packages/opentelemetry-tracing/src/export/ConsoleSpanExporter.ts
+++ b/packages/opentelemetry-tracing/src/export/ConsoleSpanExporter.ts
@@ -26,6 +26,8 @@ import {
  * This is implementation of {@link SpanExporter} that prints spans to the
  * console. This class can be used for diagnostic purposes.
  */
+
+/* eslint-disable no-console */
 export class ConsoleSpanExporter implements SpanExporter {
   /**
    * Export spans.

--- a/packages/opentelemetry-tracing/test/export/BatchSpanProcessor.test.ts
+++ b/packages/opentelemetry-tracing/test/export/BatchSpanProcessor.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { diag } from '@opentelemetry/api';
 import {
   AlwaysOnSampler,
   ExportResultCode,
@@ -237,7 +238,10 @@ describe('BatchSpanProcessor', () => {
             clock.tick(defaultBufferConfig.scheduledDelayMillis + 10);
             clock.restore();
 
-            console.log(exporter.getFinishedSpans().length);
+            diag.info(
+              'finished spans count',
+              exporter.getFinishedSpans().length
+            );
             assert.strictEqual(
               exporter.getFinishedSpans().length,
               totalSpans + 1

--- a/packages/opentelemetry-tracing/test/export/ConsoleSpanExporter.test.ts
+++ b/packages/opentelemetry-tracing/test/export/ConsoleSpanExporter.test.ts
@@ -22,6 +22,7 @@ import {
   SimpleSpanProcessor,
 } from '../../src';
 
+/* eslint-disable no-console */
 describe('ConsoleSpanExporter', () => {
   let consoleExporter: ConsoleSpanExporter;
   let previousConsoleLog: any;

--- a/packages/opentelemetry-web/src/WebTracerProvider.ts
+++ b/packages/opentelemetry-web/src/WebTracerProvider.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { diag } from '@opentelemetry/api';
 import {
   BasicTracerProvider,
   SDKRegistrationConfig,
@@ -41,7 +42,7 @@ export class WebTracerProvider extends BasicTracerProvider {
    */
   constructor(config: WebTracerConfig = {}) {
     if (typeof config.plugins !== 'undefined') {
-      console.warn(
+      diag.warn(
         'plugins option was removed, please use' +
           ' "registerInstrumentations" to load plugins'
       );

--- a/packages/opentelemetry-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-web/test/WebTracerProvider.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { diag } from '@opentelemetry/api';
 import { context, getSpan, setSpan, ContextManager } from '@opentelemetry/api';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { B3Propagator } from '@opentelemetry/propagator-b3';
@@ -49,7 +50,7 @@ describe('WebTracerProvider', () => {
 
     it('should show warning when plugins are defined', () => {
       const dummyPlugin1 = {};
-      const spyWarn = sinon.spy(window.console, 'warn');
+      const spyWarn = sinon.spy(diag, 'warn');
 
       const plugins = [dummyPlugin1];
 

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       "rangeStrategy": "bump"
     }
   ],
-  "ignoreDeps": ["gcp-metadata", "got", "mocha"],
+  "ignoreDeps": ["gcp-metadata", "got", "mocha", "husky"],
   "assignees": ["@dyladan", "@obecny", "@vmarchaud"],
   "schedule": ["before 3am on Friday"],
   "labels": ["dependencies"]


### PR DESCRIPTION
## Which problem is this PR solving?

My intention was to set up the examples so that those can be run with the unreleased versions of the packages local to the repo(using `lerna bootstrap`) and thus make it easier for anyone to hack on and contribute to the project.

I ran into an issue that probably comes from patching the module loading and detecting which instrumentations to load. There is no active context when I run `examples/http/server.js`, which makes me believe `@opentelemetry/plugin-http` was never loaded.

**Has anyone ever experienced similar symptoms / issues with plugin detection?** 

## Short description of the changes

- The package names in examples had to be unified so that the exclusions for publishing could be applied easier for examples, which we never want to publish as packages.

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->