### PR TITLE
chore: remove references to Noop classes from API

### DIFF
--- a/packages/opentelemetry-web/test/registration.test.ts
+++ b/packages/opentelemetry-web/test/registration.test.ts
@@ -46,7 +46,7 @@ describe('API registration', () => {
   it('should register configured implementations', () => {
     const tracerProvider = new WebTracerProvider();
 
-    const contextManager = { disable() { } } as any;
+    const contextManager = { disable() { }, enable() { } } as any;
     const propagator = {} as any;
 
     tracerProvider.register({

--- a/packages/opentelemetry-web/test/registration.test.ts
+++ b/packages/opentelemetry-web/test/registration.test.ts
@@ -16,8 +16,6 @@
 
 import {
   context,
-  NoopContextManager,
-  NoopTextMapPropagator,
   propagation,
   trace,
   ProxyTracerProvider,
@@ -48,8 +46,8 @@ describe('API registration', () => {
   it('should register configured implementations', () => {
     const tracerProvider = new WebTracerProvider();
 
-    const contextManager = new NoopContextManager();
-    const propagator = new NoopTextMapPropagator();
+    const contextManager = { disable() { } } as any;
+    const propagator = {} as any;
 
     tracerProvider.register({
       contextManager,
@@ -64,12 +62,13 @@ describe('API registration', () => {
   });
 
   it('should skip null context manager', () => {
+    const ctxManager = context['_getContextManager']();
     const tracerProvider = new WebTracerProvider();
     tracerProvider.register({
       contextManager: null,
     });
 
-    assert.ok(context['_getContextManager']() instanceof NoopContextManager);
+    assert.strictEqual(context['_getContextManager'](), ctxManager, "context manager should not change");
 
     assert.ok(
       propagation['_getGlobalPropagator']() instanceof CompositePropagator
@@ -79,14 +78,13 @@ describe('API registration', () => {
   });
 
   it('should skip null propagator', () => {
+    const propagator = propagation['_getGlobalPropagator']();
     const tracerProvider = new WebTracerProvider();
     tracerProvider.register({
       propagator: null,
     });
 
-    assert.ok(
-      propagation['_getGlobalPropagator']() instanceof NoopTextMapPropagator
-    );
+    assert.strictEqual(propagation["_getGlobalPropagator"](), propagator, "propagator should not change")
 
     assert.ok(context['_getContextManager']() instanceof StackContextManager);
     const apiTracerProvider = trace.getTracerProvider() as ProxyTracerProvider;


### PR DESCRIPTION
Only references from the production API package were changed. The metrics API can be handled at a later time. They were only used in tests so this is pretty straightforward.