### PR TITLE
Update SimpleSpanProcessor to fix onStart method def

### DIFF
--- a/packages/opentelemetry-tracing/src/export/SimpleSpanProcessor.ts
+++ b/packages/opentelemetry-tracing/src/export/SimpleSpanProcessor.ts
@@ -43,7 +43,7 @@ export class SimpleSpanProcessor implements SpanProcessor {
   }
 
   // does nothing.
-  onStart(_span: Span): void {}
+  onStart(_span: Span, _parentContext: Context): void {}
 
   onEnd(span: ReadableSpan): void {
     if (this._isShutdown) {


### PR DESCRIPTION
```
error TS2345: Argument of type 'SimpleSpanProcessor' is not assignable to parameter of type 'SpanProcessor'.
  Types of property 'onStart' are incompatible.
    Type '(_span: Span) => void' is not assignable to type '(span: Span, parentContext: Context) => void'.
      Types of parameters '_span' and 'span' are incompatible.

```