### PR TITLE
chore: peer depend on API

### DIFF
--- a/.github/workflows/peer-api.yaml
+++ b/.github/workflows/peer-api.yaml
@@ -1,4 +1,4 @@
-name: Lint
+name: Ensure API Peer Dependency
 
 on:
   push:

--- a/.github/workflows/peer-api.yaml
+++ b/.github/workflows/peer-api.yaml
@@ -1,0 +1,22 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  peer-api-check:
+    runs-on: ubuntu-latest
+    container:
+      image: node:14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+      - name: Install lerna
+        run: npm install -g lerna
+
+      - name: Check API dependency semantics
+        run: lerna exec "node ../../scripts/peer-api-check.js"

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -11,7 +11,6 @@
     "compile": "tsc --build"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-async-hooks": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2",
@@ -20,6 +19,10 @@
     "express": "4.17.1"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "typescript": "4.2.3"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
   }
 }

--- a/packages/opentelemetry-api-metrics/package.json
+++ b/packages/opentelemetry-api-metrics/package.json
@@ -47,10 +47,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
     "@types/webpack-env": "1.16.0",

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -40,6 +40,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
     "@types/shimmer": "1.0.1",
@@ -52,7 +53,7 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0"
   }
 }

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.13.14",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
     "@types/sinon": "9.0.11",
@@ -69,10 +70,8 @@
     "webpack-cli": "4.6.0",
     "zone.js": "0.11.4"
   },
-  "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0"
-  },
   "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "zone.js": "^0.10.2 || ^0.11.0"
   },
   "sideEffects": false

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -50,6 +50,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/propagator-b3": "^0.18.2",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
@@ -75,8 +76,10 @@
     "typescript": "4.2.3",
     "webpack": "4.46.0"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "semver": "^7.1.3"
   }
 }

--- a/packages/opentelemetry-exporter-collector-grpc/package.json
+++ b/packages/opentelemetry-exporter-collector-grpc/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.13.14",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
@@ -62,9 +63,11 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
     "@grpc/proto-loader": "^0.5.4",
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/exporter-collector": "^0.18.2",
     "@opentelemetry/metrics": "^0.18.2",

--- a/packages/opentelemetry-exporter-collector-proto/package.json
+++ b/packages/opentelemetry-exporter-collector-proto/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.13.14",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
@@ -62,9 +63,11 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
     "@grpc/proto-loader": "^0.5.4",
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/exporter-collector": "^0.18.2",
     "@opentelemetry/metrics": "^0.18.2",

--- a/packages/opentelemetry-exporter-collector/package.json
+++ b/packages/opentelemetry-exporter-collector/package.json
@@ -48,6 +48,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@babel/core": "7.13.14",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
@@ -76,8 +77,10 @@
     "webpack-cli": "4.6.0",
     "webpack-merge": "5.7.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/metrics": "^0.18.2",

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -40,6 +40,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/resources": "^0.18.2",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
@@ -55,8 +56,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2",
     "jaeger-client": "^3.15.0"

--- a/packages/opentelemetry-exporter-prometheus/package.json
+++ b/packages/opentelemetry-exporter-prometheus/package.json
@@ -39,6 +39,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
     "@types/sinon": "9.0.11",
@@ -52,8 +53,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/metrics": "^0.18.2"

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.13.14",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
     "@types/sinon": "9.0.11",
@@ -74,8 +75,10 @@
     "webpack-cli": "4.6.0",
     "webpack-merge": "5.7.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/resources": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2"

--- a/packages/opentelemetry-grpc-utils/package.json
+++ b/packages/opentelemetry-grpc-utils/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@grpc/grpc-js": "1.2.12",
     "@grpc/proto-loader": "0.5.6",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-async-hooks": "^0.18.2",
     "@opentelemetry/node": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2",
@@ -63,8 +64,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",
     "shimmer": "1.2.1"

--- a/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/packages/opentelemetry-instrumentation-fetch/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.13.14",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-zone": "^0.18.2",
     "@opentelemetry/propagator-b3": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2",
@@ -73,8 +74,10 @@
     "webpack-cli": "4.6.0",
     "webpack-merge": "5.7.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/instrumentation": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",

--- a/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/packages/opentelemetry-instrumentation-grpc/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@grpc/grpc-js": "1.2.12",
     "@grpc/proto-loader": "0.5.6",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-async-hooks": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/node": "^0.18.2",
@@ -65,8 +66,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "@opentelemetry/instrumentation": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2"

--- a/packages/opentelemetry-instrumentation-http/package.json
+++ b/packages/opentelemetry-instrumentation-http/package.json
@@ -41,6 +41,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-async-hooks": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/node": "^0.18.2",
@@ -68,8 +69,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/instrumentation": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",
     "semver": "^7.1.3"

--- a/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.13.14",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-zone": "^0.18.2",
     "@opentelemetry/propagator-b3": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2",
@@ -72,8 +73,10 @@
     "webpack-cli": "4.6.0",
     "webpack-merge": "5.7.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/instrumentation": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",

