### PR TITLE
fix(instrumentation-fetch): `fetch(string, Request)` silently drops request body

### DIFF
--- a/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -300,7 +300,7 @@ export class FetchInstrumentation extends InstrumentationBase<
         const options = input instanceof Request ? input : init || {};
         const createdSpan = plugin._createSpan(url, options);
         if (!createdSpan) {
-          return original.apply(this, options instanceof Request ? [options] : [url, options]);
+          return original.apply(this, arguments);
         }
         const spanData = plugin._prepareSpanData(url);
 

--- a/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -300,7 +300,7 @@ export class FetchInstrumentation extends InstrumentationBase<
         const options = input instanceof Request ? input : init || {};
         const createdSpan = plugin._createSpan(url, options);
         if (!createdSpan) {
-          return original.apply(this, [url, options]);
+          return original.apply(this, options instanceof Request ? [options] : [url, options]);
         }
         const spanData = plugin._prepareSpanData(url);
 
@@ -380,7 +380,7 @@ export class FetchInstrumentation extends InstrumentationBase<
               plugin._addHeaders(options, url);
               plugin._tasksCount++;
               return original
-                .apply(this, [url, options])
+                .apply(this, options instanceof Request ? [options] : [url, options])
                 .then(
                   (onSuccess as any).bind(this, createdSpan, resolve),
                   onError.bind(this, createdSpan, reject)


### PR DESCRIPTION
## Which problem is this PR solving?

tl;dr: Fetch instrumentation drops request body when using `Request` object.

Currently fetch instrumentation forwards calls via 2 parameter signature regardless if 'fetch(Request)` or `fetch(url, object)` signature is being used:

https://github.com/open-telemetry/opentelemetry-js/blob/90ea0fed52f406005550862f9b645803f89e36a9/packages/opentelemetry-instrumentation-fetch/src/fetch.ts#L299

This however is causing a bug where passing request object as 2nd parameter drops request body: https://jsfiddle.net/t2t2/bc53reqf/

<img width="1297" alt="image" src="https://user-images.githubusercontent.com/1122555/129204451-629885dd-c7cf-4a01-abba-09a586a4815b.png">

(confirmed with both Firefox 90.0.2 & Chrome 92.0.4515.131)

In quick research found that while [Request.body](https://developer.mozilla.org/en-US/docs/Web/API/Request/body) should return a `ReadableStream` none of the browsers actually do it right now. `fetch(url, object)` is probably trying to find body from 2nd parameter as a normal object but isn't finding anything.

## Short description of the changes

In case of `fetch(Request)` call original method with the same signature.