### PR TITLE
chore: use span interface from API

### DIFF
--- a/packages/opentelemetry-tracing/src/MultiSpanProcessor.ts
+++ b/packages/opentelemetry-tracing/src/MultiSpanProcessor.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { Context } from '@opentelemetry/api';
+import { Context, Span } from '@opentelemetry/api';
 import { globalErrorHandler } from '@opentelemetry/core';
 import { ReadableSpan } from './export/ReadableSpan';
-import { Span } from './Span';
 import { SpanProcessor } from './SpanProcessor';
 
 /**

--- a/packages/opentelemetry-tracing/src/NoopSpanProcessor.ts
+++ b/packages/opentelemetry-tracing/src/NoopSpanProcessor.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { Context } from '@opentelemetry/api';
+import { Context, Span } from '@opentelemetry/api';
 import { ReadableSpan } from './export/ReadableSpan';
-import { Span } from './Span';
 import { SpanProcessor } from './SpanProcessor';
 
 /** No-op implementation of SpanProcessor */

--- a/packages/opentelemetry-tracing/src/SpanProcessor.ts
+++ b/packages/opentelemetry-tracing/src/SpanProcessor.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { Context } from '@opentelemetry/api';
+import { Context, Span } from '@opentelemetry/api';
 import { ReadableSpan } from './export/ReadableSpan';
-import { Span } from './Span';
 
 /**
  * SpanProcessor is the interface Tracer SDK uses to allow synchronous hooks

--- a/packages/opentelemetry-tracing/src/export/BatchSpanProcessor.ts
+++ b/packages/opentelemetry-tracing/src/export/BatchSpanProcessor.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import { context, suppressInstrumentation } from '@opentelemetry/api';
+import { context, Span, suppressInstrumentation } from '@opentelemetry/api';
 import {
   ExportResultCode,
   globalErrorHandler,
   unrefTimer,
   getEnv,
 } from '@opentelemetry/core';
-import { Span } from '../Span';
 import { SpanProcessor } from '../SpanProcessor';
 import { BufferConfig } from '../types';
 import { ReadableSpan } from './ReadableSpan';

--- a/packages/opentelemetry-tracing/src/export/SimpleSpanProcessor.ts
+++ b/packages/opentelemetry-tracing/src/export/SimpleSpanProcessor.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { context, suppressInstrumentation } from '@opentelemetry/api';
+import { context, suppressInstrumentation, Span } from '@opentelemetry/api';
 import { ExportResultCode, globalErrorHandler } from '@opentelemetry/core';
-import { Span } from '../Span';
 import { SpanExporter } from './SpanExporter';
 import { SpanProcessor } from '../SpanProcessor';
 import { ReadableSpan } from './ReadableSpan';


### PR DESCRIPTION
In #2065 an issue was raised that compilation can fail if multiple versions of `tracing` are installed because the `SpanProcessor` interface refers to the concrete `Span` class instead of the interface from the API.

Using the interface makes this module more backwards compatible.