### PR TITLE
Follow spec defined port 4318 for HTTP exporter

### DIFF
--- a/examples/basic-tracer-node/docker/ot/docker-compose.yaml
+++ b/examples/basic-tracer-node/docker/ot/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     ports:
       - "9464:9464"
       - "4317:4317"
-      - "55681:55681"
+      - "4318:4318"
     depends_on:
       - jaeger-all-in-one
 

--- a/examples/collector-exporter-node/docker/docker-compose.yaml
+++ b/examples/collector-exporter-node/docker/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     ports:
       - "9464:9464"
       - "4317:4317"
-      - "55681:55681"
+      - "4318:4318"
     depends_on:
       - zipkin-all-in-one
 

--- a/examples/collector-exporter-node/metrics.js
+++ b/examples/collector-exporter-node/metrics.js
@@ -12,7 +12,7 @@ const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventi
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 
 const metricExporter = new CollectorMetricExporter({
-  // url: 'http://localhost:55681/v1/metrics',
+  // url: 'http://localhost:4318/v1/metrics',
 });
 
 const meter = new MeterProvider({

--- a/packages/opentelemetry-exporter-collector-proto/README.md
+++ b/packages/opentelemetry-exporter-collector-proto/README.md
@@ -25,7 +25,7 @@ const { BasicTracerProvider, SimpleSpanProcessor } = require('@opentelemetry/tra
 const { CollectorTraceExporter } =  require('@opentelemetry/exporter-collector-proto');
 
 const collectorOptions = {
-  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:55681/v1/traces
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:4318/v1/traces
   headers: {
     foo: 'bar'
   }, //an optional object containing custom headers to be sent with each request will only work with http
@@ -45,7 +45,7 @@ provider.register();
 const { MeterProvider } = require('@opentelemetry/metrics');
 const { CollectorMetricExporter } =  require('@opentelemetry/exporter-collector-proto');
 const collectorOptions = {
-  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:55681/v1/metrics
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:4318/v1/metrics
 };
 const exporter = new CollectorMetricExporter(collectorOptions);
 

--- a/packages/opentelemetry-exporter-collector-proto/src/CollectorMetricExporter.ts
+++ b/packages/opentelemetry-exporter-collector-proto/src/CollectorMetricExporter.ts
@@ -24,7 +24,7 @@ import { ServiceClientType } from './types';
 import { CollectorExporterNodeBase } from './CollectorExporterNodeBase';
 import { getEnv, baggageUtils } from '@opentelemetry/core';
 
-const DEFAULT_COLLECTOR_URL = 'http://localhost:55681/v1/metrics';
+const DEFAULT_COLLECTOR_URL = 'http://localhost:4318/v1/metrics';
 
 /**
  * Collector Metric Exporter for Node with protobuf

--- a/packages/opentelemetry-exporter-collector-proto/src/CollectorTraceExporter.ts
+++ b/packages/opentelemetry-exporter-collector-proto/src/CollectorTraceExporter.ts
@@ -24,7 +24,7 @@ import {
 import { ServiceClientType } from './types';
 import { getEnv, baggageUtils } from '@opentelemetry/core';
 
-const DEFAULT_COLLECTOR_URL = 'http://localhost:55681/v1/traces';
+const DEFAULT_COLLECTOR_URL = 'http://localhost:4318/v1/traces';
 
 /**
  * Collector Trace Exporter for Node with protobuf

--- a/packages/opentelemetry-exporter-collector/README.md
+++ b/packages/opentelemetry-exporter-collector/README.md
@@ -28,7 +28,7 @@ import { WebTracerProvider } from '@opentelemetry/web';
 import { CollectorTraceExporter } from '@opentelemetry/exporter-collector';
 
 const collectorOptions = {
-  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:55681/v1/trace
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:4318/v1/trace
   headers: {}, // an optional object containing custom headers to be sent with each request
   concurrencyLimit: 10, // an optional limit on pending requests
 };
@@ -58,7 +58,7 @@ The CollectorMetricExporter in Web expects the endpoint to end in `/v1/metrics`.
 import { MeterProvider } from '@opentelemetry/metrics';
 import { CollectorMetricExporter } from '@opentelemetry/exporter-collector';
 const collectorOptions = {
-  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:55681/v1/metrics
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:4318/v1/metrics
   headers: {}, // an optional object containing custom headers to be sent with each request
   concurrencyLimit: 1, // an optional limit on pending requests
 };
@@ -83,7 +83,7 @@ const { BasicTracerProvider, BatchSpanProcessor } = require('@opentelemetry/trac
 const { CollectorTraceExporter } =  require('@opentelemetry/exporter-collector');
 
 const collectorOptions = {
-  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:55681/v1/trace
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:4318/v1/trace
   headers: {
     foo: 'bar'
   }, // an optional object containing custom headers to be sent with each request will only work with http
@@ -109,7 +109,7 @@ provider.register();
 const { MeterProvider } = require('@opentelemetry/metrics');
 const { CollectorMetricExporter } =  require('@opentelemetry/exporter-collector');
 const collectorOptions = {
-  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:55681/v1/metrics
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:4318/v1/metrics
   concurrencyLimit: 1, // an optional limit on pending requests
 };
 const exporter = new CollectorMetricExporter(collectorOptions);

--- a/packages/opentelemetry-exporter-collector/src/platform/browser/CollectorMetricExporter.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/browser/CollectorMetricExporter.ts
@@ -21,7 +21,7 @@ import { CollectorExporterBrowserBase } from './CollectorExporterBrowserBase';
 import { toCollectorExportMetricServiceRequest } from '../../transformMetrics';
 import { getEnv, baggageUtils } from '@opentelemetry/core';
 
-const DEFAULT_COLLECTOR_URL = 'http://localhost:55681/v1/metrics';
+const DEFAULT_COLLECTOR_URL = 'http://localhost:4318/v1/metrics';
 
 /**
  * Collector Metric Exporter for Web

--- a/packages/opentelemetry-exporter-collector/src/platform/browser/CollectorTraceExporter.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/browser/CollectorTraceExporter.ts
@@ -21,7 +21,7 @@ import { toCollectorExportTraceServiceRequest } from '../../transform';
 import * as collectorTypes from '../../types';
 import { getEnv, baggageUtils } from '@opentelemetry/core';
 
-const DEFAULT_COLLECTOR_URL = 'http://localhost:55681/v1/traces';
+const DEFAULT_COLLECTOR_URL = 'http://localhost:4318/v1/traces';
 
 /**
  * Collector Trace Exporter for Web

--- a/packages/opentelemetry-exporter-collector/src/platform/node/CollectorMetricExporter.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/node/CollectorMetricExporter.ts
@@ -21,7 +21,7 @@ import { CollectorExporterNodeBase } from './CollectorExporterNodeBase';
 import { toCollectorExportMetricServiceRequest } from '../../transformMetrics';
 import { getEnv, baggageUtils } from '@opentelemetry/core';
 
-const DEFAULT_COLLECTOR_URL = 'http://localhost:55681/v1/metrics';
+const DEFAULT_COLLECTOR_URL = 'http://localhost:4318/v1/metrics';
 
 /**
  * Collector Metric Exporter for Node

--- a/packages/opentelemetry-exporter-collector/src/platform/node/CollectorTraceExporter.ts
+++ b/packages/opentelemetry-exporter-collector/src/platform/node/CollectorTraceExporter.ts
@@ -21,7 +21,7 @@ import * as collectorTypes from '../../types';
 import { toCollectorExportTraceServiceRequest } from '../../transform';
 import { getEnv, baggageUtils } from '@opentelemetry/core';
 
-const DEFAULT_COLLECTOR_URL = 'http://localhost:55681/v1/traces';
+const DEFAULT_COLLECTOR_URL = 'http://localhost:4318/v1/traces';
 
 /**
  * Collector Trace Exporter for Node

--- a/packages/opentelemetry-exporter-collector/test/browser/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/browser/CollectorTraceExporter.test.ts
@@ -293,7 +293,7 @@ describe('CollectorTraceExporter - browser (getDefaultUrl)', () => {
     setTimeout(() => {
       assert.strictEqual(
         collectorExporter['url'],
-        'http://localhost:55681/v1/traces'
+        'http://localhost:4318/v1/traces'
       );
       done();
     });

--- a/packages/opentelemetry-exporter-collector/test/node/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/node/CollectorMetricExporter.test.ts
@@ -292,7 +292,7 @@ describe('CollectorMetricExporter - node with json over http', () => {
       setTimeout(() => {
         assert.strictEqual(
           collectorExporter['url'],
-          'http://localhost:55681/v1/metrics'
+          'http://localhost:4318/v1/metrics'
         );
         done();
       });

--- a/packages/opentelemetry-exporter-collector/test/node/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/node/CollectorTraceExporter.test.ts
@@ -317,7 +317,7 @@ describe('CollectorTraceExporter - node with json over http', () => {
       setTimeout(() => {
         assert.strictEqual(
           collectorExporter['url'],
-          'http://localhost:55681/v1/traces'
+          'http://localhost:4318/v1/traces'
         );
         done();
       });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Follow up to #2331 , the specifications just updated the HTTP port to be `4318` in this PR: https://github.com/open-telemetry/opentelemetry-specification/pull/1839

Likewise, the Collector also plans to updated from `55681` to `4318`, but will support both for some time.

## Short description of the changes

- Updates port for Metrics/Trace HTTP exporter to `4318`
