### PR TITLE
fix: preventing double enable for instrumentation that has been already enabled

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/src/autoLoaderUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/autoLoaderUtils.ts
@@ -62,7 +62,13 @@ export function enableInstrumentations(
     if (meterProvider) {
       instrumentation.setMeterProvider(meterProvider);
     }
-    instrumentation.enable();
+    // instrumentations have been already enabled during creation
+    // so enable only if user prevented that by setting enabled to false
+    // this is to prevent double enabling but when calling register all
+    // instrumentations should be now enabled
+    if (!instrumentation.getConfig().enabled) {
+      instrumentation.enable();
+    }
   }
 }
 

--- a/experimental/packages/opentelemetry-instrumentation/test/common/autoLoader.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation/test/common/autoLoader.test.ts
@@ -72,8 +72,28 @@ describe('autoLoader', () => {
         }
       });
 
-      it('should enable instrumentation', () => {
+      it('should enable disabled instrumentation', () => {
+        if (typeof unload === 'function') {
+          unload();
+          unload = undefined;
+        }
+        instrumentation = new FooInstrumentation(
+          'foo',
+          '1',
+          { enabled: false }
+        );
+        enableSpy = sinon.spy(instrumentation, 'enable');
+        setTracerProviderSpy = sinon.stub(instrumentation, 'setTracerProvider');
+        unload = registerInstrumentations({
+          instrumentations: [instrumentation],
+          tracerProvider,
+          meterProvider,
+        });
         assert.strictEqual(enableSpy.callCount, 1);
+      });
+
+      it('should NOT enable enabled instrumentation', () => {
+        assert.strictEqual(enableSpy.callCount, 0);
       });
 
       it('should set TracerProvider', () => {


### PR DESCRIPTION
## Which problem is this PR solving?
preventing double enable for instrumentation that has been already enabled during startup based on default config value 

