### PR TITLE
chore: update stable dependencies to 1.0

### DIFF
--- a/experimental/backwards-compatability/node10/package.json
+++ b/experimental/backwards-compatability/node10/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@opentelemetry/sdk-node": "0.25.0",
-    "@opentelemetry/sdk-trace-base": "0.26.0"
+    "@opentelemetry/sdk-trace-base": "1.0.0"
   },
   "devDependencies": {
     "@types/node": "10.17.60",

--- a/experimental/backwards-compatability/node12/package.json
+++ b/experimental/backwards-compatability/node12/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@opentelemetry/sdk-node": "0.25.0",
-    "@opentelemetry/sdk-trace-base": "0.26.0"
+    "@opentelemetry/sdk-trace-base": "1.0.0"
   },
   "devDependencies": {
     "@types/node": "12.20.20",

--- a/experimental/backwards-compatability/node8/package.json
+++ b/experimental/backwards-compatability/node8/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@opentelemetry/sdk-node": "0.25.0",
-    "@opentelemetry/sdk-trace-base": "0.26.0"
+    "@opentelemetry/sdk-trace-base": "1.0.0"
   },
   "devDependencies": {
     "@types/node": "8.10.66",

--- a/experimental/packages/opentelemetry-exporter-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-otlp-grpc/package.json
@@ -69,10 +69,10 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.3.7",
     "@grpc/proto-loader": "^0.6.4",
-    "@opentelemetry/core": "0.26.0",
+    "@opentelemetry/core": "1.0.0",
     "@opentelemetry/exporter-otlp-http": "0.25.0",
     "@opentelemetry/sdk-metrics-base": "0.25.0",
-    "@opentelemetry/resources": "0.26.0",
-    "@opentelemetry/sdk-trace-base": "0.26.0"
+    "@opentelemetry/resources": "1.0.0",
+    "@opentelemetry/sdk-trace-base": "1.0.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-otlp-http/package.json
@@ -87,9 +87,9 @@
   },
   "dependencies": {
     "@opentelemetry/api-metrics": "0.25.0",
-    "@opentelemetry/core": "0.26.0",
-    "@opentelemetry/resources": "0.26.0",
+    "@opentelemetry/core": "1.0.0",
+    "@opentelemetry/resources": "1.0.0",
     "@opentelemetry/sdk-metrics-base": "0.25.0",
-    "@opentelemetry/sdk-trace-base": "0.26.0"
+    "@opentelemetry/sdk-trace-base": "1.0.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-otlp-proto/package.json
@@ -68,11 +68,11 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.6.4",
-    "@opentelemetry/core": "0.26.0",
+    "@opentelemetry/core": "1.0.0",
     "@opentelemetry/exporter-otlp-http": "0.25.0",
     "@opentelemetry/sdk-metrics-base": "0.25.0",
-    "@opentelemetry/resources": "0.26.0",
-    "@opentelemetry/sdk-trace-base": "0.26.0",
+    "@opentelemetry/resources": "1.0.0",
+    "@opentelemetry/sdk-trace-base": "1.0.0",
     "protobufjs": "^6.9.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@opentelemetry/api-metrics": "0.25.0",
-    "@opentelemetry/core": "0.26.0",
+    "@opentelemetry/core": "1.0.0",
     "@opentelemetry/sdk-metrics-base": "0.25.0"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -50,9 +50,9 @@
   "devDependencies": {
     "@babel/core": "7.15.0",
     "@opentelemetry/api": "^1.0.2",
-    "@opentelemetry/context-zone": "0.26.0",
-    "@opentelemetry/propagator-b3": "0.26.0",
-    "@opentelemetry/sdk-trace-base": "0.26.0",
+    "@opentelemetry/context-zone": "1.0.0",
+    "@opentelemetry/propagator-b3": "1.0.0",
+    "@opentelemetry/sdk-trace-base": "1.0.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/sinon": "10.0.2",
@@ -81,9 +81,9 @@
     "@opentelemetry/api": "^1.0.2"
   },
   "dependencies": {
-    "@opentelemetry/core": "0.26.0",
+    "@opentelemetry/core": "1.0.0",
     "@opentelemetry/instrumentation": "0.25.0",
-    "@opentelemetry/sdk-trace-web": "0.26.0",
-    "@opentelemetry/semantic-conventions": "0.26.0"
+    "@opentelemetry/sdk-trace-web": "1.0.0",
+    "@opentelemetry/semantic-conventions": "1.0.0"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -46,10 +46,10 @@
     "@grpc/grpc-js": "1.3.7",
     "@grpc/proto-loader": "0.6.4",
     "@opentelemetry/api": "^1.0.2",
-    "@opentelemetry/context-async-hooks": "0.26.0",
-    "@opentelemetry/core": "0.26.0",
-    "@opentelemetry/sdk-trace-base": "0.26.0",
-    "@opentelemetry/sdk-trace-node": "0.26.0",
+    "@opentelemetry/context-async-hooks": "1.0.0",
+    "@opentelemetry/core": "1.0.0",
+    "@opentelemetry/sdk-trace-base": "1.0.0",
+    "@opentelemetry/sdk-trace-node": "1.0.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/semver": "7.3.8",
@@ -71,6 +71,6 @@
   "dependencies": {
     "@opentelemetry/api-metrics": "0.25.0",
     "@opentelemetry/instrumentation": "0.25.0",
-    "@opentelemetry/semantic-conventions": "0.26.0"
+    "@opentelemetry/semantic-conventions": "1.0.0"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -44,9 +44,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.2",
-    "@opentelemetry/context-async-hooks": "0.26.0",
-    "@opentelemetry/sdk-trace-base": "0.26.0",
-    "@opentelemetry/sdk-trace-node": "0.26.0",
+    "@opentelemetry/context-async-hooks": "1.0.0",
+    "@opentelemetry/sdk-trace-base": "1.0.0",
+    "@opentelemetry/sdk-trace-node": "1.0.0",
     "@types/got": "9.6.12",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
@@ -72,9 +72,9 @@
     "@opentelemetry/api": "^1.0.2"
   },
   "dependencies": {
-    "@opentelemetry/core": "0.26.0",
+    "@opentelemetry/core": "1.0.0",
     "@opentelemetry/instrumentation": "0.25.0",
-    "@opentelemetry/semantic-conventions": "0.26.0",
+    "@opentelemetry/semantic-conventions": "1.0.0",
     "semver": "^7.3.5"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -50,9 +50,9 @@
   "devDependencies": {
     "@babel/core": "7.15.0",
     "@opentelemetry/api": "^1.0.2",
-    "@opentelemetry/context-zone": "0.26.0",
-    "@opentelemetry/propagator-b3": "0.26.0",
-    "@opentelemetry/sdk-trace-base": "0.26.0",
+    "@opentelemetry/context-zone": "1.0.0",
+    "@opentelemetry/propagator-b3": "1.0.0",
+    "@opentelemetry/sdk-trace-base": "1.0.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/sinon": "10.0.2",
@@ -81,9 +81,9 @@
     "@opentelemetry/api": "^1.0.2"
   },
   "dependencies": {
-    "@opentelemetry/core": "0.26.0",
+    "@opentelemetry/core": "1.0.0",
     "@opentelemetry/instrumentation": "0.25.0",
-    "@opentelemetry/sdk-trace-web": "0.26.0",
-    "@opentelemetry/semantic-conventions": "0.26.0"
+    "@opentelemetry/sdk-trace-web": "1.0.0",
+    "@opentelemetry/semantic-conventions": "1.0.0"
   }
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -64,8 +64,8 @@
   },
   "dependencies": {
     "@opentelemetry/api-metrics": "0.25.0",
-    "@opentelemetry/core": "0.26.0",
-    "@opentelemetry/resources": "0.26.0",
+    "@opentelemetry/core": "1.0.0",
+    "@opentelemetry/resources": "1.0.0",
     "lodash.merge": "^4.6.2"
   }
 }

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -43,21 +43,21 @@
   },
   "dependencies": {
     "@opentelemetry/api-metrics": "0.25.0",
-    "@opentelemetry/core": "0.26.0",
+    "@opentelemetry/core": "1.0.0",
     "@opentelemetry/instrumentation": "0.25.0",
     "@opentelemetry/resource-detector-aws": "0.24.0",
     "@opentelemetry/resource-detector-gcp": "0.24.0",
-    "@opentelemetry/resources": "0.26.0",
+    "@opentelemetry/resources": "1.0.0",
     "@opentelemetry/sdk-metrics-base": "0.25.0",
-    "@opentelemetry/sdk-trace-base": "0.26.0",
-    "@opentelemetry/sdk-trace-node": "0.26.0"
+    "@opentelemetry/sdk-trace-base": "1.0.0",
+    "@opentelemetry/sdk-trace-node": "1.0.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.2"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.2",
-    "@opentelemetry/context-async-hooks": "0.26.0",
+    "@opentelemetry/context-async-hooks": "1.0.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/semver": "7.3.8",


### PR DESCRIPTION
Update stable dependencies of all experimental packages. This is just a number since the code for 0.26 packages is identical to the 1.0 packages.