### PR TITLE
feat: upgrading esm targets to targeting es2017

### DIFF
--- a/tsconfig.base.esm.json
+++ b/tsconfig.base.esm.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.es5.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "ES6",
     "moduleResolution": "node"


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes: https://github.com/open-telemetry/opentelemetry-js/issues/2471

## Short description of the changes

- Targeting ES2017 on esm builds.
- No longer polyfills for `await`.

 _ | `await` | `import` statement
 --- | --- | ---
Chrome | 55 | 61
Firefox | 52 | 60
Edge | 14 | 16

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#browser_compatibility
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#browser_compatibility
