### PR TITLE
fix(api-metrics): distinguish bound counter and bound up down counter type

### DIFF
--- a/experimental/packages/opentelemetry-api-metrics/src/NoopMeter.ts
+++ b/experimental/packages/opentelemetry-api-metrics/src/NoopMeter.ts
@@ -31,6 +31,7 @@ import {
 import {
   BoundHistogram,
   BoundCounter,
+  BoundUpDownCounter,
   BoundObservableBase,
 } from './types/BoundInstrument';
 import { ObservableResult } from './types/ObservableResult';
@@ -67,7 +68,7 @@ export class NoopMeter implements Meter {
    * @param [options] the metric options.
    */
   createUpDownCounter(_name: string, _options?: MetricOptions): UpDownCounter {
-    return NOOP_COUNTER_METRIC;
+    return NOOP_UP_DOWN_COUNTER_METRIC;
   }
 
   /**
@@ -166,6 +167,14 @@ export class NoopCounterMetric
   }
 }
 
+export class NoopUpDownCounterMetric
+  extends NoopMetric<BoundUpDownCounter>
+  implements Counter {
+  add(value: number, labels: Labels): void {
+    this.bind(labels).add(value);
+  }
+}
+
 export class NoopHistogramMetric
   extends NoopMetric<BoundHistogram>
   implements Histogram {
@@ -193,6 +202,12 @@ export class NoopBoundCounter implements BoundCounter {
   }
 }
 
+export class NoopBoundUpDownCounter implements BoundUpDownCounter {
+  add(_value: number): void {
+    return;
+  }
+}
+
 export class NoopBoundHistogram implements BoundHistogram {
   record(_value: number, _baggage?: unknown, _spanContext?: unknown): void {
     return;
@@ -206,6 +221,8 @@ export class NoopBoundObservableBase implements BoundObservableBase {
 export const NOOP_METER = new NoopMeter();
 export const NOOP_BOUND_COUNTER = new NoopBoundCounter();
 export const NOOP_COUNTER_METRIC = new NoopCounterMetric(NOOP_BOUND_COUNTER);
+export const NOOP_BOUND_UP_DOWN_COUNTER = new NoopBoundUpDownCounter();
+export const NOOP_UP_DOWN_COUNTER_METRIC = new NoopUpDownCounterMetric(NOOP_BOUND_UP_DOWN_COUNTER);
 
 export const NOOP_BOUND_HISTOGRAM = new NoopBoundHistogram();
 export const NOOP_HISTOGRAM_METRIC = new NoopHistogramMetric(

--- a/experimental/packages/opentelemetry-api-metrics/src/types/BoundInstrument.ts
+++ b/experimental/packages/opentelemetry-api-metrics/src/types/BoundInstrument.ts
@@ -17,10 +17,19 @@
 /** An Instrument for Counter Metric. */
 export interface BoundCounter {
   /**
-   * Adds the given value to the current value. Values cannot be negative.
+   * Increment the Counter by a fixed amount. Values cannot be negative.
    * @param value the value to add.
    */
   add(value: number): void;
+}
+
+/** An Instrument for UpDownCounter Metric. */
+export interface BoundUpDownCounter {
+/**
+   * Increment or decrement the UpDownCounter by a fixed amount. Values can be negative.
+   * @param value the value to add.
+   */
+ add(value: number): void;
 }
 
 /** Histogram to report instantaneous measurement of a value. */

--- a/experimental/packages/opentelemetry-api-metrics/src/types/Metric.ts
+++ b/experimental/packages/opentelemetry-api-metrics/src/types/Metric.ts
@@ -17,6 +17,7 @@
 import {
   BoundObservableBase,
   BoundCounter,
+  BoundUpDownCounter,
   BoundHistogram,
 } from './BoundInstrument';
 import {
@@ -137,14 +138,14 @@ export interface UnboundMetric<T> extends Metric {
  */
 export interface Counter extends UnboundMetric<BoundCounter> {
   /**
-   * Adds the given value to the current value. Values cannot be negative.
+   * Increment the Counter by a fixed amount. Values cannot be negative.
    */
   add(value: number, labels?: Labels): void;
 }
 
-export interface UpDownCounter extends UnboundMetric<BoundCounter> {
+export interface UpDownCounter extends UnboundMetric<BoundUpDownCounter> {
   /**
-   * Adds the given value to the current value. Values can be negative.
+   * Increment or decrement the UpDownCounter by a fixed amount. Values can be negative.
    */
   add(value: number, labels?: Labels): void;
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/README.md
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/README.md
@@ -61,15 +61,15 @@ const { MeterProvider } = require('@opentelemetry/sdk-metrics-base');
 // Initialize the Meter to capture measurements in various ways.
 const meter = new MeterProvider().getMeter('your-meter-name');
 
-const counter = meter.createUpDownCounter('metric_name', {
+const upDownCounter = meter.createUpDownCounter('metric_name', {
   description: 'Example of a UpDownCounter'
 });
 
 const labels = { pid: process.pid };
 
 // Create a BoundInstrument associated with specified label values.
-const boundCounter = counter.bind(labels);
-boundCounter.add(Math.random() > 0.5 ? 1 : -1);
+const boundUpDownCounter = upDownCounter.bind(labels);
+boundUpDownCounter.add(Math.random() > 0.5 ? 1 : -1);
 
 ```
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/BoundInstrument.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/BoundInstrument.ts
@@ -99,7 +99,7 @@ export class BoundCounter
  */
 export class BoundUpDownCounter
   extends BaseBoundInstrument
-  implements api.BoundCounter {
+  implements api.BoundUpDownCounter {
   constructor(
     labels: api.Labels,
     disabled: boolean,

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/Meter.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/Meter.test.ts
@@ -370,13 +370,13 @@ describe('Meter', () => {
     describe('.bind()', () => {
       it('should create a UpDownCounter instrument', async () => {
         const upDownCounter = meter.createUpDownCounter('name');
-        const boundCounter = upDownCounter.bind(labels);
-        boundCounter.add(10);
+        const boundUpDownCounter = upDownCounter.bind(labels);
+        boundUpDownCounter.add(10);
         await meter.collect();
         const [record1] = meter.getProcessor().checkPointSet();
 
         assert.strictEqual(record1.aggregator.toPoint().value, 10);
-        boundCounter.add(-200);
+        boundUpDownCounter.add(-200);
         assert.strictEqual(record1.aggregator.toPoint().value, -190);
       });
 
@@ -384,18 +384,18 @@ describe('Meter', () => {
         const upDownCounter = meter.createUpDownCounter(
           'name'
         ) as UpDownCounterMetric;
-        const boundCounter = upDownCounter.bind(labels);
-        boundCounter.add(20);
-        assert.ok(boundCounter.getAggregator() instanceof SumAggregator);
-        assert.strictEqual(boundCounter.getLabels(), labels);
+        const boundUpDownCounter = upDownCounter.bind(labels);
+        boundUpDownCounter.add(20);
+        assert.ok(boundUpDownCounter.getAggregator() instanceof SumAggregator);
+        assert.strictEqual(boundUpDownCounter.getLabels(), labels);
       });
 
       it('should not add the instrument data when disabled', async () => {
         const upDownCounter = meter.createUpDownCounter('name', {
           disabled: true,
         });
-        const boundCounter = upDownCounter.bind(labels);
-        boundCounter.add(10);
+        const boundUpDownCounter = upDownCounter.bind(labels);
+        boundUpDownCounter.add(10);
         await meter.collect();
         const [record1] = meter.getProcessor().checkPointSet();
         assert.strictEqual(record1.aggregator.toPoint().value, 0);
@@ -403,25 +403,25 @@ describe('Meter', () => {
 
       it('should return same instrument on same label values', async () => {
         const upDownCounter = meter.createUpDownCounter('name');
-        const boundCounter = upDownCounter.bind(labels);
-        boundCounter.add(10);
-        const boundCounter1 = upDownCounter.bind(labels);
-        boundCounter1.add(10);
+        const boundUpDownCounter = upDownCounter.bind(labels);
+        boundUpDownCounter.add(10);
+        const boundUpDownCounter1 = upDownCounter.bind(labels);
+        boundUpDownCounter1.add(10);
         await meter.collect();
         const [record1] = meter.getProcessor().checkPointSet();
 
         assert.strictEqual(record1.aggregator.toPoint().value, 20);
-        assert.strictEqual(boundCounter, boundCounter1);
+        assert.strictEqual(boundUpDownCounter, boundUpDownCounter1);
       });
 
       it('should truncate non-integer values for INT valueType', async () => {
         const upDownCounter = meter.createUpDownCounter('name', {
           valueType: api.ValueType.INT,
         });
-        const boundCounter = upDownCounter.bind(labels);
+        const boundUpDownCounter = upDownCounter.bind(labels);
 
         [-1.1, 2.2].forEach(val => {
-          boundCounter.add(val);
+          boundUpDownCounter.add(val);
         });
         await meter.collect();
         const [record1] = meter.getProcessor().checkPointSet();
@@ -432,12 +432,12 @@ describe('Meter', () => {
         const upDownCounter = meter.createUpDownCounter('name', {
           valueType: api.ValueType.DOUBLE,
         });
-        const boundCounter = upDownCounter.bind(labels);
+        const boundUpDownCounter = upDownCounter.bind(labels);
 
         await Promise.all(
           nonNumberValues.map(async val => {
             // @ts-expect-error verify non number types
-            boundCounter.add(val);
+            boundUpDownCounter.add(val);
             await meter.collect();
             const [record1] = meter.getProcessor().checkPointSet();
 
@@ -450,12 +450,12 @@ describe('Meter', () => {
         const upDownCounter = meter.createUpDownCounter('name', {
           valueType: api.ValueType.DOUBLE,
         });
-        const boundCounter = upDownCounter.bind(labels);
+        const boundUpDownCounter = upDownCounter.bind(labels);
 
         await Promise.all(
           nonNumberValues.map(async val => {
             // @ts-expect-error verify non number types
-            boundCounter.add(val);
+            boundUpDownCounter.add(val);
             await meter.collect();
             const [record1] = meter.getProcessor().checkPointSet();
 
@@ -470,13 +470,13 @@ describe('Meter', () => {
         const upDownCounter = meter.createUpDownCounter(
           'name'
         ) as UpDownCounterMetric;
-        const boundCounter = upDownCounter.bind(labels);
+        const boundUpDownCounter = upDownCounter.bind(labels);
         assert.strictEqual(upDownCounter['_instruments'].size, 1);
         upDownCounter.unbind(labels);
         assert.strictEqual(upDownCounter['_instruments'].size, 0);
-        const boundCounter1 = upDownCounter.bind(labels);
+        const boundUpDownCounter1 = upDownCounter.bind(labels);
         assert.strictEqual(upDownCounter['_instruments'].size, 1);
-        assert.notStrictEqual(boundCounter, boundCounter1);
+        assert.notStrictEqual(boundUpDownCounter, boundUpDownCounter1);
       });
 
       it('should not fail when removing non existing instrument', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

- https://github.com/open-telemetry/opentelemetry-js/issues/2480
- metrics SDK `UpDownCounter` implements `api.BoundCounter` under the hood, while `api.BoundCounter` specifying that it does not accept negative values.

## Short description of the changes

- `api.UpDownCounter` interface is defined with the same definition with `api.Counter` (i.e. TypeScript will not complain if we assign an `api.UpDownCounter` to `api.Counter`). This PR doesn't change this and added a new API `api.BoundUpDownCounter` to keep this pattern on the bound metric types.
- Clean up in the examples that an `UpDownCounter` should be named as `upDownCounter` to help people understand that it is not a `Counter` type.
- This PR is not breaking since those two types are not distinguished by the TypeScript type system.