### PR TITLE
feat(core): add specific context key to store rpc metadata

### DIFF
--- a/packages/opentelemetry-core/src/index.ts
+++ b/packages/opentelemetry-core/src/index.ts
@@ -27,6 +27,7 @@ export * from './platform';
 export * from './propagation/composite';
 export * from './trace/HttpTraceContextPropagator';
 export * from './trace/IdGenerator';
+export * from './trace/rpc-metadata';
 export * from './trace/sampler/AlwaysOffSampler';
 export * from './trace/sampler/AlwaysOnSampler';
 export * from './trace/sampler/ParentBasedSampler';

--- a/packages/opentelemetry-core/src/trace/rpc-metadata.ts
+++ b/packages/opentelemetry-core/src/trace/rpc-metadata.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Context, createContextKey, Span } from '@opentelemetry/api';
+
+const RPC_METADATA_KEY = createContextKey(
+  'OpenTelemetry SDK Context Key RPC_METADATA'
+);
+
+export enum RPCType {
+  HTTP = 'http',
+}
+
+type HTTPMetadata = {
+  type: RPCType.HTTP;
+  route?: string;
+  span: Span;
+};
+
+/**
+ * Allows for future rpc metadata to be used with this mechanism
+ */
+export type RPCMetadata = HTTPMetadata;
+
+export function setRPCMetadata(context: Context, meta: RPCMetadata): Context {
+  return context.setValue(RPC_METADATA_KEY, meta);
+}
+
+export function deleteRPCMetadata(context: Context): Context {
+  return context.deleteValue(RPC_METADATA_KEY);
+}
+
+export function getRPCMetadata(context: Context): RPCMetadata | undefined {
+  return context.getValue(RPC_METADATA_KEY) as RPCMetadata | undefined;
+}


### PR DESCRIPTION

## Which problem is this PR solving?

- https://github.com/open-telemetry/opentelemetry-js-contrib/issues/464: We previously had a implicit dependency between http instrumentation and some http framework instrumentation, specially express one where both http was using express metadata to assign a attribute and express was using the http one to rename the main span it creates.

## Short description of the changes

- This PR introduces a new context api to store "RPC Metadata" which is for now only for HTTP but might later on be completed with specific metadata for GRPC or any other RPC system so instrumentations "works" together to have the maximum data available. For now the http metadata only contains a span (which is the root span that the http instrumentation creates for each new request) and a optional `route` that might be set by other instrumentation later on in the request.
