### PR TITLE
chore: fix compilation errors

### DIFF
--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/tsconfig.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/tsconfig.json
@@ -11,6 +11,18 @@
   "references": [
     {
       "path": "../opentelemetry-api-metrics"
+    },
+    {
+      "path": "../opentelemetry-exporter-metrics-otlp-http"
+    },
+    {
+      "path": "../opentelemetry-exporter-trace-otlp-grpc"
+    },
+    {
+      "path": "../opentelemetry-exporter-trace-otlp-http"
+    },
+    {
+      "path": "../opentelemetry-sdk-metrics-base"
     }
   ]
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/tsconfig.esm.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/tsconfig.esm.json
@@ -7,5 +7,16 @@
   },
   "include": [
     "src/**/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../opentelemetry-api-metrics/tsconfig.esm.json"
+    },
+    {
+      "path": "../opentelemetry-exporter-trace-otlp-http/tsconfig.esm.json"
+    },
+    {
+      "path": "../opentelemetry-sdk-metrics-base/tsconfig.esm.json"
+    }
   ]
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/tsconfig.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/tsconfig.json
@@ -7,5 +7,16 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts"
+  ],
+  "references": [
+    {
+      "path": "../opentelemetry-api-metrics"
+    },
+    {
+      "path": "../opentelemetry-exporter-trace-otlp-http"
+    },
+    {
+      "path": "../opentelemetry-sdk-metrics-base"
+    }
   ]
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/tsconfig.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/tsconfig.json
@@ -10,10 +10,19 @@
   ],
   "references": [
     {
-      "path": "../opentelemetry-sdk-metrics-base"
+      "path": "../opentelemetry-api-metrics"
     },
     {
       "path": "../opentelemetry-exporter-metrics-otlp-http"
+    },
+    {
+      "path": "../opentelemetry-exporter-trace-otlp-http"
+    },
+    {
+      "path": "../opentelemetry-exporter-trace-otlp-proto"
+    },
+    {
+      "path": "../opentelemetry-sdk-metrics-base"
     }
   ]
 }

--- a/experimental/packages/opentelemetry-exporter-trace-otlp-grpc/tsconfig.json
+++ b/experimental/packages/opentelemetry-exporter-trace-otlp-grpc/tsconfig.json
@@ -10,13 +10,7 @@
   ],
   "references": [
     {
-      "path": "../opentelemetry-api-metrics"
-    },
-    {
       "path": "../opentelemetry-exporter-trace-otlp-http"
-    },
-    {
-      "path": "../opentelemetry-sdk-metrics-base"
     }
   ]
 }

--- a/experimental/packages/opentelemetry-exporter-trace-otlp-http/tsconfig.esm.json
+++ b/experimental/packages/opentelemetry-exporter-trace-otlp-http/tsconfig.esm.json
@@ -7,13 +7,5 @@
   },
   "include": [
     "src/**/*.ts"
-  ],
-  "references": [
-    {
-      "path": "../opentelemetry-api-metrics/tsconfig.esm.json"
-    },
-    {
-      "path": "../opentelemetry-sdk-metrics-base/tsconfig.esm.json"
-    }
   ]
 }

--- a/experimental/packages/opentelemetry-exporter-trace-otlp-http/tsconfig.json
+++ b/experimental/packages/opentelemetry-exporter-trace-otlp-http/tsconfig.json
@@ -7,13 +7,5 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts"
-  ],
-  "references": [
-    {
-      "path": "../opentelemetry-api-metrics"
-    },
-    {
-      "path": "../opentelemetry-sdk-metrics-base"
-    }
   ]
 }

--- a/experimental/packages/opentelemetry-exporter-trace-otlp-proto/tsconfig.json
+++ b/experimental/packages/opentelemetry-exporter-trace-otlp-proto/tsconfig.json
@@ -10,13 +10,7 @@
   ],
   "references": [
     {
-      "path": "../opentelemetry-api-metrics"
-    },
-    {
       "path": "../opentelemetry-exporter-trace-otlp-http"
-    },
-    {
-      "path": "../opentelemetry-sdk-metrics-base"
     }
   ]
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
@@ -56,7 +56,6 @@ export class MeterProvider implements api.MeterProvider {
         new Meter({
           name,
           version,
-          // @ts-expect-error ts(2345) TODO: upgrade @opentelemetry/core InstrumentationLibrary definition
           schemaUrl: options?.schemaUrl
         }, this._config)
       );

--- a/experimental/tsconfig.esm.json
+++ b/experimental/tsconfig.esm.json
@@ -6,6 +6,18 @@
       "path": "packages/opentelemetry-api-metrics/tsconfig.esm.json"
     },
     {
+      "path": "packages/opentelemetry-exporter-metrics-otlp-grpc"
+    },
+    {
+      "path": "packages/opentelemetry-exporter-metrics-otlp-http/tsconfig.esm.json"
+    },
+    {
+      "path": "packages/opentelemetry-exporter-metrics-otlp-proto"
+    },
+    {
+      "path": "packages/opentelemetry-exporter-prometheus"
+    },
+    {
       "path": "packages/opentelemetry-exporter-trace-otlp-grpc"
     },
     {
@@ -13,9 +25,6 @@
     },
     {
       "path": "packages/opentelemetry-exporter-trace-otlp-proto"
-    },
-    {
-      "path": "packages/opentelemetry-exporter-prometheus"
     },
     {
       "path": "packages/opentelemetry-instrumentation-fetch/tsconfig.esm.json"

--- a/experimental/tsconfig.json
+++ b/experimental/tsconfig.json
@@ -6,6 +6,18 @@
       "path": "packages/opentelemetry-api-metrics"
     },
     {
+      "path": "packages/opentelemetry-exporter-metrics-otlp-grpc"
+    },
+    {
+      "path": "packages/opentelemetry-exporter-metrics-otlp-http"
+    },
+    {
+      "path": "packages/opentelemetry-exporter-metrics-otlp-proto"
+    },
+    {
+      "path": "packages/opentelemetry-exporter-prometheus"
+    },
+    {
       "path": "packages/opentelemetry-exporter-trace-otlp-grpc"
     },
     {
@@ -13,9 +25,6 @@
     },
     {
       "path": "packages/opentelemetry-exporter-trace-otlp-proto"
-    },
-    {
-      "path": "packages/opentelemetry-exporter-prometheus"
     },
     {
       "path": "packages/opentelemetry-instrumentation-fetch"
@@ -31,15 +40,6 @@
     },
     {
       "path": "packages/opentelemetry-instrumentation"
-    },
-    {
-      "path": "packages/opentelemetry-exporter-metrics-otlp-http"
-    },
-    {
-      "path": "packages/opentelemetry-exporter-metrics-otlp-grpc"
-    },
-    {
-      "path": "packages/opentelemetry-exporter-metrics-otlp-proto"
     },
     {
       "path": "packages/opentelemetry-sdk-metrics-base"


### PR DESCRIPTION
Now that the core dependencies have been updated, remove the `@ts-ignore` directives. They are actually causing the build to fail now as can be seen here: https://github.com/open-telemetry/opentelemetry-js/runs/4179375965?check_suite_focus=true