### PR TITLE
fix(instrumentation-http): set outgoing request attributes on start span

### DIFF
--- a/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -38,7 +38,6 @@ import {
   HttpInstrumentationConfig,
   HttpRequestArgs,
   Https,
-  ParsedRequestOptions,
   ResponseEndArgs,
 } from './types';
 import * as utils from './utils';
@@ -72,7 +71,9 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
     return this._config;
   }
 
-  override setConfig(config: HttpInstrumentationConfig & InstrumentationConfig = {}) {
+  override setConfig(
+    config: HttpInstrumentationConfig & InstrumentationConfig = {}
+  ) {
     this._config = Object.assign({}, config);
   }
 
@@ -272,20 +273,10 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
    * @param span representing the current operation
    */
   private _traceClientRequest(
-    component: 'http' | 'https',
     request: http.ClientRequest,
-    options: ParsedRequestOptions,
+    hostname: string,
     span: Span
   ): http.ClientRequest {
-    const hostname =
-      options.hostname ||
-      options.host?.replace(/^(.*)(:[0-9]{1,5})/, '$1') ||
-      'localhost';
-    const attributes = utils.getOutgoingRequestAttributes(options, {
-      component,
-      hostname,
-    });
-    span.setAttributes(attributes);
     if (this._getConfig().requestHook) {
       this._callRequestHook(span, request);
     }
@@ -378,13 +369,17 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
         : '/';
       const method = request.method || 'GET';
 
-      instrumentation._diag.debug('%s instrumentation incomingRequest', component);
+      instrumentation._diag.debug(
+        '%s instrumentation incomingRequest',
+        component
+      );
 
       if (
         utils.isIgnored(
           pathname,
           instrumentation._getConfig().ignoreIncomingPaths,
-          (e: Error) => instrumentation._diag.error('caught ignoreIncomingPaths error: ', e)
+          (e: Error) =>
+            instrumentation._diag.error('caught ignoreIncomingPaths error: ', e)
         )
       ) {
         return context.with(suppressTracing(context.active()), () => {
@@ -528,15 +523,27 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
         utils.isIgnored(
           origin + pathname,
           instrumentation._getConfig().ignoreOutgoingUrls,
-          (e: Error) => instrumentation._diag.error('caught ignoreOutgoingUrls error: ', e)
+          (e: Error) =>
+            instrumentation._diag.error('caught ignoreOutgoingUrls error: ', e)
         )
       ) {
         return original.apply(this, [optionsParsed, ...args]);
       }
 
       const operationName = `${component.toUpperCase()} ${method}`;
+
+      const hostname =
+        optionsParsed.hostname ||
+        optionsParsed.host?.replace(/^(.*)(:[0-9]{1,5})/, '$1') ||
+        'localhost';
+      const attributes = utils.getOutgoingRequestAttributes(optionsParsed, {
+        component,
+        hostname,
+      });
+
       const spanOptions: SpanOptions = {
         kind: SpanKind.CLIENT,
+        attributes,
       };
       const span = instrumentation._startHttpSpan(operationName, spanOptions);
 
@@ -569,12 +576,14 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
           }
         );
 
-        instrumentation._diag.debug('%s instrumentation outgoingRequest', component);
+        instrumentation._diag.debug(
+          '%s instrumentation outgoingRequest',
+          component
+        );
         context.bind(parentContext, request);
         return instrumentation._traceClientRequest(
-          component,
           request,
-          optionsParsed,
+          hostname,
           span
         );
       });

--- a/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -71,9 +71,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
     return this._config;
   }
 
