### PR TITLE
feat: allow instrumented modules to be provided directly

### DIFF
--- a/packages/opentelemetry-instrumentation/src/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation/src/instrumentation.ts
@@ -31,7 +31,7 @@ import * as types from './types';
  */
 export abstract class InstrumentationAbstract<T = any>
   implements types.Instrumentation {
-  protected _config: types.InstrumentationConfig;
+  protected _config: types.InstrumentationConfig<T>;
 
   private _tracer: Tracer;
   private _meter: Meter;
@@ -40,7 +40,7 @@ export abstract class InstrumentationAbstract<T = any>
   constructor(
     public readonly instrumentationName: string,
     public readonly instrumentationVersion: string,
-    config: types.InstrumentationConfig = {}
+    config: types.InstrumentationConfig<T> = {}
   ) {
     this._config = {
       enabled: true,

--- a/packages/opentelemetry-instrumentation/src/types.ts
+++ b/packages/opentelemetry-instrumentation/src/types.ts
@@ -59,7 +59,19 @@ export interface Instrumentation {
   supportedVersions?: string[];
 }
 
-export interface InstrumentationConfig {
+/**
+ * A reference to an already loaded module. Use this
+ * with [InstrumentationConfig#loadedModules] to provide
+ * a reference to the already loaded module
+ */
+export type AlreadyLoadedDefinition<WrappedType> = {
+  /* The module name */
+  name: string;
+  /* A reference to the loaded module (loaded with `require` or `import * as ...`) */
+  module: WrappedType;
+}
+
+export interface InstrumentationConfig<WrappedType = any> {
   /**
    * Whether to enable the plugin.
    * @default true
@@ -71,6 +83,14 @@ export interface InstrumentationConfig {
    * @default '@opentelemetry/plugin-http' in case of http.
    */
   path?: string;
+
+  /**
+   * The already required library to be wrapped. This may be
+   * useful when the existing auto-instrumentation does
+   * not work for your environment (such as when webpack
+   * is used)
+   */
+  loadedModules?: AlreadyLoadedDefinition<WrappedType> | AlreadyLoadedDefinition<WrappedType>[];
 }
 
 /**


### PR DESCRIPTION


## Which problem is this PR solving?

- see #2419 - this PR allows a module to be provided directly for instrumentation in the cases that a dynamic require will not work

## Short description of the changes

- adds new configuration property to `InstrumentationBase` called `loadedModules`, which is a list of the already-loaded modules with their name and a reference to them.
- update to `InstrumentationBase` to check the list of `loadedModules` before using require-in-the-middle to instrument the library.
