### PR TITLE
chore: move api into dependencies in integration tests

### DIFF
--- a/.github/workflows/peer-api.yaml
+++ b/.github/workflows/peer-api.yaml
@@ -19,4 +19,4 @@ jobs:
         run: npm install -g lerna
 
       - name: Check API dependency semantics
-        run: lerna exec "node ../../scripts/peer-api-check.js"
+        run: lerna exec --ignore propagation-validation-server "node ../../scripts/peer-api-check.js"

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -11,6 +11,7 @@
     "compile": "tsc --build"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.0.1",
     "@opentelemetry/context-async-hooks": "0.24.0",
     "@opentelemetry/core": "0.24.0",
     "@opentelemetry/tracing": "0.24.0",
@@ -19,10 +20,6 @@
     "express": "4.17.1"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^1.0.1",
     "typescript": "4.3.5"
-  },
-  "peerDependencies": {
-    "@opentelemetry/api": "^1.0.1"
   }
 }


### PR DESCRIPTION
Integration tests require the OTel API. Therefore move it into dependencies section and remove the peer-dependency.
