### PR TITLE
fix: remove redundant try-catch from http/https server examples

### DIFF
--- a/examples/http/server.js
+++ b/examples/http/server.js
@@ -29,21 +29,17 @@ function handleRequest(request, response) {
   });
   // Annotate our span to capture metadata about the operation
   span.addEvent('invoking handleRequest');
-  try {
-    const body = [];
-    request.on('error', (err) => console.log(err));
-    request.on('data', (chunk) => body.push(chunk));
-    request.on('end', () => {
-      // deliberately sleeping to mock some action.
-      setTimeout(() => {
-        span.end();
-        response.end('Hello World!');
-      }, 2000);
-    });
-  } catch (err) {
-    console.error(err);
-    span.end();
-  }
+
+  const body = [];
+  request.on('error', (err) => console.log(err));
+  request.on('data', (chunk) => body.push(chunk));
+  request.on('end', () => {
+    // deliberately sleeping to mock some action.
+    setTimeout(() => {
+      span.end();
+      response.end('Hello World!');
+    }, 2000);
+  });
 }
 
 startServer(8080);

--- a/examples/https/server.js
+++ b/examples/https/server.js
@@ -34,21 +34,17 @@ function handleRequest(request, response) {
   });
   // Annotate our span to capture metadata about the operation
   span.addEvent('invoking handleRequest');
-  try {
-    const body = [];
-    request.on('error', (err) => console.log(err));
-    request.on('data', (chunk) => body.push(chunk));
-    request.on('end', () => {
-      // deliberately sleeping to mock some action.
-      setTimeout(() => {
-        span.end();
-        response.end('Hello World!');
-      }, 2000);
-    });
-  } catch (err) {
-    console.log(err);
-    span.end();
-  }
+
+  const body = [];
+  request.on('error', (err) => console.log(err));
+  request.on('data', (chunk) => body.push(chunk));
+  request.on('end', () => {
+    // deliberately sleeping to mock some action.
+    setTimeout(() => {
+      span.end();
+      response.end('Hello World!');
+    }, 2000);
+  });
 }
 
 startServer(443);


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Remove redundant try-catch from http/https server examples.

## Short description of the changes

- The blocks inside the try-catch are not going to throw anything.
