### PR TITLE
feat: upgrade semantic conventions to the latest 1.6.1 version

### DIFF
--- a/packages/opentelemetry-semantic-conventions/src/resource/SemanticResourceAttributes.ts
+++ b/packages/opentelemetry-semantic-conventions/src/resource/SemanticResourceAttributes.ts
@@ -28,14 +28,14 @@ export const SemanticResourceAttributes = {
   CLOUD_ACCOUNT_ID: 'cloud.account.id',
 
   /**
-  * The geographical region the resource is running. Refer to your provider&#39;s docs to see the available regions, for example [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), or [Google Cloud regions](https://cloud.google.com/about/locations).
+  * The geographical region the resource is running. Refer to your provider&#39;s docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), or [Google Cloud regions](https://cloud.google.com/about/locations).
   */
   CLOUD_REGION: 'cloud.region',
 
   /**
   * Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
   *
-  * Note: Availability zones are called &#34;zones&#34; on Google Cloud.
+  * Note: Availability zones are called &#34;zones&#34; on Alibaba Cloud and Google Cloud.
   */
   CLOUD_AVAILABILITY_ZONE: 'cloud.availability_zone',
 
@@ -480,6 +480,8 @@ As an alternative, consider setting `faas.id` as a span attribute instead.
 
 
 export enum CloudProviderValues {
+  /** Alibaba Cloud. */
+  ALIBABA_CLOUD = 'alibaba_cloud',
   /** Amazon Web Services. */
   AWS = 'aws',
   /** Microsoft Azure. */
@@ -492,6 +494,10 @@ export enum CloudProviderValues {
 
 
 export enum CloudPlatformValues {
+  /** Alibaba Cloud Elastic Compute Service. */
+  ALIBABA_CLOUD_ECS = 'alibaba_cloud_ecs',
+  /** Alibaba Cloud Function Compute. */
+  ALIBABA_CLOUD_FC = 'alibaba_cloud_fc',
   /** AWS Elastic Compute Cloud. */
   AWS_EC2 = 'aws_ec2',
   /** AWS Elastic Container Service. */

--- a/packages/opentelemetry-semantic-conventions/src/trace/SemanticAttributes.ts
+++ b/packages/opentelemetry-semantic-conventions/src/trace/SemanticAttributes.ts
@@ -275,6 +275,36 @@ clear whether the exception will escape.
   NET_HOST_NAME: 'net.host.name',
 
   /**
+  * The internet connection type currently being used by the host.
+  */
+  NET_HOST_CONNECTION_TYPE: 'net.host.connection.type',
+
+  /**
+  * This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection.
+  */
+  NET_HOST_CONNECTION_SUBTYPE: 'net.host.connection.subtype',
+
+  /**
+  * The name of the mobile carrier.
+  */
+  NET_HOST_CARRIER_NAME: 'net.host.carrier.name',
+
+  /**
+  * The mobile carrier country code.
+  */
+  NET_HOST_CARRIER_MCC: 'net.host.carrier.mcc',
+
+  /**
+  * The mobile carrier network code.
+  */
+  NET_HOST_CARRIER_MNC: 'net.host.carrier.mnc',
+
+  /**
+  * The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network.
+  */
+  NET_HOST_CARRIER_ICC: 'net.host.carrier.icc',
+
+  /**
   * The [`service.name`](../../resource/semantic_conventions/README.md#service) of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any.
   */
   PEER_SERVICE: 'peer.service',
@@ -814,6 +844,8 @@ export enum FaasDocumentOperationValues {
 
 
 export enum FaasInvokedProviderValues {
+  /** Alibaba Cloud. */
+  ALIBABA_CLOUD = 'alibaba_cloud',
   /** Amazon Web Services. */
   AWS = 'aws',
   /** Microsoft Azure. */
@@ -840,6 +872,70 @@ export enum NetTransportValues {
   INPROC = 'inproc',
   /** Something else (non IP-based). */
   OTHER = 'other',
+}
+
+
+
+
+export enum NetHostConnectionTypeValues {
+  /** wifi. */
+  WIFI = 'wifi',
+  /** wired. */
+  WIRED = 'wired',
+  /** cell. */
+  CELL = 'cell',
+  /** unavailable. */
+  UNAVAILABLE = 'unavailable',
+  /** unknown. */
+  UNKNOWN = 'unknown',
+}
+
+
+
+
+export enum NetHostConnectionSubtypeValues {
+  /** GPRS. */
+  GPRS = 'gprs',
+  /** EDGE. */
+  EDGE = 'edge',
+  /** UMTS. */
+  UMTS = 'umts',
+  /** CDMA. */
+  CDMA = 'cdma',
+  /** EVDO Rel. 0. */
+  EVDO_0 = 'evdo_0',
+  /** EVDO Rev. A. */
+  EVDO_A = 'evdo_a',
+  /** CDMA2000 1XRTT. */
+  CDMA2000_1XRTT = 'cdma2000_1xrtt',
+  /** HSDPA. */
+  HSDPA = 'hsdpa',
+  /** HSUPA. */
+  HSUPA = 'hsupa',
+  /** HSPA. */
+  HSPA = 'hspa',
+  /** IDEN. */
+  IDEN = 'iden',
+  /** EVDO Rev. B. */
+  EVDO_B = 'evdo_b',
+  /** LTE. */
+  LTE = 'lte',
+  /** EHRPD. */
+  EHRPD = 'ehrpd',
+  /** HSPAP. */
+  HSPAP = 'hspap',
+  /** GSM. */
+  GSM = 'gsm',
+  /** TD-SCDMA. */
+  TD_SCDMA = 'td_scdma',
+  /** IWLAN. */
+  IWLAN = 'iwlan',
+  /** 5G NR (New Radio). */
+  NR = 'nr',
+  /** 5G NRNSA (New Radio Non-Standalone). */
+  NRNSA = 'nrnsa',
+  /** LTE CA. */
+  LTE_CA = 'lte_ca',
 }
 
 

--- a/scripts/semconv/generate.sh
+++ b/scripts/semconv/generate.sh
@@ -4,8 +4,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"
 
 # freeze the spec version to make SpanAttributess generation reproducible
-SPEC_VERSION=v1.5.0
-GENERATOR_VERSION=0.3.1
+SPEC_VERSION=v1.6.1
+GENERATOR_VERSION=0.5.0
 
 cd ${SCRIPT_DIR}
 


### PR DESCRIPTION
Regenerated the `@opentelemetry-js/semantic-conventions`-package to use
the latest definitions from the Opentelemetry specification

## Which problem is this PR solving?

- Resolves issue #2407 

## Short description of the changes

- Update semantic conventions to the latest version of the spec

