### PR TITLE
chore: adding Rauno56 to js approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @dyladan @mayurkale22 @OlivierAlbertini @vmarchaud @markwolff @obecny @mwear @naseemkullah @legendecas @Flarna @johnbley @MSNev
+* @dyladan @mayurkale22 @OlivierAlbertini @vmarchaud @markwolff @obecny @mwear @naseemkullah @legendecas @Flarna @johnbley @MSNev @Rauno56

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Approvers ([@open-telemetry/js-approvers](https://github.com/orgs/open-telemetry
 - [Naseem K. Ullah](https://github.com/naseemkullah), Transit
 - [Neville Wylie](https://github.com/MSNev), Microsoft
 - [Olivier Albertini](https://github.com/OlivierAlbertini), Ville de Montréal
+- [Rauno Viskus](https://github.com/Rauno56), Splunk
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).*
 


### PR DESCRIPTION
I wanted to promote @Rauno56 to js approver. He has been contributing for this project for a while and is quite active in otel as well.

PRs:
https://github.com/open-telemetry/opentelemetry-js-contrib/commits?author=Rauno56
https://github.com/open-telemetry/opentelemetry-js/commits?author=Rauno56
https://github.com/open-telemetry/opentelemetry-js-api/commits?author=Rauno56

Thx @Rauno56 for all of you contributions so far.
