### PR TITLE
Add ability to see attributes

### DIFF
--- a/packages/opentelemetry-tracing/src/Span.ts
+++ b/packages/opentelemetry-tracing/src/Span.ts
@@ -116,6 +116,14 @@ export class Span implements api.Span, ReadableSpan {
     return this;
   }
 
+  getAttribute(key: string): api.SpanAttributes {
+    return this.attributes[key];
+  }
+
+  getAttributes(): api.SpanAttributes {
+    return this.attributes;
+  }
+
   /**
    *
    * @param name Span Name


### PR DESCRIPTION
## Which problem is this PR solving?

We have quite a complex flow for some of our spans and sometimes we'd like to see whether an attribute has been set or not on the span. In TS the only way to do this at the moment is by doing something like this:

```ts
((span as unknown) as {
  attributes: api.SpanAttributes;
});
```

I want to add a `getAttribute(s)` API to the Span to make it easier to access the span's attributes.

## Short description of the changes

- Added 2 getters to the Span class.