### PR TITLE
fix: remove usage of serviceName property in tests for otel collector

### DIFF
--- a/packages/opentelemetry-exporter-otlp-http/test/node/CollectorMetricExporter.test.ts
+++ b/packages/opentelemetry-exporter-otlp-http/test/node/CollectorMetricExporter.test.ts
@@ -72,7 +72,6 @@ describe('OTLPMetricExporter - node with json over http', () => {
       // Need to stub/spy on the underlying logger as the "diag" instance is global
       const spyLoggerWarn = sinon.stub(diag, 'warn');
       collectorExporter = new OTLPMetricExporter({
-        serviceName: 'basic-service',
         url: address,
         metadata,
       } as any);

--- a/packages/opentelemetry-exporter-otlp-http/test/node/CollectorTraceExporter.test.ts
+++ b/packages/opentelemetry-exporter-otlp-http/test/node/CollectorTraceExporter.test.ts
@@ -58,7 +58,6 @@ describe('OTLPTraceExporter - node with json over http', () => {
       // Need to stub/spy on the underlying logger as the "diag" instance is global
       const spyLoggerWarn = sinon.stub(diag, 'warn');
       collectorExporter = new OTLPTraceExporter({
-        serviceName: 'basic-service',
         metadata,
         url: address,
       } as any);


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->
## Which problem is this PR solving?

- resolves #2278 
- removes incorrect usage of `serviceName` property from tests in opentelemetry-exporter-otlp-http package

## Short description of the changes

- Two test cases in package opentelemetry-exporter-otlp-http are using the `serviceName` property for configuration of OTLPTraceExporter and OTPLMetricExporter.`serviceName` is not a valid property of the config object (OTLPExporterNodeConfigBase), this PR removes the usage of this property in the test cases.
