### PR TITLE
chore: update API dependency to 1.0.0-rc.0

### DIFF
--- a/examples/basic-tracer-node/package.json
+++ b/examples/basic-tracer-node/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/exporter-jaeger": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2"
   },

--- a/examples/collector-exporter-node/package.json
+++ b/examples/collector-exporter-node/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/exporter-collector": "^0.18.2",
     "@opentelemetry/exporter-collector-grpc": "^0.18.2",

--- a/examples/grpc-js/package.json
+++ b/examples/grpc-js/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.0.5",
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/exporter-jaeger": "^0.18.2",
     "@opentelemetry/exporter-zipkin": "^0.18.2",
     "@opentelemetry/instrumentation": "^0.18.2",

--- a/examples/grpc/package.json
+++ b/examples/grpc/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/exporter-jaeger": "^0.18.2",
     "@opentelemetry/exporter-zipkin": "^0.18.2",
     "@opentelemetry/instrumentation": "^0.18.2",

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -28,7 +28,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/exporter-jaeger": "^0.18.2",
     "@opentelemetry/exporter-zipkin": "^0.18.2",
     "@opentelemetry/instrumentation": "^0.18.2",

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/exporter-jaeger": "^0.18.2",
     "@opentelemetry/exporter-zipkin": "^0.18.2",
     "@opentelemetry/instrumentation": "^0.18.2",

--- a/examples/tracer-web/package.json
+++ b/examples/tracer-web/package.json
@@ -34,7 +34,7 @@
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-zone": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/exporter-collector": "^0.18.2",

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -11,7 +11,7 @@
     "compile": "tsc --build"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-async-hooks": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2",

--- a/packages/opentelemetry-api-metrics/package.json
+++ b/packages/opentelemetry-api-metrics/package.json
@@ -48,7 +48,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1"
+    "@opentelemetry/api": "^1.0.0-rc.0"
   },
   "devDependencies": {
     "@types/mocha": "8.2.2",

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -53,6 +53,6 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1"
+    "@opentelemetry/api": "^1.0.0-rc.0"
   }
 }

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -70,7 +70,7 @@
     "zone.js": "0.11.4"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1"
+    "@opentelemetry/api": "^1.0.0-rc.0"
   },
   "peerDependencies": {
     "zone.js": "^0.10.2 || ^0.11.0"

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -76,7 +76,7 @@
     "webpack": "4.46.0"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "semver": "^7.1.3"
   }
 }

--- a/packages/opentelemetry-exporter-collector-grpc/package.json
+++ b/packages/opentelemetry-exporter-collector-grpc/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.5.4",
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/exporter-collector": "^0.18.2",
     "@opentelemetry/metrics": "^0.18.2",

--- a/packages/opentelemetry-exporter-collector-proto/package.json
+++ b/packages/opentelemetry-exporter-collector-proto/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.5.4",
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/exporter-collector": "^0.18.2",
     "@opentelemetry/metrics": "^0.18.2",

--- a/packages/opentelemetry-exporter-collector/package.json
+++ b/packages/opentelemetry-exporter-collector/package.json
@@ -77,7 +77,7 @@
     "webpack-merge": "5.7.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/metrics": "^0.18.2",

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2",
     "jaeger-client": "^3.15.0"

--- a/packages/opentelemetry-exporter-prometheus/package.json
+++ b/packages/opentelemetry-exporter-prometheus/package.json
@@ -53,7 +53,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/metrics": "^0.18.2"

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -75,7 +75,7 @@
     "webpack-merge": "5.7.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/resources": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2"

--- a/packages/opentelemetry-grpc-utils/package.json
+++ b/packages/opentelemetry-grpc-utils/package.json
@@ -64,7 +64,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",
     "shimmer": "1.2.1"

--- a/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/packages/opentelemetry-instrumentation-fetch/package.json
@@ -74,7 +74,7 @@
     "webpack-merge": "5.7.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/instrumentation": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",

--- a/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/packages/opentelemetry-instrumentation-grpc/package.json
@@ -66,7 +66,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "@opentelemetry/instrumentation": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2"

--- a/packages/opentelemetry-instrumentation-http/package.json
+++ b/packages/opentelemetry-instrumentation-http/package.json
@@ -69,7 +69,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/instrumentation": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",
     "semver": "^7.1.3"

--- a/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -73,7 +73,7 @@
     "webpack-merge": "5.7.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/instrumentation": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",

--- a/packages/opentelemetry-instrumentation/package.json
+++ b/packages/opentelemetry-instrumentation/package.json
@@ -54,7 +54,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "require-in-the-middle": "^5.0.3",
     "semver": "^7.3.2",

--- a/packages/opentelemetry-metrics/package.json
+++ b/packages/opentelemetry-metrics/package.json
@@ -55,7 +55,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/resources": "^0.18.2",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-async-hooks": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2",

--- a/packages/opentelemetry-plugin-grpc-js/package.json
+++ b/packages/opentelemetry-plugin-grpc-js/package.json
@@ -64,7 +64,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",
     "shimmer": "1.2.1"

--- a/packages/opentelemetry-plugin-grpc/package.json
+++ b/packages/opentelemetry-plugin-grpc/package.json
@@ -63,7 +63,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",
     "shimmer": "^1.2.1"

--- a/packages/opentelemetry-plugin-http/package.json
+++ b/packages/opentelemetry-plugin-http/package.json
@@ -69,7 +69,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",
     "semver": "^7.1.3",

--- a/packages/opentelemetry-plugin-https/package.json
+++ b/packages/opentelemetry-plugin-https/package.json
@@ -68,7 +68,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/plugin-http": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1"
+    "@opentelemetry/api": "^1.0.0-rc.0"
   },
   "devDependencies": {
     "@types/mocha": "8.2.2",

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -67,7 +67,7 @@
     "webpack": "4.46.0"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2"
   }
 }

--- a/packages/opentelemetry-resource-detector-aws/package.json
+++ b/packages/opentelemetry-resource-detector-aws/package.json
@@ -54,7 +54,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/resources": "^0.18.2"
   }

--- a/packages/opentelemetry-resource-detector-gcp/package.json
+++ b/packages/opentelemetry-resource-detector-gcp/package.json
@@ -54,7 +54,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/resources": "^0.18.2",
     "gcp-metadata": "^4.1.4",
     "semver": "7.3.5"

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -58,7 +58,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2"
   }
 }

--- a/packages/opentelemetry-sdk-node/package.json
+++ b/packages/opentelemetry-sdk-node/package.json
@@ -40,7 +40,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/instrumentation": "^0.18.2",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -53,7 +53,7 @@
     "typescript": "4.2.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "opentracing": "^0.14.4"
   }

--- a/packages/opentelemetry-tracing/package.json
+++ b/packages/opentelemetry-tracing/package.json
@@ -73,7 +73,7 @@
     "webpack": "4.46.0"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/resources": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",

--- a/packages/opentelemetry-web/package.json
+++ b/packages/opentelemetry-web/package.json
@@ -74,7 +74,7 @@
     "webpack-merge": "5.7.3"
   },
   "dependencies": {
-    "@opentelemetry/api": "^0.18.1",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2"


### PR DESCRIPTION
After downgrading to fix the backwards incompatibility with 0.18.1, this reverts the downgrade which may now be released as 0.19.0