### PR TITLE
chore: fix tracer-web example webpack config

### DIFF
--- a/examples/tracer-web/webpack.config.js
+++ b/examples/tracer-web/webpack.config.js
@@ -8,7 +8,6 @@ const common = {
   mode: 'development',
   entry: {
     metrics: 'examples/metrics/index.js',
-    test: 'examples/test/test.ts',
     fetch: 'examples/fetch/index.js',
     'xml-http-request': 'examples/xml-http-request/index.js',
     zipkin: 'examples/zipkin/index.js',


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Closes #2325 
- Webpack config for the examples included bundling a file that was not in the examples dir, preventing the example from running as per the instructions.

## Short description of the changes

- Removed offending line from webpack config
