### PR TITLE
chore: do not upgrade backwards compatibility

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,11 @@
     {
       "matchPackageNames": ["@opentelemetry/api"],
       "rangeStrategy": "bump"
+    },
+    {
+      "matchPaths": ["backwards-compatibility/**"],
+      "matchPackageNames": ["@types/node"],
+      "enabled": false
     }
   ],
   "ignoreDeps": ["gcp-metadata", "got", "mocha", "husky", "karma-webpack"],


### PR DESCRIPTION
Prevent bad upgrades like those pointed out by @Flarna in #2236 