### PR TITLE
feat(@opentelemetry/propagator-jaeger): support custom baggage prefix

### DIFF
--- a/packages/opentelemetry-propagator-jaeger/test/JaegerPropagator.test.ts
+++ b/packages/opentelemetry-propagator-jaeger/test/JaegerPropagator.test.ts
@@ -34,7 +34,9 @@ import {
 describe('JaegerPropagator', () => {
   const jaegerPropagator = new JaegerPropagator();
   const customHeader = 'new-header';
+  const customBaggageHeaderPrefix = 'custom-baggage-header-prefix';
   const customJaegerPropagator = new JaegerPropagator(customHeader);
+  const customBaggagePrefixJaegerPropagator = new JaegerPropagator(undefined, customBaggageHeaderPrefix);
   let carrier: { [key: string]: unknown };
 
   beforeEach(() => {
@@ -111,6 +113,28 @@ describe('JaegerPropagator', () => {
       assert.strictEqual(carrier[`${UBER_BAGGAGE_HEADER_PREFIX}-test`], '1');
       assert.strictEqual(
         carrier[`${UBER_BAGGAGE_HEADER_PREFIX}-myuser`],
+        encodeURIComponent('%id%')
+      );
+    });
+
+    it('should propagate baggage with custom prefix with url encoded values', () => {
+      const baggage = propagation.createBaggage({
+        test: {
+          value: '1',
+        },
+        myuser: {
+          value: '%id%',
+        },
+      });
+
+      customBaggagePrefixJaegerPropagator.inject(
+        propagation.setBaggage(ROOT_CONTEXT, baggage),
+        carrier,
+        defaultTextMapSetter
+      );
+      assert.strictEqual(carrier[`${customBaggageHeaderPrefix}-test`], '1');
+      assert.strictEqual(
+        carrier[`${customBaggageHeaderPrefix}-myuser`],
         encodeURIComponent('%id%')
       );
     });
@@ -205,6 +229,21 @@ describe('JaegerPropagator', () => {
       carrier[`${UBER_BAGGAGE_HEADER_PREFIX}-myuser`] = '%25id%25';
       const extractedBaggage = propagation.getBaggage(
         jaegerPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
+      );
+
+      const firstEntry = extractedBaggage?.getEntry('test');
+      assert(typeof firstEntry !== 'undefined');
+      assert(firstEntry.value === 'value');
+      const secondEntry = extractedBaggage?.getEntry('myuser');
+      assert(typeof secondEntry !== 'undefined');
+      assert(secondEntry.value === '%id%');
+    });
+
+    it('should extract baggage with custom prefix from carrier', () => {
+      carrier[`${customBaggageHeaderPrefix}-test`] = 'value';
+      carrier[`${customBaggageHeaderPrefix}-myuser`] = '%25id%25';
+      const extractedBaggage = propagation.getBaggage(
+        customBaggagePrefixJaegerPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
       );
 
       const firstEntry = extractedBaggage?.getEntry('test');


### PR DESCRIPTION
## Which problem is this PR solving?

Adds support custom baggage header prefix to make JaegerPropagator API more flexible.