### PR TITLE
feat(opentelemetry-web): capture decodedBodySize / http.response_content_length_uncompressed

### DIFF
--- a/packages/opentelemetry-web/src/enums/PerformanceTimingNames.ts
+++ b/packages/opentelemetry-web/src/enums/PerformanceTimingNames.ts
@@ -17,6 +17,7 @@
 export enum PerformanceTimingNames {
   CONNECT_END = 'connectEnd',
   CONNECT_START = 'connectStart',
+  DECODED_BODY_SIZE = 'decodedBodySize',
   DOM_COMPLETE = 'domComplete',
   DOM_CONTENT_LOADED_EVENT_END = 'domContentLoadedEventEnd',
   DOM_CONTENT_LOADED_EVENT_START = 'domContentLoadedEventStart',

--- a/packages/opentelemetry-web/src/types.ts
+++ b/packages/opentelemetry-web/src/types.ts
@@ -18,6 +18,7 @@ import { PerformanceTimingNames } from './enums/PerformanceTimingNames';
 export type PerformanceEntries = {
   [PerformanceTimingNames.CONNECT_END]?: number;
   [PerformanceTimingNames.CONNECT_START]?: number;
+  [PerformanceTimingNames.DECODED_BODY_SIZE]?: number;
   [PerformanceTimingNames.DOM_COMPLETE]?: number;
   [PerformanceTimingNames.DOM_CONTENT_LOADED_EVENT_END]?: number;
   [PerformanceTimingNames.DOM_CONTENT_LOADED_EVENT_START]?: number;

--- a/packages/opentelemetry-web/src/utils.ts
+++ b/packages/opentelemetry-web/src/utils.ts
@@ -87,11 +87,19 @@ export function addSpanNetworkEvents(
   addSpanNetworkEvent(span, PTN.REQUEST_START, resource);
   addSpanNetworkEvent(span, PTN.RESPONSE_START, resource);
   addSpanNetworkEvent(span, PTN.RESPONSE_END, resource);
-  const contentLength = resource[PTN.ENCODED_BODY_SIZE];
-  if (contentLength !== undefined) {
+  const encodedLength = resource[PTN.ENCODED_BODY_SIZE];
+  if (encodedLength !== undefined) {
     span.setAttribute(
       SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH,
-      contentLength
+      encodedLength
+    );
+  }
+  const decodedLength = resource[PTN.DECODED_BODY_SIZE];
+  // Spec: Not set if transport encoding not used (in which case encoded and decoded sizes match)
+  if (decodedLength !== undefined && encodedLength !== decodedLength) {
+    span.setAttribute(
+      SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
+      decodedLength
     );
   }
 }

--- a/packages/opentelemetry-web/test/utils.test.ts
+++ b/packages/opentelemetry-web/test/utils.test.ts
@@ -146,7 +146,8 @@ describe('utils', () => {
         [PTN.REQUEST_START]: 123,
         [PTN.RESPONSE_START]: 123,
         [PTN.RESPONSE_END]: 123,
-        [PTN.ENCODED_BODY_SIZE]: 123,
+        [PTN.DECODED_BODY_SIZE]: 123,
+        [PTN.ENCODED_BODY_SIZE]: 61,
       } as PerformanceEntries;
 
       assert.strictEqual(addEventSpy.callCount, 0);
@@ -154,6 +155,25 @@ describe('utils', () => {
       addSpanNetworkEvents(span, entries);
 
       assert.strictEqual(addEventSpy.callCount, 9);
+      assert.strictEqual(setAttributeSpy.callCount, 2);
+    });
+    it('should only include encoded size when content encoding is being used', () => {
+      const addEventSpy = sinon.spy();
+      const setAttributeSpy = sinon.spy();
+      const span = ({
+        addEvent: addEventSpy,
+        setAttribute: setAttributeSpy,
+      } as unknown) as tracing.Span;
+      const entries = {
+        [PTN.DECODED_BODY_SIZE]: 123,
+        [PTN.ENCODED_BODY_SIZE]: 123,
+      } as PerformanceEntries;
+
+      assert.strictEqual(setAttributeSpy.callCount, 0);
+
+      addSpanNetworkEvents(span, entries);
+
+      assert.strictEqual(addEventSpy.callCount, 0);
       assert.strictEqual(setAttributeSpy.callCount, 1);
     });
   });


### PR DESCRIPTION
Add capturing [decodedBodySize from resource timings](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/decodedBodySize). [As per spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes) it should be only included if content encoding (eg. gzip, brotli) is being used (in which case encoded and decoded sizes are different)

Past related: https://github.com/open-telemetry/opentelemetry-js/pull/1262#discussion_r448697119