### PR TITLE
chore: release proposal v1.0.1 / v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 ### :bug: (Bug Fix)
 
 * Other
+  * [#2610](https://github.com/open-telemetry/opentelemetry-js/pull/2610) fix: preventing double enable for instrumentation that has been already enabled ([@obecny](https://github.com/obecny))
   * [#2581](https://github.com/open-telemetry/opentelemetry-js/pull/2581) feat: lazy initialization of the gzip stream ([@fungiboletus](https://github.com/fungiboletus))
   * [#2584](https://github.com/open-telemetry/opentelemetry-js/pull/2584) fix: fixing compatibility versions for detectors ([@obecny](https://github.com/obecny))
   * [#2558](https://github.com/open-telemetry/opentelemetry-js/pull/2558) fix(@opentelemetry/exporter-prometheus): unref prometheus server to prevent process running indefinitely ([@mothershipper](https://github.com/mothershipper))
@@ -45,33 +46,35 @@ All notable changes to this project will be documented in this file.
 
 ### :books: (Refine Doc)
 
-* `opentelemetry-core`
-  * [#2604](https://github.com/open-telemetry/opentelemetry-js/pull/2604) Docs: Document the HrTime format ([@JamesJHPark](https://github.com/JamesJHPark))
 * Other
+  * [#2561](https://github.com/open-telemetry/opentelemetry-js/pull/2561) Use new canonical path to Getting Started ([@chalin](https://github.com/chalin))
   * [#2576](https://github.com/open-telemetry/opentelemetry-js/pull/2576) docs(instrumentation): update links in the Readme ([@OlivierAlbertini](https://github.com/OlivierAlbertini))
   * [#2600](https://github.com/open-telemetry/opentelemetry-js/pull/2600) docs: fix URLs in README post-experimental move ([@arbourd](https://github.com/arbourd))
   * [#2579](https://github.com/open-telemetry/opentelemetry-js/pull/2579) doc: Move upgrade propagator notes to correct section ([@NathanielRN](https://github.com/NathanielRN))
   * [#2568](https://github.com/open-telemetry/opentelemetry-js/pull/2568) chore(doc): update matrix with contrib version for 1.0 core ([@vmarchaud](https://github.com/vmarchaud))
   * [#2555](https://github.com/open-telemetry/opentelemetry-js/pull/2555) docs: expose existing comments ([@moander](https://github.com/moander))
   * [#2493](https://github.com/open-telemetry/opentelemetry-js/pull/2493) chore: remove getting started and link to documentation. ([@svrnm](https://github.com/svrnm))
+* `opentelemetry-core`
+  * [#2604](https://github.com/open-telemetry/opentelemetry-js/pull/2604) Docs: Document the HrTime format ([@JamesJHPark](https://github.com/JamesJHPark))
 
 ### :house: (Internal)
 
-* `opentelemetry-sdk-trace-base`, `opentelemetry-sdk-trace-node`, `opentelemetry-sdk-trace-web`
-  * [#2607](https://github.com/open-telemetry/opentelemetry-js/pull/2607) chore: update npm badge image links ([@legendecas](https://github.com/legendecas))
 * Other
+  * [#2533](https://github.com/open-telemetry/opentelemetry-js/pull/2533) chore: regularly close stale issues ([@Rauno56](https://github.com/Rauno56))
   * [#2570](https://github.com/open-telemetry/opentelemetry-js/pull/2570) chore: adding selenium tests with browserstack ([@obecny](https://github.com/obecny))
   * [#2522](https://github.com/open-telemetry/opentelemetry-js/pull/2522) chore: cleanup setting config in instrumentations ([@Flarna](https://github.com/Flarna))
   * [#2541](https://github.com/open-telemetry/opentelemetry-js/pull/2541) chore: slim font size for section title in PR template ([@legendecas](https://github.com/legendecas))
   * [#2509](https://github.com/open-telemetry/opentelemetry-js/pull/2509) chore: expand pull request template with action items ([@pragmaticivan](https://github.com/pragmaticivan))
   * [#2488](https://github.com/open-telemetry/opentelemetry-js/pull/2488) chore: inline sources in source maps ([@dyladan](https://github.com/dyladan))
   * [#2514](https://github.com/open-telemetry/opentelemetry-js/pull/2514) chore: update stable dependencies to 1.0 ([@dyladan](https://github.com/dyladan))
+* `opentelemetry-sdk-trace-base`, `opentelemetry-sdk-trace-node`, `opentelemetry-sdk-trace-web`
+  * [#2607](https://github.com/open-telemetry/opentelemetry-js/pull/2607) chore: update npm badge image links ([@legendecas](https://github.com/legendecas))
 * `opentelemetry-context-async-hooks`, `opentelemetry-context-zone-peer-dep`, `opentelemetry-core`, `opentelemetry-exporter-jaeger`, `opentelemetry-exporter-zipkin`, `opentelemetry-propagator-b3`, `opentelemetry-propagator-jaeger`, `opentelemetry-resources`, `opentelemetry-sdk-trace-base`, `opentelemetry-sdk-trace-node`, `opentelemetry-sdk-trace-web`, `opentelemetry-shim-opentracing`
   * [#2531](https://github.com/open-telemetry/opentelemetry-js/pull/2531) chore(deps): pin minor API version ([@Flarna](https://github.com/Flarna))
 * `opentelemetry-core`
   * [#2520](https://github.com/open-telemetry/opentelemetry-js/pull/2520) chore(deps): remove unused semver  ([@mhennoch](https://github.com/mhennoch))
 
-### Committers: 20
+### Committers: 22
 
 * (Eliseo) Nathaniel Ruiz Nowell ([@NathanielRN](https://github.com/NathanielRN))
 * Antoine Pultier ([@fungiboletus](https://github.com/fungiboletus))
@@ -85,6 +88,8 @@ All notable changes to this project will be documented in this file.
 * James ([@JamesJHPark](https://github.com/JamesJHPark))
 * MartenH ([@mhennoch](https://github.com/mhennoch))
 * Olivier Albertini ([@OlivierAlbertini](https://github.com/OlivierAlbertini))
+* Patrice Chalin ([@chalin](https://github.com/chalin))
+* Rauno Viskus ([@Rauno56](https://github.com/Rauno56))
 * Severin Neumann ([@svrnm](https://github.com/svrnm))
 * Valentin Marchaud ([@vmarchaud](https://github.com/vmarchaud))
 * Weyert de Boer ([@weyert](https://github.com/weyert))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,96 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## 1.0.1 / Experimental 0.27.0
+
+### :boom: Breaking Change
+
+* Other
+  * [#2566](https://github.com/open-telemetry/opentelemetry-js/pull/2566) feat!(metrics): remove batch observer ([@dyladan](https://github.com/dyladan))
+  * [#2485](https://github.com/open-telemetry/opentelemetry-js/pull/2485) feat!: Split metric and trace exporters into new experimental packages ([@willarmiros](https://github.com/willarmiros))
+  * [#2540](https://github.com/open-telemetry/opentelemetry-js/pull/2540) fix(sdk-metrics-base): remove metric kind BATCH_OBSERVER ([@legendecas](https://github.com/legendecas))
+  * [#2496](https://github.com/open-telemetry/opentelemetry-js/pull/2496) feat(api-metrics): rename metric instruments to match feature-freeze API specification ([@legendecas](https://github.com/legendecas))
+* `opentelemetry-core`
+  * [#2529](https://github.com/open-telemetry/opentelemetry-js/pull/2529) feat(api-metrics): add schemaUrl to meter creations ([@legendecas](https://github.com/legendecas))
+
+### :rocket: (Enhancement)
+
+* Other
+  * [#2523](https://github.com/open-telemetry/opentelemetry-js/pull/2523) feat: Rename Labels to Attributes ([@pirgeo](https://github.com/pirgeo))
+  * [#2559](https://github.com/open-telemetry/opentelemetry-js/pull/2559) feat(api-metrics): remove bind/unbind and bound instruments ([@legendecas](https://github.com/legendecas))
+  * [#2563](https://github.com/open-telemetry/opentelemetry-js/pull/2563) feat(sdk-metrics-base): remove per-meter config on MeterProvider.getMeter ([@legendecas](https://github.com/legendecas))
+* `opentelemetry-core`
+  * [#2465](https://github.com/open-telemetry/opentelemetry-js/pull/2465) fix: prefer globalThis instead of window to support webworkers ([@legendecas](https://github.com/legendecas))
+* `opentelemetry-semantic-conventions`
+  * [#2532](https://github.com/open-telemetry/opentelemetry-js/pull/2532) feat(@opentelemetry/semantic-conventions): change enum to object literals ([@echoontheway](https://github.com/echoontheway))
+  * [#2528](https://github.com/open-telemetry/opentelemetry-js/pull/2528) feat: upgrade semantic-conventions to latest v1.7.0 spec ([@weyert](https://github.com/weyert))
+* `opentelemetry-core`, `opentelemetry-sdk-trace-base`
+  * [#2484](https://github.com/open-telemetry/opentelemetry-js/pull/2484) feat: new merge function ([@obecny](https://github.com/obecny))
+
+### :bug: (Bug Fix)
+
+* Other
+  * [#2581](https://github.com/open-telemetry/opentelemetry-js/pull/2581) feat: lazy initialization of the gzip stream ([@fungiboletus](https://github.com/fungiboletus))
+  * [#2584](https://github.com/open-telemetry/opentelemetry-js/pull/2584) fix: fixing compatibility versions for detectors ([@obecny](https://github.com/obecny))
+  * [#2558](https://github.com/open-telemetry/opentelemetry-js/pull/2558) fix(@opentelemetry/exporter-prometheus): unref prometheus server to prevent process running indefinitely ([@mothershipper](https://github.com/mothershipper))
+  * [#2495](https://github.com/open-telemetry/opentelemetry-js/pull/2495) fix(sdk-metrics-base): metrics name should be in the max length of 63 ([@legendecas](https://github.com/legendecas))
+  * [#2497](https://github.com/open-telemetry/opentelemetry-js/pull/2497) feat(@opentelemetry-instrumentation-fetch): support reading response body from the hook applyCustomAttributesOnSpan ([@echoontheway](https://github.com/echoontheway))
+* `opentelemetry-core`
+  * [#2560](https://github.com/open-telemetry/opentelemetry-js/pull/2560) fix(core): support regex global flag in urlMatches ([@moander](https://github.com/moander))
+* `opentelemetry-exporter-zipkin`
+  * [#2519](https://github.com/open-telemetry/opentelemetry-js/pull/2519) fix(exporter-zipkin): correct status tags names ([@t2t2](https://github.com/t2t2))
+
+### :books: (Refine Doc)
+
+* `opentelemetry-core`
+  * [#2604](https://github.com/open-telemetry/opentelemetry-js/pull/2604) Docs: Document the HrTime format ([@JamesJHPark](https://github.com/JamesJHPark))
+* Other
+  * [#2576](https://github.com/open-telemetry/opentelemetry-js/pull/2576) docs(instrumentation): update links in the Readme ([@OlivierAlbertini](https://github.com/OlivierAlbertini))
+  * [#2600](https://github.com/open-telemetry/opentelemetry-js/pull/2600) docs: fix URLs in README post-experimental move ([@arbourd](https://github.com/arbourd))
+  * [#2579](https://github.com/open-telemetry/opentelemetry-js/pull/2579) doc: Move upgrade propagator notes to correct section ([@NathanielRN](https://github.com/NathanielRN))
+  * [#2568](https://github.com/open-telemetry/opentelemetry-js/pull/2568) chore(doc): update matrix with contrib version for 1.0 core ([@vmarchaud](https://github.com/vmarchaud))
+  * [#2555](https://github.com/open-telemetry/opentelemetry-js/pull/2555) docs: expose existing comments ([@moander](https://github.com/moander))
+  * [#2493](https://github.com/open-telemetry/opentelemetry-js/pull/2493) chore: remove getting started and link to documentation. ([@svrnm](https://github.com/svrnm))
+
+### :house: (Internal)
+
+* `opentelemetry-sdk-trace-base`, `opentelemetry-sdk-trace-node`, `opentelemetry-sdk-trace-web`
+  * [#2607](https://github.com/open-telemetry/opentelemetry-js/pull/2607) chore: update npm badge image links ([@legendecas](https://github.com/legendecas))
+* Other
+  * [#2570](https://github.com/open-telemetry/opentelemetry-js/pull/2570) chore: adding selenium tests with browserstack ([@obecny](https://github.com/obecny))
+  * [#2522](https://github.com/open-telemetry/opentelemetry-js/pull/2522) chore: cleanup setting config in instrumentations ([@Flarna](https://github.com/Flarna))
+  * [#2541](https://github.com/open-telemetry/opentelemetry-js/pull/2541) chore: slim font size for section title in PR template ([@legendecas](https://github.com/legendecas))
+  * [#2509](https://github.com/open-telemetry/opentelemetry-js/pull/2509) chore: expand pull request template with action items ([@pragmaticivan](https://github.com/pragmaticivan))
+  * [#2488](https://github.com/open-telemetry/opentelemetry-js/pull/2488) chore: inline sources in source maps ([@dyladan](https://github.com/dyladan))
+  * [#2514](https://github.com/open-telemetry/opentelemetry-js/pull/2514) chore: update stable dependencies to 1.0 ([@dyladan](https://github.com/dyladan))
+* `opentelemetry-context-async-hooks`, `opentelemetry-context-zone-peer-dep`, `opentelemetry-core`, `opentelemetry-exporter-jaeger`, `opentelemetry-exporter-zipkin`, `opentelemetry-propagator-b3`, `opentelemetry-propagator-jaeger`, `opentelemetry-resources`, `opentelemetry-sdk-trace-base`, `opentelemetry-sdk-trace-node`, `opentelemetry-sdk-trace-web`, `opentelemetry-shim-opentracing`
+  * [#2531](https://github.com/open-telemetry/opentelemetry-js/pull/2531) chore(deps): pin minor API version ([@Flarna](https://github.com/Flarna))
+* `opentelemetry-core`
+  * [#2520](https://github.com/open-telemetry/opentelemetry-js/pull/2520) chore(deps): remove unused semver  ([@mhennoch](https://github.com/mhennoch))
+
+### Committers: 20
+
+* (Eliseo) Nathaniel Ruiz Nowell ([@NathanielRN](https://github.com/NathanielRN))
+* Antoine Pultier ([@fungiboletus](https://github.com/fungiboletus))
+* Bartlomiej Obecny ([@obecny](https://github.com/obecny))
+* Daniel Dyla ([@dyladan](https://github.com/dyladan))
+* Dylan Arbour ([@arbourd](https://github.com/arbourd))
+* Georg Pirklbauer ([@pirgeo](https://github.com/pirgeo))
+* Gerhard Stöbich ([@Flarna](https://github.com/Flarna))
+* Ivan Santos ([@pragmaticivan](https://github.com/pragmaticivan))
+* Jack ([@mothershipper](https://github.com/mothershipper))
+* James ([@JamesJHPark](https://github.com/JamesJHPark))
+* MartenH ([@mhennoch](https://github.com/mhennoch))
+* Olivier Albertini ([@OlivierAlbertini](https://github.com/OlivierAlbertini))
+* Severin Neumann ([@svrnm](https://github.com/svrnm))
+* Valentin Marchaud ([@vmarchaud](https://github.com/vmarchaud))
+* Weyert de Boer ([@weyert](https://github.com/weyert))
+* William Armiros ([@willarmiros](https://github.com/willarmiros))
+* [@echoontheway](https://github.com/echoontheway)
+* legendecas ([@legendecas](https://github.com/legendecas))
+* moander ([@moander](https://github.com/moander))
+* t2t2 ([@t2t2](https://github.com/t2t2))
+
 ## 1.0.0
 
 No changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable changes to this project will be documented in this file.
 ### :house: (Internal)
 
 * Other
+  * [#2404](https://github.com/open-telemetry/opentelemetry-js/pull/2404) chore: Fix lint warnings in instrumentation package ([@alisabzevari](https://github.com/alisabzevari))
   * [#2533](https://github.com/open-telemetry/opentelemetry-js/pull/2533) chore: regularly close stale issues ([@Rauno56](https://github.com/Rauno56))
   * [#2570](https://github.com/open-telemetry/opentelemetry-js/pull/2570) chore: adding selenium tests with browserstack ([@obecny](https://github.com/obecny))
   * [#2522](https://github.com/open-telemetry/opentelemetry-js/pull/2522) chore: cleanup setting config in instrumentations ([@Flarna](https://github.com/Flarna))
@@ -74,9 +75,10 @@ All notable changes to this project will be documented in this file.
 * `opentelemetry-core`
   * [#2520](https://github.com/open-telemetry/opentelemetry-js/pull/2520) chore(deps): remove unused semver  ([@mhennoch](https://github.com/mhennoch))
 
-### Committers: 22
+### Committers: 23
 
 * (Eliseo) Nathaniel Ruiz Nowell ([@NathanielRN](https://github.com/NathanielRN))
+* Ali Sabzevari ([@alisabzevari](https://github.com/alisabzevari))
 * Antoine Pultier ([@fungiboletus](https://github.com/fungiboletus))
 * Bartlomiej Obecny ([@obecny](https://github.com/obecny))
 * Daniel Dyla ([@dyladan](https://github.com/dyladan))

--- a/experimental/backwards-compatability/node10/package.json
+++ b/experimental/backwards-compatability/node10/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node10",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "private": true,
   "description": "Backwards compatability app for node8 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -8,7 +8,7 @@
     "test:backcompat": "tsc --noEmit index.ts && tsc --noEmit --esModuleInterop index.ts"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.26.0",
+    "@opentelemetry/sdk-node": "0.27.0",
     "@opentelemetry/sdk-trace-base": "1.0.0"
   },
   "devDependencies": {

--- a/experimental/backwards-compatability/node10/package.json
+++ b/experimental/backwards-compatability/node10/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@opentelemetry/sdk-node": "0.27.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0"
+    "@opentelemetry/sdk-trace-base": "1.0.1"
   },
   "devDependencies": {
     "@types/node": "10.17.60",

--- a/experimental/backwards-compatability/node12/package.json
+++ b/experimental/backwards-compatability/node12/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node12",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "private": true,
   "description": "Backwards compatability app for node8 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -8,7 +8,7 @@
     "test:backcompat": "tsc --noEmit index.ts && tsc --noEmit --esModuleInterop index.ts"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.26.0",
+    "@opentelemetry/sdk-node": "0.27.0",
     "@opentelemetry/sdk-trace-base": "1.0.0"
   },
   "devDependencies": {

--- a/experimental/backwards-compatability/node12/package.json
+++ b/experimental/backwards-compatability/node12/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@opentelemetry/sdk-node": "0.27.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0"
+    "@opentelemetry/sdk-trace-base": "1.0.1"
   },
   "devDependencies": {
     "@types/node": "12.20.20",

--- a/experimental/backwards-compatability/node8/package.json
+++ b/experimental/backwards-compatability/node8/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@opentelemetry/sdk-node": "0.27.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0"
+    "@opentelemetry/sdk-trace-base": "1.0.1"
   },
   "devDependencies": {
     "@types/node": "8.10.66",

--- a/experimental/backwards-compatability/node8/package.json
+++ b/experimental/backwards-compatability/node8/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node8",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "private": true,
   "description": "Backwards compatability app for node8 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -8,7 +8,7 @@
     "test:backcompat": "tsc --noEmit index.ts && tsc --noEmit --esModuleInterop index.ts"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.26.0",
+    "@opentelemetry/sdk-node": "0.27.0",
     "@opentelemetry/sdk-trace-base": "1.0.0"
   },
   "devDependencies": {

--- a/experimental/lerna.json
+++ b/experimental/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "3.13.4",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "npmClient": "npm",
   "packages": [
     "packages/*",

--- a/experimental/packages/opentelemetry-api-metrics/package.json
+++ b/experimental/packages/opentelemetry-api-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-metrics",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Public metrics API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@babel/core": "7.15.0",
     "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/api-metrics": "0.26.0",
+    "@opentelemetry/api-metrics": "0.27.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/sinon": "10.0.2",
@@ -70,10 +70,10 @@
     "@grpc/grpc-js": "^1.3.7",
     "@grpc/proto-loader": "^0.6.4",
     "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.26.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.26.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.26.0",
-    "@opentelemetry/sdk-metrics-base": "0.26.0",
-    "@opentelemetry/resources": "1.0.0"
+    "@opentelemetry/exporter-metrics-otlp-http": "0.27.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.27.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.27.0",
+    "@opentelemetry/resources": "1.0.0",
+    "@opentelemetry/sdk-metrics-base": "0.27.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -69,11 +69,11 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.3.7",
     "@grpc/proto-loader": "^0.6.4",
-    "@opentelemetry/core": "1.0.0",
+    "@opentelemetry/core": "1.0.1",
     "@opentelemetry/exporter-metrics-otlp-http": "0.27.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.27.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.27.0",
-    "@opentelemetry/resources": "1.0.0",
+    "@opentelemetry/resources": "1.0.1",
     "@opentelemetry/sdk-metrics-base": "0.27.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -87,9 +87,9 @@
   },
   "dependencies": {
     "@opentelemetry/api-metrics": "0.27.0",
-    "@opentelemetry/core": "1.0.0",
+    "@opentelemetry/core": "1.0.1",
     "@opentelemetry/exporter-trace-otlp-http": "0.27.0",
-    "@opentelemetry/resources": "1.0.0",
+    "@opentelemetry/resources": "1.0.1",
     "@opentelemetry/sdk-metrics-base": "0.27.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-http",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -55,8 +55,8 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^1.0.3",
     "@babel/core": "7.15.0",
+    "@opentelemetry/api": "^1.0.3",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/sinon": "10.0.2",
@@ -86,10 +86,10 @@
     "@opentelemetry/api": "^1.0.3"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.26.0",
+    "@opentelemetry/api-metrics": "0.27.0",
     "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.26.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.27.0",
     "@opentelemetry/resources": "1.0.0",
-    "@opentelemetry/sdk-metrics-base": "0.26.0"
+    "@opentelemetry/sdk-metrics-base": "0.27.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-proto",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -47,9 +47,9 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^1.0.3",
     "@babel/core": "7.15.0",
-    "@opentelemetry/api-metrics": "0.26.0",
+    "@opentelemetry/api": "^1.0.3",
+    "@opentelemetry/api-metrics": "0.27.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/sinon": "10.0.2",
@@ -69,11 +69,11 @@
   "dependencies": {
     "@grpc/proto-loader": "^0.6.4",
     "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.26.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.26.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.26.0",
-    "@opentelemetry/sdk-metrics-base": "0.26.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.27.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.27.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.27.0",
     "@opentelemetry/resources": "1.0.0",
+    "@opentelemetry/sdk-metrics-base": "0.27.0",
     "protobufjs": "^6.9.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -68,11 +68,11 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.6.4",
-    "@opentelemetry/core": "1.0.0",
+    "@opentelemetry/core": "1.0.1",
     "@opentelemetry/exporter-metrics-otlp-http": "0.27.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.27.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.27.0",
-    "@opentelemetry/resources": "1.0.0",
+    "@opentelemetry/resources": "1.0.1",
     "@opentelemetry/sdk-metrics-base": "0.27.0",
     "protobufjs": "^6.9.0"
   }

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@opentelemetry/api-metrics": "0.27.0",
-    "@opentelemetry/core": "1.0.0",
+    "@opentelemetry/core": "1.0.1",
     "@opentelemetry/sdk-metrics-base": "0.27.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -57,8 +57,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.26.0",
+    "@opentelemetry/api-metrics": "0.27.0",
     "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/sdk-metrics-base": "0.26.0"
+    "@opentelemetry/sdk-metrics-base": "0.27.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-trace-otlp-grpc/package.json
@@ -68,9 +68,9 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.3.7",
     "@grpc/proto-loader": "^0.6.4",
-    "@opentelemetry/core": "1.0.0",
+    "@opentelemetry/core": "1.0.1",
     "@opentelemetry/exporter-trace-otlp-http": "0.27.0",
-    "@opentelemetry/resources": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0"
+    "@opentelemetry/resources": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-trace-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-grpc",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -69,7 +69,7 @@
     "@grpc/grpc-js": "^1.3.7",
     "@grpc/proto-loader": "^0.6.4",
     "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.26.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.27.0",
     "@opentelemetry/resources": "1.0.0",
     "@opentelemetry/sdk-trace-base": "1.0.0"
   }

--- a/experimental/packages/opentelemetry-exporter-trace-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-trace-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-http",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "OpenTelemetry Collector Trace Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/opentelemetry-exporter-trace-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-trace-otlp-http/package.json
@@ -86,8 +86,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/resources": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0"
+    "@opentelemetry/core": "1.0.1",
+    "@opentelemetry/resources": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-trace-otlp-proto/package.json
@@ -67,10 +67,10 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.6.4",
-    "@opentelemetry/core": "1.0.0",
+    "@opentelemetry/core": "1.0.1",
     "@opentelemetry/exporter-trace-otlp-http": "0.27.0",
-    "@opentelemetry/resources": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
+    "@opentelemetry/resources": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1",
     "protobufjs": "^6.9.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-trace-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-proto",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -68,7 +68,7 @@
   "dependencies": {
     "@grpc/proto-loader": "^0.6.4",
     "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.26.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.27.0",
     "@opentelemetry/resources": "1.0.0",
     "@opentelemetry/sdk-trace-base": "1.0.0",
     "protobufjs": "^6.9.0"

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-fetch",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "OpenTelemetry fetch automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/instrumentation": "0.26.0",
+    "@opentelemetry/instrumentation": "0.27.0",
     "@opentelemetry/sdk-trace-web": "1.0.0",
     "@opentelemetry/semantic-conventions": "1.0.0"
   }

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -50,9 +50,9 @@
   "devDependencies": {
     "@babel/core": "7.15.0",
     "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/context-zone": "1.0.0",
-    "@opentelemetry/propagator-b3": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
+    "@opentelemetry/context-zone": "1.0.1",
+    "@opentelemetry/propagator-b3": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/sinon": "10.0.2",
@@ -81,9 +81,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
+    "@opentelemetry/core": "1.0.1",
     "@opentelemetry/instrumentation": "0.27.0",
-    "@opentelemetry/sdk-trace-web": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0"
+    "@opentelemetry/sdk-trace-web": "1.0.1",
+    "@opentelemetry/semantic-conventions": "1.0.1"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -46,10 +46,10 @@
     "@grpc/grpc-js": "1.3.7",
     "@grpc/proto-loader": "0.6.4",
     "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/context-async-hooks": "1.0.0",
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
-    "@opentelemetry/sdk-trace-node": "1.0.0",
+    "@opentelemetry/context-async-hooks": "1.0.1",
+    "@opentelemetry/core": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/semver": "7.3.8",
@@ -71,6 +71,6 @@
   "dependencies": {
     "@opentelemetry/api-metrics": "0.27.0",
     "@opentelemetry/instrumentation": "0.27.0",
-    "@opentelemetry/semantic-conventions": "1.0.0"
+    "@opentelemetry/semantic-conventions": "1.0.1"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-grpc",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "OpenTelemetry grpc automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -69,8 +69,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.26.0",
-    "@opentelemetry/instrumentation": "0.26.0",
+    "@opentelemetry/api-metrics": "0.27.0",
+    "@opentelemetry/instrumentation": "0.27.0",
     "@opentelemetry/semantic-conventions": "1.0.0"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-http",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "OpenTelemetry http/https automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/instrumentation": "0.26.0",
+    "@opentelemetry/instrumentation": "0.27.0",
     "@opentelemetry/semantic-conventions": "1.0.0",
     "semver": "^7.3.5"
   }

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -44,9 +44,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/context-async-hooks": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
-    "@opentelemetry/sdk-trace-node": "1.0.0",
+    "@opentelemetry/context-async-hooks": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/got": "9.6.12",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
@@ -72,9 +72,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
+    "@opentelemetry/core": "1.0.1",
     "@opentelemetry/instrumentation": "0.27.0",
-    "@opentelemetry/semantic-conventions": "1.0.0",
+    "@opentelemetry/semantic-conventions": "1.0.1",
     "semver": "^7.3.5"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -50,9 +50,9 @@
   "devDependencies": {
     "@babel/core": "7.15.0",
     "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/context-zone": "1.0.0",
-    "@opentelemetry/propagator-b3": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
+    "@opentelemetry/context-zone": "1.0.1",
+    "@opentelemetry/propagator-b3": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/sinon": "10.0.2",
@@ -81,9 +81,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
+    "@opentelemetry/core": "1.0.1",
     "@opentelemetry/instrumentation": "0.27.0",
-    "@opentelemetry/sdk-trace-web": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0"
+    "@opentelemetry/sdk-trace-web": "1.0.1",
+    "@opentelemetry/semantic-conventions": "1.0.1"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-xml-http-request",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "OpenTelemetry XMLHttpRequest automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/instrumentation": "0.26.0",
+    "@opentelemetry/instrumentation": "0.27.0",
     "@opentelemetry/sdk-trace-web": "1.0.0",
     "@opentelemetry/semantic-conventions": "1.0.0"
   }

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "Base class for node which OpenTelemetry instrumentation modules extend",
   "author": "OpenTelemetry Authors",
   "homepage": "https://github.com/open-telemetry/opentelemetry-js#readme",
@@ -61,7 +61,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.26.0",
+    "@opentelemetry/api-metrics": "0.27.0",
     "require-in-the-middle": "^5.0.3",
     "semver": "^7.3.2",
     "shimmer": "^1.2.1"

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -64,8 +64,8 @@
   },
   "dependencies": {
     "@opentelemetry/api-metrics": "0.27.0",
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/resources": "1.0.0",
+    "@opentelemetry/core": "1.0.1",
+    "@opentelemetry/resources": "1.0.1",
     "lodash.merge": "^4.6.2"
   }
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics-base",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -63,7 +63,7 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.26.0",
+    "@opentelemetry/api-metrics": "0.27.0",
     "@opentelemetry/core": "1.0.0",
     "@opentelemetry/resources": "1.0.0",
     "lodash.merge": "^4.6.2"

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "~1.0.3",
-    "@opentelemetry/context-async-hooks": "1.0.0",
+    "@opentelemetry/context-async-hooks": "1.0.1",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/semver": "7.3.8",

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-node",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "OpenTelemetry SDK for Node.js",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -42,13 +42,13 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "~0.26.0",
+    "@opentelemetry/api-metrics": "0.27.0",
     "@opentelemetry/core": "~1.0.0",
-    "@opentelemetry/instrumentation": "~0.26.0",
+    "@opentelemetry/instrumentation": "0.27.0",
     "@opentelemetry/resource-detector-aws": "~1.0.0",
     "@opentelemetry/resource-detector-gcp": "~0.26.0",
     "@opentelemetry/resources": "~1.0.0",
-    "@opentelemetry/sdk-metrics-base": "~0.26.0",
+    "@opentelemetry/sdk-metrics-base": "0.27.0",
     "@opentelemetry/sdk-trace-base": "~1.0.0",
     "@opentelemetry/sdk-trace-node": "~1.0.0"
   },

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/context-async-hooks": "1.0.0",
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
+    "@opentelemetry/context-async-hooks": "1.0.1",
+    "@opentelemetry/core": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1",
     "axios": "0.21.1",
     "body-parser": "1.19.0",
     "express": "4.17.1"

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "3.13.4",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "npmClient": "npm",
   "packages": [
     "benchmark/*",

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -68,7 +68,7 @@
     "webpack-merge": "5.8.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.0.0",
+    "@opentelemetry/context-zone-peer-dep": "1.0.1",
     "zone.js": "^0.11.0"
   },
   "sideEffects": true

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -84,6 +84,6 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.0.0"
+    "@opentelemetry/semantic-conventions": "1.0.1"
   }
 }

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/resources": "1.0.0",
+    "@opentelemetry/resources": "1.0.1",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/sinon": "10.0.2",
@@ -60,9 +60,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0",
+    "@opentelemetry/core": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/semantic-conventions": "1.0.1",
     "jaeger-client": "^3.15.0"
   }
 }

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -84,9 +84,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/resources": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0"
+    "@opentelemetry/core": "1.0.1",
+    "@opentelemetry/resources": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/semantic-conventions": "1.0.1"
   }
 }

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0"
+    "@opentelemetry/core": "1.0.1"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.1.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -75,6 +75,6 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0"
+    "@opentelemetry/core": "1.0.1"
   }
 }

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -67,7 +67,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0"
+    "@opentelemetry/core": "1.0.1",
+    "@opentelemetry/semantic-conventions": "1.0.1"
   }
 }

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -81,8 +81,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/resources": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0"
+    "@opentelemetry/core": "1.0.1",
+    "@opentelemetry/resources": "1.0.1",
+    "@opentelemetry/semantic-conventions": "1.0.1"
   }
 }

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,8 +44,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "~1.0.3",
-    "@opentelemetry/resources": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0",
+    "@opentelemetry/resources": "1.0.1",
+    "@opentelemetry/semantic-conventions": "1.0.1",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "@types/semver": "7.3.8",
@@ -62,11 +62,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.0.0",
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/propagator-b3": "1.0.0",
-    "@opentelemetry/propagator-jaeger": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
+    "@opentelemetry/context-async-hooks": "1.0.1",
+    "@opentelemetry/core": "1.0.1",
+    "@opentelemetry/propagator-b3": "1.0.1",
+    "@opentelemetry/propagator-jaeger": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1",
     "semver": "^7.3.5"
   }
 }

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -49,9 +49,9 @@
   "devDependencies": {
     "@babel/core": "7.15.0",
     "@opentelemetry/api": "~1.0.3",
-    "@opentelemetry/context-zone": "1.0.0",
-    "@opentelemetry/propagator-b3": "1.0.0",
-    "@opentelemetry/resources": "1.0.0",
+    "@opentelemetry/context-zone": "1.0.1",
+    "@opentelemetry/propagator-b3": "1.0.1",
+    "@opentelemetry/resources": "1.0.1",
     "@types/jquery": "3.5.6",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
@@ -82,8 +82,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0"
+    "@opentelemetry/core": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/semantic-conventions": "1.0.1"
   }
 }

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -41,9 +41,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "~1.0.3",
-    "@opentelemetry/propagator-b3": "1.0.0",
-    "@opentelemetry/propagator-jaeger": "1.0.0",
-    "@opentelemetry/sdk-trace-base": "1.0.0",
+    "@opentelemetry/propagator-b3": "1.0.1",
+    "@opentelemetry/propagator-jaeger": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.11",
     "codecov": "3.8.3",
@@ -57,8 +57,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.1.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.0",
-    "@opentelemetry/semantic-conventions": "1.0.0",
+    "@opentelemetry/core": "1.0.1",
+    "@opentelemetry/semantic-conventions": "1.0.1",
     "opentracing": "^0.14.4"
   }
 }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "0.0.1",
+  "version": "1.0.1",
+  "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
   "repository": "open-telemetry/opentelemetry-js",
@@ -27,7 +28,7 @@
     "node": ">=10.0.0"
   },
   "publishConfig": {
-    "access": "private"
+    "access": "restricted"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",
@@ -55,16 +56,16 @@
     "@opentelemetry/api": "^1.0.3"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "^1.0.0",
-    "@opentelemetry/core": "^1.0.0",
+    "@opentelemetry/context-zone-peer-dep": "1.0.1",
+    "@opentelemetry/core": "1.0.1",
     "@opentelemetry/exporter-otlp-http": "^0.26.0",
-    "@opentelemetry/exporter-zipkin": "^1.0.0",
+    "@opentelemetry/exporter-zipkin": "1.0.1",
     "@opentelemetry/instrumentation": "^0.26.0",
     "@opentelemetry/instrumentation-fetch": "^0.26.0",
     "@opentelemetry/instrumentation-xml-http-request": "^0.26.0",
     "@opentelemetry/sdk-metrics-base": "^0.26.0",
-    "@opentelemetry/sdk-trace-base": "^1.0.0",
-    "@opentelemetry/sdk-trace-web": "^1.0.0",
+    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/sdk-trace-web": "1.0.1",
     "zone.js": "^0.10.3"
   }
 }


### PR DESCRIPTION
Alternative of #2609 which releases both stable and experimental

### :boom: Breaking Change

* Other
  * [#2566](https://github.com/open-telemetry/opentelemetry-js/pull/2566) feat!(metrics): remove batch observer ([@dyladan](https://github.com/dyladan))
  * [#2485](https://github.com/open-telemetry/opentelemetry-js/pull/2485) feat!: Split metric and trace exporters into new experimental packages ([@willarmiros](https://github.com/willarmiros))
  * [#2540](https://github.com/open-telemetry/opentelemetry-js/pull/2540) fix(sdk-metrics-base): remove metric kind BATCH_OBSERVER ([@legendecas](https://github.com/legendecas))
  * [#2496](https://github.com/open-telemetry/opentelemetry-js/pull/2496) feat(api-metrics): rename metric instruments to match feature-freeze API specification ([@legendecas](https://github.com/legendecas))
* `opentelemetry-core`
  * [#2529](https://github.com/open-telemetry/opentelemetry-js/pull/2529) feat(api-metrics): add schemaUrl to meter creations ([@legendecas](https://github.com/legendecas))

### :rocket: (Enhancement)

* Other
  * [#2523](https://github.com/open-telemetry/opentelemetry-js/pull/2523) feat: Rename Labels to Attributes ([@pirgeo](https://github.com/pirgeo))
  * [#2559](https://github.com/open-telemetry/opentelemetry-js/pull/2559) feat(api-metrics): remove bind/unbind and bound instruments ([@legendecas](https://github.com/legendecas))
  * [#2563](https://github.com/open-telemetry/opentelemetry-js/pull/2563) feat(sdk-metrics-base): remove per-meter config on MeterProvider.getMeter ([@legendecas](https://github.com/legendecas))
* `opentelemetry-core`
  * [#2465](https://github.com/open-telemetry/opentelemetry-js/pull/2465) fix: prefer globalThis instead of window to support webworkers ([@legendecas](https://github.com/legendecas))
* `opentelemetry-semantic-conventions`
  * [#2532](https://github.com/open-telemetry/opentelemetry-js/pull/2532) feat(@opentelemetry/semantic-conventions): change enum to object literals ([@echoontheway](https://github.com/echoontheway))
  * [#2528](https://github.com/open-telemetry/opentelemetry-js/pull/2528) feat: upgrade semantic-conventions to latest v1.7.0 spec ([@weyert](https://github.com/weyert))
* `opentelemetry-core`, `opentelemetry-sdk-trace-base`
  * [#2484](https://github.com/open-telemetry/opentelemetry-js/pull/2484) feat: new merge function ([@obecny](https://github.com/obecny))

### :bug: (Bug Fix)

* Other
  * [#2610](https://github.com/open-telemetry/opentelemetry-js/pull/2610) fix: preventing double enable for instrumentation that has been already enabled ([@obecny](https://github.com/obecny))
  * [#2581](https://github.com/open-telemetry/opentelemetry-js/pull/2581) feat: lazy initialization of the gzip stream ([@fungiboletus](https://github.com/fungiboletus))
  * [#2584](https://github.com/open-telemetry/opentelemetry-js/pull/2584) fix: fixing compatibility versions for detectors ([@obecny](https://github.com/obecny))
  * [#2558](https://github.com/open-telemetry/opentelemetry-js/pull/2558) fix(@opentelemetry/exporter-prometheus): unref prometheus server to prevent process running indefinitely ([@mothershipper](https://github.com/mothershipper))
  * [#2495](https://github.com/open-telemetry/opentelemetry-js/pull/2495) fix(sdk-metrics-base): metrics name should be in the max length of 63 ([@legendecas](https://github.com/legendecas))
  * [#2497](https://github.com/open-telemetry/opentelemetry-js/pull/2497) feat(@opentelemetry-instrumentation-fetch): support reading response body from the hook applyCustomAttributesOnSpan ([@echoontheway](https://github.com/echoontheway))
* `opentelemetry-core`
  * [#2560](https://github.com/open-telemetry/opentelemetry-js/pull/2560) fix(core): support regex global flag in urlMatches ([@moander](https://github.com/moander))
* `opentelemetry-exporter-zipkin`
  * [#2519](https://github.com/open-telemetry/opentelemetry-js/pull/2519) fix(exporter-zipkin): correct status tags names ([@t2t2](https://github.com/t2t2))

### :books: (Refine Doc)

* Other
  * [#2561](https://github.com/open-telemetry/opentelemetry-js/pull/2561) Use new canonical path to Getting Started ([@chalin](https://github.com/chalin))
  * [#2576](https://github.com/open-telemetry/opentelemetry-js/pull/2576) docs(instrumentation): update links in the Readme ([@OlivierAlbertini](https://github.com/OlivierAlbertini))
  * [#2600](https://github.com/open-telemetry/opentelemetry-js/pull/2600) docs: fix URLs in README post-experimental move ([@arbourd](https://github.com/arbourd))
  * [#2579](https://github.com/open-telemetry/opentelemetry-js/pull/2579) doc: Move upgrade propagator notes to correct section ([@NathanielRN](https://github.com/NathanielRN))
  * [#2568](https://github.com/open-telemetry/opentelemetry-js/pull/2568) chore(doc): update matrix with contrib version for 1.0 core ([@vmarchaud](https://github.com/vmarchaud))
  * [#2555](https://github.com/open-telemetry/opentelemetry-js/pull/2555) docs: expose existing comments ([@moander](https://github.com/moander))
  * [#2493](https://github.com/open-telemetry/opentelemetry-js/pull/2493) chore: remove getting started and link to documentation. ([@svrnm](https://github.com/svrnm))
* `opentelemetry-core`
  * [#2604](https://github.com/open-telemetry/opentelemetry-js/pull/2604) Docs: Document the HrTime format ([@JamesJHPark](https://github.com/JamesJHPark))

### :house: (Internal)

* Other
  * [#2404](https://github.com/open-telemetry/opentelemetry-js/pull/2404) chore: Fix lint warnings in instrumentation package ([@alisabzevari](https://github.com/alisabzevari))
  * [#2533](https://github.com/open-telemetry/opentelemetry-js/pull/2533) chore: regularly close stale issues ([@Rauno56](https://github.com/Rauno56))
  * [#2570](https://github.com/open-telemetry/opentelemetry-js/pull/2570) chore: adding selenium tests with browserstack ([@obecny](https://github.com/obecny))
  * [#2522](https://github.com/open-telemetry/opentelemetry-js/pull/2522) chore: cleanup setting config in instrumentations ([@Flarna](https://github.com/Flarna))
  * [#2541](https://github.com/open-telemetry/opentelemetry-js/pull/2541) chore: slim font size for section title in PR template ([@legendecas](https://github.com/legendecas))
  * [#2509](https://github.com/open-telemetry/opentelemetry-js/pull/2509) chore: expand pull request template with action items ([@pragmaticivan](https://github.com/pragmaticivan))
  * [#2488](https://github.com/open-telemetry/opentelemetry-js/pull/2488) chore: inline sources in source maps ([@dyladan](https://github.com/dyladan))
  * [#2514](https://github.com/open-telemetry/opentelemetry-js/pull/2514) chore: update stable dependencies to 1.0 ([@dyladan](https://github.com/dyladan))
* `opentelemetry-sdk-trace-base`, `opentelemetry-sdk-trace-node`, `opentelemetry-sdk-trace-web`
  * [#2607](https://github.com/open-telemetry/opentelemetry-js/pull/2607) chore: update npm badge image links ([@legendecas](https://github.com/legendecas))
* `opentelemetry-context-async-hooks`, `opentelemetry-context-zone-peer-dep`, `opentelemetry-core`, `opentelemetry-exporter-jaeger`, `opentelemetry-exporter-zipkin`, `opentelemetry-propagator-b3`, `opentelemetry-propagator-jaeger`, `opentelemetry-resources`, `opentelemetry-sdk-trace-base`, `opentelemetry-sdk-trace-node`, `opentelemetry-sdk-trace-web`, `opentelemetry-shim-opentracing`
  * [#2531](https://github.com/open-telemetry/opentelemetry-js/pull/2531) chore(deps): pin minor API version ([@Flarna](https://github.com/Flarna))
* `opentelemetry-core`
  * [#2520](https://github.com/open-telemetry/opentelemetry-js/pull/2520) chore(deps): remove unused semver  ([@mhennoch](https://github.com/mhennoch))

### Committers: 23

* (Eliseo) Nathaniel Ruiz Nowell ([@NathanielRN](https://github.com/NathanielRN))
* Ali Sabzevari ([@alisabzevari](https://github.com/alisabzevari))
* Antoine Pultier ([@fungiboletus](https://github.com/fungiboletus))
* Bartlomiej Obecny ([@obecny](https://github.com/obecny))
* Daniel Dyla ([@dyladan](https://github.com/dyladan))
* Dylan Arbour ([@arbourd](https://github.com/arbourd))
* Georg Pirklbauer ([@pirgeo](https://github.com/pirgeo))
* Gerhard Stöbich ([@Flarna](https://github.com/Flarna))
* Ivan Santos ([@pragmaticivan](https://github.com/pragmaticivan))
* Jack ([@mothershipper](https://github.com/mothershipper))
* James ([@JamesJHPark](https://github.com/JamesJHPark))
* MartenH ([@mhennoch](https://github.com/mhennoch))
* Olivier Albertini ([@OlivierAlbertini](https://github.com/OlivierAlbertini))
* Patrice Chalin ([@chalin](https://github.com/chalin))
* Rauno Viskus ([@Rauno56](https://github.com/Rauno56))
* Severin Neumann ([@svrnm](https://github.com/svrnm))
* Valentin Marchaud ([@vmarchaud](https://github.com/vmarchaud))
* Weyert de Boer ([@weyert](https://github.com/weyert))
* William Armiros ([@willarmiros](https://github.com/willarmiros))
* [@echoontheway](https://github.com/echoontheway)
* legendecas ([@legendecas](https://github.com/legendecas))
* moander ([@moander](https://github.com/moander))
* t2t2 ([@t2t2](https://github.com/t2t2))