### PR TITLE
Use user URL if validation returns empty endpoint

### DIFF
--- a/packages/opentelemetry-exporter-collector-grpc/src/util.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/src/util.ts
@@ -108,11 +108,15 @@ export function send<ExportItem, ServiceRequest>(
 }
 
 export function validateAndNormalizeUrl(url: string): string {
-  const hasProtocol = url.match(/^([\w]{1,8}):\/\//);
-  if (!hasProtocol) {
-    url = `https://${url}`;
-  }
   const target = new URL(url);
+
+  if (target.host === '') {
+    diag.warn(
+      'Parsing URL failed to return a valid host. Returning raw url.'
+    );
+    return url
+  }
+
   if (target.pathname && target.pathname !== '/') {
     diag.warn(
       'URL path should not be set when using grpc, the path part of the URL will be ignored.'
@@ -123,5 +127,6 @@ export function validateAndNormalizeUrl(url: string): string {
       'URL protocol should be http(s):// or grpc(s)://. Using grpc://.'
     );
   }
-  return target.host;
+
+  return target.host
 }

--- a/packages/opentelemetry-exporter-collector-grpc/test/util.test.ts
+++ b/packages/opentelemetry-exporter-collector-grpc/test/util.test.ts
@@ -24,19 +24,21 @@ import { validateAndNormalizeUrl } from '../src/util';
 describe('validateAndNormalizeUrl()', () => {
   const tests = [
     {
-      name: 'bare hostname should return same value',
-      input: 'api.datacat.io',
-      expected: 'api.datacat.io',
-    },
-    {
-      name: 'host:port should return same value',
-      input: 'api.datacat.io:1234',
-      expected: 'api.datacat.io:1234',
-    },
-    {
       name: 'grpc://host:port should trim off protocol',
       input: 'grpc://api.datacat.io:1234',
       expected: 'api.datacat.io:1234',
+    },
+    {
+      name: 'bare hostname should warn but return same value',
+      input: 'api.datacat.io',
+      expected: 'api.datacat.io',
+      warn: 'Parsing URL failed to return a valid host. Returning raw url.',
+    },
+    {
+      name: 'host:port should warn but return same value',
+      input: 'api.datacat.io:1234',
+      expected: 'api.datacat.io:1234',
+      warn: 'Parsing URL failed to return a valid host. Returning raw url.',
     },
     {
       name: 'bad protocol should warn but return host:port',


### PR DESCRIPTION
## Which problem is this PR solving?

If a user sets the exporter URL to be something like `localhost:8080`, then we will run their string through the `validateAndNormalizeUrl(url: string)` function.

However, the `new URL(url)` constructor used in `validateAndNormalizeUrl` will return the following:

```bash
$ node
Welcome to Node.js v14.17.1.
Type ".help" for more information.
> const URL = require('url').URL;
undefined
> new URL('localhost:8080')
URL {
  href: 'localhost:8080',
  origin: 'null',
  protocol: 'localhost:',
  username: '',
  password: '',
  host: '', # Empty string!
  hostname: '',
  port: '',
  pathname: '8080',
  search: '',
  searchParams: URLSearchParams {},
  hash: ''
}
>
```

`validateAndNormalizeUrl` does not check the result of the parsing before it returns `target.host` which in the case above is just `''`.

The correct URL would have been `http://localhost:8080` which would have provided the correct `target.host` value:

```bash
> new URL('http://localhost:8080')
URL {
  href: 'http://localhost:8080/',
  origin: 'http://localhost:8080',
  protocol: 'http:',
  username: '',
  password: '',
  host: 'localhost:8080', # The correct value!
  hostname: 'localhost',
  port: '8080',
  pathname: '/',
  search: '',
  searchParams: URLSearchParams {},
  hash: ''
}
>
```

## Short description of the changes

[In Python](https://github.com/open-telemetry/opentelemetry-python/blob/39927787cc911af8567731728a37afc24f935d1e/exporter/opentelemetry-exporter-otlp-proto-grpc/src/opentelemetry/exporter/otlp/proto/grpc/exporter.py#L215-L228) we only return the `.host` (called `.netloc`) if **it is not the empty string**. Otherwise, we will try to access the exporter at the **raw URL** that the user provided.

These changes does the same: Try to validate and normalize the URL, but if the URL is the empty string, use the raw URL instead.
