### PR TITLE
chore: Fix lint warnings in instrumentation package

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/src/autoLoaderUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/autoLoaderUtils.ts
@@ -18,7 +18,6 @@ import { TracerProvider } from '@opentelemetry/api';
 import { MeterProvider } from '@opentelemetry/api-metrics';
 import { Instrumentation } from './types';
 import { AutoLoaderResult, InstrumentationOption } from './types_internal';
-import { InstrumentationBase } from './platform';
 
 /**
  * Parses the options and returns instrumentations, node plugins and
@@ -30,26 +29,19 @@ export function parseInstrumentationOptions(
 ): AutoLoaderResult {
   let instrumentations: Instrumentation[] = [];
   for (let i = 0, j = options.length; i < j; i++) {
-    const option = options[i];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const option = options[i] as any;
     if (Array.isArray(option)) {
       const results = parseInstrumentationOptions(option);
       instrumentations = instrumentations.concat(results.instrumentations);
-    } else if (isInstrumentationClass(option)) {
+    } else if (typeof option === 'function') {
       instrumentations.push(new option());
-    } else if (isInstrumentation(option)) {
+    } else if ((option as Instrumentation).instrumentationName) {
       instrumentations.push(option);
     }
   }
 
   return { instrumentations };
-}
-
-function isInstrumentationClass<T extends InstrumentationBase>(option: InstrumentationOption): option is new () => T {
-  return typeof option === 'function';
-}
-
-function isInstrumentation(option: InstrumentationOption): option is Instrumentation {
-  return Boolean((option as Instrumentation).instrumentationName);
 }
 
 /**

--- a/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
@@ -74,7 +74,7 @@ export abstract class InstrumentationAbstract<T = any>
    * Sets MeterProvider to this plugin
    * @param meterProvider
    */
