### PR TITLE
chore: ignore backcompat in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,8 +11,8 @@
       "rangeStrategy": "bump"
     },
     {
-      "matchPaths": ["backwards-compatibility/**"],
-      "ignoreDeps": ["@types/node"],
+      "matchPaths": ["backwards-compatibility"],
+      "matchPackageNames": ["@types/node"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
Yet another crack at updating renovate so it will not do #2236 

This version comes from a suggestion from the folks at renovate so it should work.