### PR TITLE
docs: fix examples in website_docs/instrumentation.md

### DIFF
--- a/website_docs/getting_started/nodejs.md
+++ b/website_docs/getting_started/nodejs.md
@@ -72,9 +72,9 @@ The following dependencies are required to trace a Node.js application.
 
 These dependencies are required to configure the tracing SDK and create spans.
 
-- `@opentelemetry/api`
-- `@opentelemetry/sdk-trace-node`
-- `@opentelemetry/sdk-trace-base`
+```shell
+npm install @opentelemetry/sdk-node @opentelemetry/api
+```
 
 #### Exporter
 
@@ -91,6 +91,10 @@ Many common modules such as the `http` standard library module, `express`, and o
 
 You can also install all instrumentations maintained by the OpenTelemetry authors by using the `@opentelemetry/auto-instrumentations-node` module.
 
+```shell
+npm install @opentelemetry/auto-instrumentations-node
+```
+
 ### Setup
 
 The tracing setup and configuration should be run before your application code. One tool commonly used for this task is the [`-r, --require module`](https://nodejs.org/api/cli.html#cli_r_require_module) flag.
@@ -101,38 +105,18 @@ Create a file with a name like `tracing.js` which will contain your tracing setu
 /* tracing.js */
 
 // Require dependencies
-const { NodeTracerProvider } = require("@opentelemetry/sdk-trace-node");
-const { SimpleSpanProcessor, ConsoleSpanExporter } = require("@opentelemetry/sdk-trace-base");
-const { getNodeAutoInstrumentations } = require("@opentelemetry/auto-instrumentations-node');
-const { registerInstrumentations } = require('@opentelemetry/instrumentation');
+const opentelemetry = require("@opentelemetry/sdk-node");
+const { getNodeAutoInstrumentations } = require("@opentelemetry/auto-instrumentations-node");
 
-// Create a tracer provider
-const provider = new NodeTracerProvider();
-
-// The exporter handles sending spans to your tracing backend
-const exporter = new ConsoleSpanExporter();
-
-// The simple span processor sends spans to the exporter as soon as they are ended.
-const processor = new SimpleSpanProcessor(exporter);
-provider.addSpanProcessor(processor);
-
-// The provider must be registered in order to
-// be used by the OpenTelemetry API and instrumentations
-provider.register();
-
-// This will automatically enable all instrumentations
-registerInstrumentations({
-  instrumentations: [getNodeAutoInstrumentations()],
+const sdk = new opentelemetry.NodeSDK({
+  traceExporter: new opentelemetry.tracing.ConsoleSpanExporter(),
+  instrumentations: [getNodeAutoInstrumentations()]
 });
+
+sdk.start()
 ```
 
 ### Run Application
-
-First, install the dependencies as described above. Here you need to add the following:
-
-```shell
-npm install --save @opentelemetry/sdk-trace-node @opentelemetry/auto-instrumentations-node
-```
 
 Now you can run your application as you normally would, but you can use the `--require` flag to load the tracing code before the application code.
 
@@ -141,7 +125,7 @@ $ node --require './tracing.js' app.js
 Listening for requests on http://localhost:8080
 ```
 
-Now, when you open <http://localhost:8080> in your web browser, you should see the spans printed in the console by the `ConsoleSpanExporter`.
+Open <http://localhost:8080> in your web browser and reload the page a few times, after a while you should see the spans printed in the console by the `ConsoleSpanExporter`.
 
 <details>
 <summary>View example output</summary>

--- a/website_docs/instrumentation.md
+++ b/website_docs/instrumentation.md
@@ -108,9 +108,8 @@ for (let i = 0; i < 10; i += 1) {
 function doWork(parent) {
   // Start another span. In this example, the main method already started a
   // span, so that'll be the parent span, and this will be a child span.
-  const span = tracer.startSpan('doWork', {
-    parent,
-  });
+  const ctx = opentelemetry.trace.setSpan(opentelemetry.context.active(), parent);
+  const span = tracer.startSpan('doWork', undefined, ctx);
 
   // simulate some random work.
   for (let i = 0; i <= Math.floor(Math.random() * 40000000); i += 1) {
@@ -118,6 +117,8 @@ function doWork(parent) {
   }
   span.end();
 }
+// Be sure to end the span.
+parentSpan.end();
 ```
 
 Invoking your application once again will give you a list of traces being exported.
@@ -128,9 +129,8 @@ Attributes can be used to describe your spans. Attributes can be added to a span
 
 ```javascript
 function doWork(parent) {
-  const span = tracer.startSpan('doWork', {
-    parent, attributes: { attribute1 : 'value1' }
-  });
+  const ctx = opentelemetry.trace.setSpan(opentelemetry.context.active(), parent);
+  const span = tracer.startSpan('doWork', { attributes: { attribute1 : 'value1' } }, ctx);
   for (let i = 0; i <= Math.floor(Math.random() * 40000000); i += 1) {
     // empty
   }
@@ -159,9 +159,8 @@ Finally, you can update your file to include semantic attributes:
 
 ```javascript
 function doWork(parent) {
-  const span = tracer.startSpan('doWork', {
-    parent, attributes: { SemanticAttributes.CODE_FUNCTION : 'doWork' }
-  });
+  const ctx = opentelemetry.trace.setSpan(opentelemetry.context.active(), parent);
+  const span = tracer.startSpan('doWork', { attributes: { [SemanticAttributes.CODE_FUNCTION] : 'doWork' } }, ctx);
   for (let i = 0; i <= Math.floor(Math.random() * 40000000); i += 1) {
     // empty
   }
@@ -178,9 +177,9 @@ The status can be set at any time before the span is finished:
 
 ```javascript
 function doWork(parent) {
-  const span = tracer.startSpan('doWork', {
-    parent,
-  });
+  const ctx = opentelemetry.trace.setSpan(opentelemetry.context.active(), parent);
+  const span = tracer.startSpan('doWork', undefined, ctx);
+
   span.setStatus({
     code: opentelemetry.SpanStatusCode.OK,
     message: 'Ok.'


### PR DESCRIPTION
Like https://github.com/open-telemetry/opentelemetry-js-api/pull/116 this fixes the examples in the website docs to work properly again. 