### PR TITLE
fix: tracer typo in fetchxhr examples

### DIFF
--- a/examples/tracer-web/examples/fetchXhr/index.js
+++ b/examples/tracer-web/examples/fetchXhr/index.js
@@ -68,7 +68,7 @@ const prepareClickEvent = () => {
   const element1 = document.getElementById('button1');
   const element2 = document.getElementById('button2');
 
-  const clickHandler = (fetchFn) => () => {
+  const clickHandler = (fetchFn) => {
     const singleSpan = webTracerWithZone.startSpan('files-series-info');
     context.with(trace.setSpan(context.active(), singleSpan), () => {
       fetchFn(url).then((_data) => {

--- a/examples/tracer-web/examples/fetchXhrB3/index.js
+++ b/examples/tracer-web/examples/fetchXhrB3/index.js
@@ -70,7 +70,7 @@ const prepareClickEvent = () => {
   const element1 = document.getElementById('button1');
   const element2 = document.getElementById('button2');
 
-  const clickHandler = (fetchFn) => () => {
+  const clickHandler = (fetchFn) => {
     const singleSpan = webTracerWithZone.startSpan('files-series-info');
     context.with(trace.setSpan(context.active(), singleSpan), () => {
       fetchFn(url).then((_data) => {


### PR DESCRIPTION
Fixing some minor issues in the new combined fetch plus xhr tracer-web examples that was stopping the click event from actually being executed.