### PR TITLE
fix(opentelemetry-sdk-node): move nock to dev dependencies

### DIFF
--- a/packages/opentelemetry-sdk-node/package.json
+++ b/packages/opentelemetry-sdk-node/package.json
@@ -48,8 +48,7 @@
     "@opentelemetry/resource-detector-aws": "0.19.0",
     "@opentelemetry/resource-detector-gcp": "0.19.0",
     "@opentelemetry/resources": "0.19.0",
-    "@opentelemetry/tracing": "0.19.0",
-    "nock": "12.0.3"
+    "@opentelemetry/tracing": "0.19.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0"
@@ -65,6 +64,7 @@
     "gcp-metadata": "^4.1.4",
     "istanbul-instrumenter-loader": "3.0.1",
     "mocha": "7.2.0",
+    "nock": "12.0.3",
     "nyc": "15.1.0",
     "semver": "7.3.5",
     "sinon": "10.0.0",


### PR DESCRIPTION
This PR moves `nock` from `dependencies` to `devDependencies` since the library is only required during development.
