### PR TITLE
feat: otlp-grpc exporter uses headers environment variables

### DIFF
--- a/packages/opentelemetry-exporter-collector-grpc/src/CollectorExporterNodeBase.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/src/CollectorExporterNodeBase.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-import * as grpc from '@grpc/grpc-js'
 import { diag } from '@opentelemetry/api';
 import {
   CollectorExporterBase,
   collectorTypes,
 } from '@opentelemetry/exporter-collector';
-import type { Metadata } from '@grpc/grpc-js';
+import { Metadata } from '@grpc/grpc-js';
 import {
   CollectorExporterConfigNode,
   GRPCQueueItem,
@@ -51,7 +50,7 @@ export abstract class CollectorExporterNodeBase<
       diag.warn('Headers cannot be set when using grpc');
     }
     const headers = baggageUtils.parseKeyPairsIntoRecord(getEnv().OTEL_EXPORTER_OTLP_HEADERS);
-    this.metadata = config.metadata || new grpc.Metadata();
+    this.metadata = config.metadata || new Metadata();
     for (const [k, v] of Object.entries(headers)) {
       this.metadata.set(k, v)
     }

--- a/packages/opentelemetry-exporter-collector-grpc/src/CollectorExporterNodeBase.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/src/CollectorExporterNodeBase.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as grpc from '@grpc/grpc-js'
 import { diag } from '@opentelemetry/api';
 import {
   CollectorExporterBase,
@@ -26,6 +27,7 @@ import {
   ServiceClientType,
 } from './types';
 import { ServiceClient } from './types';
+import { getEnv, baggageUtils } from "@opentelemetry/core";
 
 /**
  * Collector Metric Exporter abstract base class
@@ -48,8 +50,13 @@ export abstract class CollectorExporterNodeBase<
     if (config.headers) {
       diag.warn('Headers cannot be set when using grpc');
     }
-    this.metadata = config.metadata;
+    const headers = baggageUtils.parseKeyPairsIntoRecord(getEnv().OTEL_EXPORTER_OTLP_HEADERS);
+    this.metadata = config.metadata || new grpc.Metadata();
+    for (const [k, v] of Object.entries(headers)) {
+      this.metadata.set(k, v)
+    }
   }
+
   private _sendPromise(
     objects: ExportItem[],
     onSuccess: () => void,

--- a/packages/opentelemetry-exporter-collector-grpc/src/CollectorMetricExporter.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/src/CollectorMetricExporter.ts
@@ -21,8 +21,9 @@ import {
 import { MetricRecord, MetricExporter } from '@opentelemetry/metrics';
 import { CollectorExporterConfigNode, ServiceClientType } from './types';
 import { CollectorExporterNodeBase } from './CollectorExporterNodeBase';
-import { getEnv } from '@opentelemetry/core';
+import { baggageUtils, getEnv } from '@opentelemetry/core';
 import { validateAndNormalizeUrl } from './util';
+import * as grpc from "@grpc/grpc-js";
 
 const DEFAULT_COLLECTOR_URL = 'localhost:4317';
 
@@ -37,6 +38,15 @@ export class CollectorMetricExporter
   implements MetricExporter {
   // Converts time to nanoseconds
   protected readonly _startTime = new Date().getTime() * 1000000;
+
+  constructor(config: CollectorExporterConfigNode = {}) {
+    super(config);
+    const headers = baggageUtils.parseKeyPairsIntoRecord(getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS);
+    this.metadata ||= new grpc.Metadata();
+    for (const [k, v] of Object.entries(headers)) {
+      this.metadata.set(k, v)
+    }
+  }
 
   convert(
     metrics: MetricRecord[]

--- a/packages/opentelemetry-exporter-collector-grpc/src/CollectorMetricExporter.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/src/CollectorMetricExporter.ts
@@ -23,7 +23,7 @@ import { CollectorExporterConfigNode, ServiceClientType } from './types';
 import { CollectorExporterNodeBase } from './CollectorExporterNodeBase';
 import { baggageUtils, getEnv } from '@opentelemetry/core';
 import { validateAndNormalizeUrl } from './util';
-import * as grpc from "@grpc/grpc-js";
+import { Metadata } from "@grpc/grpc-js";
 
 const DEFAULT_COLLECTOR_URL = 'localhost:4317';
 
@@ -42,7 +42,7 @@ export class CollectorMetricExporter
   constructor(config: CollectorExporterConfigNode = {}) {
     super(config);
     const headers = baggageUtils.parseKeyPairsIntoRecord(getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS);
-    this.metadata ||= new grpc.Metadata();
+    this.metadata ||= new Metadata();
     for (const [k, v] of Object.entries(headers)) {
       this.metadata.set(k, v)
     }

--- a/packages/opentelemetry-exporter-collector-grpc/src/CollectorTraceExporter.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/src/CollectorTraceExporter.ts
@@ -23,7 +23,7 @@ import {
 import { CollectorExporterConfigNode, ServiceClientType } from './types';
 import { baggageUtils, getEnv } from '@opentelemetry/core';
 import { validateAndNormalizeUrl } from './util';
-import * as grpc from "@grpc/grpc-js";
+import { Metadata } from "@grpc/grpc-js";
 
 const DEFAULT_COLLECTOR_URL = 'localhost:4317';
 
@@ -40,7 +40,7 @@ export class CollectorTraceExporter
   constructor(config: CollectorExporterConfigNode = {}) {
     super(config);
     const headers = baggageUtils.parseKeyPairsIntoRecord(getEnv().OTEL_EXPORTER_OTLP_TRACES_HEADERS);
-    this.metadata ||= new grpc.Metadata();
+    this.metadata ||= new Metadata();
     for (const [k, v] of Object.entries(headers)) {
       this.metadata.set(k, v)
     }

--- a/packages/opentelemetry-exporter-collector-grpc/src/CollectorTraceExporter.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/src/CollectorTraceExporter.ts
@@ -21,8 +21,9 @@ import {
   toCollectorExportTraceServiceRequest,
 } from '@opentelemetry/exporter-collector';
 import { CollectorExporterConfigNode, ServiceClientType } from './types';
-import { getEnv } from '@opentelemetry/core';
+import { baggageUtils, getEnv } from '@opentelemetry/core';
 import { validateAndNormalizeUrl } from './util';
+import * as grpc from "@grpc/grpc-js";
 
 const DEFAULT_COLLECTOR_URL = 'localhost:4317';
 
@@ -35,6 +36,16 @@ export class CollectorTraceExporter
     collectorTypes.opentelemetryProto.collector.trace.v1.ExportTraceServiceRequest
   >
   implements SpanExporter {
+
+  constructor(config: CollectorExporterConfigNode = {}) {
+    super(config);
+    const headers = baggageUtils.parseKeyPairsIntoRecord(getEnv().OTEL_EXPORTER_OTLP_TRACES_HEADERS);
+    this.metadata ||= new grpc.Metadata();
+    for (const [k, v] of Object.entries(headers)) {
+      this.metadata.set(k, v)
+    }
+  }
+
   convert(
     spans: ReadableSpan[]
   ): collectorTypes.opentelemetryProto.collector.trace.v1.ExportTraceServiceRequest {

--- a/packages/opentelemetry-exporter-collector-grpc/test/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/test/CollectorMetricExporter.test.ts
@@ -278,6 +278,25 @@ describe('when configuring via environment', () => {
     envSource.OTEL_EXPORTER_OTLP_ENDPOINT = '';
     envSource.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = '';
   });
+  it('should use headers defined via env', () => {
+    envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar';
+    const collectorExporter = new CollectorMetricExporter();
+    assert.deepStrictEqual(collectorExporter.metadata?.get('foo'), ['bar']);
+    envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
+  });
+  it('should override global headers config with signal headers defined via env', () => {
+    const metadata = new grpc.Metadata();
+    metadata.set('foo', 'bar');
+    metadata.set('goo', 'lol');
+    envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=jar,bar=foo';
+    envSource.OTEL_EXPORTER_OTLP_METRICS_HEADERS = 'foo=boo';
+    const collectorExporter = new CollectorMetricExporter({ metadata });
+    assert.deepStrictEqual(collectorExporter.metadata?.get('foo'), ['boo']);
+    assert.deepStrictEqual(collectorExporter.metadata?.get('bar'), ['foo']);
+    assert.deepStrictEqual(collectorExporter.metadata?.get('goo'), ['lol']);
+    envSource.OTEL_EXPORTER_OTLP_METRICS_HEADERS = '';
+    envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
+  });
 });
 
 testCollectorMetricExporter({ useTLS: true });

--- a/packages/opentelemetry-exporter-collector-grpc/test/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/test/CollectorTraceExporter.test.ts
@@ -240,6 +240,25 @@ describe('when configuring via environment', () => {
     envSource.OTEL_EXPORTER_OTLP_ENDPOINT = '';
     envSource.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = '';
   });
+  it('should use headers defined via env', () => {
+    envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar';
+    const collectorExporter = new CollectorTraceExporter();
+    assert.deepStrictEqual(collectorExporter.metadata?.get('foo'), ['bar']);
+    envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
+  });
+  it('should override global headers config with signal headers defined via env', () => {
+    const metadata = new grpc.Metadata();
+    metadata.set('foo', 'bar');
+    metadata.set('goo', 'lol');
+    envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=jar,bar=foo';
+    envSource.OTEL_EXPORTER_OTLP_TRACES_HEADERS = 'foo=boo';
+    const collectorExporter = new CollectorTraceExporter({ metadata });
+    assert.deepStrictEqual(collectorExporter.metadata?.get('foo'), ['boo']);
+    assert.deepStrictEqual(collectorExporter.metadata?.get('bar'), ['foo']);
+    assert.deepStrictEqual(collectorExporter.metadata?.get('goo'), ['lol']);
+    envSource.OTEL_EXPORTER_OTLP_TRACES_HEADERS = '';
+    envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
+  });
 });
 
 testCollectorExporter({ useTLS: true });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- OTLP-gRPC exporter needs to honor the OTEL_EXPORTER_OTLP(*)HEADERS env var
- from spec:
> Key-value pairs to be used as headers associated with gRPC or HTTP requests.
- fixes #2303 

## Short description of the changes

- Merge headers into gRPC exporters' metadata
