### PR TITLE
chore: simplify unit test cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,31 +28,17 @@ jobs:
         with:
           args: "./**/*.md -i ./CHANGELOG.md"
 
-      - name: restore lock files
-        uses: actions/cache@master # must use unreleased master to cache multiple paths
+      - name: restore lerna
         id: cache
+        uses: actions/cache@v2
         with:
-          # must be done before bootstrap to not include node_modules files in the cache paths
           path: |
-            package-lock.json
-            packages/*/package-lock.json
-            benchmark/*/package-lock.json
-            backwards-compatability/*/package-lock.json
-            metapackages/*/package-lock.json
-            packages/*/package-lock.json
-            integration-tests/*/package-lock.json
-          # increment the trailing number to break the cache manually
-          key: ${{ runner.os }}-lint-${{ hashFiles('**/package.json') }}-0
+            node_modules
+            */*/node_modules
+          key: lint-${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('**/package.json') }}
 
-      # On a cache hit, use ci to speed up the install process
-      - name: Bootstrap (cache hit)
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: |
-          npm ci --ignore-scripts
-          npx lerna bootstrap --ignore-scripts --hoist --nohoist='zone.js'
-
-      # On a cache miss, fall back to a regular install
-      - name: Bootstrap (cache miss)
+      # On a cache miss, install dependencies
+      - name: Bootstrap
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           npm install --ignore-scripts

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,33 +22,23 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
 
-      - name: restore lock files
-        uses: actions/cache@master # must use unreleased master to cache multiple paths
+      - name: restore lerna
         id: cache
+        uses: actions/cache@v2
         with:
-          # must be done before bootstrap to not include node_modules files in the cache paths
           path: |
-            package-lock.json
-            packages/*/package-lock.json
-            benchmark/*/package-lock.json
-            backwards-compatability/*/package-lock.json
-            metapackages/*/package-lock.json
-            packages/*/package-lock.json
-            integration-tests/*/package-lock.json
-          key: ${{ runner.os }}-unit_test-${{ matrix.node_version }}-${{ hashFiles('**/package.json') }}
-      - name: Install and Build (cache miss) 🔧
+            node_modules
+            */*/node_modules
+          key: unittest-${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('**/package.json') }}
+
+      - name: Bootstrap
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           npm install --ignore-scripts
           npx lerna bootstrap --no-ci --hoist --nohoist='zone.js'
-          npm run compile
 
-      - name: Install and Build (cache hit) 🔧
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: |
-          npm ci --ignore-scripts
-          npx lerna bootstrap --hoist --nohoist='zone.js'
-          npm run compile
+      - name: Build 🔧
+        run: npm run compile
 
       - name: Unit tests
         run: npm run test
@@ -66,35 +56,24 @@ jobs:
         uses: actions/checkout@v1
       - name: Permission Setup
         run: sudo chmod -R 777 /github /__w
-      - name: restore lock files
-        uses: actions/cache@master # must use unreleased master to cache multiple paths
+
+      - name: restore lerna
+        uses: actions/cache@v2
         id: cache
         with:
-          # must be done before bootstrap to not include node_modules files in the cache paths
           path: |
-            package-lock.json
-            packages/*/package-lock.json
-            benchmark/*/package-lock.json
-            backwards-compatability/*/package-lock.json
-            metapackages/*/package-lock.json
-            packages/*/package-lock.json
-            integration-tests/*/package-lock.json
-          key: ${{ runner.os }}-unit_test-${{ matrix.container }}-${{ hashFiles('**/package.json') }}
+            node_modules
+            */*/node_modules
+          key: unittest-${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('**/package.json') }}
 
-      - name: Install and Build (cache miss) 🔧
+      - name: Bootstrap
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           npm install --ignore-scripts
           npx lerna bootstrap --no-ci --hoist --nohoist='zone.js'
-          npm run compile
 
-      - name: Install and Build (cache hit) 🔧
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: |
-          npm ci --ignore-scripts
-          npx lerna bootstrap --hoist --nohoist='zone.js'
-          npm run compile
-
+      - name: Build 🔧
+        run: npm run compile
       - name: Unit tests
         run: npm run test:browser
       - name: Report Coverage


### PR DESCRIPTION
Now that we are hoisting modules, the caching step is significantly more efficient than it used to be. Combined with the latest version of the caching action supporting multiple paths properly, this drastically simplifies the caching part of our action and speeds up the tests.

### Cache Hit

~2-3 minutes

![image](https://user-images.githubusercontent.com/1612643/131151857-3c1b16d6-af17-4185-9c0c-f7f8ffd7e70e.png)

### Cache Miss

~3-4 minutes

![image](https://user-images.githubusercontent.com/1612643/131149266-e4fb0551-3171-470d-895b-2eab70e3f760.png)
