### PR TITLE
fix AGGREGATION_TEMPORALITY_DELTA difference in tests

### DIFF
--- a/packages/opentelemetry-exporter-collector-grpc/test/helper.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/test/helper.ts
@@ -343,7 +343,7 @@ export function ensureExportedCounterIsCorrect(
         },
       ],
       isMonotonic: true,
-      aggregationTemporality: 'AGGREGATION_TEMPORALITY_CUMULATIVE',
+      aggregationTemporality: 'AGGREGATION_TEMPORALITY_DELTA',
     },
   });
 }
@@ -395,7 +395,7 @@ export function ensureExportedValueRecorderIsCorrect(
           explicitBounds,
         },
       ],
-      aggregationTemporality: 'AGGREGATION_TEMPORALITY_CUMULATIVE',
+      aggregationTemporality: 'AGGREGATION_TEMPORALITY_DELTA',
     },
   });
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes test failure.

## Short description of the changes

- No changelog entry required, just an internal test fix, I think?
