### PR TITLE
Change default HTTP exporter port to 55681

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+* `opentelemetry-exporter-collector-proto`
+  * [#2331](https://github.com/open-telemetry/opentelemetry-js/pull/2331) fix(opentelemetry-exporter-collector-proto): Change default HTTP exporter port to 55681 ([@NathanielRN](https://github.com/NathanielRN))
 
 ## 0.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-* `opentelemetry-exporter-collector-proto`
-  * [#2331](https://github.com/open-telemetry/opentelemetry-js/pull/2331) fix(opentelemetry-exporter-collector-proto): Change default HTTP exporter port to 55681 ([@NathanielRN](https://github.com/NathanielRN))
 
 ## 0.23.0
 

--- a/packages/opentelemetry-exporter-collector-proto/src/CollectorMetricExporter.ts
+++ b/packages/opentelemetry-exporter-collector-proto/src/CollectorMetricExporter.ts
@@ -24,7 +24,7 @@ import { ServiceClientType } from './types';
 import { CollectorExporterNodeBase } from './CollectorExporterNodeBase';
 import { getEnv, baggageUtils } from '@opentelemetry/core';
 
-const DEFAULT_COLLECTOR_URL = 'http://localhost:4317/v1/metrics';
+const DEFAULT_COLLECTOR_URL = 'http://localhost:55681/v1/metrics';
 
 /**
  * Collector Metric Exporter for Node with protobuf

--- a/packages/opentelemetry-exporter-collector-proto/src/CollectorTraceExporter.ts
+++ b/packages/opentelemetry-exporter-collector-proto/src/CollectorTraceExporter.ts
@@ -24,7 +24,7 @@ import {
 import { ServiceClientType } from './types';
 import { getEnv, baggageUtils } from '@opentelemetry/core';
 
-const DEFAULT_COLLECTOR_URL = 'http://localhost:4317/v1/traces';
+const DEFAULT_COLLECTOR_URL = 'http://localhost:55681/v1/traces';
 
 /**
  * Collector Trace Exporter for Node with protobuf


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes: #2330 

## Short description of the changes

- Changes default HTTP exporter port to be `55681` instead of `4317` because `4317` is reserved for gRPC [in the specs](https://github.com/open-telemetry/opentelemetry-specification/blob/2a712f7626cb62b21ae210ef3175612e7744f285/specification/protocol/otlp.md#otlpgrpc-default-port)
- `55681` is [used by](https://github.com/open-telemetry/opentelemetry-collector/blob/f3784a92def81ae9b5c770c97ac2d5bed4f9b804/receiver/otlpreceiver/factory.go#L33-L34) `opentelemetry-collector` so it should be a good choice
