### PR TITLE
Update links to packages moved to experimental

### DIFF
--- a/doc/instrumentation-guide.md
+++ b/doc/instrumentation-guide.md
@@ -5,7 +5,7 @@ A detailed explained guide how to instrument a package is available at [instrume
 For more comprehensive examples please refer to the [HTTP instrumentation][http-instrumentation] or [gRPC instrumentation][grpc-instrumentation] for node
 and [XMLHttpRequest instrumentation][xhr-instrumentation] for web.
 
-[base-instrumentation]: https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-instrumentation
-[http-instrumentation]: https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-instrumentation-http/src/http.ts#L59
-[grpc-instrumentation]: https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts#L28
-[xhr-instrumentation]: https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts#L71
+[base-instrumentation]: https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation
+[http-instrumentation]: https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-http/src/http.ts#L59
+[grpc-instrumentation]: https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts#L28
+[xhr-instrumentation]: https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts#L71


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

These links were broken in the doc

## Short description of the changes

I found in git log that the referenced packages were moved. So here are the links to point to their new location.

The line numbers referenced in the links aren't all quite right anymore, but at least the links take you into the right file now.
