### PR TITLE
fix: propagate x-b3-parentspanid header with B3MultiPropagator

### DIFF
--- a/packages/opentelemetry-propagator-b3/src/common.ts
+++ b/packages/opentelemetry-propagator-b3/src/common.ts
@@ -20,3 +20,7 @@ import { createContextKey } from '@opentelemetry/api';
 export const B3_DEBUG_FLAG_KEY = createContextKey(
   'OpenTelemetry Context Key B3 Debug Flag'
 );
+
+export const B3_PARENT_SPAN_ID_KEY = createContextKey(
+  'OpenTelemetry Context Key B3 Parent Span Id'
+);


### PR DESCRIPTION
## Which problem is this PR solving?
When using the B3MultiPropagator the `x-b3-parentspanid` header was not being propagated. This PR fixes that.

## Short description of the changes
propagate `x-b3-parentspanid` header with B3MultiPropagator

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Added asserts to existing tests.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
