### PR TITLE
chore: change codeowners to point to team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @dyladan @mayurkale22 @OlivierAlbertini @vmarchaud @markwolff @obecny @mwear @naseemkullah @legendecas @Flarna @johnbley @MSNev @Rauno56
+* @open-telemetry/javascript-approvers


### PR DESCRIPTION
This will mean we don't have to make a PR every time an approver is changed.