### PR TITLE
chore: use unknown in catch

### DIFF
--- a/experimental/tsconfig.json
+++ b/experimental/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "useUnknownInCatchVariables": false
+  },
   "files": [],
   "references": [
     {

--- a/packages/opentelemetry-core/src/index.ts
+++ b/packages/opentelemetry-core/src/index.ts
@@ -35,6 +35,7 @@ export * from './trace/sampler/TraceIdRatioBasedSampler';
 export * from './trace/suppress-tracing';
 export * from './trace/TraceState';
 export * from './utils/environment';
+export * from './utils/error';
 export * from './utils/merge';
 export * from './utils/sampling';
 export * from './utils/url';

--- a/packages/opentelemetry-core/src/propagation/composite.ts
+++ b/packages/opentelemetry-core/src/propagation/composite.ts
@@ -21,6 +21,7 @@ import {
   diag,
   TextMapSetter,
 } from '@opentelemetry/api';
+import { ensureError } from '../utils/error';
 
 /** Configuration object for composite propagator */
 export interface CompositePropagatorConfig {
@@ -69,11 +70,9 @@ export class CompositePropagator implements TextMapPropagator {
       try {
         propagator.inject(context, carrier, setter);
       } catch (err) {
-        if (err instanceof Error) {
-          diag.warn(
-            `Failed to inject with ${propagator.constructor.name}. Err: ${err.message}`
-          );
-        }
+        diag.warn(
+          `Failed to inject with ${propagator.constructor.name}. Err: ${ensureError(err).message}`
+        );
       }
     }
   }
@@ -92,11 +91,9 @@ export class CompositePropagator implements TextMapPropagator {
       try {
         return propagator.extract(ctx, carrier, getter);
       } catch (err) {
-        if (err instanceof Error) {
-          diag.warn(
-            `Failed to inject with ${propagator.constructor.name}. Err: ${err.message}`
-          );
-        }
+        diag.warn(
+          `Failed to extract with ${propagator.constructor.name}. Err: ${ensureError(err).message}`
+        );
       }
       return ctx;
     }, context);

--- a/packages/opentelemetry-core/src/propagation/composite.ts
+++ b/packages/opentelemetry-core/src/propagation/composite.ts
@@ -69,9 +69,11 @@ export class CompositePropagator implements TextMapPropagator {
       try {
         propagator.inject(context, carrier, setter);
       } catch (err) {
-        diag.warn(
-          `Failed to inject with ${propagator.constructor.name}. Err: ${err.message}`
-        );
+        if (err instanceof Error) {
+          diag.warn(
+            `Failed to inject with ${propagator.constructor.name}. Err: ${err.message}`
+          );
+        }
       }
     }
   }
@@ -90,9 +92,11 @@ export class CompositePropagator implements TextMapPropagator {
       try {
         return propagator.extract(ctx, carrier, getter);
       } catch (err) {
-        diag.warn(
-          `Failed to inject with ${propagator.constructor.name}. Err: ${err.message}`
-        );
+        if (err instanceof Error) {
+          diag.warn(
+            `Failed to inject with ${propagator.constructor.name}. Err: ${err.message}`
+          );
+        }
       }
       return ctx;
     }, context);

--- a/packages/opentelemetry-core/src/utils/error.ts
+++ b/packages/opentelemetry-core/src/utils/error.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function ensureError(unknownError: unknown): Error {
+    let error: Error;
+    if (unknownError instanceof Error) {
+        error = unknownError;
+    } else {
+        const errorString = String(unknownError);
+        error = new Error(errorString);
+        error.stack = `Unknown Error [missing stack trace]: ${errorString}`
+    }
+
+    return error;
+}

