### PR TITLE
feat(instrumentation): support ESM in node via import-in-the-middle

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@opentelemetry/api-metrics": "0.27.0",
+    "import-in-the-middle": "^1.1.2",
     "require-in-the-middle": "^5.0.3",
     "semver": "^7.3.2",
     "shimmer": "^1.2.1"

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/import-in-the-middle.d.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/import-in-the-middle.d.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare module 'import-in-the-middle' {
+  namespace hook {
+    type Options = {
+      internals?: boolean;
+    };
+    type OnRequireFn = <T>(exports: T, name: string, basedir?: string) => T;
+    type Hooked = { unhook(): void };
+  }
+  function hook(
+    modules: string[] | null,
+    options: hook.Options | null,
+    onRequire: hook.OnRequireFn
+  ): hook.Hooked;
+  function hook(
+    modules: string[] | null,
+    onRequire: hook.OnRequireFn
+  ): hook.Hooked;
+  function hook(onRequire: hook.OnRequireFn): hook.Hooked;
+  export = hook;
+}

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -17,6 +17,7 @@
 import * as types from '../../types';
 import * as path from 'path';
 import * as RequireInTheMiddle from 'require-in-the-middle';
+import ImportInTheMiddle from 'import-in-the-middle';
 import { satisfies } from 'semver';
 import { InstrumentationAbstract } from '../../instrumentation';
 import { InstrumentationModuleDefinition } from './types';
@@ -29,7 +30,7 @@ export abstract class InstrumentationBase<T = any>
   extends InstrumentationAbstract
   implements types.Instrumentation {
   private _modules: InstrumentationModuleDefinition<T>[];
-  private _hooks: RequireInTheMiddle.Hooked[] = [];
+  private _hooks = 0;
   private _enabled = false;
 
   constructor(
@@ -120,7 +121,7 @@ export abstract class InstrumentationBase<T = any>
     this._enabled = true;
 
     // already hooked, just call patch again
-    if (this._hooks.length > 0) {
+    if (this._hooks > 0) {
       for (const module of this._modules) {
         if (typeof module.patch === 'function' && module.moduleExports) {
           module.patch(module.moduleExports, module.moduleVersion);
@@ -135,22 +136,19 @@ export abstract class InstrumentationBase<T = any>
     }
 
     for (const module of this._modules) {
-      this._hooks.push(
-        RequireInTheMiddle(
-          [module.name],
-          { internals: true },
-          (exports, name, baseDir) => {
-            return this._onRequire<typeof exports>(
-              (module as unknown) as InstrumentationModuleDefinition<
-                typeof exports
-              >,
-              exports,
-              name,
-              baseDir
-            );
-          }
-        )
-      );
+      this._hooks++;
+      const hookFn = (exports, name, baseDir) => {
+          return this._onRequire<typeof exports>(
+            (module as unknown) as InstrumentationModuleDefinition<
+            typeof exports
+          >,
+            exports,
+            name,
+            baseDir
+          );
+        };
+      RequireInTheMiddle([module.name], { internals: true }, hookFn);
+      ImportInTheMiddle([module.name], { internals: true }, hookFn);
     }
   }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Node.js ESM support.

## Short description of the changes

Adds `import-in-the-middle` alongside `require-in-the-middle`. Also avoids hanging on to the hooks, because they're unnecessary (not used in disable).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The existing tests pass. The part of code that uses `require-in-the-middle` does not appear to be tested by the test files in the package. Are there other tests elsewhere that cover it? If so, happy to add appropriate tests there. I'll call this a draft until there's something better here.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
