### PR TITLE
chore: fix the compilation for typescript 4.4

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/types.ts
@@ -30,7 +30,7 @@ export type OpenFunction = (
 /**
  * method "send" from XMLHttpRequest
  */
-export type SendFunction = (body?: SendBody) => void;
+export type SendFunction = typeof XMLHttpRequest.prototype.send;
 
 export type SendBody =
   | string

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,7 +19,8 @@
     "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
-    "target": "es2017"
+    "target": "es2017",
+    "useUnknownInCatchVariables": false
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Looks like updating to typescript 4.4 caused the compilation to break due to errors being recognized as unknown types. This disables that option temporarily and in a follow-up PR I will update the repo to take advantage of the new default behavior.