### PR TITLE
chore: update npm badge image links

### DIFF
--- a/experimental/packages/opentelemetry-exporter-trace-otlp-grpc/README.md
+++ b/experimental/packages/opentelemetry-exporter-trace-otlp-grpc/README.md
@@ -133,7 +133,7 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [devDependencies-image]: https://status.david-dm.org/gh/open-telemetry/opentelemetry-js.svg?path=packages%2Fopentelemetry-exporter-trace-otlp-grpc&type=dev
 [devDependencies-url]: https://david-dm.org/open-telemetry/opentelemetry-js?path=packages%2Fopentelemetry-exporter-trace-otlp-grpc&type=dev
 [npm-url]: https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-grpc
-[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fexporter-otlp-grpc.svg
+[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fexporter-trace-otlp-grpc.svg
 [opentelemetry-collector-url]: https://github.com/open-telemetry/opentelemetry-collector
 [semconv-resource-service-name]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service
 [metrics-exporter-url]: https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-metrics-otlp-grpc

--- a/experimental/packages/opentelemetry-exporter-trace-otlp-http/README.md
+++ b/experimental/packages/opentelemetry-exporter-trace-otlp-http/README.md
@@ -134,7 +134,7 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [npm-url]: https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-http
 [npm-url-grpc]: https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-grpc
 [npm-url-proto]: https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-proto
-[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fexporter-otlp-http.svg
+[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fexporter-trace-otlp-http.svg
 [opentelemetry-collector-url]: https://github.com/open-telemetry/opentelemetry-collector
 [opentelemetry-spec-protocol-exporter]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options
 [semconv-resource-service-name]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service

--- a/experimental/packages/opentelemetry-exporter-trace-otlp-proto/README.md
+++ b/experimental/packages/opentelemetry-exporter-trace-otlp-proto/README.md
@@ -64,7 +64,7 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [devDependencies-image]: https://status.david-dm.org/gh/open-telemetry/opentelemetry-js.svg?path=packages%2Fopentelemetry-exporter-trace-otlp-proto&type=dev
 [devDependencies-url]: https://david-dm.org/open-telemetry/opentelemetry-js?path=packages%2Fopentelemetry-exporter-trace-otlp-proto&type=dev
 [npm-url]: https://www.npmjs.com/package/@opentelemetry/exporter-trace-otlp-proto
-[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fexporter-collector-otlp-proto.svg
+[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fexporter-trace-otlp-proto.svg
 [opentelemetry-collector-url]: https://github.com/open-telemetry/opentelemetry-collector
 [semconv-resource-service-name]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service
 [metrics-exporter-url]: https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-metrics-otlp-proto

--- a/experimental/packages/opentelemetry-sdk-metrics-base/README.md
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/README.md
@@ -207,4 +207,4 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [devDependencies-image]: https://status.david-dm.org/gh/open-telemetry/opentelemetry-js.svg?path=packages%2Fopentelemetry-sdk-metrics-base&type=dev
 [devDependencies-url]: https://david-dm.org/open-telemetry/opentelemetry-js?path=packages%2Fopentelemetry-sdk-metrics-base&type=dev
 [npm-url]: https://www.npmjs.com/package/@opentelemetry/sdk-metrics-base
-[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fmetrics.svg
+[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fsdk-metrics-base.svg

--- a/packages/opentelemetry-sdk-trace-base/README.md
+++ b/packages/opentelemetry-sdk-trace-base/README.md
@@ -70,4 +70,4 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [devDependencies-image]: https://status.david-dm.org/gh/open-telemetry/opentelemetry-js.svg?path=packages%2Fopentelemetry-sdk-trace-base&type=dev
 [devDependencies-url]: https://david-dm.org/open-telemetry/opentelemetry-js?path=packages%2Fopentelemetry-sdk-trace-base&type=dev
 [npm-url]: https://www.npmjs.com/package/@opentelemetry/sdk-trace-base
-[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Ftracing.svg
+[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fsdk-trace-base.svg

--- a/packages/opentelemetry-sdk-trace-node/README.md
+++ b/packages/opentelemetry-sdk-trace-node/README.md
@@ -124,4 +124,4 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [devDependencies-image]: https://status.david-dm.org/gh/open-telemetry/opentelemetry-js.svg?path=packages%2Fopentelemetry-sdk-trace-node&type=dev
 [devDependencies-url]: https://david-dm.org/open-telemetry/opentelemetry-js?path=packages%2Fopentelemetry-sdk-trace-node&type=dev
 [npm-url]: https://www.npmjs.com/package/@opentelemetry/sdk-trace-node
-[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fnode.svg
+[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fsdk-trace-node.svg

--- a/packages/opentelemetry-sdk-trace-web/README.md
+++ b/packages/opentelemetry-sdk-trace-web/README.md
@@ -74,4 +74,4 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [devDependencies-image]: https://status.david-dm.org/gh/open-telemetry/opentelemetry-js.svg?path=packages%2Fopentelemetry-sdk-trace-web&type=dev
 [devDependencies-url]: https://david-dm.org/open-telemetry/opentelemetry-js?path=packages%2Fopentelemetry-sdk-trace-web&type=dev
 [npm-url]: https://www.npmjs.com/package/@opentelemetry/sdk-trace-web
-[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fweb.svg
+[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fsdk-trace-web.svg


### PR DESCRIPTION

## Which problem is this PR solving?

The npm badges on the README page links to the correct npm package but display an incorrect version.

## Type of change

- [x] This change requires a documentation update

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Documentation has been updated
