### PR TITLE
chore: adding info to debug whenever headers are being skipped due to cors policy

### DIFF
--- a/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -537,10 +537,19 @@ describe('fetch', () => {
     });
 
     describe('when propagateTraceHeaderCorsUrls does NOT MATCH', () => {
+      let spyDebug: sinon.SinonSpy;
       beforeEach(done => {
+        const diagLogger = new api.DiagConsoleLogger();
+        spyDebug = sinon.spy();
+        diagLogger.debug = spyDebug;
+        api.diag.setLogger(diagLogger, api.DiagLogLevel.ALL);
         clearData();
         prepareData(done, url, {});
       });
+      afterEach(() => {
+        sinon.restore();
+      });
+
       it('should NOT set trace headers', () => {
         assert.strictEqual(
           lastResponse.headers[X_B3_TRACE_ID],
@@ -556,6 +565,12 @@ describe('fetch', () => {
           lastResponse.headers[X_B3_SAMPLED],
           undefined,
           `trace header '${X_B3_SAMPLED}' should not be set`
+        );
+      });
+      it('should debug info that injecting headers was skipped', () => {
+        assert.strictEqual(
+          spyDebug.lastCall.args[0],
+          'headers inject skipped due to CORS policy'
         );
       });
     });

--- a/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -106,6 +106,11 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
         this._getConfig().propagateTraceHeaderCorsUrls
       )
     ) {
+      const headers: Partial<Record<string, unknown>> = {};
+      api.propagation.inject(api.context.active(), headers);
+      if (Object.keys(headers).length > 0) {
+        api.diag.debug('headers inject skipped due to CORS policy');
+      }
       return;
     }
     const headers: { [key: string]: unknown } = {};

--- a/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -549,7 +549,12 @@ describe('xhr', () => {
           'AND origin does NOT match window.location And does NOT match' +
             ' with propagateTraceHeaderCorsUrls',
           () => {
+            let spyDebug: sinon.SinonSpy;
             beforeEach(done => {
+              const diagLogger = new api.DiagConsoleLogger();
+              spyDebug = sinon.spy();
+              diagLogger.debug = spyDebug;
+              api.diag.setLogger(diagLogger, api.DiagLogLevel.ALL);
               clearData();
               prepareData(
                 done,
@@ -571,6 +576,13 @@ describe('xhr', () => {
                 requests[0].requestHeaders[X_B3_SAMPLED],
                 undefined,
                 `trace header '${X_B3_SAMPLED}' should not be set`
+              );
+            });
+
+            it('should debug info that injecting headers was skipped', () => {
+              assert.strictEqual(
+                spyDebug.lastCall.args[0],
+                'headers inject skipped due to CORS policy'
               );
             });
           }


### PR DESCRIPTION
## Which problem is this PR solving?

- fixes #2044

## Short description of the changes

- It will debug information whenever adding headers was prevented because origin didn't match the config property `propagateTraceHeaderCorsUrls` 
