### PR TITLE
feat: allow setting attributes when recording exceptions

### DIFF
--- a/packages/opentelemetry-tracing/test/common/Span.test.ts
+++ b/packages/opentelemetry-tracing/test/common/Span.test.ts
@@ -719,6 +719,71 @@ describe('Span', () => {
         span.recordException('boom', [0, 123]);
         const event = span.events[0];
         assert.deepStrictEqual(event.time, [0, 123]);
+        assert.deepStrictEqual(event.attributes, { [SemanticAttributes.EXCEPTION_MESSAGE]: 'boom' });
+      });
+    });
+
+    describe('when attributes are provided', () => {
+      it('should record an exception with those attributes', () => {
+        const span = new Span(
+          tracer,
+          ROOT_CONTEXT,
+          name,
+          spanContext,
+          SpanKind.CLIENT
+        );
+        assert.strictEqual(span.events.length, 0);
+        span.recordException('boom', { meow: 123, woof: "hello" });
+        const event = span.events[0];
+        assert.deepStrictEqual(event.attributes, {
+          [SemanticAttributes.EXCEPTION_MESSAGE]: 'boom',
+          meow: 123,
+          woof: "hello"
+        });
+      });
+
+      it('provided attributes should take precedence over generated ones', () => {
+        const span = new Span(
+          tracer,
+          ROOT_CONTEXT,
+          name,
+          spanContext,
+          SpanKind.CLIENT
+        );
+        assert.strictEqual(span.events.length, 0);
+        span.recordException({ name: 'Error', message: 'boom', stack: 'bar' },
+          {
+            [SemanticAttributes.EXCEPTION_TYPE]: 'My Special Error',
+            [SemanticAttributes.EXCEPTION_MESSAGE]: 'My Special Message',
+            [SemanticAttributes.EXCEPTION_STACKTRACE]: 'My Special Stack',
+          });
+        const event = span.events[0];
+        assert.deepStrictEqual(event.attributes, {
+          [SemanticAttributes.EXCEPTION_TYPE]: 'My Special Error',
+          [SemanticAttributes.EXCEPTION_MESSAGE]: 'My Special Message',
+          [SemanticAttributes.EXCEPTION_STACKTRACE]: 'My Special Stack',
+        });
+      });
+    });
+
+    describe('when both attributes and time are provided', () => {
+      it('should record an exception with provided attributes and time', () => {
+        const span = new Span(
+          tracer,
+          ROOT_CONTEXT,
+          name,
+          spanContext,
+          SpanKind.CLIENT
+        );
+        assert.strictEqual(span.events.length, 0);
+        span.recordException('boom', { meow: 123, woof: 'hello' }, [0, 123]);
+        const event = span.events[0];
+        assert.deepStrictEqual(event.time, [0, 123]);
+        assert.deepStrictEqual(event.attributes, {
+          [SemanticAttributes.EXCEPTION_MESSAGE]: 'boom',
+          meow: 123,
+          woof: "hello"
+        })
       });
     });
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- `span.recordException` needs to allow setting event attributes per [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#record-exception)
> If RecordException is provided, the method MUST accept an optional parameter to provide any additional event attributes (this SHOULD be done in the same way as for the AddEvent method). If attributes with the same name would be generated by the method already, the additional attributes take precedence.
- API change: https://github.com/open-telemetry/opentelemetry-js-api/pull/97

## Short description of the changes

- allow setting attributes when recording exception, same as the `span.addEvent` interface
