### PR TITLE
replaced word plugin with instrumentation

### DIFF
--- a/website_docs/getting_started/browser.md
+++ b/website_docs/getting_started/browser.md
@@ -18,7 +18,7 @@ Copy the following file into an empty directory and call it `index.html`.
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Document Load Plugin Example</title>
+  <title>Document Load Instrumentation Example</title>
   <base href="/">
   <!--
     https://www.w3.org/TR/trace-context/
@@ -33,14 +33,14 @@ Copy the following file into an empty directory and call it `index.html`.
   <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
-  Example of using Web Tracer with document load plugin with console exporter and collector exporter
+  Example of using Web Tracer with document load instrumentation with console exporter and collector exporter
 </body>
 </html>
 ```
 
 ## Installation
 
-To create traces in the browser, you will need `@opentelemetry/web`, and the plugin `@opentelemetry/plugin-document-load`:
+To create traces in the browser, you will need `@opentelemetry/web`, and the instrumentation `@opentelemetry/instrumentation-document-load`:
 
 ```shell
 npm init -y
@@ -59,7 +59,7 @@ We will add some code that will trace the document load timings and output those
 
 ## Creating a Tracer Provider
 
-Add the following code to the `document-load.js` to create a tracer provider, which brings the plugin to trace document load:
+Add the following code to the `document-load.js` to create a tracer provider, which brings the instrumentaion to trace document load:
 
 ```javascript
 import { WebTracerProvider } from '@opentelemetry/web';
@@ -74,7 +74,7 @@ provider.register({
   contextManager: new ZoneContextManager(),
 });
 
-// Registering instrumentations / plugins
+// Registering instrumentations
 registerInstrumentations({
   instrumentations: [
     new DocumentLoadInstrumentation(),
@@ -113,7 +113,7 @@ provider.register({
   contextManager: new ZoneContextManager(),
 });
 
-// Registering instrumentations / plugins
+// Registering instrumentations
 registerInstrumentations({
   instrumentations: [
     new DocumentLoadInstrumentation(),


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- website_docs , consistency in using words plugin versus instrumentation. Replaced the word plugin with instrumentation 

## Short description of the changes

- The package for instrumentation of `document load` is named @opentelemetry/instrumentation-document-load . But the website_docs use often the word `plugin` in order to reference this instrumentation, e.g by informing the user to install the @opentelemetry/plugin-document-load . It should actually be:  @opentelemetry/instrumentation-document-load