--- a/packages/opentelemetry-instrumentation/package.json
+++ b/packages/opentelemetry-instrumentation/package.json
@@ -54,14 +54,17 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "require-in-the-middle": "^5.0.3",
     "semver": "^7.3.2",
     "shimmer": "^1.2.1"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "devDependencies": {
     "@babel/core": "7.13.14",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
     "@types/semver": "7.3.4",

--- a/packages/opentelemetry-metrics/package.json
+++ b/packages/opentelemetry-metrics/package.json
@@ -40,6 +40,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@types/lodash.merge": "4.6.6",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
@@ -54,8 +55,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/resources": "^0.18.2",

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -41,6 +41,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/resources": "^0.18.2",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
@@ -58,8 +59,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-async-hooks": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2",

--- a/packages/opentelemetry-plugin-grpc-js/package.json
+++ b/packages/opentelemetry-plugin-grpc-js/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@grpc/grpc-js": "1.2.12",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-async-hooks": "^0.18.2",
     "@opentelemetry/grpc-utils": "^0.18.2",
     "@opentelemetry/node": "^0.18.2",
@@ -63,8 +64,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",
     "shimmer": "1.2.1"

--- a/packages/opentelemetry-plugin-grpc/package.json
+++ b/packages/opentelemetry-plugin-grpc/package.json
@@ -40,6 +40,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-async-hooks": "^0.18.2",
     "@opentelemetry/grpc-utils": "^0.18.2",
     "@opentelemetry/node": "^0.18.2",
@@ -62,8 +63,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",
     "shimmer": "^1.2.1"

--- a/packages/opentelemetry-plugin-http/package.json
+++ b/packages/opentelemetry-plugin-http/package.json
@@ -41,6 +41,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-async-hooks": "^0.18.2",
     "@opentelemetry/node": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2",
@@ -68,8 +69,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",
     "semver": "^7.1.3",

--- a/packages/opentelemetry-plugin-https/package.json
+++ b/packages/opentelemetry-plugin-https/package.json
@@ -40,6 +40,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-async-hooks": "^0.18.2",
     "@opentelemetry/node": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2",
@@ -67,8 +68,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/plugin-http": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -38,10 +38,11 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
     "codecov": "3.8.1",

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -43,6 +43,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
     "@types/sinon": "9.0.11",
@@ -66,8 +67,10 @@
     "typescript": "4.2.3",
     "webpack": "4.46.0"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2"
   }
 }

--- a/packages/opentelemetry-resource-detector-aws/package.json
+++ b/packages/opentelemetry-resource-detector-aws/package.json
@@ -39,6 +39,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
     "@types/sinon": "9.0.11",
@@ -53,8 +54,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/resources": "^0.18.2"
   }

--- a/packages/opentelemetry-resource-detector-gcp/package.json
+++ b/packages/opentelemetry-resource-detector-gcp/package.json
@@ -39,6 +39,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
@@ -53,8 +54,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/resources": "^0.18.2",
     "gcp-metadata": "^4.1.4",
     "semver": "7.3.5"

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -43,6 +43,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
     "@types/sinon": "9.0.11",
@@ -57,8 +58,10 @@
     "ts-node": "9.1.1",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2"
   }
 }

--- a/packages/opentelemetry-sdk-node/package.json
+++ b/packages/opentelemetry-sdk-node/package.json
@@ -40,7 +40,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/api-metrics": "^0.18.2",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/instrumentation": "^0.18.2",
@@ -52,7 +51,11 @@
     "@opentelemetry/tracing": "^0.18.2",
     "nock": "12.0.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-async-hooks": "^0.18.2",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -38,6 +38,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/tracing": "^0.18.2",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
@@ -52,8 +53,10 @@
     "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "opentracing": "^0.14.4"
   }

--- a/packages/opentelemetry-tracing/package.json
+++ b/packages/opentelemetry-tracing/package.json
@@ -48,6 +48,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@types/lodash.merge": "4.6.6",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",
@@ -72,8 +73,10 @@
     "typescript": "4.2.3",
     "webpack": "4.46.0"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/resources": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",

--- a/packages/opentelemetry-web/package.json
+++ b/packages/opentelemetry-web/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.13.14",
+    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/context-zone": "^0.18.2",
     "@opentelemetry/propagator-b3": "^0.18.2",
     "@opentelemetry/resources": "^0.18.2",
@@ -73,8 +74,10 @@
     "webpack-cli": "4.6.0",
     "webpack-merge": "5.7.3"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0-rc.0"
+  },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.18.2",
     "@opentelemetry/semantic-conventions": "^0.18.2",
     "@opentelemetry/tracing": "^0.18.2"

--- a/scripts/peer-api-check.js
+++ b/scripts/peer-api-check.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const appRoot = process.cwd();
+
+const packageJsonUrl = path.resolve(`${appRoot}/package.json`);
+const pjson = require(packageJsonUrl);
+
+if (pjson.dependencies && pjson.dependencies["@opentelemetry/api"]) 
+    throw new Error(`Package ${pjson.name} depends on API but it should be a peer dependency`);
+
+const peerVersion = pjson.peerDependencies && pjson.peerDependencies["@opentelemetry/api"]
+const devVersion = pjson.devDependencies && pjson.devDependencies["@opentelemetry/api"]
+if (peerVersion) {
+    if (peerVersion !== devVersion) {
+        throw new Error(`Package ${pjson.name} depends on peer API version ${peerVersion} but version ${devVersion} in development`);
+    }
+    console.log(`${pjson.name} OK`);
+}


### PR DESCRIPTION
Depending on the API as a peer dependency in all sdk/instrumention packages leaves the end-user to install a compatible version of the API. In versions of NPM >= 7, this is done automatically. If the user has installed a set of packages which makes this impossible, they will be warned by NPM at install time.