### PR TITLE
feat(sdk-trace-web): ignore unavailable span network events

### DIFF
--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -61,7 +61,8 @@ export function addSpanNetworkEvent(
 ): api.Span | undefined {
   if (
     hasKey(entries, performanceName) &&
-    typeof entries[performanceName] === 'number'
+    typeof entries[performanceName] === 'number' &&
+    entries[performanceName] !== 0
   ) {
     span.addEvent(performanceName, entries[performanceName]);
     return span;

--- a/packages/opentelemetry-sdk-trace-web/test/utils.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/utils.test.ts
@@ -178,7 +178,7 @@ describe('utils', () => {
     });
   });
   describe('addSpanNetworkEvent', () => {
-    [0, -2, 123].forEach(value => {
+    [-2, 123].forEach(value => {
       describe(`when entry is ${value}`, () => {
         it('should add event to span', () => {
           const addEventSpy = sinon.spy();
@@ -199,6 +199,27 @@ describe('utils', () => {
           assert.strictEqual(args[0], 'fetchStart');
           assert.strictEqual(args[1], value);
         });
+      });
+    });
+    describe('when entry is 0', () => {
+      it('should NOT add event to span', () => {
+        const addEventSpy = sinon.spy();
+        const span = ({
+          addEvent: addEventSpy,
+        } as unknown) as tracing.Span;
+        const entries = {
+          [PTN.FETCH_START]: 0,
+        } as PerformanceEntries;
+
+        assert.strictEqual(addEventSpy.callCount, 0);
+
+        addSpanNetworkEvent(
+          span,
+          PTN.FETCH_START,
+          entries
+        );
+
+        assert.strictEqual(addEventSpy.callCount, 0);
       });
     });
     describe('when entry is not numeric', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

When doing cross-origin XHR/Fetch requests browsers expect Timing-Allow-Origin HTTP header to explicitly allow getting network performance timings. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Timing-Allow-Origin for more.

Right now, on such cross-origin requests, we record all events with negative timings (relative to the span creation time).
It can be often misleading and can contribute to invalid metrics when calculating same event from multiple spans.

## Short description of the changes

Network events equal `0` are not recorded.
