### PR TITLE
feat(sdk-metrics-base): remove per-meter config on MeterProvider.getMeter

### DIFF
--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -216,10 +216,9 @@ describe('PrometheusExporter', () => {
       exporter = new PrometheusExporter({}, () => {
         meterProvider = new MeterProvider({
           interval: Math.pow(2, 31) - 1,
-        });
-        meter = meterProvider.getMeter('test-prometheus', '1', {
           exporter,
         });
+        meter = meterProvider.getMeter('test-prometheus', '1');
         done();
       });
     });
@@ -352,25 +351,15 @@ describe('PrometheusExporter', () => {
       counter.bind({ counterKey1: 'labelValue2' }).add(20);
       counter.bind({ counterKey1: 'labelValue3' }).add(30);
       meterProvider.shutdown().then(() => {
+        // exporter has been shut down along with meter provider.
         http
           .get('http://localhost:9464/metrics', res => {
-            res.on('data', chunk => {
-              const body = chunk.toString();
-              const lines = body.split('\n');
-
-              assert.deepStrictEqual(lines, [
-                '# HELP counter_total a test description',
-                '# TYPE counter_total counter',
-                `counter_total{counterKey1="labelValue1"} 10 ${mockedHrTimeMs}`,
-                `counter_total{counterKey1="labelValue2"} 20 ${mockedHrTimeMs}`,
-                `counter_total{counterKey1="labelValue3"} 30 ${mockedHrTimeMs}`,
-                '',
-              ]);
-
-              done();
-            });
+            errorHandler(done)(new Error('unreachable'));
           })
-          .on('error', errorHandler(done));
+          .on('error', err => {
+            assert(`${err}`.match('ECONNREFUSED'));
+            done();
+          });
       });
     });
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
@@ -48,12 +48,12 @@ export class MeterProvider implements api.MeterProvider {
    *
    * @returns Meter A Meter with the given name and version
    */
-  getMeter(name: string, version?: string, config?: MeterConfig): Meter {
+  getMeter(name: string, version?: string): Meter {
     const key = `${name}@${version || ''}`;
     if (!this._meters.has(key)) {
       this._meters.set(
         key,
-        new Meter({ name, version }, config || this._config)
+        new Meter({ name, version }, this._config)
       );
     }
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
@@ -57,7 +57,7 @@ export class MeterProvider implements api.MeterProvider {
           name,
           version,
           // @ts-expect-error ts(2345) TODO: upgrade @opentelemetry/core InstrumentationLibrary definition
-          schemaUrl: config?.schemaUrl
+          schemaUrl: options?.schemaUrl
         }, this._config)
       );
     }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/Meter.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/Meter.test.ts
@@ -21,7 +21,6 @@ import { Resource } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import {
-  Aggregator,
   CounterMetric,
   Histogram,
   LastValue,
@@ -29,7 +28,6 @@ import {
   Meter,
   MeterProvider,
   Metric,
-  MetricDescriptor,
   MetricKind,
   MetricRecord,
   Sum,
@@ -40,7 +38,6 @@ import {
 import { BatchObserver } from '../src/BatchObserver';
 import { BatchObserverResult } from '../src/BatchObserverResult';
 import { SumAggregator } from '../src/export/aggregators';
-import { Processor } from '../src/export/Processor';
 import { ObservableCounterMetric } from '../src/ObservableCounterMetric';
 import { ObservableUpDownCounterMetric } from '../src/ObservableUpDownCounterMetric';
 import { hashLabels } from '../src/Utils';
@@ -1364,27 +1361,7 @@ describe('Meter', () => {
       assert.strictEqual(value, 10);
     });
   });
-
-  it('should allow custom processor', () => {
-    const customMeter = new MeterProvider().getMeter('custom-processor', '*', {
-      processor: new CustomProcessor(),
-    });
-    assert.throws(() => {
-      const histogram = customMeter.createHistogram('myHistogram');
-      histogram.bind({}).record(1);
-    }, /aggregatorFor method not implemented/);
-  });
 });
-
-class CustomProcessor extends Processor {
-  process(record: MetricRecord): void {
-    throw new Error('process method not implemented.');
-  }
-
-  aggregatorFor(metricKind: MetricDescriptor): Aggregator {
-    throw new Error('aggregatorFor method not implemented.');
-  }
-}
 
 function ensureMetric(metric: MetricRecord, name?: string, value?: LastValue) {
   assert.ok(metric.aggregator instanceof LastValueAggregator);

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
@@ -16,7 +16,15 @@
 
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { MeterProvider, Meter, CounterMetric } from '../src';
+import {
+  MeterProvider,
+  Meter,
+  CounterMetric,
+  MetricRecord,
+  MetricDescriptor,
+  Aggregator,
+  Processor,
+} from '../src';
 
 describe('MeterProvider', () => {
   afterEach(() => {
@@ -73,6 +81,27 @@ describe('MeterProvider', () => {
       const meter3 = provider.getMeter('meter2', 'ver2');
       const meter4 = provider.getMeter('meter3', 'ver2');
       assert.notEqual(meter3, meter4);
+    });
+
+    it('should allow custom processor', () => {
+      class CustomProcessor extends Processor {
+        process(record: MetricRecord): void {
+          throw new Error('process method not implemented.');
+        }
+
+        aggregatorFor(metricKind: MetricDescriptor): Aggregator {
+          throw new Error('aggregatorFor method not implemented.');
+        }
+      }
+
+      const meter = new MeterProvider({
+        processor: new CustomProcessor(),
+      }).getMeter('custom-processor', '*');
+
+      assert.throws(() => {
+        const histogram = meter.createHistogram('myHistogram');
+        histogram.bind({}).record(1);
+      }, /aggregatorFor method not implemented/);
     });
   });
 


### PR DESCRIPTION

## Which problem is this PR solving?

API doesn't allow to pass a meter config to `getMeter`.

Related: #2546
Related: #2547

## Short description of the changes

Removes per-meter config on `MeterProvider.getMeter`.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
