### PR TITLE
chore: cleanup setting config in instrumentations

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -76,11 +76,11 @@ export class FetchInstrumentation extends InstrumentationBase<
   private _usedResources = new WeakSet<PerformanceResourceTiming>();
   private _tasksCount = 0;
 
-  constructor(config: FetchInstrumentationConfig = {}) {
+  constructor(config?: FetchInstrumentationConfig) {
     super(
       '@opentelemetry/instrumentation-fetch',
       VERSION,
-      Object.assign({}, config)
+      config
     );
   }
 

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/clientUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/clientUtils.ts
@@ -48,7 +48,7 @@ export function getMethodsToWrap(
 
   // For a method defined in .proto as "UnaryMethod"
   Object.entries(methods).forEach(([name, { originalName }]) => {
-    if (!_methodIsIgnored(name, this._config.ignoreGrpcMethods)) {
+    if (!_methodIsIgnored(name, this.getConfig().ignoreGrpcMethods)) {
       methodList.push(name); // adds camel case method name: "unaryMethod"
       if (
         originalName &&

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/index.ts
@@ -19,10 +19,7 @@ import {
   InstrumentationNodeModuleDefinition,
   isWrapped,
 } from '@opentelemetry/instrumentation';
-import {
-  InstrumentationBase,
-  InstrumentationConfig,
-} from '@opentelemetry/instrumentation';
+import { InstrumentationBase } from '@opentelemetry/instrumentation';
 import { GrpcInstrumentationConfig } from '../types';
 import {
   ServerCallWithMeta,
@@ -56,17 +53,11 @@ import { AttributeNames } from '../enums/AttributeNames';
 
 export class GrpcJsInstrumentation extends InstrumentationBase {
   constructor(
-    protected override _config: GrpcInstrumentationConfig & InstrumentationConfig = {},
     name: string,
-    version: string
+    version: string,
+    config?: GrpcInstrumentationConfig,
   ) {
-    super(name, version, _config);
-  }
-
-  public override setConfig(
-    config: GrpcInstrumentationConfig & InstrumentationConfig = {}
-  ) {
-    this._config = Object.assign({}, config);
+    super(name, version, config);
   }
 
   init() {
@@ -125,6 +116,10 @@ export class GrpcJsInstrumentation extends InstrumentationBase {
     ];
   }
 
+  override getConfig(): GrpcInstrumentationConfig {
+    return super.getConfig();
+  }
+
   /**
    * Patch for grpc.Server.prototype.register(...) function. Provides auto-instrumentation for
    * client_stream, server_stream, bidi, unary server handler calls.
@@ -134,7 +129,7 @@ export class GrpcJsInstrumentation extends InstrumentationBase {
   ) => ServerRegisterFunction {
     const instrumentation = this;
     return (originalRegister: ServerRegisterFunction) => {
-      const config = this._config;
+      const config = this.getConfig();
       instrumentation._diag.debug('patched gRPC server');
       return function register<RequestType, ResponseType>(
         this: grpcJs.Server,

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/index.ts
@@ -19,7 +19,6 @@ import {
   InstrumentationNodeModuleDefinition,
   InstrumentationNodeModuleFile,
   InstrumentationBase,
-  InstrumentationConfig,
   isWrapped,
 } from '@opentelemetry/instrumentation';
 import {
@@ -55,17 +54,11 @@ export class GrpcNativeInstrumentation extends InstrumentationBase<
   typeof grpcTypes
 > {
   constructor(
-    protected override _config: GrpcInstrumentationConfig & InstrumentationConfig = {},
     name: string,
-    version: string
+    version: string,
+    config?: GrpcInstrumentationConfig
   ) {
-    super(name, version, _config);
-  }
-
-  public override setConfig(
-    config: GrpcInstrumentationConfig & InstrumentationConfig = {}
-  ) {
-    this._config = Object.assign({}, config);
+    super(name, version, config);
   }
 
   init() {
@@ -105,6 +98,10 @@ export class GrpcNativeInstrumentation extends InstrumentationBase<
         this._getInternalPatchs()
       ),
     ];
+  }
+
+  override getConfig(): GrpcInstrumentationConfig {
+    return super.getConfig();
   }
 
   private _getInternalPatchs() {
@@ -268,7 +265,7 @@ export class GrpcNativeInstrumentation extends InstrumentationBase<
 
     // For a method defined in .proto as "UnaryMethod"
     Object.entries(methods).forEach(([name, { originalName }]) => {
-      if (!_methodIsIgnored(name, this._config.ignoreGrpcMethods)) {
+      if (!_methodIsIgnored(name, this.getConfig().ignoreGrpcMethods)) {
         methodList.push(name); // adds camel case method name: "unaryMethod"
         if (
           originalName &&

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/serverUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/serverUtils.ts
@@ -131,6 +131,6 @@ export const shouldNotTraceServerCall = function (
   const parsedName = name.split('/');
   return _methodIsIgnored(
     parsedName[parsedName.length - 1] || name,
-    this._config.ignoreGrpcMethods
+    this.getConfig().ignoreGrpcMethods
   );
 };

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { GrpcInstrumentationConfig } from './types';
 import { VERSION } from './version';
 import { GrpcNativeInstrumentation } from './grpc';
@@ -34,26 +33,23 @@ export class GrpcInstrumentation {
   public readonly instrumentationVersion: string = VERSION;
 
   constructor(
-    protected _config: GrpcInstrumentationConfig & InstrumentationConfig = {}
+    config?: GrpcInstrumentationConfig
   ) {
     this._grpcJsInstrumentation = new GrpcJsInstrumentation(
-      _config,
       this.instrumentationName,
-      this.instrumentationVersion
+      this.instrumentationVersion,
+      config
     );
     this._grpcNativeInstrumentation = new GrpcNativeInstrumentation(
-      _config,
       this.instrumentationName,
-      this.instrumentationVersion
+      this.instrumentationVersion,
+      config
     );
   }
 
-  public setConfig(
-    config: GrpcInstrumentationConfig & InstrumentationConfig = {}
-  ) {
-    this._config = Object.assign({}, config);
-    this._grpcJsInstrumentation.setConfig(this._config);
-    this._grpcNativeInstrumentation.setConfig(this._config);
+  public setConfig(config?: GrpcInstrumentationConfig) {
+    this._grpcJsInstrumentation.setConfig(config);
+    this._grpcNativeInstrumentation.setConfig(config);
   }
 
   /**
@@ -61,8 +57,9 @@ export class GrpcInstrumentation {
    * Public reference to the protected BaseInstrumentation `_config` instance to be used by this
    * plugin's external helper functions
    */
-  public getConfig() {
-    return this._config;
+  public getConfig(): GrpcInstrumentationConfig {
+    // grpcNative and grpcJs have their own config copy which should be identical so just pick one
+    return this._grpcJsInstrumentation.getConfig();
   }
 
   init() {

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -44,7 +44,6 @@ import * as utils from './utils';
 import { VERSION } from './version';
 import {
   InstrumentationBase,
-  InstrumentationConfig,
   InstrumentationNodeModuleDefinition,
   isWrapped,
   safeExecuteInTheMiddle,
@@ -60,11 +59,11 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
   private readonly _version = process.versions.node;
   private _headerCapture;
 
-  constructor(config: HttpInstrumentationConfig & InstrumentationConfig = {}) {
+  constructor(config?: HttpInstrumentationConfig) {
     super(
       '@opentelemetry/instrumentation-http',
       VERSION,
-      Object.assign({}, config)
+      config
     );
 
     this._headerCapture = this._createHeaderCapture();
@@ -74,8 +73,8 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
     return this._config;
   }
 
-  override setConfig(config: HttpInstrumentationConfig & InstrumentationConfig = {}): void {
-    this._config = Object.assign({}, config);
+  override setConfig(config?: HttpInstrumentationConfig): void {
+    super.setConfig(config);
     this._headerCapture = this._createHeaderCapture();
   }
 

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -87,13 +87,11 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
   private _xhrMem = new WeakMap<XMLHttpRequest, XhrMem>();
   private _usedResources = new WeakSet<PerformanceResourceTiming>();
 
-  constructor(
-    config: XMLHttpRequestInstrumentationConfig & InstrumentationConfig = {}
-  ) {
+  constructor(config?: XMLHttpRequestInstrumentationConfig) {
     super(
       '@opentelemetry/instrumentation-xml-http-request',
       VERSION,
-      Object.assign({}, config)
+      config
     );
   }
 


### PR DESCRIPTION
## Short description of the changes

There is no need to create a copy of the config object as this is done in base class.
Remove defaulting to an empty config object at several places as this is done in the base class.
Remove the intersection type with `InstrumentationConfig` as all config types extend this type.
Avoid overriding the _config property in the grpc instrumentation.

