### PR TITLE
fix: remove `require` usages in esm build

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -34,7 +34,7 @@ import {
   WebTracerProvider,
 } from '@opentelemetry/sdk-trace-web';
 import * as assert from 'assert';
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 import {
   FetchInstrumentation,
   FetchInstrumentationConfig,

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
@@ -18,7 +18,7 @@ import {
   context,
   propagation,
   Span as ISpan,
-  SpanKind, 
+  SpanKind,
   trace,
   SpanAttributes,
 } from '@opentelemetry/api';
@@ -31,8 +31,8 @@ import {
   NetTransportValues,
   SemanticAttributes,
 } from '@opentelemetry/semantic-conventions';
-import * as assert from 'assert';
-import * as nock from 'nock';
+import assert from 'assert';
+import nock from 'nock';
 import * as path from 'path';
 import { HttpInstrumentation } from '../../src/http';
 import { HttpInstrumentationConfig } from '../../src/types';
@@ -507,7 +507,7 @@ describe('HttpInstrumentation', () => {
             hostname: 'localhost',
             pathname: '/',
             forceStatus: {
-              code: SpanStatusCode.ERROR, 
+              code: SpanStatusCode.ERROR,
               message: err.message,
             },
             component: 'http',

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-package.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-package.test.ts
@@ -33,9 +33,9 @@ instrumentation.enable();
 instrumentation.disable();
 
 import * as http from 'http';
-import * as request from 'request-promise-native';
+import request from 'request-promise-native';
 import * as superagent from 'superagent';
-import * as got from 'got';
+import got from 'got';
 import * as nock from 'nock';
 import axios, { AxiosResponse } from 'axios';
 

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
@@ -36,7 +36,7 @@ import {
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as semver from 'semver';
-import * as nock from 'nock';
+import nock from 'nock';
 import * as path from 'path';
 import { HttpInstrumentation } from '../../src/http';
 import { assertSpan } from '../utils/assertSpan';

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-package.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-package.test.ts
@@ -33,9 +33,9 @@ instrumentation.enable();
 instrumentation.disable();
 
 import * as http from 'http';
-import * as request from 'request-promise-native';
+import request from 'request-promise-native';
 import * as superagent from 'superagent';
-import * as got from 'got';
+import got from 'got';
 import * as nock from 'nock';
 import axios, { AxiosResponse } from 'axios';
 

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -32,7 +32,7 @@ import {
   parseUrl,
 } from '@opentelemetry/sdk-trace-web';
 import * as assert from 'assert';
-import * as sinon from 'sinon';
+import sinon from 'sinon';
 import { EventNames } from '../src/enums/EventNames';
 import {
   XMLHttpRequestInstrumentation,

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -16,7 +16,7 @@
 
 import * as types from '../../types';
 import * as path from 'path';
-import * as RequireInTheMiddle from 'require-in-the-middle';
+import RequireInTheMiddle from 'require-in-the-middle';
 import { satisfies } from 'semver';
 import { InstrumentationAbstract } from '../../instrumentation';
 import { InstrumentationModuleDefinition } from './types';
@@ -67,7 +67,7 @@ export abstract class InstrumentationBase<T = any>
     } catch (error) {
       diag.warn('Failed extracting version', baseDir);
     }
-    
+
     return undefined;
   }
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
@@ -18,6 +18,7 @@ import { diag } from '@opentelemetry/api';
 import * as api from '@opentelemetry/api-metrics';
 import { InstrumentationLibrary } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
+import merge from 'lodash.merge';
 import { BatchObserver } from './BatchObserver';
 import { BaseBoundInstrument } from './BoundInstrument';
 import { CounterMetric } from './CounterMetric';
@@ -31,8 +32,6 @@ import { UpDownCounterMetric } from './UpDownCounterMetric';
 import { UpDownSumObserverMetric } from './UpDownSumObserverMetric';
 import { ValueObserverMetric } from './ValueObserverMetric';
 import { ValueRecorderMetric } from './ValueRecorderMetric';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const merge = require('lodash.merge');
 
 /**
  * Meter is an implementation of the {@link Meter} interface.

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
@@ -16,10 +16,9 @@
 
 import * as api from '@opentelemetry/api-metrics';
 import { Resource } from '@opentelemetry/resources';
+import merge from 'lodash.merge';
 import { Meter } from '.';
 import { DEFAULT_CONFIG, MeterConfig } from './types';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const merge = require('lodash.merge');
 
 /**
  * This class represents a meter provider which platform libraries can extend

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/export/aggregators/Histogram.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/export/aggregators/Histogram.test.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
+import assert from 'assert';
 import { HistogramAggregator } from '../../../src/export/aggregators';
 import { Histogram } from '../../../src';
 import { hrTime, hrTimeToMilliseconds } from '@opentelemetry/core';
-import sinon = require('sinon');
+import sinon from 'sinon';
 
 describe('HistogramAggregator', () => {
   describe('constructor()', () => {

--- a/packages/opentelemetry-context-async-hooks/test/AsyncHooksContextManager.test.ts
+++ b/packages/opentelemetry-context-async-hooks/test/AsyncHooksContextManager.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
+import assert from 'assert';
 import {
   AsyncHooksContextManager,
   AsyncLocalStorageContextManager,

--- a/packages/opentelemetry-context-zone-peer-dep/test/ZoneContextManager.test.ts
+++ b/packages/opentelemetry-context-zone-peer-dep/test/ZoneContextManager.test.ts
@@ -16,7 +16,7 @@
 
 import 'zone.js';
 import * as sinon from 'sinon';
-import * as assert from 'assert';
+import assert from 'assert';
 import { ZoneContextManager } from '../src';
 import { ROOT_CONTEXT, createContextKey } from '@opentelemetry/api';
 

--- a/packages/opentelemetry-core/test/trace/AlwaysOffSampler.test.ts
+++ b/packages/opentelemetry-core/test/trace/AlwaysOffSampler.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as assert from 'assert';
+import assert from 'assert';
 import * as api from '@opentelemetry/api';
 import { AlwaysOffSampler } from '../../src/trace/sampler/AlwaysOffSampler';
 

--- a/packages/opentelemetry-exporter-collector-proto/test/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-proto/test/CollectorMetricExporter.test.ts
@@ -27,7 +27,7 @@ import {
 } from '@opentelemetry/exporter-collector';
 import * as metrics from '@opentelemetry/sdk-metrics-base';
 import * as assert from 'assert';
-import * as http from 'http';
+import http from 'http';
 import * as sinon from 'sinon';
 import { CollectorMetricExporter } from '../src';
 import { getExportRequestProto } from '../src/util';

--- a/packages/opentelemetry-exporter-collector-proto/test/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector-proto/test/CollectorTraceExporter.test.ts
@@ -23,7 +23,7 @@ import {
 } from '@opentelemetry/exporter-collector';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
-import * as http from 'http';
+import http from 'http';
 import * as sinon from 'sinon';
 import { Stream } from 'stream';
 import * as zlib from 'zlib';

--- a/packages/opentelemetry-exporter-collector/test/node/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/node/CollectorMetricExporter.test.ts
@@ -29,7 +29,7 @@ import {
   MetricRecord,
 } from '@opentelemetry/sdk-metrics-base';
 import * as assert from 'assert';
-import * as http from 'http';
+import http from 'http';
 import * as sinon from 'sinon';
 import {
   CollectorExporterNodeConfigBase,

--- a/packages/opentelemetry-exporter-collector/test/node/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-collector/test/node/CollectorTraceExporter.test.ts
@@ -17,7 +17,7 @@
 import { diag } from '@opentelemetry/api';
 import * as core from '@opentelemetry/core';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import * as http from 'http';
+import http from 'http';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { PassThrough, Stream } from 'stream';

--- a/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
+import assert from 'assert';
 import { JaegerExporter } from '../src';
 import { ExportResult, ExportResultCode } from '@opentelemetry/core';
 import * as api from '@opentelemetry/api';
@@ -22,7 +22,7 @@ import { ThriftProcess } from '../src/types';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { TraceFlags } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
-import * as nock from 'nock';
+import nock from 'nock';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 
 describe('JaegerExporter', () => {

--- a/packages/opentelemetry-exporter-prometheus/test/PrometheusLabelsBatcher.test.ts
+++ b/packages/opentelemetry-exporter-prometheus/test/PrometheusLabelsBatcher.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as assert from 'assert';
+import assert from 'assert';
 import { PrometheusLabelsBatcher } from '../src/PrometheusLabelsBatcher';
 import {
   CounterMetric,

--- a/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -24,7 +24,7 @@ import {
   ValueObserverMetric,
 } from '@opentelemetry/sdk-metrics-base';
 import { diag, DiagLogLevel } from '@opentelemetry/api';
-import * as assert from 'assert';
+import assert from 'assert';
 import { Labels } from '@opentelemetry/api-metrics';
 import { PrometheusSerializer } from '../src/PrometheusSerializer';
 import { PrometheusLabelsBatcher } from '../src/PrometheusLabelsBatcher';

--- a/packages/opentelemetry-exporter-zipkin/test/browser/zipkin.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/browser/zipkin.test.ts
@@ -19,7 +19,7 @@ import {
   loggingErrorHandler,
 } from '@opentelemetry/core';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import * as assert from 'assert';
+import assert from 'assert';
 import * as sinon from 'sinon';
 import { ZipkinExporter } from '../../src';
 import * as zipkinTypes from '../../src/types';

--- a/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
@@ -15,7 +15,7 @@
  */
 
 import * as assert from 'assert';
-import * as nock from 'nock';
+import nock from 'nock';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import {
   ExportResult,

--- a/packages/opentelemetry-propagator-jaeger/test/JaegerPropagator.test.ts
+++ b/packages/opentelemetry-propagator-jaeger/test/JaegerPropagator.test.ts
@@ -24,7 +24,7 @@ import {
   TraceFlags,
 } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import * as assert from 'assert';
+import assert from 'assert';
 import {
   JaegerPropagator,
   UBER_TRACE_ID_HEADER,

--- a/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -50,7 +50,7 @@ import {
   HOST_ADDRESS,
   SECONDARY_HOST_ADDRESS,
 } from 'gcp-metadata';
-import * as nock from 'nock';
+import nock from 'nock';
 import * as semver from 'semver';
 import * as Sinon from 'sinon';
 import { NodeSDK } from '../src';

--- a/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts
@@ -29,13 +29,12 @@ import {
   getEnv,
 } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
+import merge from 'lodash.merge';
 import { SpanProcessor, Tracer } from '.';
 import { DEFAULT_CONFIG } from './config';
 import { MultiSpanProcessor } from './MultiSpanProcessor';
 import { NoopSpanProcessor } from './export/NoopSpanProcessor';
 import { SDKRegistrationConfig, TracerConfig } from './types';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const merge = require('lodash.merge');
 import { SpanExporter } from './export/SpanExporter';
 import { BatchSpanProcessor } from './platform';
 

--- a/packages/opentelemetry-sdk-trace-base/test/common/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/BasicTracerProvider.test.ts
@@ -34,7 +34,7 @@ import {
   TraceState,
 } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
-import * as assert from 'assert';
+import assert from 'assert';
 import * as sinon from 'sinon';
 import {
   BasicTracerProvider,

--- a/packages/opentelemetry-sdk-trace-base/test/common/Tracer.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Tracer.test.ts
@@ -31,7 +31,7 @@ import {
   InstrumentationLibrary,
   suppressTracing
 } from '@opentelemetry/core';
-import * as assert from 'assert';
+import assert from 'assert';
 import { BasicTracerProvider, Span, Tracer } from '../../src';
 import { TestStackContextManager } from './export/TestStackContextManager';
 import * as sinon from 'sinon';

--- a/packages/opentelemetry-sdk-trace-web/test/StackContextManager.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/StackContextManager.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { createContextKey, ROOT_CONTEXT } from '@opentelemetry/api';
-import * as assert from 'assert';
+import assert from 'assert';
 import { StackContextManager } from '../src';
 
 describe('StackContextManager', () => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "composite": true,
     "declaration": true,
     "declarationMap": true,
+    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "module": "commonjs",
     "noEmitOnError": true,


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes https://github.com/open-telemetry/opentelemetry-js/issues/2464

## Short description of the changes

- Enabled `esModuleInterop` flag in `tsconfig.base.json`.
- Removes `require` usages in esm build.
- Also fixes that assuming esmodule namespace object as callable in tests.
- Notably, `sinon.stub` cannot be used with esmodule namespace objects as fields of namespace objects are readonly. Instead, we should stub on the modules' default exported object, like
```javascript
import http from 'http';
sinon.stub(http, 'request'); 
// modifications on variable `http` can be reflected to 
// either `import * as http from 'http` or 
// `import { request } from 'http'` in other modules by 
// "live binding" semantics.
```
- `sinon.useFakeTimers` and `sinon.clock` cannot be used with star import anymore as `sinon.clock` was defined after `sinon.useFakeTimers()` but not statically
```javascript
import * as sinon from 'sinon'; // namespace object was sealed with exported names.
sinon.useFakeTimers(); // installs `sinon.clock`, not installed to the namespace object
sinon.clock // => undefined


import sinon from 'sinon'; // default exported object is identical to the exported one.
sinon.useFakeTimer(); // installs `sinon.clock`
sinon.clock // => [SinonFakeClock]
```
