### PR TITLE
feat(opentelemetry-instrumentation): getConfig and setConfig

### DIFF
--- a/packages/opentelemetry-instrumentation/src/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation/src/instrumentation.ts
@@ -70,6 +70,19 @@ export abstract class InstrumentationAbstract<T = any>
     );
   }
 
+  /* Returns InstrumentationConfig */
+  public getConfig() {
+    return this._config;
+  }
+
+  /**
+   * Sets InstrumentationConfig to this plugin
+   * @param InstrumentationConfig
+   */
+  public setConfig(config: types.InstrumentationConfig = {}) {
+    this._config = Object.assign({}, config);
+  }
+
   /**
    * Sets TraceProvider to this plugin
    * @param tracerProvider

--- a/packages/opentelemetry-instrumentation/src/types.ts
+++ b/packages/opentelemetry-instrumentation/src/types.ts
@@ -44,6 +44,12 @@ export interface Instrumentation {
   /** Method to set meter provider  */
   setMeterProvider(meterProvider: MeterProvider): void;
 
+  /** Method to set instrumentation config  */
+  setConfig(config: InstrumentationConfig & any): void;
+
+  /** Method to get instrumentation config  */
+  getConfig(): InstrumentationConfig & any;
+
   /**
    * Contains all supported versions.
    * All versions must be compatible with [semver](https://semver.org/spec/v2.0.0.html) format.

--- a/packages/opentelemetry-instrumentation/src/types.ts
+++ b/packages/opentelemetry-instrumentation/src/types.ts
@@ -45,10 +45,10 @@ export interface Instrumentation {
   setMeterProvider(meterProvider: MeterProvider): void;
 
   /** Method to set instrumentation config  */
-  setConfig(config: InstrumentationConfig & any): void;
+  setConfig(config: InstrumentationConfig): void;
 
   /** Method to get instrumentation config  */
-  getConfig(): InstrumentationConfig & any;
+  getConfig(): InstrumentationConfig;
 
   /**
    * Contains all supported versions.

--- a/packages/opentelemetry-instrumentation/test/common/Instrumentation.test.ts
+++ b/packages/opentelemetry-instrumentation/test/common/Instrumentation.test.ts
@@ -70,15 +70,20 @@ describe('BaseInstrumentation', () => {
       const instrumentation: Instrumentation = new TestInstrumentation({
         isActive: false,
       });
-      const configuration = instrumentation.getConfig();
+      const configuration =
+        instrumentation.getConfig() as TestInstrumentationConfig;
       assert.notStrictEqual(configuration, null);
       assert.strictEqual(configuration.isActive, false);
     });
 
     it('should modify config', () => {
       const instrumentation: Instrumentation = new TestInstrumentation();
-      instrumentation.setConfig({ isActive: true });
-      const configuration = instrumentation.getConfig();
+      const config: TestInstrumentationConfig = {
+        isActive: true,
+      };
+      instrumentation.setConfig(config);
+      const configuration =
+        instrumentation.getConfig() as TestInstrumentationConfig;
       assert.strictEqual(configuration.isActive, true);
     });
   });

--- a/packages/opentelemetry-instrumentation/test/common/Instrumentation.test.ts
+++ b/packages/opentelemetry-instrumentation/test/common/Instrumentation.test.ts
@@ -65,8 +65,8 @@ describe('BaseInstrumentation', () => {
     });
   });
 
-  describe('config', () => {
-    it('should get config', () => {
+  describe('getConfig', () => {
+    it('should return instrumentation config', () => {
       const instrumentation: Instrumentation = new TestInstrumentation({
         isActive: false,
       });
@@ -75,8 +75,10 @@ describe('BaseInstrumentation', () => {
       assert.notStrictEqual(configuration, null);
       assert.strictEqual(configuration.isActive, false);
     });
+  });
 
-    it('should modify config', () => {
+  describe('setConfig', () => {
+    it('should set a new config for instrumentation', () => {
       const instrumentation: Instrumentation = new TestInstrumentation();
       const config: TestInstrumentationConfig = {
         isActive: true,

--- a/packages/opentelemetry-instrumentation/test/common/Instrumentation.test.ts
+++ b/packages/opentelemetry-instrumentation/test/common/Instrumentation.test.ts
@@ -15,11 +15,19 @@
  */
 
 import * as assert from 'assert';
-import { Instrumentation, InstrumentationBase } from '../../src';
+import {
+  Instrumentation,
+  InstrumentationBase,
+  InstrumentationConfig,
+} from '../../src';
+
+interface TestInstrumentationConfig extends InstrumentationConfig {
+  isActive?: boolean;
+}
 
 class TestInstrumentation extends InstrumentationBase {
-  constructor() {
-    super('test', '1.0.0');
+  constructor(config: TestInstrumentationConfig & InstrumentationConfig = {}) {
+    super('test', '1.0.0', Object.assign({}, config));
   }
   enable() {}
   disable() {}
@@ -54,6 +62,24 @@ describe('BaseInstrumentation', () => {
       }
       instrumentation = new TestInstrumentation2();
       assert.strictEqual(called, true);
+    });
+  });
+
+  describe('config', () => {
+    it('should get config', () => {
+      const instrumentation: Instrumentation = new TestInstrumentation({
+        isActive: false,
+      });
+      const configuration = instrumentation.getConfig();
+      assert.notStrictEqual(configuration, null);
+      assert.strictEqual(configuration.isActive, false);
+    });
+
+    it('should modify config', () => {
+      const instrumentation: Instrumentation = new TestInstrumentation();
+      instrumentation.setConfig({ isActive: true });
+      const configuration = instrumentation.getConfig();
+      assert.strictEqual(configuration.isActive, true);
     });
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
Plugins should be able to modify configuration at run time; many plugins implement this. There is no reason this shouldn't be in the base class, so all plugins have this functionality.  

## Short description of the changes
Added `getConfig` and `setConfig` to `InstrumentationAbstract` and `Instrumentation`
Fixes #2174 

