### PR TITLE
feat: allow patching of absolute path requires

### DIFF
--- a/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -91,9 +91,9 @@ export abstract class InstrumentationBase<T = any>
 
     const version = require(path.join(baseDir, 'package.json')).version;
     module.moduleVersion = version;
-    if (module.name === name) {
+    if (!module.files || module.files.length === 0) {
       // main module
-      if (typeof version === 'string' && this._isSupported(name, version)) {
+      if (this._isSupported(module.name, version)) {
         if (typeof module.patch === 'function') {
           module.moduleExports = exports;
           if (this._enabled) {
@@ -103,7 +103,7 @@ export abstract class InstrumentationBase<T = any>
       }
     } else {
       // internal file
-      const files = module.files ?? [];
+      const files = module.files;
       const file = files.find(file => file.name === name);
       if (
         file &&


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- In https://github.com/open-telemetry/opentelemetry-js-contrib/pull/399 I am trying to patch a "user handler", in this case there is a private runtime, AWS Lambda, which loads a user function using an absolute path require statement. Currently, the patching infrastructure does not work with absolute path requires, only nodejs core modules or standard require statements served from node_modules

## Short description of the changes

- Because `_isSupported` checks whether the name matches, instead of checking it to determine whether the module is an internal file or not, check the files property instead
