### PR TITLE
chore: update wip metrics api references

### DIFF
--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Instruments.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Instruments.ts
@@ -15,7 +15,7 @@
  */
 
 import * as api from '@opentelemetry/api';
-import * as metrics from '@opentelemetry/api-metrics';
+import * as metrics from '@opentelemetry/api-metrics-wip';
 import { Meter } from './Meter';
 
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Measurement.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Measurement.ts
@@ -15,7 +15,7 @@
  */
 
 import * as api from '@opentelemetry/api'
-import { Attributes } from '@opentelemetry/api-metrics'
+import { Attributes } from '@opentelemetry/api-metrics-wip'
 
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#measurement
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as metrics from '@opentelemetry/api-metrics';
+import * as metrics from '@opentelemetry/api-metrics-wip';
 import { InstrumentationLibrary } from '@opentelemetry/core';
 import { Counter, Histogram, UpDownCounter } from './Instruments';
 import { Measurement } from './Measurement';

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
@@ -15,7 +15,7 @@
  */
 
 import * as api from '@opentelemetry/api';
-import * as metrics from '@opentelemetry/api-metrics';
+import * as metrics from '@opentelemetry/api-metrics-wip';
 import { Resource } from '@opentelemetry/resources';
 import { Measurement } from './Measurement';
 import { Meter } from './Meter';


### PR DESCRIPTION
In #2629 the metrics API and SDK packages were renamed and made private to prevent them from being linked with other packages by lerna. This PR cleans up some references that were missed and still point to the released API.