### PR TITLE
fix: add isEnabled to InstrumentationBase

### DIFF
--- a/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -30,7 +30,7 @@ export abstract class InstrumentationBase<T = any>
   implements types.Instrumentation {
   private _modules: InstrumentationModuleDefinition<T>[];
   private _hooks: RequireInTheMiddle.Hooked[] = [];
-  protected _enabled = false;
+  private _enabled = false;
 
   constructor(
     instrumentationName: string,
@@ -159,6 +159,10 @@ export abstract class InstrumentationBase<T = any>
         }
       }
     }
+  }
+
+  public isEnabled() {
+    return this._enabled;
   }
 }
 

--- a/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -30,7 +30,7 @@ export abstract class InstrumentationBase<T = any>
   implements types.Instrumentation {
   private _modules: InstrumentationModuleDefinition<T>[];
   private _hooks: RequireInTheMiddle.Hooked[] = [];
-  private _enabled = false;
+  protected _enabled = false;
 
   constructor(
     instrumentationName: string,


### PR DESCRIPTION

## Which problem is this PR solving?

#2131 

## Short description of the changes

Instrumentations need access to the enabled flag, this is to avoid defining it multiple times.
