### PR TITLE
Website: support GH page links to canonical src

### DIFF
--- a/website_docs/_index.md
+++ b/website_docs/_index.md
@@ -1,9 +1,14 @@
 ---
-title: "Javascript"
+title: Javascript
 weight: 20
-description: >
+description: >-
   <img width="35" src="https://raw.github.com/open-telemetry/opentelemetry.io/main/iconography/32x32/JS_SDK.svg"></img>
   A language-specific implementation of OpenTelemetry in JavaScript (for Node.JS & the browser).
+cascade:
+  github_repo: &repo https://github.com/open-telemetry/opentelemetry-js
+  github_subdir: website_docs
+  path_base_for_github_subdir: content/en/docs/js/
+  github_project_repo: *repo
 ---
 
 This page contains an introduction to OpenTelemetry in JavaScript. This guide


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/542

/cc @carlosalberto @mtwo @shelbyspees @austinlparker 

While I can't (currently) show you a preview of this PR, you can see the [corresponding change for **OTel Java**](https://github.com/open-telemetry/opentelemetry-java/pull/3501) in action by clicking on the **Edit this page** and related links, from https://opentelemetry.io/docs/java/ and it's subpages.

@dyladan @obecny @vmarchaud: I see that this repo doesn't yet have a `docs-update` GitHub action. If you prefer, I can link OTel JS `website_docs` to the OTel website via a git submodule -- similar to what I did for Go in [_Link to OTel Go website_docs via submodule_ - open-telemetry/opentelemetry.io#690](https://github.com/open-telemetry/opentelemetry.io/pull/690). That way you won't need to submit website_docs PRs.