### PR TITLE
[sampler] treat invalid SpanContext as no SpanContext

### DIFF
--- a/packages/opentelemetry-core/src/trace/sampler/ParentBasedSampler.ts
+++ b/packages/opentelemetry-core/src/trace/sampler/ParentBasedSampler.ts
@@ -18,6 +18,7 @@ import {
   SpanAttributes,
   Context,
   getSpanContext,
+  isSpanContextValid,
   Link,
   Sampler,
   SamplingResult,
@@ -69,7 +70,7 @@ export class ParentBasedSampler implements Sampler {
   ): SamplingResult {
     const parentContext = getSpanContext(context);
 
-    if (!parentContext) {
+    if (!parentContext || !isSpanContextValid(parentContext)) {
       return this._root.shouldSample(
         context,
         traceId,

--- a/packages/opentelemetry-core/test/trace/ParentBasedSampler.test.ts
+++ b/packages/opentelemetry-core/test/trace/ParentBasedSampler.test.ts
@@ -71,6 +71,24 @@ describe('ParentBasedSampler', () => {
     );
   });
 
+  it('should return api.SamplingDecision.RECORD_AND_SAMPLED for invalid parent spanContext while composited with AlwaysOnSampler', () => {
+    const sampler = new ParentBasedSampler({ root: new AlwaysOnSampler() });
+
+    assert.deepStrictEqual(
+      sampler.shouldSample(
+        setSpanContext(api.ROOT_CONTEXT, api.INVALID_SPAN_CONTEXT),
+        traceId,
+        spanName,
+        SpanKind.CLIENT,
+        {},
+        []
+      ),
+      {
+        decision: api.SamplingDecision.RECORD_AND_SAMPLED,
+      }
+    );
+  });
+
   it('should return api.SamplingDecision.RECORD_AND_SAMPLED while composited with AlwaysOnSampler', () => {
     const sampler = new ParentBasedSampler({ root: new AlwaysOnSampler() });
 
@@ -108,6 +126,24 @@ describe('ParentBasedSampler', () => {
       ),
       {
         decision: api.SamplingDecision.RECORD_AND_SAMPLED,
+      }
+    );
+  });
+
+  it('should return api.SamplingDecision.NOT_RECORD for invalid parent spanContext while composited with AlwaysOffSampler', () => {
+    const sampler = new ParentBasedSampler({ root: new AlwaysOffSampler() });
+
+    assert.deepStrictEqual(
+      sampler.shouldSample(
+        setSpanContext(api.ROOT_CONTEXT, api.INVALID_SPAN_CONTEXT),
+        traceId,
+        spanName,
+        SpanKind.CLIENT,
+        {},
+        []
+      ),
+      {
+        decision: api.SamplingDecision.NOT_RECORD,
       }
     );
   });


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #2164

## Short description of the changes

- Add a check for invalid parent `SpanContext`
- Add unit tests
