### PR TITLE
chore(exporter): fix lint warnings

### DIFF
--- a/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -100,7 +100,7 @@ export class PrometheusExporter implements MetricExporter {
    * @param records Metrics to be sent to the prometheus backend
    * @param cb result callback to be called on finish
    */
-  export(records: MetricRecord[], cb: (result: ExportResult) => void) {
+  export(records: MetricRecord[], cb: (result: ExportResult) => void): void {
     if (!this._server) {
       // It is conceivable that the _server may not be started as it is an async startup
       // However unlikely, if this happens the caller may retry the export
@@ -180,7 +180,7 @@ export class PrometheusExporter implements MetricExporter {
   public getMetricsRequestHandler(
     _request: IncomingMessage,
     response: ServerResponse
-  ) {
+  ): void {
     this._exportMetrics(response);
   }
 

--- a/packages/opentelemetry-exporter-prometheus/src/PrometheusLabelsBatcher.ts
+++ b/packages/opentelemetry-exporter-prometheus/src/PrometheusLabelsBatcher.ts
@@ -29,11 +29,11 @@ interface BatcherCheckpoint {
 export class PrometheusLabelsBatcher {
   private _batchMap = new Map<string, BatcherCheckpoint>();
 
-  get hasMetric() {
+  get hasMetric(): boolean {
     return this._batchMap.size > 0;
   }
 
-  process(record: MetricRecord) {
+  process(record: MetricRecord): void {
     const name = record.descriptor.name;
     let item = this._batchMap.get(name);
     if (item === undefined) {

--- a/packages/opentelemetry-exporter-zipkin/src/platform/browser/util.ts
+++ b/packages/opentelemetry-exporter-zipkin/src/platform/browser/util.ts
@@ -28,7 +28,7 @@ import * as zipkinTypes from '../../types';
  * @param headers - headers
  * send
  */
-export function prepareSend(urlStr: string, headers?: Record<string, string>) {
+export function prepareSend(urlStr: string, headers?: Record<string, string>): zipkinTypes.SendFn {
   let xhrHeaders: Record<string, string>;
   const useBeacon = typeof navigator.sendBeacon === 'function' && !headers;
   if (headers) {

--- a/packages/opentelemetry-exporter-zipkin/src/platform/node/util.ts
+++ b/packages/opentelemetry-exporter-zipkin/src/platform/node/util.ts
@@ -27,7 +27,7 @@ import * as zipkinTypes from '../../types';
  * @param headers - headers
  * send
  */
-export function prepareSend(urlStr: string, headers?: Record<string, string>) {
+export function prepareSend(urlStr: string, headers?: Record<string, string>): zipkinTypes.SendFn {
   const urlOpts = url.parse(urlStr);
 
   const reqOpts: http.RequestOptions = Object.assign(

--- a/packages/opentelemetry-exporter-zipkin/src/transform.ts
+++ b/packages/opentelemetry-exporter-zipkin/src/transform.ts
@@ -29,8 +29,8 @@ const ZIPKIN_SPAN_KIND_MAPPING = {
   [api.SpanKind.INTERNAL]: undefined,
 };
 
-export const statusCodeTagName = 'ot.status_code';
-export const statusDescriptionTagName = 'ot.status_description';
+export const defaultStatusCodeTagName = 'ot.status_code';
+export const defaultStatusDescriptionTagName = 'ot.status_description';
 
 /**
  * Translate OpenTelemetry ReadableSpan to ZipkinSpan format

--- a/packages/opentelemetry-exporter-zipkin/src/types.ts
+++ b/packages/opentelemetry-exporter-zipkin/src/types.ts
@@ -187,3 +187,5 @@ export type SendFunction = (
 ) => void;
 
 export type GetHeaders = () => Record<string, string> | undefined;
+
+export type SendFn = (zipkinSpans: Span[], done: (result: ExportResult) => void) => void;

--- a/packages/opentelemetry-exporter-zipkin/src/zipkin.ts
+++ b/packages/opentelemetry-exporter-zipkin/src/zipkin.ts
@@ -21,8 +21,8 @@ import { prepareSend } from './platform/index';
 import * as zipkinTypes from './types';
 import {
   toZipkinSpan,
-  statusCodeTagName,
-  statusDescriptionTagName,
+  defaultStatusCodeTagName,
+  defaultStatusDescriptionTagName,
 } from './transform';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { prepareGetHeaders } from './utils';
@@ -45,9 +45,9 @@ export class ZipkinExporter implements SpanExporter {
     this._urlStr = config.url || getEnv().OTEL_EXPORTER_ZIPKIN_ENDPOINT;
     this._send = prepareSend(this._urlStr, config.headers);
     this._serviceName = config.serviceName;
-    this._statusCodeTagName = config.statusCodeTagName || statusCodeTagName;
+    this._statusCodeTagName = config.statusCodeTagName || defaultStatusCodeTagName;
     this._statusDescriptionTagName =
-      config.statusDescriptionTagName || statusDescriptionTagName;
+      config.statusDescriptionTagName || defaultStatusDescriptionTagName;
     this._isShutdown = false;
     if (typeof config.getExportRequestHeaders === 'function') {
       this._getHeaders = prepareGetHeaders(config.getExportRequestHeaders);
@@ -63,7 +63,7 @@ export class ZipkinExporter implements SpanExporter {
   export(
     spans: ReadableSpan[],
     resultCallback: (result: ExportResult) => void
-  ) {
+  ): void {
     const serviceName = String(
       this._serviceName ||
         spans[0].resource.attributes[SemanticResourceAttributes.SERVICE_NAME] ||

--- a/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
@@ -25,8 +25,8 @@ import { BasicTracerProvider, Span } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import {
-  statusCodeTagName,
-  statusDescriptionTagName,
+  defaultStatusCodeTagName,
+  defaultStatusDescriptionTagName,
   toZipkinSpan,
   _toZipkinAnnotations,
   _toZipkinTags,
@@ -78,8 +78,8 @@ describe('transform', () => {
       const zipkinSpan = toZipkinSpan(
         span,
         'my-service',
-        statusCodeTagName,
-        statusDescriptionTagName
+        defaultStatusCodeTagName,
+        defaultStatusDescriptionTagName
       );
       assert.deepStrictEqual(zipkinSpan, {
         kind: 'SERVER',
@@ -101,7 +101,7 @@ describe('transform', () => {
         tags: {
           key1: 'value1',
           key2: 'value2',
-          [statusCodeTagName]: 'UNSET',
+          [defaultStatusCodeTagName]: 'UNSET',
           [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
           'telemetry.sdk.language': language,
           'telemetry.sdk.name': 'opentelemetry',
@@ -124,8 +124,8 @@ describe('transform', () => {
       const zipkinSpan = toZipkinSpan(
         span,
         'my-service',
-        statusCodeTagName,
-        statusDescriptionTagName
+        defaultStatusCodeTagName,
+        defaultStatusDescriptionTagName
       );
       assert.deepStrictEqual(zipkinSpan, {
         kind: 'SERVER',
@@ -140,7 +140,7 @@ describe('transform', () => {
         name: span.name,
         parentId: undefined,
         tags: {
-          [statusCodeTagName]: 'UNSET',
+          [defaultStatusCodeTagName]: 'UNSET',
           [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
           'telemetry.sdk.language': language,
           'telemetry.sdk.name': 'opentelemetry',
@@ -173,8 +173,8 @@ describe('transform', () => {
         const zipkinSpan = toZipkinSpan(
           span,
           'my-service',
-          statusCodeTagName,
-          statusDescriptionTagName
+          defaultStatusCodeTagName,
+          defaultStatusDescriptionTagName
         );
         assert.deepStrictEqual(zipkinSpan, {
           kind: item.zipkin,
@@ -189,7 +189,7 @@ describe('transform', () => {
           name: span.name,
           parentId: undefined,
           tags: {
-            [statusCodeTagName]: 'UNSET',
+            [defaultStatusCodeTagName]: 'UNSET',
             [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
             'telemetry.sdk.language': language,
             'telemetry.sdk.name': 'opentelemetry',
@@ -219,15 +219,15 @@ describe('transform', () => {
       const tags: zipkinTypes.Tags = _toZipkinTags(
         span.attributes,
         span.status,
-        statusCodeTagName,
-        statusDescriptionTagName,
+        defaultStatusCodeTagName,
+        defaultStatusDescriptionTagName,
         DUMMY_RESOURCE
       );
 
       assert.deepStrictEqual(tags, {
         key1: 'value1',
         key2: 'value2',
-        [statusCodeTagName]: 'UNSET',
+        [defaultStatusCodeTagName]: 'UNSET',
         cost: '112.12',
         service: 'ui',
         version: '1',
@@ -254,8 +254,8 @@ describe('transform', () => {
       const tags: zipkinTypes.Tags = _toZipkinTags(
         span.attributes,
         span.status,
-        statusCodeTagName,
-        statusDescriptionTagName,
+        defaultStatusCodeTagName,
+        defaultStatusDescriptionTagName,
         Resource.empty().merge(
           new Resource({
             [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
@@ -266,7 +266,7 @@ describe('transform', () => {
       assert.deepStrictEqual(tags, {
         key1: 'value1',
         key2: 'value2',
-        [statusCodeTagName]: 'ERROR',
+        [defaultStatusCodeTagName]: 'ERROR',
         [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
       });
     });
@@ -291,8 +291,8 @@ describe('transform', () => {
       const tags: zipkinTypes.Tags = _toZipkinTags(
         span.attributes,
         span.status,
-        statusCodeTagName,
-        statusDescriptionTagName,
+        defaultStatusCodeTagName,
+        defaultStatusDescriptionTagName,
         Resource.empty().merge(
           new Resource({
             [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
@@ -303,8 +303,8 @@ describe('transform', () => {
       assert.deepStrictEqual(tags, {
         key1: 'value1',
         key2: 'value2',
-        [statusCodeTagName]: 'ERROR',
-        [statusDescriptionTagName]: status.message,
+        [defaultStatusCodeTagName]: 'ERROR',
+        [defaultStatusDescriptionTagName]: status.message,
         [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
       });
     });

--- a/packages/opentelemetry-shim-opentracing/src/shim.ts
+++ b/packages/opentelemetry-shim-opentracing/src/shim.ts
@@ -107,7 +107,7 @@ export class SpanContextShim extends opentracing.SpanContext {
     return this._baggage.getEntry(key)?.value;
   }
 
-  setBaggageItem(key: string, value: string) {
+  setBaggageItem(key: string, value: string): void {
     this._baggage = this._baggage.setEntry(key, { value });
   }
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

related to #1093

## Which problem is this PR solving?

- This PR fixes lint warnings in `exporter-prometheus` and `exporter-zipkin` packages.


## Short description of the changes

- Fix lint warnings
- The warnings regarding the deprecation of `url.parse` haven't been fixed because they need more manual work. I will tackle them in a different PR if needed.
- I have renamed `statusCodeTagName` and `statusDescriptionTagName` exported variables to fix the name shadowing issue in `transform.ts`, but I am not sure this doesn't have any side effects. Let me know if I should revert them.