### PR TITLE
fix!: remove 'Http' from W3C propagator names

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,9 @@ To request automatic tracing support for a module not on this list, please [file
   - @opentelemetry/web -> @opentelemetry/sdk-trace-web
   - @opentelemetry/metrics -> @opentelemetry/sdk-metrics-base
   - @opentelemetry/node-sdk -> @opentelemetry/sdk-node
+- W3C propagators in @opentelemetry/core were renamed
+  - `HttpTraceContextPropagator` -> `W3CTraceContextPropagator`
+  - `W3CBaggagePropagator` -> `W3CBaggagePropagator`
 
 ### 0.23.x to 0.24.x
 

--- a/benchmark/propagator.js
+++ b/benchmark/propagator.js
@@ -17,8 +17,8 @@ const setups = [
     }
   },
   {
-    name: 'HttpTraceContextPropagator',
-    propagator: new opentelemetry.HttpTraceContextPropagator(),
+    name: 'W3CTraceContextPropagator',
+    propagator: new opentelemetry.W3CTraceContextPropagator(),
     injectCarrier: {},
     extractCarrier: {
       traceparent: '00-d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-00'

--- a/integration-tests/propagation-validation-server/validation-server.js
+++ b/integration-tests/propagation-validation-server/validation-server.js
@@ -1,5 +1,5 @@
 const axios = require("axios");
-const { HttpTraceContextPropagator } = require("@opentelemetry/core");
+const { W3CTraceContextPropagator } = require("@opentelemetry/core");
 const { BasicTracerProvider } = require("@opentelemetry/sdk-trace-base");
 const { context, propagation, trace, ROOT_CONTEXT } = require("@opentelemetry/api");
 const {
@@ -8,7 +8,7 @@ const {
 const bodyParser = require("body-parser");
 
 // set global propagator
-propagation.setGlobalPropagator(new HttpTraceContextPropagator());
+propagation.setGlobalPropagator(new W3CTraceContextPropagator());
 
 // set global context manager
 context.setGlobalContextManager(new AsyncHooksContextManager());

--- a/packages/opentelemetry-core/README.md
+++ b/packages/opentelemetry-core/README.md
@@ -12,7 +12,7 @@ This package provides default implementations of the OpenTelemetry API for trace
 - [OpenTelemetry Core](#opentelemetry-core)
   - [Built-in Implementations](#built-in-implementations)
     - [Built-in Propagators](#built-in-propagators)
-      - [HttpTraceContextPropagator Propagator](#httptracecontext-propagator)
+      - [W3CTraceContextPropagator Propagator](#httptracecontext-propagator)
       - [Composite Propagator](#composite-propagator)
       - [Baggage Propagator](#baggage-propagator)
     - [Built-in Sampler](#built-in-sampler)
@@ -25,16 +25,16 @@ This package provides default implementations of the OpenTelemetry API for trace
 
 ### Built-in Propagators
 
-#### HttpTraceContextPropagator Propagator
+#### W3CTraceContextPropagator Propagator
 
 OpenTelemetry provides a text-based approach to propagate context to remote services using the [W3C Trace Context](https://www.w3.org/TR/trace-context/) HTTP headers.
 
 ```js
 const api = require("@opentelemetry/api");
-const { HttpTraceContextPropagator } = require("@opentelemetry/core");
+const { W3CTraceContextPropagator } = require("@opentelemetry/core");
 
 /* Set Global Propagator */
-api.propagation.setGlobalPropagator(new HttpTraceContextPropagator());
+api.propagation.setGlobalPropagator(new W3CTraceContextPropagator());
 ```
 
 #### Composite Propagator
@@ -57,10 +57,10 @@ Provides a text-based approach to propagate [baggage](https://w3c.github.io/bagg
 
 ```js
 const api = require("@opentelemetry/api");
-const { HttpBaggagePropagator } = require("@opentelemetry/core");
+const { W3CBaggagePropagator } = require("@opentelemetry/core");
 
 /* Set Global Propagator */
-api.propagation.setGlobalPropagator(new HttpBaggagePropagator());
+api.propagation.setGlobalPropagator(new W3CBaggagePropagator());
 ```
 
 ### Built-in Sampler

--- a/packages/opentelemetry-core/src/baggage/propagation/W3CBaggagePropagator.ts
+++ b/packages/opentelemetry-core/src/baggage/propagation/W3CBaggagePropagator.ts
@@ -42,7 +42,7 @@ import {
  * Based on the Baggage specification:
  * https://w3c.github.io/baggage/
  */
-export class HttpBaggagePropagator implements TextMapPropagator {
+export class W3CBaggagePropagator implements TextMapPropagator {
   inject(context: Context, carrier: unknown, setter: TextMapSetter): void {
     const baggage = propagation.getBaggage(context);
     if (!baggage || isTracingSuppressed(context)) return;

--- a/packages/opentelemetry-core/src/index.ts
+++ b/packages/opentelemetry-core/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export * from './baggage/propagation/HttpBaggagePropagator';
+export * from './baggage/propagation/W3CBaggagePropagator';
 export * from './common/attributes';
 export * from './common/global-error-handler';
 export * from './common/logging-error-handler';
@@ -25,7 +25,7 @@ export * from './version';
 export * as baggageUtils from './baggage/utils';
 export * from './platform';
 export * from './propagation/composite';
-export * from './trace/HttpTraceContextPropagator';
+export * from './trace/W3CTraceContextPropagator';
 export * from './trace/IdGenerator';
 export * from './trace/rpc-metadata';
 export * from './trace/sampler/AlwaysOffSampler';

--- a/packages/opentelemetry-core/src/trace/W3CTraceContextPropagator.ts
+++ b/packages/opentelemetry-core/src/trace/W3CTraceContextPropagator.ts
@@ -70,7 +70,7 @@ export function parseTraceParent(traceParent: string): SpanContext | null {
  * Based on the Trace Context specification:
  * https://www.w3.org/TR/trace-context/
  */
-export class HttpTraceContextPropagator implements TextMapPropagator {
+export class W3CTraceContextPropagator implements TextMapPropagator {
   inject(context: Context, carrier: unknown, setter: TextMapSetter): void {
     const spanContext = trace.getSpanContext(context);
     if (

--- a/packages/opentelemetry-core/test/baggage/W3CBaggagePropagator.test.ts
+++ b/packages/opentelemetry-core/test/baggage/W3CBaggagePropagator.test.ts
@@ -23,11 +23,11 @@ import {
 } from '@opentelemetry/api';
 import { ROOT_CONTEXT } from '@opentelemetry/api';
 import * as assert from 'assert';
-import { HttpBaggagePropagator } from '../../src/baggage/propagation/HttpBaggagePropagator';
+import { W3CBaggagePropagator } from '../../src/baggage/propagation/W3CBaggagePropagator';
 import { BAGGAGE_HEADER } from '../../src/baggage/constants';
 
-describe('HttpBaggagePropagator', () => {
-  const httpBaggagePropagator = new HttpBaggagePropagator();
+describe('W3CBaggagePropagator', () => {
+  const httpBaggagePropagator = new W3CBaggagePropagator();
 
   let carrier: { [key: string]: unknown };
 
@@ -196,7 +196,7 @@ describe('HttpBaggagePropagator', () => {
 
   describe('fields()', () => {
     it('returns the fields used by the baggage spec', () => {
-      const propagator = new HttpBaggagePropagator();
+      const propagator = new W3CBaggagePropagator();
       assert.deepStrictEqual(propagator.fields(), [BAGGAGE_HEADER]);
     });
   });

--- a/packages/opentelemetry-core/test/propagation/composite.test.ts
+++ b/packages/opentelemetry-core/test/propagation/composite.test.ts
@@ -26,13 +26,13 @@ import { Context, ROOT_CONTEXT } from '@opentelemetry/api';
 import * as assert from 'assert';
 import {
   CompositePropagator,
-  HttpTraceContextPropagator,
+  W3CTraceContextPropagator,
   RandomIdGenerator,
 } from '../../src';
 import {
   TRACE_PARENT_HEADER,
   TRACE_STATE_HEADER,
-} from '../../src/trace/HttpTraceContextPropagator';
+} from '../../src/trace/W3CTraceContextPropagator';
 import { TraceState } from '../../src/trace/TraceState';
 
 class DummyPropagator implements TextMapPropagator {
@@ -78,7 +78,7 @@ describe('Composite Propagator', () => {
 
     it('should inject context using all configured propagators', () => {
       const composite = new CompositePropagator({
-        propagators: [new DummyPropagator(), new HttpTraceContextPropagator()],
+        propagators: [new DummyPropagator(), new W3CTraceContextPropagator()],
       });
       composite.inject(ctxWithSpanContext, carrier, defaultTextMapSetter);
 
@@ -94,7 +94,7 @@ describe('Composite Propagator', () => {
       const composite = new CompositePropagator({
         propagators: [
           new ThrowingPropagator(),
-          new HttpTraceContextPropagator(),
+          new W3CTraceContextPropagator(),
         ],
       });
       composite.inject(ctxWithSpanContext, carrier, defaultTextMapSetter);
@@ -119,7 +119,7 @@ describe('Composite Propagator', () => {
 
     it('should extract context using all configured propagators', () => {
       const composite = new CompositePropagator({
-        propagators: [new DummyPropagator(), new HttpTraceContextPropagator()],
+        propagators: [new DummyPropagator(), new W3CTraceContextPropagator()],
       });
       const spanContext = trace.getSpanContext(
         composite.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
@@ -140,7 +140,7 @@ describe('Composite Propagator', () => {
       const composite = new CompositePropagator({
         propagators: [
           new ThrowingPropagator(),
-          new HttpTraceContextPropagator(),
+          new W3CTraceContextPropagator(),
         ],
       });
       const spanContext = trace.getSpanContext(

--- a/packages/opentelemetry-core/test/trace/W3CTraceContextPropagator.test.ts
+++ b/packages/opentelemetry-core/test/trace/W3CTraceContextPropagator.test.ts
@@ -25,15 +25,15 @@ import {
 } from '@opentelemetry/api';
 import * as assert from 'assert';
 import {
-  HttpTraceContextPropagator,
+  W3CTraceContextPropagator,
   TRACE_PARENT_HEADER,
   TRACE_STATE_HEADER,
-} from '../../src/trace/HttpTraceContextPropagator';
+} from '../../src/trace/W3CTraceContextPropagator';
 import { suppressTracing } from '../../src/trace/suppress-tracing';
 import { TraceState } from '../../src/trace/TraceState';
 
-describe('HttpTraceContextPropagator', () => {
-  const httpTraceContext = new HttpTraceContextPropagator();
+describe('W3CTraceContextPropagator', () => {
+  const httpTraceContext = new W3CTraceContextPropagator();
   let carrier: { [key: string]: unknown };
 
   beforeEach(() => {

--- a/packages/opentelemetry-instrumentation-grpc/test/helper.ts
+++ b/packages/opentelemetry-instrumentation-grpc/test/helper.ts
@@ -19,7 +19,7 @@ import {
   SpanKind,
   propagation, trace,
 } from '@opentelemetry/api';
-import { HttpTraceContextPropagator } from '@opentelemetry/core';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { ContextManager } from '@opentelemetry/api';
@@ -386,7 +386,7 @@ export const runTests = (
     let contextManager: ContextManager;
 
     before(() => {
-      propagation.setGlobalPropagator(new HttpTraceContextPropagator());
+      propagation.setGlobalPropagator(new W3CTraceContextPropagator());
     });
 
     beforeEach(() => {

--- a/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts
@@ -24,8 +24,8 @@ import {
 } from '@opentelemetry/api';
 import {
   CompositePropagator,
-  HttpBaggagePropagator,
-  HttpTraceContextPropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
   getEnv,
 } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
@@ -57,8 +57,8 @@ export class BasicTracerProvider implements TracerProvider {
     string,
     PROPAGATOR_FACTORY
   >([
-    ['tracecontext', () => new HttpTraceContextPropagator()],
-    ['baggage', () => new HttpBaggagePropagator()],
+    ['tracecontext', () => new W3CTraceContextPropagator()],
+    ['baggage', () => new W3CBaggagePropagator()],
   ]);
 
   protected static readonly _registeredExporters = new Map<

--- a/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
+++ b/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
@@ -20,8 +20,8 @@ import { BasicTracerProvider, Span } from '@opentelemetry/sdk-trace-base';
 import { SpanContextShim, SpanShim, TracerShim } from '../src/shim';
 import {
   CompositePropagator,
-  HttpBaggagePropagator,
-  HttpTraceContextPropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
   timeInputToHrTime,
 } from '@opentelemetry/core';
 import {
@@ -41,8 +41,8 @@ import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 describe('OpenTracing Shim', () => {
   const compositePropagator = new CompositePropagator({
     propagators: [
-      new HttpTraceContextPropagator(),
-      new HttpBaggagePropagator(),
+      new W3CTraceContextPropagator(),
+      new W3CBaggagePropagator(),
     ],
   });
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes #2428

## Short description of the changes

Renames:
- `HttpTraceContextPropagator` to `W3CTraceContextPropagator`
- `HttpBaggagePropagator` to `W3CBaggagePropagator`

This is a breaking change

Fix in the contrib repo: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/644. I didn't find any places that need updating in `opentelemetrry-js-api` or `opentelemetry.io` repos.