--- a/packages/opentelemetry-exporter-jaeger/src/jaeger.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/jaeger.ts
@@ -119,8 +119,9 @@ export class JaegerExporter implements SpanExporter {
     for (const span of thriftSpan) {
       try {
         await this._append(span);
-      } catch (error) {
+      } catch (unknownError) {
         // TODO right now we break out on first error, is that desirable?
+        const error = unknownError instanceof Error ? unknownError : new Error(String(unknownError));
         if (done) return done({ code: ExportResultCode.FAILED, error });
       }
     }

--- a/packages/opentelemetry-resources/src/platform/node/detect-resources.ts
+++ b/packages/opentelemetry-resources/src/platform/node/detect-resources.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { Resource } from '../../Resource';
-import { ResourceDetectionConfig } from '../../config';
 import { diag } from '@opentelemetry/api';
+import { ensureError } from '@opentelemetry/core';
 import * as util from 'util';
+import { ResourceDetectionConfig } from '../../config';
+import { Resource } from '../../Resource';
 
 /**
  * Runs all resource detectors and returns the results merged into a single
@@ -37,9 +38,7 @@ export const detectResources = async (
         diag.debug(`${d.constructor.name} found resource.`, resource);
         return resource;
       } catch (e) {
-        if (e instanceof Error) {
-          diag.debug(`${d.constructor.name} failed: ${e.message}`);
-        }
+        diag.debug(`${d.constructor.name} failed: ${ensureError(e).message}`);
         return Resource.empty();
       }
     })

--- a/packages/opentelemetry-resources/src/platform/node/detect-resources.ts
+++ b/packages/opentelemetry-resources/src/platform/node/detect-resources.ts
@@ -37,7 +37,9 @@ export const detectResources = async (
         diag.debug(`${d.constructor.name} found resource.`, resource);
         return resource;
       } catch (e) {
-        diag.debug(`${d.constructor.name} failed: ${e.message}`);
+        if (e instanceof Error) {
+          diag.debug(`${d.constructor.name} failed: ${e.message}`);
+        }
         return Resource.empty();
       }
     })

--- a/packages/opentelemetry-resources/src/platform/node/detectors/EnvDetector.ts
+++ b/packages/opentelemetry-resources/src/platform/node/detectors/EnvDetector.ts
@@ -67,7 +67,9 @@ class EnvDetector implements Detector {
         const parsedAttributes = this._parseResourceAttributes(rawAttributes);
         Object.assign(attributes, parsedAttributes);
       } catch (e) {
-        diag.debug(`EnvDetector failed: ${e.message}`);
+        if (e instanceof Error) {
+          diag.debug(`EnvDetector failed: ${e.message}`);
+        }
       }
     }
 

--- a/packages/opentelemetry-resources/src/platform/node/detectors/EnvDetector.ts
+++ b/packages/opentelemetry-resources/src/platform/node/detectors/EnvDetector.ts
@@ -15,13 +15,11 @@
  */
 
 import { diag } from '@opentelemetry/api';
-import { getEnv } from '@opentelemetry/core';
+import { ensureError, getEnv } from '@opentelemetry/core';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import {
   Detector,
-  Resource,
-  ResourceDetectionConfig,
-  ResourceAttributes,
+  Resource, ResourceAttributes, ResourceDetectionConfig
 } from '../../../';
 
 /**
@@ -67,9 +65,7 @@ class EnvDetector implements Detector {
         const parsedAttributes = this._parseResourceAttributes(rawAttributes);
         Object.assign(attributes, parsedAttributes);
       } catch (e) {
-        if (e instanceof Error) {
-          diag.debug(`EnvDetector failed: ${e.message}`);
-        }
+        diag.debug(`EnvDetector failed: ${ensureError(e).message}`);
       }
     }
 

--- a/packages/opentelemetry-sdk-trace-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/WebTracerProvider.test.ts
@@ -54,7 +54,7 @@ describe('WebTracerProvider', () => {
     });
 
     it('should throw error when context manager is passed in constructor', () => {
-      let error = '';
+      let error: unknown = '';
       try {
         new WebTracerProvider({
           contextManager: new ZoneContextManager(),
@@ -70,7 +70,7 @@ describe('WebTracerProvider', () => {
     });
 
     it('should throw error when propagator is passed in constructor', () => {
-      let error = '';
+      let error: unknown = '';
       try {
         new WebTracerProvider({
           propagator: new B3Propagator(),

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,8 +19,7 @@
     "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
-    "target": "es2017",
-    "useUnknownInCatchVariables": false
+    "target": "es2017"
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
The default behavior for typescript 4.4 is to treat catch clauses as unknown types, which increases safety. This PR takes advantage of that default.