### PR TITLE
feat(sdk-metrics-base) Add pull controller

### DIFF
--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/export/Controller.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/export/Controller.ts
@@ -78,10 +78,10 @@ export class PullController extends Controller {
   }
 
   shutdown(): Promise<void> {
-    return this._collect();
+    return this.collect();
   }
 
-  public async _collect(): Promise<void> {
+  public async collect(): Promise<void> {
     await this._meter.collect();
     return new Promise(resolve => {
       this._exporter.export(

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/export/types.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/export/types.ts
@@ -22,6 +22,7 @@ import {
 } from '@opentelemetry/api-metrics';
 import { ExportResult, InstrumentationLibrary } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
+import { PullController } from './Controller';
 
 /** The kind of metric. */
 export enum MetricKind {
@@ -102,6 +103,11 @@ export interface MetricExporter {
   export(
     metrics: MetricRecord[],
     resultCallback: (result: ExportResult) => void
+  ): void;
+
+  /** Registers a {@Link PullController}. If this function is defined, the MetricsExporter will use a {@Link PullController} instead of a {@Link PushController} */
+  registerPullController?(
+    pullController: PullController
   ): void;
 
   /** Stops the exporter. */


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/796

This PR introduces a Pull Controller. In contrast to the Push Controller which collects metrics at a fixed interval, this controller leaves the decision of when to collect to the MetricExporter. The implementation is based on @dyladan's comment here: https://github.com/open-telemetry/opentelemetry-js/issues/796#issuecomment-597626485. This kind of controller is great for e.g. a Prometheus exporter as Prometheus is generally pull-based (Except for their Pushgateway)



## Short description of the changes


An optional function `registerPullController` can be defined on the MetricExporter. If defined, a PullController is created instead of a PushController. The MetricExporter must then itself call `collect` on the PullController to collect metrics when needed.

