### PR TITLE
fix: exception.type should always be a string

### DIFF
--- a/packages/opentelemetry-tracing/src/Span.ts
+++ b/packages/opentelemetry-tracing/src/Span.ts
@@ -193,7 +193,7 @@ export class Span implements api.Span, ReadableSpan {
       attributes[ExceptionAttribute.MESSAGE] = exception;
     } else if (exception) {
       if (exception.code) {
-        attributes[ExceptionAttribute.TYPE] = exception.code;
+        attributes[ExceptionAttribute.TYPE] = exception.code.toString();
       } else if (exception.name) {
         attributes[ExceptionAttribute.TYPE] = exception.name;
       }

--- a/packages/opentelemetry-tracing/test/Span.test.ts
+++ b/packages/opentelemetry-tracing/test/Span.test.ts
@@ -732,7 +732,9 @@ describe('Span', () => {
         assert.strictEqual(span.events.length, 0);
         span.recordException({ code: 12 });
         const event = span.events[0];
-        assert.strictEqual(event.attributes[ExceptionAttribute.TYPE], '12');
+        assert.deepStrictEqual(event.attributes, {
+          [ExceptionAttribute.TYPE]: '12',
+        });
       });
     });
   });

--- a/packages/opentelemetry-tracing/test/Span.test.ts
+++ b/packages/opentelemetry-tracing/test/Span.test.ts
@@ -719,5 +719,21 @@ describe('Span', () => {
         assert.deepStrictEqual(event.time, [0, 123]);
       });
     });
+
+    describe('when exception code is numeric', () => {
+      it('should record an exception with string value', () => {
+        const span = new Span(
+          tracer,
+          ROOT_CONTEXT,
+          name,
+          spanContext,
+          SpanKind.CLIENT
+        );
+        assert.strictEqual(span.events.length, 0);
+        span.recordException({ code: 12 });
+        const event = span.events[0];
+        assert.strictEqual(event.attributes[ExceptionAttribute.TYPE], '12');
+      });
+    });
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
By [Semantic Conventions for Exceptions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/exceptions.md#Attributes) - `exception.type` should be a string.
 


## Short description of the changes
Cast to string for numeric exception codes.


