### PR TITLE
chore: update package template engines version

### DIFF
--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.5.0"
   },
   "scripts": {
     "compile": "tsc --build",


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- The [packages template](https://github.com/jonchurch/opentelemetry-js/blob/main/packages/template/package.json#L22) lists Node.js >=8.0.0 under supported engines in the default package.json. OTLP JS lists v8.5.0 as the min supported Node.js version. New packages that copy the template may fail to update the current default.

## Short description of the changes

- Bump the engines field in package.json to `>=8.5.0` to be in line with Node.js version support of the project.

closes #2318 