-  override setConfig(
-    config: HttpInstrumentationConfig & InstrumentationConfig = {}
-  ) {
+  override setConfig(config: HttpInstrumentationConfig & InstrumentationConfig = {}) {
     this._config = Object.assign({}, config);
   }
 
@@ -369,17 +367,13 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
         : '/';
       const method = request.method || 'GET';
 
-      instrumentation._diag.debug(
-        '%s instrumentation incomingRequest',
-        component
-      );
+      instrumentation._diag.debug('%s instrumentation incomingRequest', component);
 
       if (
         utils.isIgnored(
           pathname,
           instrumentation._getConfig().ignoreIncomingPaths,
-          (e: Error) =>
-            instrumentation._diag.error('caught ignoreIncomingPaths error: ', e)
+          (e: Error) => instrumentation._diag.error('caught ignoreIncomingPaths error: ', e)
         )
       ) {
         return context.with(suppressTracing(context.active()), () => {
@@ -523,8 +517,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
         utils.isIgnored(
           origin + pathname,
           instrumentation._getConfig().ignoreOutgoingUrls,
-          (e: Error) =>
-            instrumentation._diag.error('caught ignoreOutgoingUrls error: ', e)
+          (e: Error) => instrumentation._diag.error('caught ignoreOutgoingUrls error: ', e)
         )
       ) {
         return original.apply(this, [optionsParsed, ...args]);
@@ -576,10 +569,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
           }
         );
 
-        instrumentation._diag.debug(
-          '%s instrumentation outgoingRequest',
-          component
-        );
+        instrumentation._diag.debug('%s instrumentation outgoingRequest', component);
         context.bind(parentContext, request);
         return instrumentation._traceClientRequest(
           request,

--- a/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -69,8 +69,13 @@ export const getAbsoluteUrl = (
  * Parse status code from HTTP response. [More details](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-http.md#status)
  */
 export const parseResponseStatus = (
-  statusCode: number
+  statusCode: number | undefined,
 ): Omit<SpanStatus, 'message'> => {
+
+  if(statusCode === undefined) {
+    return { code: SpanStatusCode.ERROR };
+  }
+
   // 1xx, 2xx, 3xx are OK
   if (statusCode >= 100 && statusCode < 400) {
     return { code: SpanStatusCode.OK };

--- a/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
@@ -482,7 +482,7 @@ describe('HttpInstrumentation', () => {
       it('should have 1 ended span when request throw on bad "options" object', done => {
         try {
           http.request({ headers: { cookie: undefined} }); // <===== this makes http.request throw
-          done('exception should have being thrown but did not');
+          done('exception should have been thrown but did not');
         } catch (error) {
           const spans = memoryExporter.getFinishedSpans();
           assert.strictEqual(spans.length, 1);
@@ -495,7 +495,7 @@ describe('HttpInstrumentation', () => {
             pathname: '/',
             forceStatus: {
               code: SpanStatusCode.ERROR, 
-              message: 'Invalid value "undefined" for header "cookie"',
+              message: error.message,
             },
             component: 'http',
             noNetPeer: true,

--- a/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
+++ b/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
@@ -479,11 +479,8 @@ describe('HttpInstrumentation', () => {
         });
       }
 
-      it('should have 1 ended span when request throw on bad "options" object', done => {
-        try {
-          http.request({ headers: { cookie: undefined} }); // <===== this makes http.request throw
-          done('exception should have been thrown but did not');
-        } catch (error) {
+      it('should have 1 ended span when request throw on bad "options" object', () => {
+        assert.throws(() => http.request({ headers: { cookie: undefined} }), err => {
           const spans = memoryExporter.getFinishedSpans();
           assert.strictEqual(spans.length, 1);
 
@@ -495,14 +492,14 @@ describe('HttpInstrumentation', () => {
             pathname: '/',
             forceStatus: {
               code: SpanStatusCode.ERROR, 
-              message: error.message,
+              message: err.message,
             },
             component: 'http',
             noNetPeer: true,
           }
           assertSpan(spans[0], SpanKind.CLIENT, validations);
-          done();
-        }
+          return true;
+        });
       });
 
       it('should have 1 ended span when response.end throw an exception', async () => {

--- a/packages/opentelemetry-instrumentation-http/test/utils/assertSpan.ts
+++ b/packages/opentelemetry-instrumentation-http/test/utils/assertSpan.ts
@@ -27,7 +27,7 @@ export const assertSpan = (
   span: ReadableSpan,
   kind: SpanKind,
   validations: {
-    httpStatusCode: number;
+    httpStatusCode?: number;
     httpMethod: string;
     resHeaders: http.IncomingHttpHeaders;
     hostname: string;
@@ -37,6 +37,7 @@ export const assertSpan = (
     forceStatus?: SpanStatus;
     serverName?: string;
     component: string;
+    noNetPeer?: boolean; // we don't expect net peer info when request throw before being sent
   }
 ) => {
   assert.strictEqual(span.spanContext().traceId.length, 32);
@@ -110,14 +111,16 @@ export const assertSpan = (
       validations.hostname,
       'must be consistent (PEER_NAME and hostname)'
     );
-    assert.ok(
-      span.attributes[SemanticAttributes.NET_PEER_IP],
-      'must have PEER_IP'
-    );
-    assert.ok(
-      span.attributes[SemanticAttributes.NET_PEER_PORT],
-      'must have PEER_PORT'
-    );
+    if(!validations.noNetPeer) {
+      assert.ok(
+        span.attributes[SemanticAttributes.NET_PEER_IP],
+        'must have PEER_IP'
+      );
+      assert.ok(
+        span.attributes[SemanticAttributes.NET_PEER_PORT],
+        'must have PEER_PORT'
+      );  
+    }
     assert.ok(
       (span.attributes[SemanticAttributes.HTTP_URL] as string).indexOf(
         span.attributes[SemanticAttributes.NET_PEER_NAME] as string


### PR DESCRIPTION

## Which problem is this PR solving?

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/1255
Fixes #2320 
And fix an HTTP instrumentation test: `'should have 1 ended span when request throw on bad "options" object'`

For HTTP instrumentation, the span for outgoing request is currently started (`startSpan`) without any attributes. Only later when response arrives, request and response attributes are calculated and set on it. This is problematic in 2 situations:
- if exception is thrown before the response arrives (for example, if the parameters are not valid), then the span is closed and there are no attributes on it for user to understand the context (no URL, method).
- sampler can only take decisions based on attributes that are available during `startSpan` function call (on the options). Request attributes are already available at this point, but since they are not sent to startSpan, sampling is impossible for this case.

Additionally, there is a test for HTTP instrumentation called `'should have 1 ended span when request throw on bad "options" object'`, which calls `http.request` assuming it will throw, and then asserting in the `catch` block, but the function did not actually throw, so the test didn't check anything at all.

## Short description of the changes

I moved the request attributes calculation to happen before starting the span (instead of doing it when response arrive), which solves the 2 issues above.
I also changed the mentioned test so it actually throws an error, and added assertions in it for the logic I changed in the code.
