### PR TITLE
fix: ReferenceError when OTEL_TRACES_SAMPLER used without OTEL_TRACES_SAMPLER_ARG

### DIFF
--- a/packages/opentelemetry-sdk-trace-base/src/config.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/config.ts
@@ -27,6 +27,7 @@ import {
 
 const env = getEnv();
 const FALLBACK_OTEL_TRACES_SAMPLER = TracesSamplerValues.AlwaysOn;
+const DEFAULT_RATIO = 1;
 
 /**
  * Default configuration. For fields with primitive values, any user-provided
@@ -78,8 +79,6 @@ export function buildSamplerFromEnv(
       return new AlwaysOnSampler();
   }
 }
-
-const DEFAULT_RATIO = 1;
 
 function getSamplerProbabilityFromEnv(
   env: Required<ENVIRONMENT>


### PR DESCRIPTION
## Which problem is this PR solving?
When OTEL_TRACES_SAMPLER is used without OTEL_TRACES_SAMPLER_ARG there would be a ReferenceError due to getSamplerProbabilityFromEnv being called above the definition of DEFAULT_RATIO.

```
ReferenceError: Cannot access 'DEFAULT_RATIO' before initialization
    at null.getSamplerProbabilityFromEnv (/app/node_modules/@opentelemetry/tracing/src/config.ts:91:58)
    at null.buildSamplerFromEnv (/app/node_modules/@opentelemetry/tracing/src/config.ts:71:44)
    at Object.<anonymous> (/app/node_modules/@opentelemetry/tracing/src/config.ts:38:12)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:784:16)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:92:18)
    at Object.<anonymous> (/app/node_modules/@opentelemetry/tracing/src/utility.ts:17:1)
```

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Short description of the changes
Moving constant higher up in the code.