### PR TITLE
fix(sdk-metrics-base): metrics name should be in the max length of 63

### DIFF
--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
@@ -350,6 +350,6 @@ export class Meter implements api.Meter {
    * @param name Name of metric to be created
    */
   private _isValidName(name: string): boolean {
-    return Boolean(name.match(/^[a-z][a-z0-9_.-]*$/i));
+    return Boolean(name.match(/^[a-z][a-z0-9_.-]{0,62}$/i));
   }
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/Meter.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/Meter.test.ts
@@ -295,6 +295,11 @@ describe('Meter', () => {
         const counter = meter.createCounter('name with invalid characters^&*(');
         assert.ok(counter instanceof api.NoopMetric);
       });
+
+      it('should return no op metric if name exceeded length of 63', () => {
+        const counter = meter.createCounter('name_with_length_of_64_so_this_is_soooooooooooooooooooooooo_long');
+        assert.ok(counter instanceof api.NoopMetric);
+      });
     });
   });
 


### PR DESCRIPTION

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Refs: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument
- Metrics name should not exceed a length of 63.

