### PR TITLE
feat: ensure the label names are sanitised

### DIFF
--- a/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -111,19 +111,19 @@ function stringify(
   let labelsStr = '';
 
   for (const [key, val] of Object.entries(labels)) {
-    const santizedLabelName = sanitizePrometheusMetricName(key);
+    const sanitizedLabelName = sanitizePrometheusMetricName(key);
     hasLabel = true;
     labelsStr += `${
       labelsStr.length > 0 ? ',' : ''
-    }${santizedLabelName}="${escapeLabelValue(val)}"`;
+    }${sanitizedLabelName}="${escapeLabelValue(val)}"`;
   }
   if (additionalLabels) {
     for (const [key, val] of Object.entries(additionalLabels)) {
-      const santizedLabelName = sanitizePrometheusMetricName(key);
+      const sanitizedLabelName = sanitizePrometheusMetricName(key);
       hasLabel = true;
       labelsStr += `${
         labelsStr.length > 0 ? ',' : ''
-      }${santizedLabelName}="${escapeLabelValue(val)}"`;
+      }${sanitizedLabelName}="${escapeLabelValue(val)}"`;
     }
   }
 

--- a/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -111,7 +111,7 @@ function stringify(
   let labelsStr = '';
 
   for (const [key, val] of Object.entries(labels)) {
-    const santisedLabelName = sanitizePrometheusMetricName(key);
+    const sanitisedLabelName = sanitisePrometheusMetricName(key);
     hasLabel = true;
     labelsStr += `${
       labelsStr.length > 0 ? ',' : ''

--- a/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -111,17 +111,19 @@ function stringify(
   let labelsStr = '';
 
   for (const [key, val] of Object.entries(labels)) {
+    const santisedLabelName = sanitizePrometheusMetricName(key);
     hasLabel = true;
-    labelsStr += `${labelsStr.length > 0 ? ',' : ''}${key}="${escapeLabelValue(
-      val
-    )}"`;
+    labelsStr += `${
+      labelsStr.length > 0 ? ',' : ''
+    }${santisedLabelName}="${escapeLabelValue(val)}"`;
   }
   if (additionalLabels) {
     for (const [key, val] of Object.entries(additionalLabels)) {
+      const santisedLabelName = sanitizePrometheusMetricName(key);
       hasLabel = true;
       labelsStr += `${
         labelsStr.length > 0 ? ',' : ''
-      }${key}="${escapeLabelValue(val)}"`;
+      }${santisedLabelName}="${escapeLabelValue(val)}"`;
     }
   }
 

--- a/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -111,19 +111,19 @@ function stringify(
   let labelsStr = '';
 
   for (const [key, val] of Object.entries(labels)) {
-    const sanitisedLabelName = sanitisePrometheusMetricName(key);
+    const santizedLabelName = sanitizePrometheusMetricName(key);
     hasLabel = true;
     labelsStr += `${
       labelsStr.length > 0 ? ',' : ''
-    }${santisedLabelName}="${escapeLabelValue(val)}"`;
+    }${santizedLabelName}="${escapeLabelValue(val)}"`;
   }
   if (additionalLabels) {
     for (const [key, val] of Object.entries(additionalLabels)) {
-      const santisedLabelName = sanitizePrometheusMetricName(key);
+      const santizedLabelName = sanitizePrometheusMetricName(key);
       hasLabel = true;
       labelsStr += `${
         labelsStr.length > 0 ? ',' : ''
-      }${santisedLabelName}="${escapeLabelValue(val)}"`;
+      }${santizedLabelName}="${escapeLabelValue(val)}"`;
     }
   }
 

--- a/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -488,5 +488,30 @@ describe('PrometheusSerializer', () => {
         );
       });
     });
+
+    it('should sanitise label names', async () => {
+      const serializer = new PrometheusSerializer();
+
+      const meter = new MeterProvider({
+        processor: new ExactProcessor(SumAggregator),
+      }).getMeter('test');
+      const counter = meter.createCounter('test') as CounterMetric;
+      // if you try to use a label name like account-id prometheus will complain
+      // with an error like:
+      // error while linting: text format parsing error in line 282: expected '=' after label name, found '-'
+      counter
+        .bind(({
+          'account-id': '123456',
+        } as unknown) as Labels)
+        .add(1);
+      const records = await counter.getMetricRecord();
+      const record = records[0];
+
+      const result = serializer.serializeRecord(record.descriptor.name, record);
+      assert.strictEqual(
+        result,
+        `test{account_id="123456"} 1 ${mockedHrTimeMs}\n`
+      );
+    });
   });
 });

--- a/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -487,31 +487,34 @@ describe('PrometheusSerializer', () => {
             `} 1 ${mockedHrTimeMs}\n`
         );
       });
-    });
 
-    it('should sanitise label names', async () => {
-      const serializer = new PrometheusSerializer();
+      it('should sanitise label names', async () => {
+        const serializer = new PrometheusSerializer();
 
-      const meter = new MeterProvider({
-        processor: new ExactProcessor(SumAggregator),
-      }).getMeter('test');
-      const counter = meter.createCounter('test') as CounterMetric;
-      // if you try to use a label name like account-id prometheus will complain
-      // with an error like:
-      // error while linting: text format parsing error in line 282: expected '=' after label name, found '-'
-      counter
-        .bind(({
-          'account-id': '123456',
-        } as unknown) as Labels)
-        .add(1);
-      const records = await counter.getMetricRecord();
-      const record = records[0];
+        const meter = new MeterProvider({
+          processor: new ExactProcessor(SumAggregator),
+        }).getMeter('test');
+        const counter = meter.createCounter('test') as CounterMetric;
+        // if you try to use a label name like account-id prometheus will complain
+        // with an error like:
+        // error while linting: text format parsing error in line 282: expected '=' after label name, found '-'
+        counter
+          .bind(({
+            'account-id': '123456',
+          } as unknown) as Labels)
+          .add(1);
+        const records = await counter.getMetricRecord();
+        const record = records[0];
 
-      const result = serializer.serializeRecord(record.descriptor.name, record);
-      assert.strictEqual(
-        result,
-        `test{account_id="123456"} 1 ${mockedHrTimeMs}\n`
-      );
+        const result = serializer.serializeRecord(
+          record.descriptor.name,
+          record
+        );
+        assert.strictEqual(
+          result,
+          `test{account_id="123456"} 1 ${mockedHrTimeMs}\n`
+        );
+      });
     });
   });
 });

--- a/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -488,7 +488,7 @@ describe('PrometheusSerializer', () => {
         );
       });
 
-      it('should sanitise label names', async () => {
+      it('should sanitize label names', async () => {
         const serializer = new PrometheusSerializer();
 
         const meter = new MeterProvider({


### PR DESCRIPTION
Sanitises the attribute names to match the naming convention enforced by
Prometheus

## Which problem is this PR solving?

If you have a label name with `-` then Prometheus will fall over this issue with an error like:
`error while linting: text format parsing error in line 282: expected '=' after label name, found '-'`

## Short description of the changes

The change is to also sanitise the label name and not only the metric names
