### PR TITLE
chore: fix lint errors on opentelemetry-context-async-hooks

### DIFF
--- a/packages/opentelemetry-context-async-hooks/src/AsyncHooksContextManager.ts
+++ b/packages/opentelemetry-context-async-hooks/src/AsyncHooksContextManager.ts
@@ -46,7 +46,7 @@ export class AsyncHooksContextManager extends AbstractAsyncHooksContextManager {
   ): ReturnType<F> {
     this._enterContext(context);
     try {
-      return fn.call(thisArg!, ...args);
+      return fn.call(thisArg, ...args);
     } finally {
       this._exitContext();
     }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- https://github.com/open-telemetry/opentelemetry-js/issues/1093

## Short description of the changes

Fix the following lint errors:
```
\opentelemetry-js\packages\opentelemetry-context-async-hooks\src\AbstractAsyncHooksContextManager.ts
   71:35  warning  Don't use `Function` as a type  @typescript-eslint/ban-types
  133:60  warning  Don't use `Function` as a type  @typescript-eslint/ban-types
  151:64  warning  Don't use `Function` as a type  @typescript-eslint/ban-types
  175:15  warning  Don't use `Function` as a type  @typescript-eslint/ban-types

\opentelemetry-js\packages\opentelemetry-context-async-hooks\src\AsyncHooksContextManager.ts
  49:22  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
```