-  public setMeterProvider(meterProvider: MeterProvider) {
+  public setMeterProvider(meterProvider: MeterProvider): void {
     this._meter = meterProvider.getMeter(
       this.instrumentationName,
       this.instrumentationVersion
@@ -82,7 +82,7 @@ export abstract class InstrumentationAbstract<T = any>
   }
 
   /* Returns InstrumentationConfig */
-  public getConfig() {
+  public getConfig(): types.InstrumentationConfig {
     return this._config;
   }
 
@@ -90,7 +90,7 @@ export abstract class InstrumentationAbstract<T = any>
    * Sets InstrumentationConfig to this plugin
    * @param InstrumentationConfig
    */
-  public setConfig(config: types.InstrumentationConfig = {}) {
+  public setConfig(config: types.InstrumentationConfig = {}): void {
     this._config = Object.assign({}, config);
   }
 
@@ -98,7 +98,7 @@ export abstract class InstrumentationAbstract<T = any>
    * Sets TraceProvider to this plugin
    * @param tracerProvider
    */
-  public setTracerProvider(tracerProvider: TracerProvider) {
+  public setTracerProvider(tracerProvider: TracerProvider): void {
     this._tracer = tracerProvider.getTracer(
       this.instrumentationName,
       this.instrumentationVersion

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -76,7 +76,7 @@ export abstract class InstrumentationBase<T = any>
     exports: T,
     name: string,
     baseDir?: string
-  ): U {
+  ): InstrumentationModuleType {
     if (!baseDir) {
       if (typeof module.patch === 'function') {
         module.moduleExports = exports;

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -76,7 +76,7 @@ export abstract class InstrumentationBase<T = any>
     exports: T,
     name: string,
     baseDir?: string
-  ): InstrumentationModuleType {
+  ): T {
     if (!baseDir) {
       if (typeof module.patch === 'function') {
         module.moduleExports = exports;

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -76,7 +76,7 @@ export abstract class InstrumentationBase<T = any>
     exports: T,
     name: string,
     baseDir?: string
-  ): T {
+  ): U {
     if (!baseDir) {
       if (typeof module.patch === 'function') {
         module.moduleExports = exports;
@@ -102,7 +102,7 @@ export abstract class InstrumentationBase<T = any>
     } else {
       // internal file
       const files = module.files ?? [];
-      const file = files.find(file => file.name === name);
+      const file = files.find(f => f.name === name);
       if (file && isSupported(file.supportedVersions, version, module.includePrerelease)) {
         file.moduleExports = exports;
         if (this._enabled) {
@@ -113,7 +113,7 @@ export abstract class InstrumentationBase<T = any>
     return exports;
   }
 
-  public enable() {
+  public enable(): void {
     if (this._enabled) {
       return;
     }
@@ -154,7 +154,7 @@ export abstract class InstrumentationBase<T = any>
     }
   }
 
-  public disable() {
+  public disable(): void {
     if (!this._enabled) {
       return;
     }
@@ -172,7 +172,7 @@ export abstract class InstrumentationBase<T = any>
     }
   }
 
-  public isEnabled() {
+  public isEnabled(): boolean {
     return this._enabled;
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/types.ts
@@ -45,7 +45,8 @@ export interface InstrumentationModuleDefinition<T> {
   supportedVersions: string[];
 
   /** Module internal files to be patched  */
-  files: InstrumentationModuleFile<T>[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  files: InstrumentationModuleFile<any>[];
 
   /** If set to true, the includePrerelease check will be included when calling semver.satisfies */
   includePrerelease?: boolean;

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/types.ts
@@ -45,7 +45,7 @@ export interface InstrumentationModuleDefinition<T> {
   supportedVersions: string[];
 
   /** Module internal files to be patched  */
-  files: InstrumentationModuleFile<any>[];
+  files: InstrumentationModuleFile<T>[];
 
   /** If set to true, the includePrerelease check will be included when calling semver.satisfies */
   includePrerelease?: boolean;

--- a/experimental/packages/opentelemetry-instrumentation/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/types.ts
@@ -77,8 +77,10 @@ export interface InstrumentationConfig {
  * This interface defines the params that are be added to the wrapped function
  * using the "shimmer.wrap"
  */
-export interface ShimWrapped {
+export interface ShimWrapped extends Function {
   __wrapped: boolean;
+  // eslint-disable-next-line @typescript-eslint/ban-types
   __unwrap: Function;
+  // eslint-disable-next-line @typescript-eslint/ban-types
   __original: Function;
 }

--- a/experimental/packages/opentelemetry-instrumentation/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/utils.ts
@@ -73,7 +73,7 @@ export async function safeExecuteInTheMiddleAsync<T>(
  * Checks if certain function has been already wrapped
  * @param func
  */
-export function isWrapped(func: any) {
+export function isWrapped(func: unknown): func is ShimWrapped {
   return (
     typeof func === 'function' &&
     typeof (func as ShimWrapped).__original === 'function' &&

--- a/experimental/packages/opentelemetry-instrumentation/test/common/autoLoader.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation/test/common/autoLoader.test.ts
@@ -34,6 +34,7 @@ class FooInstrumentation extends InstrumentationBase {
 }
 
 describe('autoLoader', () => {
+  // eslint-disable-next-line @typescript-eslint/ban-types
   let unload: Function | undefined;
 
   afterEach(() => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

related to #1093,

## Which problem is this PR solving?

- This PR fixes lint warnings in `instrumentation` package.

## Short description of the changes

- Fix lint warnings
- Note all warnings are resolved. The following warnings are still unresolved since they need better understanding about the code and its usage. I hope I can fix them later when I gain more knowledge about the project.

```
/home/asabzevari/projects/opentelemetry/opentelemetry-js/packages/opentelemetry-instrumentation/src/instrumentation.ts
  32:51  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/asabzevari/projects/opentelemetry/opentelemetry-js/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
  28:47  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/asabzevari/projects/opentelemetry/opentelemetry-js/packages/opentelemetry-instrumentation/src/platform/node/instrumentationNodeModuleDefinition.ts
  30:39  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```
