### PR TITLE
feat(instrumentation-fetch): Add applyCustomAttributesOnSpan option

### DIFF
--- a/packages/opentelemetry-instrumentation-fetch/README.md
+++ b/packages/opentelemetry-instrumentation-fetch/README.md
@@ -61,6 +61,14 @@ fetch('http://localhost:8090/fetch.js');
 
 See [examples/tracer-web/fetch](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web) for a short example.
 
+### Fetch Instrumentation options
+
+Fetch instrumentation plugin has few options available to choose from. You can set the following:
+
+| Options                                                                                                                                           | Type                          | Description                           |
+| ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------------------------------------- |
+| [`applyCustomAttributesOnSpan`](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-instrumentation-fetch/src/fetch.ts#L47) | `HttpCustomAttributeFunction` | Function for adding custom attributes |
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -383,7 +383,13 @@ export class FetchInstrumentation extends InstrumentationBase<
     if (applyCustomAttributesOnSpan) {
       safeExecuteInTheMiddle(
         () => applyCustomAttributesOnSpan(span, request, result),
-        () => {},
+        error => {
+          if (!error) {
+            return;
+          }
+
+          api.diag.error('applyCustomAttributesOnSpan', error);
+        },
         true
       );
     }

--- a/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -378,10 +378,11 @@ export class FetchInstrumentation extends InstrumentationBase<
     request: Request | RequestInit,
     result: Response | FetchError
   ) {
-    if (this._getConfig().applyCustomAttributesOnSpan) {
+    const applyCustomAttributesOnSpan = this._getConfig()
+      .applyCustomAttributesOnSpan;
+    if (applyCustomAttributesOnSpan) {
       safeExecuteInTheMiddle(
-        () =>
-          this._getConfig().applyCustomAttributesOnSpan!(span, request, result),
+        () => applyCustomAttributesOnSpan(span, request, result),
         () => {},
         true
       );

--- a/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -203,7 +203,7 @@ export class FetchInstrumentation extends InstrumentationBase<
     }
     const method = (options.method || 'GET').toUpperCase();
     const spanName = `HTTP ${method}`;
-    const span = this.tracer.startSpan(spanName, {
+    return this.tracer.startSpan(spanName, {
       kind: api.SpanKind.CLIENT,
       attributes: {
         [AttributeNames.COMPONENT]: this.moduleName,
@@ -211,8 +211,6 @@ export class FetchInstrumentation extends InstrumentationBase<
         [SemanticAttributes.HTTP_URL]: url,
       },
     });
-
-    return span;
   }
 
   /**
@@ -325,7 +323,6 @@ export class FetchInstrumentation extends InstrumentationBase<
         ) {
           try {
             plugin._applyAttributesAfterFetch(span, options, response);
-
             if (response.status >= 200 && response.status < 400) {
               plugin._endSpan(span, spanData, response);
             } else {

--- a/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -57,6 +57,11 @@ const getData = (url: string, method?: string) =>
     },
   });
 
+const customAttributeFunction = (span: api.Span): void => {
+  span.setAttribute('span kind', api.SpanKind.CLIENT);
+  span.setAttribute('custom', 'custom-attribute-value');
+};
+
 const defaultResource = {
   connectEnd: 15,
   connectStart: 13,
@@ -285,7 +290,10 @@ describe('fetch', () => {
   describe('when request is successful', () => {
     beforeEach(done => {
       const propagateTraceHeaderCorsUrls = [url];
-      prepareData(done, url, { propagateTraceHeaderCorsUrls });
+      prepareData(done, url, {
+        propagateTraceHeaderCorsUrls,
+        applyCustomAttributesOnSpan: customAttributeFunction,
+      });
     });
 
     afterEach(() => {
@@ -367,6 +375,8 @@ describe('fetch', () => {
         (attributes[keys[8]] as number) > 0,
         `attributes ${SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH} is <= 0`
       );
+
+      assert.strictEqual(attributes['span kind'], api.SpanKind.CLIENT);
 
       assert.strictEqual(keys.length, 9, 'number of attributes is wrong');
     });

--- a/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -57,8 +57,10 @@ const getData = (url: string, method?: string) =>
     },
   });
 
+const CUSTOM_ATTRIBUTE_KEY = 'span kind';
+
 const customAttributeFunction = (span: api.Span): void => {
-  span.setAttribute('span kind', api.SpanKind.CLIENT);
+  span.setAttribute(CUSTOM_ATTRIBUTE_KEY, api.SpanKind.CLIENT);
 };
 
 const defaultResource = {
@@ -375,7 +377,19 @@ describe('fetch', () => {
         `attributes ${SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH} is <= 0`
       );
 
-      assert.strictEqual(attributes['span kind'], api.SpanKind.CLIENT);
+      delete attributes[HttpAttribute.HTTP_USER_AGENT];
+      delete attributes[HttpAttribute.HTTP_HOST];
+
+      assert.deepStrictEqual(attributes, {
+        [AttributeNames.COMPONENT]: 'fetch',
+        [HttpAttribute.HTTP_METHOD]: 'GET',
+        [HttpAttribute.HTTP_URL]: url,
+        [HttpAttribute.HTTP_STATUS_CODE]: 200,
+        [HttpAttribute.HTTP_STATUS_TEXT]: 'OK',
+        [HttpAttribute.HTTP_SCHEME]: 'http',
+        [HttpAttribute.HTTP_RESPONSE_CONTENT_LENGTH]: 30,
+        [CUSTOM_ATTRIBUTE_KEY]: api.SpanKind.CLIENT,
+      });
 
       assert.strictEqual(keys.length, 10, 'number of attributes is wrong');
     });
@@ -647,7 +661,7 @@ describe('fetch', () => {
       const attributes = span.attributes;
 
       assert.strictEqual(
-        attributes['span kind'],
+        attributes[CUSTOM_ATTRIBUTE_KEY],
         api.SpanKind.CLIENT,
         'Custom attribute was not applied'
       );


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

This PR adds an `applyCustomAttributesOnSpan`  function on the `instrumentation-fetch` package. similar to the API of [http(s) plugins](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-plugin-https/README.md#https-plugin-options).

Fixes #1287

Happy to make changes in tests or implementation if needed