### PR TITLE
feat(opentelemetry-instrumentation-http): support adding custom attri…

### DIFF
--- a/packages/opentelemetry-instrumentation-http/src/types.ts
+++ b/packages/opentelemetry-instrumentation-http/src/types.ts
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Span } from '@opentelemetry/api';
+import { 
+  Span,
+  SpanAttributes,
+ } from '@opentelemetry/api';
 import type * as http from 'http';
 import type * as https from 'https';
 import {
@@ -22,6 +25,7 @@ import {
   IncomingMessage,
   request,
   ServerResponse,
+  RequestOptions,
 } from 'http';
 import * as url from 'url';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
@@ -67,6 +71,14 @@ export interface HttpResponseCustomAttributeFunction {
   (span: Span, response: IncomingMessage | ServerResponse): void;
 }
 
+export interface StartIncomingSpanCustomAttributeFunction {
+  (request: IncomingMessage ): SpanAttributes;
+}
+
+export interface StartOutgoingSpanCustomAttributeFunction {
+  (request: RequestOptions ): SpanAttributes;
+}
+
 /**
  * Options available for the HTTP instrumentation (see [documentation](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-instrumentation-http#http-instrumentation-options))
  */
@@ -81,6 +93,10 @@ export interface HttpInstrumentationConfig extends InstrumentationConfig {
   requestHook?: HttpRequestCustomAttributeFunction;
   /** Function for adding custom attributes before response is handled */
   responseHook?: HttpResponseCustomAttributeFunction;
+  /** Function for adding custom attributes before a span is started in incomingRequest */
+  startIncomingSpanHook?: StartIncomingSpanCustomAttributeFunction;
+  /** Function for adding custom attributes before a span is started in outgoingRequest */
+  startOutgoingSpanHook?: StartOutgoingSpanCustomAttributeFunction;
   /** The primary server name of the matched virtual host. */
   serverName?: string;
   /** Require parent to create span for outgoing requests */

--- a/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -410,11 +410,11 @@ export const getOutgoingRequestAttributesOnResponse = (
 /**
  * Returns incoming request attributes scoped to the request data
  * @param {IncomingMessage} request the request object
- * @param {{ component: string, serverName?: string }} options used to pass data needed to create attributes
+ * @param {{ component: string, serverName?: string, hookAttributes?: SpanAttributes }} options used to pass data needed to create attributes
  */
 export const getIncomingRequestAttributes = (
   request: IncomingMessage,
-  options: { component: string; serverName?: string }
+  options: { component: string; serverName?: string; hookAttributes?: SpanAttributes }
 ): SpanAttributes => {
   const headers = request.headers;
   const userAgent = headers['user-agent'];
@@ -458,7 +458,7 @@ export const getIncomingRequestAttributes = (
   setRequestContentLengthAttribute(request, attributes);
 
   const httpKindAttributes = getAttributesFromHttpKind(httpVersion);
-  return Object.assign(attributes, httpKindAttributes);
+  return Object.assign(attributes, httpKindAttributes, options.hookAttributes);
 };
 
 /**

--- a/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
@@ -18,7 +18,9 @@ import {
   context,
   propagation,
   Span as ISpan,
-  SpanKind, trace,
+  SpanKind, 
+  trace,
+  SpanAttributes,
 } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/node';
 import {
@@ -39,7 +41,7 @@ import { DummyPropagation } from '../utils/DummyPropagation';
 import { httpRequest } from '../utils/httpRequest';
 import { ContextManager } from '@opentelemetry/api';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
-import type { ClientRequest, IncomingMessage, ServerResponse } from 'http';
+import type { ClientRequest, IncomingMessage, ServerResponse, RequestOptions } from 'http';
 import { isWrapped } from '@opentelemetry/instrumentation';
 import { getRPCMetadata, RPCType } from '@opentelemetry/core';
 
@@ -93,6 +95,18 @@ export const responseHookFunction = (
   response: IncomingMessage | ServerResponse
 ): void => {
   span.setAttribute('custom response hook attribute', 'response');
+};
+
+export const startIncomingSpanHookFunction = (
+  request: IncomingMessage
+): SpanAttributes => {
+  return {guid: request.headers?.guid}
+};
+
+export const startOutgoingSpanHookFunction = (
+  request: RequestOptions
+): SpanAttributes => {
+  return {guid: request.headers?.guid}
 };
 
 describe('HttpInstrumentation', () => {
@@ -201,6 +215,8 @@ describe('HttpInstrumentation', () => {
           applyCustomAttributesOnSpan: customAttributeFunction,
           requestHook: requestHookFunction,
           responseHook: responseHookFunction,
+          startIncomingSpanHook: startIncomingSpanHookFunction,
+          startOutgoingSpanHook: startOutgoingSpanHookFunction,
           serverName,
         });
         instrumentation.enable();
@@ -672,7 +688,8 @@ describe('HttpInstrumentation', () => {
 
       it('custom attributes should show up on client and server spans', async () => {
         await httpRequest.get(
-          `${protocol}://${hostname}:${serverPort}${pathname}`
+          `${protocol}://${hostname}:${serverPort}${pathname}`,
+          {headers: {guid: 'user_guid'}}
         );
         const spans = memoryExporter.getFinishedSpans();
         const [incomingSpan, outgoingSpan] = spans;
@@ -686,6 +703,14 @@ describe('HttpInstrumentation', () => {
           'response'
         );
         assert.strictEqual(
+          incomingSpan.attributes['custom response hook attribute'],
+          'response'
+        );
+        assert.strictEqual(
+          incomingSpan.attributes['guid'],
+          'user_guid'
+        );
+        assert.strictEqual(
           incomingSpan.attributes['span kind'],
           SpanKind.CLIENT
         );
@@ -697,6 +722,10 @@ describe('HttpInstrumentation', () => {
         assert.strictEqual(
           outgoingSpan.attributes['custom response hook attribute'],
           'response'
+        );
+        assert.strictEqual(
+          outgoingSpan.attributes['guid'],
+          'user_guid'
         );
         assert.strictEqual(
           outgoingSpan.attributes['span kind'],


### PR DESCRIPTION
…butes before a span is started

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

-for opentelemetry-instrumentation-http, support adding custom attributes before a span is started


## Short description of the changes

-add startIncomingSpanHook，startOutgoingSpanHook and corresponding test for opentelemetry-instrumentation-http
