### PR TITLE
chore: release proposal v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,77 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## 1.1.0
+
+### :rocket: (Enhancement)
+
+* Other
+  * [#2465](https://github.com/open-telemetry/opentelemetry-js/pull/2465) fix: prefer globalThis instead of window to support webworkers ([@legendecas](https://github.com/legendecas))
+* `opentelemetry-semantic-conventions`
+  * [#2532](https://github.com/open-telemetry/opentelemetry-js/pull/2532) feat(@opentelemetry/semantic-conventions): change enum to object literals ([@echoontheway](https://github.com/echoontheway))
+  * [#2528](https://github.com/open-telemetry/opentelemetry-js/pull/2528) feat: upgrade semantic-conventions to latest v1.7.0 spec ([@weyert](https://github.com/weyert))
+* `opentelemetry-core`, `opentelemetry-sdk-trace-base`
+  * [#2484](https://github.com/open-telemetry/opentelemetry-js/pull/2484) feat: new merge function ([@obecny](https://github.com/obecny))
+
+### :bug: (Bug Fix)
+
+* Other
+  * [#2581](https://github.com/open-telemetry/opentelemetry-js/pull/2581) feat: lazy initialization of the gzip stream ([@fungiboletus](https://github.com/fungiboletus))
+  * [#2584](https://github.com/open-telemetry/opentelemetry-js/pull/2584) fix: fixing compatibility versions for detectors ([@obecny](https://github.com/obecny))
+  * [#2560](https://github.com/open-telemetry/opentelemetry-js/pull/2560) fix(core): support regex global flag in urlMatches ([@moander](https://github.com/moander))
+* `opentelemetry-exporter-zipkin`
+  * [#2519](https://github.com/open-telemetry/opentelemetry-js/pull/2519) fix(exporter-zipkin): correct status tags names ([@t2t2](https://github.com/t2t2))
+
+### :books: (Refine Doc)
+
+* `opentelemetry-core`
+  * [#2604](https://github.com/open-telemetry/opentelemetry-js/pull/2604) Docs: Document the HrTime format ([@JamesJHPark](https://github.com/JamesJHPark))
+* Other
+  * [#2576](https://github.com/open-telemetry/opentelemetry-js/pull/2576) docs(instrumentation): update links in the Readme ([@OlivierAlbertini](https://github.com/OlivierAlbertini))
+  * [#2600](https://github.com/open-telemetry/opentelemetry-js/pull/2600) docs: fix URLs in README post-experimental move ([@arbourd](https://github.com/arbourd))
+  * [#2579](https://github.com/open-telemetry/opentelemetry-js/pull/2579) doc: Move upgrade propagator notes to correct section ([@NathanielRN](https://github.com/NathanielRN))
+  * [#2568](https://github.com/open-telemetry/opentelemetry-js/pull/2568) chore(doc): update matrix with contrib version for 1.0 core ([@vmarchaud](https://github.com/vmarchaud))
+  * [#2555](https://github.com/open-telemetry/opentelemetry-js/pull/2555) docs: expose existing comments ([@moander](https://github.com/moander))
+  * [#2493](https://github.com/open-telemetry/opentelemetry-js/pull/2493) chore: remove getting started and link to documentation. ([@svrnm](https://github.com/svrnm))
+
+### :house: (Internal)
+
+* `opentelemetry-sdk-trace-base`, `opentelemetry-sdk-trace-node`, `opentelemetry-sdk-trace-web`
+  * [#2607](https://github.com/open-telemetry/opentelemetry-js/pull/2607) chore: update npm badge image links ([@legendecas](https://github.com/legendecas))
+* Other
+  * [#2570](https://github.com/open-telemetry/opentelemetry-js/pull/2570) chore: adding selenium tests with browserstack ([@obecny](https://github.com/obecny))
+  * [#2522](https://github.com/open-telemetry/opentelemetry-js/pull/2522) chore: cleanup setting config in instrumentations ([@Flarna](https://github.com/Flarna))
+  * [#2541](https://github.com/open-telemetry/opentelemetry-js/pull/2541) chore: slim font size for section title in PR template ([@legendecas](https://github.com/legendecas))
+  * [#2509](https://github.com/open-telemetry/opentelemetry-js/pull/2509) chore: expand pull request template with action items ([@pragmaticivan](https://github.com/pragmaticivan))
+  * [#2488](https://github.com/open-telemetry/opentelemetry-js/pull/2488) chore: inline sources in source maps ([@dyladan](https://github.com/dyladan))
+* `opentelemetry-context-async-hooks`, `opentelemetry-context-zone-peer-dep`, `opentelemetry-core`, `opentelemetry-exporter-jaeger`, `opentelemetry-exporter-zipkin`, `opentelemetry-propagator-b3`, `opentelemetry-propagator-jaeger`, `opentelemetry-resources`, `opentelemetry-sdk-trace-base`, `opentelemetry-sdk-trace-node`, `opentelemetry-sdk-trace-web`, `opentelemetry-shim-opentracing`
+  * [#2531](https://github.com/open-telemetry/opentelemetry-js/pull/2531) chore(deps): pin minor API version ([@Flarna](https://github.com/Flarna))
+* `opentelemetry-core`
+  * [#2520](https://github.com/open-telemetry/opentelemetry-js/pull/2520) chore(deps): remove unused semver  ([@mhennoch](https://github.com/mhennoch))
+
+### Committers: 20
+
+* (Eliseo) Nathaniel Ruiz Nowell ([@NathanielRN](https://github.com/NathanielRN))
+* Antoine Pultier ([@fungiboletus](https://github.com/fungiboletus))
+* Bartlomiej Obecny ([@obecny](https://github.com/obecny))
+* Daniel Dyla ([@dyladan](https://github.com/dyladan))
+* Dylan Arbour ([@arbourd](https://github.com/arbourd))
+* Georg Pirklbauer ([@pirgeo](https://github.com/pirgeo))
+* Gerhard Stöbich ([@Flarna](https://github.com/Flarna))
+* Ivan Santos ([@pragmaticivan](https://github.com/pragmaticivan))
+* Jack ([@mothershipper](https://github.com/mothershipper))
+* James ([@JamesJHPark](https://github.com/JamesJHPark))
+* MartenH ([@mhennoch](https://github.com/mhennoch))
+* Olivier Albertini ([@OlivierAlbertini](https://github.com/OlivierAlbertini))
+* Severin Neumann ([@svrnm](https://github.com/svrnm))
+* Valentin Marchaud ([@vmarchaud](https://github.com/vmarchaud))
+* Weyert de Boer ([@weyert](https://github.com/weyert))
+* William Armiros ([@willarmiros](https://github.com/willarmiros))
+* [@echoontheway](https://github.com/echoontheway)
+* legendecas ([@legendecas](https://github.com/legendecas))
+* moander ([@moander](https://github.com/moander))
+* t2t2 ([@t2t2](https://github.com/t2t2))
+
 ## 1.0.0
 
 No changes

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/context-async-hooks": "1.0.0",
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
+    "@opentelemetry/context-async-hooks": "1.1.0",
+    "@opentelemetry/core": "1.1.0",
+    "@opentelemetry/sdk-trace-base": "1.1.0",
     "axios": "0.21.1",
     "body-parser": "1.19.0",
     "express": "4.17.1"

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "3.13.4",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "npmClient": "npm",
   "packages": [
     "benchmark/*",

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -68,7 +68,7 @@
     "webpack-merge": "5.8.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.0.0",
+    "@opentelemetry/context-zone-peer-dep": "1.1.0",
     "zone.js": "^0.11.0"
   },
   "sideEffects": true

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -84,6 +84,6 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.0.0"
+    "@opentelemetry/semantic-conventions": "1.1.0"
   }
 }

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/resources": "1.0.0",
+    "@opentelemetry/resources": "1.1.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/sinon": "10.0.2",
@@ -60,9 +60,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0",
+    "@opentelemetry/core": "1.1.0",
+    "@opentelemetry/sdk-trace-base": "1.1.0",
+    "@opentelemetry/semantic-conventions": "1.1.0",
     "jaeger-client": "^3.15.0"
   }
 }

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -84,9 +84,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/resources": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0"
+    "@opentelemetry/core": "1.1.0",
+    "@opentelemetry/resources": "1.1.0",
+    "@opentelemetry/sdk-trace-base": "1.1.0",
+    "@opentelemetry/semantic-conventions": "1.1.0"
   }
 }

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0"
+    "@opentelemetry/core": "1.1.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.1.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -75,6 +75,6 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0"
+    "@opentelemetry/core": "1.1.0"
   }
 }

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -67,7 +67,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0"
+    "@opentelemetry/core": "1.1.0",
+    "@opentelemetry/semantic-conventions": "1.1.0"
   }
 }

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -81,8 +81,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/resources": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0"
+    "@opentelemetry/core": "1.1.0",
+    "@opentelemetry/resources": "1.1.0",
+    "@opentelemetry/semantic-conventions": "1.1.0"
   }
 }

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,8 +44,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "~1.0.3",
-    "@opentelemetry/resources": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0",
+    "@opentelemetry/resources": "1.1.0",
+    "@opentelemetry/semantic-conventions": "1.1.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/semver": "7.3.8",
@@ -62,11 +62,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.0.0",
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/propagator-b3": "1.0.0",
-    "@opentelemetry/propagator-jaeger": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
+    "@opentelemetry/context-async-hooks": "1.1.0",
+    "@opentelemetry/core": "1.1.0",
+    "@opentelemetry/propagator-b3": "1.1.0",
+    "@opentelemetry/propagator-jaeger": "1.1.0",
+    "@opentelemetry/sdk-trace-base": "1.1.0",
     "semver": "^7.3.5"
   }
 }

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -49,9 +49,9 @@
   "devDependencies": {
     "@babel/core": "7.15.0",
     "@opentelemetry/api": "~1.0.3",
-    "@opentelemetry/context-zone": "1.0.0",
-    "@opentelemetry/propagator-b3": "1.0.0",
-    "@opentelemetry/resources": "1.0.0",
+    "@opentelemetry/context-zone": "1.1.0",
+    "@opentelemetry/propagator-b3": "1.1.0",
+    "@opentelemetry/resources": "1.1.0",
     "@types/jquery": "3.5.6",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
@@ -82,8 +82,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0"
+    "@opentelemetry/core": "1.1.0",
+    "@opentelemetry/sdk-trace-base": "1.1.0",
+    "@opentelemetry/semantic-conventions": "1.1.0"
   }
 }

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -41,9 +41,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "~1.0.3",
-    "@opentelemetry/propagator-b3": "1.0.0",
-    "@opentelemetry/propagator-jaeger": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
+    "@opentelemetry/propagator-b3": "1.1.0",
+    "@opentelemetry/propagator-jaeger": "1.1.0",
+    "@opentelemetry/sdk-trace-base": "1.1.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "codecov": "3.8.3",
@@ -57,8 +57,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0",
+    "@opentelemetry/core": "1.1.0",
+    "@opentelemetry/semantic-conventions": "1.1.0",
     "opentracing": "^0.14.4"
   }
 }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "0.0.1",
+  "version": "1.1.0",
+  "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
   "repository": "open-telemetry/opentelemetry-js",
@@ -27,7 +28,7 @@
     "node": ">=10.0.0"
   },
   "publishConfig": {
-    "access": "private"
+    "access": "restricted"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",
@@ -55,16 +56,16 @@
     "@opentelemetry/api": "^1.0.3"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "^1.0.0",
-    "@opentelemetry/core": "^1.0.0",
+    "@opentelemetry/context-zone-peer-dep": "1.1.0",
+    "@opentelemetry/core": "1.1.0",
     "@opentelemetry/exporter-otlp-http": "^0.26.0",
-    "@opentelemetry/exporter-zipkin": "^1.0.0",
+    "@opentelemetry/exporter-zipkin": "1.1.0",
     "@opentelemetry/instrumentation": "^0.26.0",
     "@opentelemetry/instrumentation-fetch": "^0.26.0",
     "@opentelemetry/instrumentation-xml-http-request": "^0.26.0",
     "@opentelemetry/sdk-metrics-base": "^0.26.0",
-    "@opentelemetry/sdk-trace-base": "^1.0.0",
-    "@opentelemetry/sdk-trace-web": "^1.0.0",
+    "@opentelemetry/sdk-trace-base": "1.1.0",
+    "@opentelemetry/sdk-trace-web": "1.1.0",
     "zone.js": "^0.10.3"
   }
 }


### PR DESCRIPTION
### :rocket: (Enhancement)

* Other
  * [#2465](https://github.com/open-telemetry/opentelemetry-js/pull/2465) fix: prefer globalThis instead of window to support webworkers ([@legendecas](https://github.com/legendecas))
* `opentelemetry-semantic-conventions`
  * [#2532](https://github.com/open-telemetry/opentelemetry-js/pull/2532) feat(@opentelemetry/semantic-conventions): change enum to object literals ([@echoontheway](https://github.com/echoontheway))
  * [#2528](https://github.com/open-telemetry/opentelemetry-js/pull/2528) feat: upgrade semantic-conventions to latest v1.7.0 spec ([@weyert](https://github.com/weyert))
* `opentelemetry-core`, `opentelemetry-sdk-trace-base`
  * [#2484](https://github.com/open-telemetry/opentelemetry-js/pull/2484) feat: new merge function ([@obecny](https://github.com/obecny))

### :bug: (Bug Fix)

* Other
  * [#2581](https://github.com/open-telemetry/opentelemetry-js/pull/2581) feat: lazy initialization of the gzip stream ([@fungiboletus](https://github.com/fungiboletus))
  * [#2584](https://github.com/open-telemetry/opentelemetry-js/pull/2584) fix: fixing compatibility versions for detectors ([@obecny](https://github.com/obecny))
  * [#2560](https://github.com/open-telemetry/opentelemetry-js/pull/2560) fix(core): support regex global flag in urlMatches ([@moander](https://github.com/moander))
* `opentelemetry-exporter-zipkin`
  * [#2519](https://github.com/open-telemetry/opentelemetry-js/pull/2519) fix(exporter-zipkin): correct status tags names ([@t2t2](https://github.com/t2t2))

### :books: (Refine Doc)

* `opentelemetry-core`
  * [#2604](https://github.com/open-telemetry/opentelemetry-js/pull/2604) Docs: Document the HrTime format ([@JamesJHPark](https://github.com/JamesJHPark))
* Other
  * [#2576](https://github.com/open-telemetry/opentelemetry-js/pull/2576) docs(instrumentation): update links in the Readme ([@OlivierAlbertini](https://github.com/OlivierAlbertini))
  * [#2600](https://github.com/open-telemetry/opentelemetry-js/pull/2600) docs: fix URLs in README post-experimental move ([@arbourd](https://github.com/arbourd))
  * [#2579](https://github.com/open-telemetry/opentelemetry-js/pull/2579) doc: Move upgrade propagator notes to correct section ([@NathanielRN](https://github.com/NathanielRN))
  * [#2568](https://github.com/open-telemetry/opentelemetry-js/pull/2568) chore(doc): update matrix with contrib version for 1.0 core ([@vmarchaud](https://github.com/vmarchaud))
  * [#2555](https://github.com/open-telemetry/opentelemetry-js/pull/2555) docs: expose existing comments ([@moander](https://github.com/moander))
  * [#2493](https://github.com/open-telemetry/opentelemetry-js/pull/2493) chore: remove getting started and link to documentation. ([@svrnm](https://github.com/svrnm))

### :house: (Internal)

* `opentelemetry-sdk-trace-base`, `opentelemetry-sdk-trace-node`, `opentelemetry-sdk-trace-web`
  * [#2607](https://github.com/open-telemetry/opentelemetry-js/pull/2607) chore: update npm badge image links ([@legendecas](https://github.com/legendecas))
* Other
  * [#2570](https://github.com/open-telemetry/opentelemetry-js/pull/2570) chore: adding selenium tests with browserstack ([@obecny](https://github.com/obecny))
  * [#2522](https://github.com/open-telemetry/opentelemetry-js/pull/2522) chore: cleanup setting config in instrumentations ([@Flarna](https://github.com/Flarna))
  * [#2541](https://github.com/open-telemetry/opentelemetry-js/pull/2541) chore: slim font size for section title in PR template ([@legendecas](https://github.com/legendecas))
  * [#2509](https://github.com/open-telemetry/opentelemetry-js/pull/2509) chore: expand pull request template with action items ([@pragmaticivan](https://github.com/pragmaticivan))
  * [#2488](https://github.com/open-telemetry/opentelemetry-js/pull/2488) chore: inline sources in source maps ([@dyladan](https://github.com/dyladan))
* `opentelemetry-context-async-hooks`, `opentelemetry-context-zone-peer-dep`, `opentelemetry-core`, `opentelemetry-exporter-jaeger`, `opentelemetry-exporter-zipkin`, `opentelemetry-propagator-b3`, `opentelemetry-propagator-jaeger`, `opentelemetry-resources`, `opentelemetry-sdk-trace-base`, `opentelemetry-sdk-trace-node`, `opentelemetry-sdk-trace-web`, `opentelemetry-shim-opentracing`
  * [#2531](https://github.com/open-telemetry/opentelemetry-js/pull/2531) chore(deps): pin minor API version ([@Flarna](https://github.com/Flarna))
* `opentelemetry-core`
  * [#2520](https://github.com/open-telemetry/opentelemetry-js/pull/2520) chore(deps): remove unused semver  ([@mhennoch](https://github.com/mhennoch))

### Committers: 20

* (Eliseo) Nathaniel Ruiz Nowell ([@NathanielRN](https://github.com/NathanielRN))
* Antoine Pultier ([@fungiboletus](https://github.com/fungiboletus))
* Bartlomiej Obecny ([@obecny](https://github.com/obecny))
* Daniel Dyla ([@dyladan](https://github.com/dyladan))
* Dylan Arbour ([@arbourd](https://github.com/arbourd))
* Georg Pirklbauer ([@pirgeo](https://github.com/pirgeo))
* Gerhard Stöbich ([@Flarna](https://github.com/Flarna))
* Ivan Santos ([@pragmaticivan](https://github.com/pragmaticivan))
* Jack ([@mothershipper](https://github.com/mothershipper))
* James ([@JamesJHPark](https://github.com/JamesJHPark))
* MartenH ([@mhennoch](https://github.com/mhennoch))
* Olivier Albertini ([@OlivierAlbertini](https://github.com/OlivierAlbertini))
* Severin Neumann ([@svrnm](https://github.com/svrnm))
* Valentin Marchaud ([@vmarchaud](https://github.com/vmarchaud))
* Weyert de Boer ([@weyert](https://github.com/weyert))
* William Armiros ([@willarmiros](https://github.com/willarmiros))
* [@echoontheway](https://github.com/echoontheway)
* legendecas ([@legendecas](https://github.com/legendecas))
* moander ([@moander](https://github.com/moander))
* t2t2 ([@t2t2](https://github.com/t2t2))