### PR TITLE
fix: parent based sampler should not sample when remote parent does not

### DIFF
--- a/packages/opentelemetry-core/test/trace/ParentBasedSampler.test.ts
+++ b/packages/opentelemetry-core/test/trace/ParentBasedSampler.test.ts
@@ -129,4 +129,28 @@ describe('ParentBasedSampler', () => {
       }
     );
   });
+
+  it('should not sample if a remote parent does not sample', () => {
+    const sampler = new ParentBasedSampler({ root: new TraceIdRatioBasedSampler(0.5) });
+
+    const spanContext = {
+      traceId,
+      spanId,
+      traceFlags: TraceFlags.NONE,
+      isRemote: true,
+    };
+    assert.deepStrictEqual(
+      sampler.shouldSample(
+        setSpanContext(api.ROOT_CONTEXT, spanContext),
+        traceId,
+        spanName,
+        SpanKind.CLIENT,
+        {},
+        []
+      ),
+      {
+        decision: api.SamplingDecision.NOT_RECORD,
+      }
+    );
+  });
 });


### PR DESCRIPTION

## Which problem is this PR solving?

I've observed parent based sampler choosing to sample even thought remote parent is not sampled. 

## Short description of the changes

I am beginning with a failing test, I could not setup the package locally so will see the test result in CI.
