### PR TITLE
feat: add NET_TRANSPORT IPC attributes

### DIFF
--- a/packages/opentelemetry-semantic-conventions/src/trace/general.ts
+++ b/packages/opentelemetry-semantic-conventions/src/trace/general.ts
@@ -36,4 +36,6 @@ export const GeneralAttribute = {
   IP_TCP: 'IP.TCP',
   IP_UDP: 'IP.UDP',
   INPROC: 'inproc',
+  PIPE: 'pipe',
+  UNIX: 'Unix',
 };


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Adds missing NET_TRANSPORT IPC semantic convention attributes. Came up as a comment on another PR: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/389#discussion_r596982199

## Short description of the changes

* Add `pipe` and `Unix` IPC attributes. (From https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-network-connection-attributes)
