### PR TITLE
fix(@opentelemetry/exporter-prometheus): unref prometheus server to prevent process running indefinitely

### DIFF
--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -68,7 +68,8 @@ export class PrometheusExporter implements MetricExporter {
       typeof config.appendTimestamp === 'boolean'
         ? config.appendTimestamp
         : PrometheusExporter.DEFAULT_OPTIONS.appendTimestamp;
-    this._server = createServer(this._requestHandler);
+    // unref to prevent prometheus exporter from holding the process open on exit
+    this._server = createServer(this._requestHandler).unref();
     this._serializer = new PrometheusSerializer(
       this._prefix,
       this._appendTimestamp


### PR DESCRIPTION
## Which problem is this PR solving?

Prometheus exporter is holding the process open for scripts that are meant to exit.

## Short description of the changes

Unrefs the prometheus exporter to allow the process to exit.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Run in our production environment, with a server that was purposely failing to boot -- something like:

```
const main = async () => {
  await initOtel()
  await initServer() // throws
}

main.catch(err => console.log)
```

Previously, prometheus would hold the process open. With this change, the process exits as expected.

