### PR TITLE
feat: add diag warning when metric name is invalid

### DIFF
--- a/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -21,6 +21,7 @@ import {
 import { PrometheusCheckpoint } from './types';
 import { Labels } from '@opentelemetry/api-metrics';
 import { hrTimeToMilliseconds } from '@opentelemetry/core';
+import { diag } from '@opentelemetry/api';
 
 type PrometheusDataTypeLiteral =
   | 'counter'
@@ -177,6 +178,16 @@ export class PrometheusSerializer {
 
   serializeRecord(name: string, record: MetricRecord): string {
     let results = '';
+
+    if (
+      record.descriptor.metricKind === MetricKind.COUNTER &&
+      !name.endsWith('_total')
+    ) {
+      diag.debug(
+        `The metric ${name} of kind Counter is missing the mandatory _total as suffix`
+      );
+    }
+
     switch (record.aggregator.kind) {
       case AggregatorKind.SUM:
       case AggregatorKind.LAST_VALUE: {


### PR DESCRIPTION
## Which problem is this PR solving?

If you are using the metric kind `counter` Prometheus expects the
metric name to have the suffix `_total` as it will throw the following
error:

```
failed_requests counter metrics should have "_total" suffix

```

This commit logs a warning message when the diag log level is DEBUG to
assist implementors

## Short description of the changes

Adds a log warning when an invalid metric name is given
