### PR TITLE
fix: context activation for HTTP instrumentation's outgoing requests

### DIFF
--- a/packages/opentelemetry-instrumentation-http/src/patch.ts
+++ b/packages/opentelemetry-instrumentation-http/src/patch.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { context, Context } from '@opentelemetry/api';
+import { EventEmitter } from 'events';
+
+const LISTENER_SYMBOL = Symbol('OtHttpInstrumentationListeners');
+
+const ADD_LISTENER_METHODS = [
+  'addListener' as const,
+  'on' as const,
+  'once' as const,
+  'prependListener' as const,
+  'prependOnceListener' as const,
+];
+
+interface ListenerMap {
+  [name: string]: WeakMap<Function, Function>;
+}
+
+function getListenerMap(emitter: EventEmitter): ListenerMap {
+  let map: ListenerMap = (emitter as never)[LISTENER_SYMBOL];
+  if (map === undefined) {
+    map = {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (emitter as any)[LISTENER_SYMBOL] = map;
+  }
+  return map;
+}
+
+export function bindEmitter<E extends EventEmitter>(
+  emitter: E,
+  getContext: (event: string) => Context
+): E {
+  function getPatchedAddFunction(original: Function) {
+    return function (this: never, event: string, listener: Function) {
+      const listenerMap = getListenerMap(emitter);
+      let listeners = listenerMap[event];
+      if (listeners === undefined) {
+        listeners = new WeakMap();
+        listenerMap[event] = listeners;
+      }
+      const patchedListener = context.bind(listener, getContext(event));
+      listeners.set(listener, patchedListener);
+      return original.call(this, event, patchedListener);
+    };
+  }
+
+  function getPatchedRemoveListener(original: Function) {
+    return function (this: never, event: string, listener: Function) {
+      const listeners = getListenerMap(emitter)[event];
+      if (listeners === undefined) {
+        return original.call(this, event, listener);
+      }
+      return original.call(this, event, listeners.get(listener) || listener);
+    };
+  }
+
+  function getPatchedRemoveAllListeners(original: Function) {
+    return function (this: never, event: string) {
+      delete getListenerMap(emitter)[event];
+      return original.call(this, event);
+    };
+  }
+
+  for (const method of ADD_LISTENER_METHODS) {
+    if (emitter[method] !== undefined) {
+      emitter[method] = getPatchedAddFunction(emitter[method]);
+    }
+  }
+
+  if (typeof emitter.removeListener === 'function') {
+    emitter.removeListener = getPatchedRemoveListener(emitter.removeListener);
+  }
+
+  if (typeof emitter.off === 'function') {
+    emitter.off = getPatchedRemoveListener(emitter.off);
+  }
+
+  if (typeof emitter.removeAllListeners === 'function') {
+    emitter.removeAllListeners = getPatchedRemoveAllListeners(
+      emitter.removeAllListeners
+    );
+  }
+
+  return emitter;
+}

--- a/packages/opentelemetry-instrumentation-http/src/types.ts
+++ b/packages/opentelemetry-instrumentation-http/src/types.ts
@@ -44,7 +44,7 @@ export type ParsedRequestOptions =
   | http.RequestOptions;
 export type Http = typeof http;
 export type Https = typeof https;
-/* tslint:disable-next-line:no-any */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Func<T> = (...args: any[]) => T;
 export type ResponseEndArgs =
   | [((() => void) | undefined)?]

--- a/packages/opentelemetry-instrumentation-http/test/functionals/patch.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/patch.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as assert from 'assert';
+import { EventEmitter } from 'events';
+import { bindEmitter } from '../../src/patch';
+import {
+  context,
+  ContextManager,
+  getSpan,
+  getSpanContext,
+  ROOT_CONTEXT,
+  setSpan,
+} from '@opentelemetry/api';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { NodeTracerProvider } from '@opentelemetry/node';
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/tracing';
+
+const memoryExporter = new InMemorySpanExporter();
+const provider = new NodeTracerProvider();
+provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+
+const TEST_EVENT = 'custom';
+
+describe('EventEmitter binding', () => {
+  let emitter: EventEmitter;
+  let contextManager: ContextManager;
+
+  beforeEach(() => {
+    emitter = new EventEmitter();
+    contextManager = new AsyncHooksContextManager().enable();
+    context.setGlobalContextManager(contextManager);
+  });
+
+  it('binds correct context for registered listeners', () => {
+    const span = provider.getTracer('test').startSpan('myspan');
+    const boundContext = setSpan(ROOT_CONTEXT, span);
+
+    bindEmitter(emitter, ev => {
+      assert.strictEqual(ev, TEST_EVENT);
+      return boundContext;
+    });
+
+    const handledEvents = [];
+
+    const check = (event: string) => () => {
+      assert.deepStrictEqual(getSpanContext(context.active()), span.context());
+      handledEvents.push(event);
+    };
+
+    assert.notDeepStrictEqual(getSpanContext(context.active()), span.context());
+    emitter.on(TEST_EVENT, check('on'));
+    emitter.addListener(TEST_EVENT, check('addListener'));
+    emitter.once(TEST_EVENT, check('once'));
+    emitter.prependListener(TEST_EVENT, check('prependListener'));
+    emitter.prependOnceListener(TEST_EVENT, check('prependOnceListener'));
+
+    emitter.emit(TEST_EVENT);
+
+    assert.deepStrictEqual(handledEvents, [
+      'prependOnceListener',
+      'prependListener',
+      'on',
+      'addListener',
+      'once',
+    ]);
+  });
+
+  it('is possible to remove a listener', () => {
+    bindEmitter(emitter, () => context.active());
+
+    const listener = () => assert.fail('listener should not be called');
+
+    emitter.removeListener(TEST_EVENT, listener);
+    emitter.on(TEST_EVENT, listener);
+    emitter.removeListener(TEST_EVENT, listener);
+    emitter.emit(TEST_EVENT);
+  });
+
+  it('is possible to remove all listeners', () => {
+    bindEmitter(emitter, () => context.active());
+
+    const listener = () => assert.fail('listener should not be called');
+
+    emitter.on(TEST_EVENT, listener);
+    emitter.once(TEST_EVENT, listener);
+    emitter.addListener(TEST_EVENT, listener);
+    emitter.prependListener(TEST_EVENT, listener);
+    emitter.prependOnceListener(TEST_EVENT, listener);
+
+    emitter.removeAllListeners(TEST_EVENT);
+
+    emitter.emit(TEST_EVENT);
+  });
+});

--- a/packages/opentelemetry-instrumentation-http/test/functionals/patch.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/patch.test.ts
@@ -19,7 +19,6 @@ import { bindEmitter } from '../../src/patch';
 import {
   context,
   ContextManager,
-  getSpan,
   getSpanContext,
   ROOT_CONTEXT,
   setSpan,
@@ -56,7 +55,7 @@ describe('EventEmitter binding', () => {
       return boundContext;
     });
 
-    const handledEvents = [];
+    const handledEvents: string[] = [];
 
     const check = (event: string) => () => {
       assert.deepStrictEqual(getSpanContext(context.active()), span.context());

--- a/packages/opentelemetry-semantic-conventions/src/trace/general.ts
+++ b/packages/opentelemetry-semantic-conventions/src/trace/general.ts
@@ -36,4 +36,6 @@ export const GeneralAttribute = {
   IP_TCP: 'IP.TCP',
   IP_UDP: 'IP.UDP',
   INPROC: 'inproc',
+  PIPE: 'pipe',
+  UNIX: 'Unix',
 };


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

A while ago context activation was removed from outgoing HTTP requests due to wrong context being activated, here: https://github.com/open-telemetry/opentelemetry-js/pull/1546

However with [`net`](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-net) module instrumentation `connect` spans were attached to the parent span of the request, which is wrong. Besides the wrong context (parent) context was being activated in the response callbacks (`data` event) even if the response was not yet finished this made it impossible accessing the outgoing request span inside the response callbacks (e.g. when processing data chunks).

## Short description of the changes

### Before
```javascript
context.with(parent, () => {
  http.get(url, response => {
    /* active context: parent */
    response.on('data', () => { /* active context: parent */ });
    response.on('end', () => { /* active context: parent */ });
});
```

### After
```javascript
context.with(parent, () => {
  http.get(url, response => {
    /* active context: outgoing request */
    response.on('data', () => { /* active context: outgoing request */ });
    response.on('end', () => { /* active context: parent */ });
});
```

### Example: chaining outgoing requests for an incoming request

```javascript
app.get('/foo', (req, res) => {
  /* active context: incoming request */
  https.get('https://www.google.com', (response) => {
    /* active context: outgoing request to www.google.com */
    response.on('chunk', () => { /* active context: outgoing request to www.google.com */ });
    response.on('end', () => {
      /* active context: incoming request */
      http.get('http://www.example.com', (response2) => {
         /* active context: outgoing request to www.example.com */
        response2.on('chunk', () => { /* active context: outgoing request to www.example.com */ });
        response2.on('end', () => {
          /* active context: incoming request */
          res.send("ok\n");
        });
      });
    });
  });
});
```
Which will produce a trace similar to this (`net` instrumentation is enabled here, thus the `connect` spans):
![image](https://user-images.githubusercontent.com/5329631/112152370-e5445180-8bea-11eb-8ad7-a5d997fa6cfe.png)


### Remarks
- There's a custom event emitter binder pretty much the same as is in `@opentelemetry/context-async-hooks`, however I decided not to request a change to `ContextManager` interface of `@opentelemetry/api` to add a `bind` method which instead of taking in a context, takes in a function which returns a context and opted for some code duplication. This is useful for event emitters which might require different contexts being activated based on the events.