### PR TITLE
fix(instrumentation-node): recursively discover package.json 

### DIFF
--- a/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -59,7 +59,7 @@ export abstract class InstrumentationBase<T = any>
     }
   }
 
-  private _onRequire<T>(
+  protected _onRequire<T>(
     module: InstrumentationModuleDefinition<T>,
     exports: T,
     name: string,
@@ -73,7 +73,7 @@ export abstract class InstrumentationBase<T = any>
       return exports;
     }
 
-    const version = require(path.join(baseDir, 'package.json')).version;
+    const version = this.getModuleVersion(baseDir)
     module.moduleVersion = version;
     if (module.name === name) {
       // main module
@@ -100,6 +100,30 @@ export abstract class InstrumentationBase<T = any>
       }
     }
     return exports;
+  }
+
+  protected getModuleVersion(directory: string): string {
+    const modulePackage = this.findModulePackage(directory);
+    if (!modulePackage) {
+      return '0.0.0';
+    }
+    return modulePackage.version;
+  }
+
+  protected findModulePackage(directory: string): any {
+    const parentDirectory = path.dirname(directory)
+    if (directory === parentDirectory) { return; }
+    let contents = null
+    try {
+      contents = this.loadModulePackage(directory)
+    } catch (err) {
+    }
+    if (contents) { return contents }
+    return this.findModulePackage(parentDirectory)
+  }
+
+  protected loadModulePackage(directory: string): any {
+    return require(path.join(directory, 'package.json'))
   }
 
   public enable() {

--- a/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -59,7 +59,7 @@ export abstract class InstrumentationBase<T = any>
     }
   }
 
-  protected _onRequire<T>(
+  private _onRequire<T>(
     module: InstrumentationModuleDefinition<T>,
     exports: T,
     name: string,
@@ -102,7 +102,7 @@ export abstract class InstrumentationBase<T = any>
     return exports;
   }
 
-  protected getModuleVersion(directory: string): string {
+  private getModuleVersion(directory: string): string {
     const modulePackage = this.findModulePackage(directory);
     if (!modulePackage) {
       return '0.0.0';
@@ -110,7 +110,7 @@ export abstract class InstrumentationBase<T = any>
     return modulePackage.version;
   }
 
-  protected findModulePackage(directory: string): any {
+  private findModulePackage(directory: string): unknown {
     const parentDirectory = path.dirname(directory)
     if (directory === parentDirectory) { return; }
     let contents = null
@@ -122,7 +122,7 @@ export abstract class InstrumentationBase<T = any>
     return this.findModulePackage(parentDirectory)
   }
 
-  protected loadModulePackage(directory: string): any {
+  private loadModulePackage(directory: string): unknown {
     return require(path.join(directory, 'package.json'))
   }
 

--- a/packages/opentelemetry-instrumentation/test/common/Instrumentation.test.ts
+++ b/packages/opentelemetry-instrumentation/test/common/Instrumentation.test.ts
@@ -25,23 +25,6 @@ class TestInstrumentation extends InstrumentationBase {
   enable() {}
   disable() {}
   init() {}
-  _onRequire<T>(
-    module: InstrumentationModuleDefinition<T>,
-    exports: T,
-    name: string,
-    baseDir?: string
-  ): T {
-    return super._onRequire(module, exports, name, baseDir)
-  }
-  getModuleVersion(directory: string): string {
-    return super.getModuleVersion(directory)
-  }
-  findModulePackage(directory: string): any {
-    return super.findModulePackage(directory)
-  }
-  loadModulePackage(directory: string): any {
-    return super.loadModulePackage(directory)
-  }
 }
 
 describe('BaseInstrumentation', () => {
@@ -78,11 +61,15 @@ describe('BaseInstrumentation', () => {
   describe('_onRequire', () => {
     it('loads package.json recursively returning 0.0.0 when undiscovered', () => {
       const instrumentation = new TestInstrumentation()
+      // @ts-expect-error access internal property for testing
       const versionSpy = sinon.spy(instrumentation, 'getModuleVersion');
+      // @ts-expect-error access internal property for testing
       const findSpy = sinon.spy(instrumentation, 'findModulePackage');
+      // @ts-expect-error access internal property for testing
       const loadSpy = sinon.spy(instrumentation, 'loadModulePackage')
 
       const moduleDefinition = {} as InstrumentationModuleDefinition<unknown>
+      // @ts-expect-error access internal property for testing
       instrumentation._onRequire<unknown>(
         moduleDefinition,
         {} as unknown,
@@ -100,8 +87,11 @@ describe('BaseInstrumentation', () => {
 
     it('loads package.json recursively returning version when discovered', () => {
       const instrumentation = new TestInstrumentation()
+      // @ts-expect-error access internal property for testing
       const versionSpy = sinon.spy(instrumentation, 'getModuleVersion');
+      // @ts-expect-error access internal property for testing
       const findSpy = sinon.spy(instrumentation, 'findModulePackage');
+      // @ts-expect-error access internal property for testing
       const loadStub = sinon.stub(instrumentation, 'loadModulePackage')
 
       loadStub.withArgs('/foo/bar').returns({
@@ -110,6 +100,7 @@ describe('BaseInstrumentation', () => {
       })
 
       const moduleDefinition = {} as InstrumentationModuleDefinition<unknown>
+      // @ts-expect-error access internal property for testing
       instrumentation._onRequire<unknown>(
         moduleDefinition,
         {} as unknown,


### PR DESCRIPTION
Recursively discover package.json from module parent directories

## Which problem is this PR solving?

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/2193

## Short description of the changes

* Recursively attempting to discover package.json from parent directories in order to set a moduleVersion
* Resolving as `0.0.0` when undiscovered rather than a hard crash