### PR TITLE
chore: Update wip metrics references

### DIFF
--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/InstrumentDescriptor.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/InstrumentDescriptor.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { MetricOptions, ValueType } from '@opentelemetry/api-metrics';
+import { MetricOptions, ValueType } from '@opentelemetry/api-metrics-wip';
 import { InstrumentType } from './Instruments';
 
 export interface InstrumentDescriptor {

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Instruments.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Instruments.ts
@@ -15,7 +15,7 @@
  */
 
 import * as api from '@opentelemetry/api';
-import * as metrics from '@opentelemetry/api-metrics';
+import * as metrics from '@opentelemetry/api-metrics-wip';
 import { InstrumentDescriptor } from './InstrumentDescriptor';
 import { WritableMetricStorage } from './state/WritableMetricStorage';
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Measurement.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Measurement.ts
@@ -15,7 +15,7 @@
  */
 
 import * as api from '@opentelemetry/api'
-import { Attributes } from '@opentelemetry/api-metrics'
+import { Attributes } from '@opentelemetry/api-metrics-wip'
 
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#measurement
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as metrics from '@opentelemetry/api-metrics';
+import * as metrics from '@opentelemetry/api-metrics-wip';
 import { InstrumentationLibrary } from '@opentelemetry/core';
 import { createInstrumentDescriptor, InstrumentDescriptor } from './InstrumentDescriptor';
 import { Counter, Histogram, InstrumentType, UpDownCounter } from './Instruments';

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
@@ -54,15 +54,27 @@ export class Meter implements metrics.Meter {
     return new UpDownCounter(storage, descriptor);
   }
 
-  createObservableGauge(_name: string, _options?: metrics.MetricOptions, _callback?: (observableResult: metrics.ObservableResult) => void): metrics.ObservableBase {
+  createObservableGauge(
+    _name: string,
+    _callback: (observableResult: metrics.ObservableResult) => void,
+    _options?: metrics.MetricOptions,
+  ): metrics.ObservableGauge {
     throw new Error('Method not implemented.');
   }
 
-  createObservableCounter(_name: string, _options?: metrics.MetricOptions, _callback?: (observableResult: metrics.ObservableResult) => void): metrics.ObservableBase {
+  createObservableCounter(
+    _name: string,
+    _callback: (observableResult: metrics.ObservableResult) => void,
+    _options?: metrics.MetricOptions,
+  ): metrics.ObservableBase {
     throw new Error('Method not implemented.');
   }
 
-  createObservableUpDownCounter(_name: string, _options?: metrics.MetricOptions, _callback?: (observableResult: metrics.ObservableResult) => void): metrics.ObservableBase {
+  createObservableUpDownCounter(
+    _name: string,
+    _callback: (observableResult: metrics.ObservableResult) => void,
+    _options?: metrics.MetricOptions,
+  ): metrics.ObservableBase {
     throw new Error('Method not implemented.');
   }
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
@@ -15,7 +15,7 @@
  */
 
 import * as api from '@opentelemetry/api';
-import * as metrics from '@opentelemetry/api-metrics';
+import * as metrics from '@opentelemetry/api-metrics-wip';
 import { Resource } from '@opentelemetry/resources';
 import { Meter } from './Meter';
 import { MetricExporter } from './MetricExporter';

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MultiWritableMetricStorage.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MultiWritableMetricStorage.ts
@@ -15,7 +15,7 @@
  */
 
 import { Context } from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics';
+import { Attributes } from '@opentelemetry/api-metrics-wip';
 import { WritableMetricStorage } from './WritableMetricStorage';
 
 export class MultiMetricStorage implements WritableMetricStorage {

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/WritableMetricStorage.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/WritableMetricStorage.ts
@@ -15,7 +15,7 @@
  */
 
 import { Context } from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics';
+import { Attributes } from '@opentelemetry/api-metrics-wip';
 
 export interface WritableMetricStorage {
   record(value: number, attributes: Attributes, context: Context): void;

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/view/AttributesProcessor.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/view/AttributesProcessor.ts
@@ -15,7 +15,7 @@
  */
 
 import { Context } from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics';
+import { Attributes } from '@opentelemetry/api-metrics-wip';
 
 /**
  * The {@link AttributesProcessor} is responsible for customizing which

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/view/Predicate.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/view/Predicate.ts
@@ -28,11 +28,12 @@ export interface Predicate {
  */
 export class PatternPredicate implements Predicate {
   private _matchAll: boolean;
-  private _regexp?: RegExp;
+  private _regexp: RegExp;
 
   constructor(pattern: string) {
     if (pattern === '*') {
       this._matchAll = true;
+      this._regexp = /.*/;
     } else {
       this._matchAll = false;
       this._regexp = new RegExp(PatternPredicate.escapePattern(pattern));
@@ -44,7 +45,7 @@ export class PatternPredicate implements Predicate {
       return true;
     }
 
-    return this._regexp!.test(str);
+    return this._regexp.test(str);
   }
 
   static escapePattern(pattern: string): string {

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/view/ViewRegistry.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/view/ViewRegistry.test.ts
@@ -15,7 +15,7 @@
  */
 
 import * as assert from 'assert';
-import { ValueType } from '@opentelemetry/api-metrics';
+import { ValueType } from '@opentelemetry/api-metrics-wip';
 import { InstrumentationLibrary } from '@opentelemetry/core';
 import { InstrumentType } from '../../src/Instruments';
 import { ViewRegistry } from '../../src/view/ViewRegistry';


### PR DESCRIPTION
In #2629 the metrics API and SDK packages were renamed and made private to prevent them from being linked with other packages by lerna. This PR cleans up some references that were missed and still point to the released API.