### PR TITLE
chore: downgrade karma-webpack

### DIFF
--- a/packages/opentelemetry-api-metrics/package.json
+++ b/packages/opentelemetry-api-metrics/package.json
@@ -67,7 +67,7 @@
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",
-    "karma-webpack": "5.0.0",
+    "karma-webpack": "4.0.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "ts-loader": "8.2.0",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -60,7 +60,7 @@
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",
-    "karma-webpack": "5.0.0",
+    "karma-webpack": "4.0.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -53,7 +53,7 @@
     "karma-chrome-launcher": "3.1.0",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",
-    "karma-webpack": "5.0.0",
+    "karma-webpack": "4.0.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -68,7 +68,7 @@
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",
-    "karma-webpack": "5.0.0",
+    "karma-webpack": "4.0.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",

--- a/packages/opentelemetry-exporter-collector/package.json
+++ b/packages/opentelemetry-exporter-collector/package.json
@@ -68,7 +68,7 @@
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",
-    "karma-webpack": "5.0.0",
+    "karma-webpack": "4.0.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -65,7 +65,7 @@
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",
-    "karma-webpack": "5.0.0",
+    "karma-webpack": "4.0.2",
     "mocha": "7.2.0",
     "nock": "12.0.3",
     "nyc": "15.1.0",

--- a/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/packages/opentelemetry-instrumentation-fetch/package.json
@@ -64,7 +64,7 @@
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",
-    "karma-webpack": "5.0.0",
+    "karma-webpack": "4.0.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",

--- a/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -63,7 +63,7 @@
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",
-    "karma-webpack": "5.0.0",
+    "karma-webpack": "4.0.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",

--- a/packages/opentelemetry-instrumentation/package.json
+++ b/packages/opentelemetry-instrumentation/package.json
@@ -85,7 +85,7 @@
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",
-    "karma-webpack": "5.0.0",
+    "karma-webpack": "4.0.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -59,7 +59,7 @@
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",
-    "karma-webpack": "5.0.0",
+    "karma-webpack": "4.0.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",

--- a/packages/opentelemetry-tracing/package.json
+++ b/packages/opentelemetry-tracing/package.json
@@ -66,7 +66,7 @@
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",
-    "karma-webpack": "5.0.0",
+    "karma-webpack": "4.0.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",

--- a/packages/opentelemetry-web/package.json
+++ b/packages/opentelemetry-web/package.json
@@ -64,7 +64,7 @@
     "karma-jquery": "0.2.4",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",
-    "karma-webpack": "5.0.0",
+    "karma-webpack": "4.0.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       "rangeStrategy": "bump"
     }
   ],
-  "ignoreDeps": ["gcp-metadata", "got", "mocha", "husky"],
+  "ignoreDeps": ["gcp-metadata", "got", "mocha", "husky", "karma-webpack"],
   "assignees": ["@dyladan", "@obecny", "@vmarchaud"],
   "schedule": ["before 3am on Friday"],
   "labels": ["dependencies"]


### PR DESCRIPTION
On MacOS the most recent version of karma-webpack is broken

Fixes #2231 
