### PR TITLE
fix: handle missing package.json file when checking for version

### DIFF
--- a/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -81,7 +81,6 @@ export abstract class InstrumentationBase<T = any>
     if (module.name === name) {
       // main module
       if (
-        typeof version === 'string' &&
         isSupported(module.supportedVersions, version, module.includePrerelease)
       ) {
         if (typeof module.patch === 'function') {
@@ -170,12 +169,12 @@ export abstract class InstrumentationBase<T = any>
 }
 
 function isSupported(supportedVersions: string[], version?: string, includePrerelease?: boolean): boolean {
-  return supportedVersions.some(supportedVersion => {
-    if (typeof version === 'undefined') {
-      // If we don't have the version, accept the wildcard case only
-      return supportedVersion === '*';
-    }
+  if (typeof version === 'undefined') {
+    // If we don't have the version, accept the wildcard case only
+    return supportedVersions.includes('*');
+  }
 
+  return supportedVersions.some(supportedVersion => {
     return satisfies(version, supportedVersion, { includePrerelease });
   });
 }

--- a/packages/opentelemetry-instrumentation/test/node/InstrumentationBase.test.ts
+++ b/packages/opentelemetry-instrumentation/test/node/InstrumentationBase.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { InstrumentationBase, InstrumentationModuleDefinition } from '../../src';
+
+const MODULE_NAME = 'test-module';
+const MODULE_FILE_NAME = 'test-module-file';
+const MODULE_VERSION = '0.1.0';
+const WILDCARD_VERSION = '*';
+const MODULE_DIR = '/random/dir';
+
+class TestInstrumentation extends InstrumentationBase {
+  constructor() {
+    super(MODULE_NAME, MODULE_VERSION);
+  }
+
+  init() {}
+}
+
+describe('InstrumentationBase', () => {
+  describe('_onRequire - module version is not available', () => {
+    let instrumentation: TestInstrumentation;
+    let modulePatchSpy: sinon.SinonSpy;
+  
+    beforeEach(() => {
+      instrumentation = new TestInstrumentation();
+      // @ts-expect-error access internal property for testing
+      instrumentation._enabled = true;
+      modulePatchSpy = sinon.spy();
+    });
+    
+    describe('when patching a module', () => {
+      it('should not patch module when there is no wildcard supported version', () => {
+        const moduleExports = {};
+        const instrumentationModule = {
+          supportedVersions: [`^${MODULE_VERSION}`],
+          name: MODULE_NAME,
+          patch: modulePatchSpy as unknown,
+        } as InstrumentationModuleDefinition<unknown>;
+
+        // @ts-expect-error access internal property for testing
+        instrumentation._onRequire<unknown>(
+          instrumentationModule,
+          moduleExports,
+          MODULE_NAME,
+          MODULE_DIR
+        );
+    
+        assert.strictEqual(instrumentationModule.moduleVersion, undefined);
+        assert.strictEqual(instrumentationModule.moduleExports, undefined);
+        sinon.assert.notCalled(modulePatchSpy);
+      });
+
+      it('should patch module when there is a wildcard supported version', () => {
+        const moduleExports = {};
+        const instrumentationModule = {
+          supportedVersions: [`^${MODULE_VERSION}`, WILDCARD_VERSION],
+          name: MODULE_NAME,
+          patch: modulePatchSpy as unknown,
+        } as InstrumentationModuleDefinition<unknown>;
+
+        // @ts-expect-error access internal property for testing
+        instrumentation._onRequire<unknown>(
+          instrumentationModule,
+          moduleExports,
+          MODULE_NAME,
+          MODULE_DIR
+        );
+    
+        assert.strictEqual(instrumentationModule.moduleVersion, undefined);
+        assert.strictEqual(instrumentationModule.moduleExports, moduleExports);
+        sinon.assert.calledOnceWithExactly(modulePatchSpy, moduleExports, undefined);
+      });
+    });
+
+    describe('when patching module files', () => {
+      let filePatchSpy: sinon.SinonSpy;
+
+      beforeEach(() => {
+        filePatchSpy = sinon.spy();
+      })
+
+      it('should not patch module file when there is no wildcard supported version', () => {
+        const moduleExports = {};
+        const supportedVersions = [`^${MODULE_VERSION}`];
+        const instrumentationModule = {
+          supportedVersions,
+          name: MODULE_NAME,
+          patch: modulePatchSpy as unknown,
+          files: [{
+            name: MODULE_FILE_NAME,
+            supportedVersions,
+            patch: filePatchSpy as unknown
+          }]
+        } as InstrumentationModuleDefinition<unknown>;
+
+        // @ts-expect-error access internal property for testing
+        instrumentation._onRequire<unknown>(
+          instrumentationModule,
+          moduleExports,
+          MODULE_FILE_NAME,
+          MODULE_DIR
+        );
+    
+        assert.strictEqual(instrumentationModule.moduleVersion, undefined);
+        assert.strictEqual(instrumentationModule.moduleExports, undefined);
+        sinon.assert.notCalled(modulePatchSpy);
+        sinon.assert.notCalled(filePatchSpy);
+      });
+
+      it('should patch module file when there is a wildcard supported version', () => {
+        const moduleExports = {};
+        const supportedVersions = [`^${MODULE_VERSION}`, WILDCARD_VERSION];
+        const instrumentationModule = {
+          supportedVersions,
+          name: MODULE_NAME,
+          patch: modulePatchSpy as unknown,
+          files: [{
+            name: MODULE_FILE_NAME,
+            supportedVersions,
+            patch: filePatchSpy as unknown
+          }]
+        } as InstrumentationModuleDefinition<unknown>;
+
+        // @ts-expect-error access internal property for testing
+        instrumentation._onRequire<unknown>(
+          instrumentationModule,
+          moduleExports,
+          MODULE_FILE_NAME,
+          MODULE_DIR
+        );
+    
+        assert.strictEqual(instrumentationModule.moduleVersion, undefined);
+        assert.strictEqual(instrumentationModule.files[0].moduleExports, moduleExports);
+        sinon.assert.notCalled(modulePatchSpy);
+        sinon.assert.calledOnceWithExactly(filePatchSpy, moduleExports, undefined);
+      });
+    });
+  });
+});

--- a/packages/opentelemetry-instrumentation/test/node/InstrumentationBase.test.ts
+++ b/packages/opentelemetry-instrumentation/test/node/InstrumentationBase.test.ts
@@ -34,6 +34,9 @@ class TestInstrumentation extends InstrumentationBase {
 
 describe('InstrumentationBase', () => {
   describe('_onRequire - module version is not available', () => {
+    // For all of these cases, there is no indication of the actual module version,
+    // so we require there to be a wildcard supported version.
+
     let instrumentation: TestInstrumentation;
     let modulePatchSpy: sinon.SinonSpy;
   

--- a/packages/opentelemetry-instrumentation/test/node/InstrumentationBase.test.ts
+++ b/packages/opentelemetry-instrumentation/test/node/InstrumentationBase.test.ts
@@ -48,49 +48,53 @@ describe('InstrumentationBase', () => {
     });
     
     describe('when patching a module', () => {
-      it('should not patch module when there is no wildcard supported version', () => {
-        const moduleExports = {};
-        const instrumentationModule = {
-          supportedVersions: [`^${MODULE_VERSION}`],
-          name: MODULE_NAME,
-          patch: modulePatchSpy as unknown,
-        } as InstrumentationModuleDefinition<unknown>;
-
-        // @ts-expect-error access internal property for testing
-        instrumentation._onRequire<unknown>(
-          instrumentationModule,
-          moduleExports,
-          MODULE_NAME,
-          MODULE_DIR
-        );
-    
-        assert.strictEqual(instrumentationModule.moduleVersion, undefined);
-        assert.strictEqual(instrumentationModule.moduleExports, undefined);
-        sinon.assert.notCalled(modulePatchSpy);
+      describe('AND there is no wildcard supported version', () => {
+        it('should not patch module', () => {
+          const moduleExports = {};
+          const instrumentationModule = {
+            supportedVersions: [`^${MODULE_VERSION}`],
+            name: MODULE_NAME,
+            patch: modulePatchSpy as unknown,
+          } as InstrumentationModuleDefinition<unknown>;
+  
+          // @ts-expect-error access internal property for testing
+          instrumentation._onRequire<unknown>(
+            instrumentationModule,
+            moduleExports,
+            MODULE_NAME,
+            MODULE_DIR
+          );
+      
+          assert.strictEqual(instrumentationModule.moduleVersion, undefined);
+          assert.strictEqual(instrumentationModule.moduleExports, undefined);
+          sinon.assert.notCalled(modulePatchSpy);
+        });
       });
 
-      it('should patch module when there is a wildcard supported version', () => {
-        const moduleExports = {};
-        const instrumentationModule = {
-          supportedVersions: [`^${MODULE_VERSION}`, WILDCARD_VERSION],
-          name: MODULE_NAME,
-          patch: modulePatchSpy as unknown,
-        } as InstrumentationModuleDefinition<unknown>;
-
-        // @ts-expect-error access internal property for testing
-        instrumentation._onRequire<unknown>(
-          instrumentationModule,
-          moduleExports,
-          MODULE_NAME,
-          MODULE_DIR
-        );
-    
-        assert.strictEqual(instrumentationModule.moduleVersion, undefined);
-        assert.strictEqual(instrumentationModule.moduleExports, moduleExports);
-        sinon.assert.calledOnceWithExactly(modulePatchSpy, moduleExports, undefined);
+      describe('AND there is a wildcard supported version', () => {
+        it('should patch module', () => {
+          const moduleExports = {};
+          const instrumentationModule = {
+            supportedVersions: [`^${MODULE_VERSION}`, WILDCARD_VERSION],
+            name: MODULE_NAME,
+            patch: modulePatchSpy as unknown,
+          } as InstrumentationModuleDefinition<unknown>;
+          
+          // @ts-expect-error access internal property for testing
+          instrumentation._onRequire<unknown>(
+            instrumentationModule,
+            moduleExports,
+            MODULE_NAME,
+            MODULE_DIR
+          );
+          
+          assert.strictEqual(instrumentationModule.moduleVersion, undefined);
+          assert.strictEqual(instrumentationModule.moduleExports, moduleExports);
+          sinon.assert.calledOnceWithExactly(modulePatchSpy, moduleExports, undefined);
+        });
       });
     });
-
+      
     describe('when patching module files', () => {
       let filePatchSpy: sinon.SinonSpy;
 
@@ -98,60 +102,64 @@ describe('InstrumentationBase', () => {
         filePatchSpy = sinon.spy();
       })
 
-      it('should not patch module file when there is no wildcard supported version', () => {
-        const moduleExports = {};
-        const supportedVersions = [`^${MODULE_VERSION}`];
-        const instrumentationModule = {
-          supportedVersions,
-          name: MODULE_NAME,
-          patch: modulePatchSpy as unknown,
-          files: [{
-            name: MODULE_FILE_NAME,
+      describe('AND there is no wildcard supported version', () => {
+        it('should not patch module file', () => {
+          const moduleExports = {};
+          const supportedVersions = [`^${MODULE_VERSION}`];
+          const instrumentationModule = {
             supportedVersions,
-            patch: filePatchSpy as unknown
-          }]
-        } as InstrumentationModuleDefinition<unknown>;
-
-        // @ts-expect-error access internal property for testing
-        instrumentation._onRequire<unknown>(
-          instrumentationModule,
-          moduleExports,
-          MODULE_FILE_NAME,
-          MODULE_DIR
-        );
-    
-        assert.strictEqual(instrumentationModule.moduleVersion, undefined);
-        assert.strictEqual(instrumentationModule.moduleExports, undefined);
-        sinon.assert.notCalled(modulePatchSpy);
-        sinon.assert.notCalled(filePatchSpy);
+            name: MODULE_NAME,
+            patch: modulePatchSpy as unknown,
+            files: [{
+              name: MODULE_FILE_NAME,
+              supportedVersions,
+              patch: filePatchSpy as unknown
+            }]
+          } as InstrumentationModuleDefinition<unknown>;
+  
+          // @ts-expect-error access internal property for testing
+          instrumentation._onRequire<unknown>(
+            instrumentationModule,
+            moduleExports,
+            MODULE_FILE_NAME,
+            MODULE_DIR
+          );
+      
+          assert.strictEqual(instrumentationModule.moduleVersion, undefined);
+          assert.strictEqual(instrumentationModule.moduleExports, undefined);
+          sinon.assert.notCalled(modulePatchSpy);
+          sinon.assert.notCalled(filePatchSpy);
+        });
       });
 
-      it('should patch module file when there is a wildcard supported version', () => {
-        const moduleExports = {};
-        const supportedVersions = [`^${MODULE_VERSION}`, WILDCARD_VERSION];
-        const instrumentationModule = {
-          supportedVersions,
-          name: MODULE_NAME,
-          patch: modulePatchSpy as unknown,
-          files: [{
-            name: MODULE_FILE_NAME,
+      describe('AND there is a wildcard supported version', () => {
+        it('should patch module file', () => {
+          const moduleExports = {};
+          const supportedVersions = [`^${MODULE_VERSION}`, WILDCARD_VERSION];
+          const instrumentationModule = {
             supportedVersions,
-            patch: filePatchSpy as unknown
-          }]
-        } as InstrumentationModuleDefinition<unknown>;
-
-        // @ts-expect-error access internal property for testing
-        instrumentation._onRequire<unknown>(
-          instrumentationModule,
-          moduleExports,
-          MODULE_FILE_NAME,
-          MODULE_DIR
-        );
-    
-        assert.strictEqual(instrumentationModule.moduleVersion, undefined);
-        assert.strictEqual(instrumentationModule.files[0].moduleExports, moduleExports);
-        sinon.assert.notCalled(modulePatchSpy);
-        sinon.assert.calledOnceWithExactly(filePatchSpy, moduleExports, undefined);
+            name: MODULE_NAME,
+            patch: modulePatchSpy as unknown,
+            files: [{
+              name: MODULE_FILE_NAME,
+              supportedVersions,
+              patch: filePatchSpy as unknown
+            }]
+          } as InstrumentationModuleDefinition<unknown>;
+  
+          // @ts-expect-error access internal property for testing
+          instrumentation._onRequire<unknown>(
+            instrumentationModule,
+            moduleExports,
+            MODULE_FILE_NAME,
+            MODULE_DIR
+          );
+      
+          assert.strictEqual(instrumentationModule.moduleVersion, undefined);
+          assert.strictEqual(instrumentationModule.files[0].moduleExports, moduleExports);
+          sinon.assert.notCalled(modulePatchSpy);
+          sinon.assert.calledOnceWithExactly(filePatchSpy, moduleExports, undefined);
+        });
       });
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

- In some cases (typically, AWS lambda; but can potentially happen in other cases) the `package.json` file may be missing at runtime for a certain module. Currently OTEL crashes in this case, unnecessarily.
- See discussion - https://github.com/open-telemetry/opentelemetry-js/issues/2193

## Short description of the changes

- In case the module's version is missing (due to a missing `package.json` file), we patch the module/file if and only if the supported versions contain a wildcard (`*`). Until now, an exception was thrown, crashing the app.
- Added tests that cover these scenarios/
