### PR TITLE
chore: rename metrics packages to prevent lerna linking

### DIFF
--- a/experimental/packages/opentelemetry-api-metrics/package.json
+++ b/experimental/packages/opentelemetry-api-metrics/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@opentelemetry/api-metrics",
-  "version": "0.27.0",
+  "version": "0.1.0",
+  "private": true,
   "description": "Public metrics API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/opentelemetry-api-metrics/package.json
+++ b/experimental/packages/opentelemetry-api-metrics/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@opentelemetry/api-metrics",
-  "version": "0.1.0",
+  "name": "@opentelemetry/api-metrics-wip",
+  "version": "0.27.0",
   "private": true,
   "description": "Public metrics API for OpenTelemetry",
   "main": "build/src/index.js",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/tsconfig.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/tsconfig.json
@@ -10,9 +10,6 @@
   ],
   "references": [
     {
-      "path": "../opentelemetry-api-metrics"
-    },
-    {
       "path": "../opentelemetry-exporter-metrics-otlp-http"
     },
     {

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/tsconfig.esm.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/tsconfig.esm.json
@@ -10,9 +10,6 @@
   ],
   "references": [
     {
-      "path": "../opentelemetry-api-metrics/tsconfig.esm.json"
-    },
-    {
       "path": "../opentelemetry-exporter-trace-otlp-http/tsconfig.esm.json"
     }
   ]

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/tsconfig.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/tsconfig.json
@@ -10,9 +10,6 @@
   ],
   "references": [
     {
-      "path": "../opentelemetry-api-metrics"
-    },
-    {
       "path": "../opentelemetry-exporter-trace-otlp-http"
     }
   ]

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/tsconfig.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/tsconfig.json
@@ -10,9 +10,6 @@
   ],
   "references": [
     {
-      "path": "../opentelemetry-api-metrics"
-    },
-    {
       "path": "../opentelemetry-exporter-metrics-otlp-http"
     },
     {

--- a/experimental/packages/opentelemetry-exporter-prometheus/tsconfig.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/tsconfig.json
@@ -7,10 +7,5 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts"
-  ],
-  "references": [
-    {
-      "path": "../opentelemetry-api-metrics"
-    }
   ]
 }

--- a/experimental/packages/opentelemetry-instrumentation-grpc/tsconfig.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/tsconfig.json
@@ -10,9 +10,6 @@
   ],
   "references": [
     {
-      "path": "../opentelemetry-api-metrics"
-    },
-    {
       "path": "../opentelemetry-instrumentation"
     }
   ]

--- a/experimental/packages/opentelemetry-instrumentation/tsconfig.esm.json
+++ b/experimental/packages/opentelemetry-instrumentation/tsconfig.esm.json
@@ -7,10 +7,5 @@
   },
   "include": [
     "src/**/*.ts"
-  ],
-  "references": [
-    {
-      "path": "../opentelemetry-api-metrics/tsconfig.esm.json"
-    }
   ]
 }

--- a/experimental/packages/opentelemetry-instrumentation/tsconfig.json
+++ b/experimental/packages/opentelemetry-instrumentation/tsconfig.json
@@ -7,10 +7,5 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts"
-  ],
-  "references": [
-    {
-      "path": "../opentelemetry-api-metrics"
-    }
   ]
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics-base-wip",
-  "version": "0.1.0",
+  "version": "0.27.0",
   "private": true,
   "description": "Work in progress OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/api-metrics": "0.1.0",
+    "@opentelemetry/api-metrics-wip": "0.27.0",
     "@types/lodash.merge": "4.6.6",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/api-metrics": "0.1.0"
+    "@opentelemetry/api-metrics-wip": "0.27.0"
   },
   "dependencies": {
     "@opentelemetry/core": "1.0.1",

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -48,7 +48,6 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/api-metrics-wip": "0.27.0",
     "@types/lodash.merge": "4.6.6",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
@@ -62,10 +61,11 @@
     "typescript": "4.4.4"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/api-metrics-wip": "0.27.0"
+    "@opentelemetry/api": "^1.0.3"
   },
+  "todo": "Move API metrics to peer dependencies. While it is using an unpublished name, lerna doesn't properly link it if it is in peer dependencies",
   "dependencies": {
+    "@opentelemetry/api-metrics-wip": "0.27.0",
     "@opentelemetry/core": "1.0.1",
     "@opentelemetry/resources": "1.0.1",
     "lodash.merge": "4.6.2"

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics-base-wip",
-  "version": "0.27.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Work in progress OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.3",
+    "@opentelemetry/api-metrics": "0.1.0",
     "@types/lodash.merge": "4.6.6",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
@@ -61,10 +62,10 @@
     "typescript": "4.4.4"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.3"
+    "@opentelemetry/api": "^1.0.3",
+    "@opentelemetry/api-metrics": "0.1.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.27.0",
     "@opentelemetry/core": "1.0.1",
     "@opentelemetry/resources": "1.0.1",
     "lodash.merge": "4.6.2"

--- a/experimental/packages/opentelemetry-sdk-node/tsconfig.json
+++ b/experimental/packages/opentelemetry-sdk-node/tsconfig.json
@@ -10,9 +10,6 @@
   ],
   "references": [
     {
-      "path": "../opentelemetry-api-metrics"
-    },
-    {
       "path": "../opentelemetry-instrumentation"
     }
   ]


### PR DESCRIPTION
This solves the issue where the WIP metrics API and SDK cause problems with existing packages by giving them a version number that does not match the dependencies of the existing packages. This means the released 0.27.0 versions will be used when bootstrapping those packages.