### PR TITLE
fix: await http response in AWS EKS detector

### DIFF
--- a/packages/opentelemetry-resource-detector-aws/src/detectors/AwsEksDetector.ts
+++ b/packages/opentelemetry-resource-detector-aws/src/detectors/AwsEksDetector.ts
@@ -66,7 +66,7 @@ export class AwsEksDetector implements Detector {
       await AwsEksDetector.fileAccessAsync(this.K8S_TOKEN_PATH);
       const k8scert = await AwsEksDetector.readFileAsync(this.K8S_CERT_PATH);
 
-      if (!this._isEks(k8scert)) {
+      if (!(await this._isEks(k8scert))) {
         return Resource.empty();
       }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Initially, I was just trying to run the test suite, and happened to be using node 15. Uncovered a couple issues with the EKS detector/test
- Fixes #1776

## Short description of the changes

- test suite was failing on node 15 because it no longer allows unhandled promise rejections
  - this was due to not awaiting a promise response from `_isEks` in the detector, so the if block was never evaluating the result of the call
- "unsuccessful" test cases were noop (error assertions never executed), because `detect` wraps itself in a try/catch, and never throws
  - updated those test cases to document current behavior
  - fixed the flipped test names
