### PR TITLE
refactor(opentelemetry-instrumentation-http): make _getConfig public and rename to getConfig

### DIFF
--- a/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -69,7 +69,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
     );
   }
 
-  private _getConfig(): HttpInstrumentationConfig {
+  getConfig(): HttpInstrumentationConfig {
     return this._config;
   }
 
@@ -287,7 +287,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       hostname,
     });
     span.setAttributes(attributes);
-    if (this._getConfig().requestHook) {
+    if (this.getConfig().requestHook) {
       this._callRequestHook(span, request);
     }
 
@@ -304,7 +304,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
           { hostname }
         );
         span.setAttributes(responseAttributes);
-        if (this._getConfig().responseHook) {
+        if (this.getConfig().responseHook) {
           this._callResponseHook(span, response);
         }
 
@@ -322,10 +322,10 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
 
           span.setStatus(status);
 
-          if (this._getConfig().applyCustomAttributesOnSpan) {
+          if (this.getConfig().applyCustomAttributesOnSpan) {
             safeExecuteInTheMiddle(
               () =>
-                this._getConfig().applyCustomAttributesOnSpan!(
+                this.getConfig().applyCustomAttributesOnSpan!(
                   span,
                   request,
                   response
@@ -384,7 +384,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       if (
         utils.isIgnored(
           pathname,
-          instrumentation._getConfig().ignoreIncomingPaths,
+          instrumentation.getConfig().ignoreIncomingPaths,
           (e: Error) => diag.error('caught ignoreIncomingPaths error: ', e)
         )
       ) {
@@ -401,7 +401,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
         kind: SpanKind.SERVER,
         attributes: utils.getIncomingRequestAttributes(request, {
           component: component,
-          serverName: instrumentation._getConfig().serverName,
+          serverName: instrumentation.getConfig().serverName,
         }),
       };
 
@@ -416,10 +416,10 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
         context.bind(request);
         context.bind(response);
 
-        if (instrumentation._getConfig().requestHook) {
+        if (instrumentation.getConfig().requestHook) {
           instrumentation._callRequestHook(span, request);
         }
-        if (instrumentation._getConfig().responseHook) {
+        if (instrumentation.getConfig().responseHook) {
           instrumentation._callResponseHook(span, response);
         }
 
@@ -452,10 +452,10 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
             .setAttributes(attributes)
             .setStatus(utils.parseResponseStatus(response.statusCode));
 
-          if (instrumentation._getConfig().applyCustomAttributesOnSpan) {
+          if (instrumentation.getConfig().applyCustomAttributesOnSpan) {
             safeExecuteInTheMiddle(
               () =>
-                instrumentation._getConfig().applyCustomAttributesOnSpan!(
+                instrumentation.getConfig().applyCustomAttributesOnSpan!(
                   span,
                   request,
                   response
@@ -521,7 +521,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       if (
         utils.isIgnored(
           origin + pathname,
-          instrumentation._getConfig().ignoreOutgoingUrls,
+          instrumentation.getConfig().ignoreOutgoingUrls,
           (e: Error) => diag.error('caught ignoreOutgoingUrls error: ', e)
         )
       ) {
@@ -586,8 +586,8 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
      */
     const requireParent =
       options.kind === SpanKind.CLIENT
-        ? this._getConfig().requireParentforOutgoingSpans
-        : this._getConfig().requireParentforIncomingSpans;
+        ? this.getConfig().requireParentforOutgoingSpans
+        : this.getConfig().requireParentforIncomingSpans;
 
     let span: Span;
     const currentSpan = getSpan(ctx);
@@ -619,7 +619,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
     response: http.IncomingMessage | http.ServerResponse
   ) {
     safeExecuteInTheMiddle(
-      () => this._getConfig().responseHook!(span, response),
+      () => this.getConfig().responseHook!(span, response),
       () => {},
       true
     );
@@ -630,7 +630,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
     request: http.ClientRequest | http.IncomingMessage
   ) {
     safeExecuteInTheMiddle(
-      () => this._getConfig().requestHook!(span, request),
+      () => this.getConfig().requestHook!(span, request),
       () => {},
       true
     );


### PR DESCRIPTION
## Which problem is this PR solving?

- we are creating socket.io instrumentation at Aspecto.
The problem occurs when socket.io uses polling as the transport method and sends an HTTP POST request, this causes a trace to be generated by the HTTP instrumentation. 
The workaround we thought about was to pass the instance of `HttpInstrumentation` to our socket.io instrumentation and modify the `HttpInstrumentationConfig.ignoreIncomingPaths` to include the path of the socket.io endpoint.
In order to do that, we need to publicize the `_getConfig` method so we can merge the new config with the existing one and call `setConfig`.

## Short description of the changes

- rename `_getConfig` to getConfig 
- change access modifier from `private` to `public` 
