### PR TITLE
fix(exporter-zipkin): Correct status tags names

### DIFF
--- a/packages/opentelemetry-exporter-zipkin/src/transform.ts
+++ b/packages/opentelemetry-exporter-zipkin/src/transform.ts
@@ -29,8 +29,8 @@ const ZIPKIN_SPAN_KIND_MAPPING = {
   [api.SpanKind.INTERNAL]: undefined,
 };
 
-export const defaultStatusCodeTagName = 'ot.status_code';
-export const defaultStatusDescriptionTagName = 'ot.status_description';
+export const defaultStatusCodeTagName = 'otel.status_code';
+export const defaultStatusDescriptionTagName = 'otel.status_description';
 
 /**
  * Translate OpenTelemetry ReadableSpan to ZipkinSpan format
@@ -78,7 +78,9 @@ export function _toZipkinTags(
   for (const key of Object.keys(attributes)) {
     tags[key] = String(attributes[key]);
   }
-  tags[statusCodeTagName] = String(api.SpanStatusCode[status.code]);
+  if (status.code !== api.SpanStatusCode.UNSET) {
+    tags[statusCodeTagName] = String(api.SpanStatusCode[status.code]);
+  }
   if (status.message) {
     tags[statusDescriptionTagName] = status.message;
   }

--- a/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
@@ -101,7 +101,6 @@ describe('transform', () => {
         tags: {
           key1: 'value1',
           key2: 'value2',
-          [defaultStatusCodeTagName]: 'UNSET',
           [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
           'telemetry.sdk.language': language,
           'telemetry.sdk.name': 'opentelemetry',
@@ -140,7 +139,6 @@ describe('transform', () => {
         name: span.name,
         parentId: undefined,
         tags: {
-          [defaultStatusCodeTagName]: 'UNSET',
           [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
           'telemetry.sdk.language': language,
           'telemetry.sdk.name': 'opentelemetry',
@@ -189,7 +187,6 @@ describe('transform', () => {
           name: span.name,
           parentId: undefined,
           tags: {
-            [defaultStatusCodeTagName]: 'UNSET',
             [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
             'telemetry.sdk.language': language,
             'telemetry.sdk.name': 'opentelemetry',
@@ -227,7 +224,6 @@ describe('transform', () => {
       assert.deepStrictEqual(tags, {
         key1: 'value1',
         key2: 'value2',
-        [defaultStatusCodeTagName]: 'UNSET',
         cost: '112.12',
         service: 'ui',
         version: '1',

--- a/packages/opentelemetry-exporter-zipkin/test/helper.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/helper.ts
@@ -71,7 +71,7 @@ export function ensureSpanIsCorrect(span: Span) {
     localEndpoint: { serviceName: 'OpenTelemetry Service' },
     tags: {
       component: 'foo',
-      'ot.status_code': 'OK',
+      'otel.status_code': 'OK',
       service: 'ui',
       version: '1',
       cost: '112.12',

--- a/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
@@ -215,7 +215,7 @@ describe('Zipkin Exporter - node', () => {
             tags: {
               key1: 'value1',
               key2: 'value2',
-              'ot.status_code': 'OK',
+              'otel.status_code': 'OK',
             },
             timestamp: startTime * MICROS_PER_SECS,
             traceId: span1.spanContext().traceId,
@@ -230,7 +230,7 @@ describe('Zipkin Exporter - node', () => {
             },
             name: span2.name,
             tags: {
-              'ot.status_code': 'OK',
+              'otel.status_code': 'OK',
             },
             timestamp: hrTimeToMicroseconds([startTime, 0]),
             traceId: span2.spanContext().traceId,


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

As per [OpenTelemetry Transformation to non-OTLP Formats spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/non-otlp.md#span-status):

> ### Span Status
> 
> Span `Status` MUST be reported as key-value pairs associated with the Span, unless the `Status` is `UNSET`. In the latter case it MUST NOT be reported.
> 
> The following table defines the OpenTelemetry `Status`'s mapping to Span's key-value pairs:
> 
> |OpenTelemetry Status Field|non-OTLP Key|non-OTLP Value|
> |--|--|--|
> |Code | `otel.status_code` | Name of the code, either `OK` or `ERROR`. MUST NOT be set if the code is `UNSET`. |
> |Description | `otel.status_description` | Description of the `Status` if it has a value otherwise not set. |

## Short description of the changes

Corrected the tag names (`ot.` -> `otel.`), check for unset status

For reference: [zipkin exporter in otel-java](https://github.com/open-telemetry/opentelemetry-java/blob/6ef3091cfb83946372da0d47d70acdf468c9e6c3/exporters/zipkin/src/main/java/io/opentelemetry/exporter/zipkin/ZipkinSpanExporter.java#L121)