### PR TITLE
feat(logging): single line JSON tracing info on console

### DIFF
--- a/packages/opentelemetry-tracing/src/export/ConsoleSpanExporter.ts
+++ b/packages/opentelemetry-tracing/src/export/ConsoleSpanExporter.ts
@@ -21,6 +21,7 @@ import {
   ExportResultCode,
   hrTimeToMicroseconds,
 } from '@opentelemetry/core';
+import * as util from 'util';
 
 /**
  * This is implementation of {@link SpanExporter} that prints spans to the
@@ -78,7 +79,7 @@ export class ConsoleSpanExporter implements SpanExporter {
     done?: (result: ExportResult) => void
   ): void {
     for (const span of spans) {
-      console.log(this._exportInfo(span));
+      console.log(util.inspect(this._exportInfo(span), {breakLength: Infinity}));
     }
     if (done) {
       return done({ code: ExportResultCode.SUCCESS });


### PR DESCRIPTION
BREAKING CHANGE: Prints JSON tracing info as a single line for better compatibility with
log aggregators

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Tracing info displayed on the console by ConsoleSpanExporter is multiline, as it is the
standard behaviour when using `console.log(obj)` - However, this causes trouble for people
using log aggregators (like Loki) which handle single line log messages better. Moreover, it is 
a safe assumption that people using a tracing library is probably using a log aggregator as well.

This option makes it easier for the case I described while being still possible to copy->paste->format
from the terminal as well for local development or if no log aggregator is in place.

-

## Short description of the changes

Prints JSON tracing info as a single line
-
