### PR TITLE
docs: remove circle-ci from development guide, update link, and fix typo.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ You will receive the following error :
 ✖   type must be one of [ci, feat, fix, docs, style, refactor, perf, test, revert, chore] [type-enum]
 ```
 
-Here an exemple that will pass the verification: `git commit -s -am "chore(opentelemetry-core): update deps"`
+Here an example that will pass the verification: `git commit -s -am "chore(opentelemetry-core): update deps"`
 
 ### Fork
 

--- a/doc/development-guide.md
+++ b/doc/development-guide.md
@@ -51,23 +51,6 @@ To fix the linter, use:
 npm run lint:fix
 ```
 
-## Continuous Integration
-
-We rely on CircleCI 2.0 for our tests. If you want to test how the CI behaves
-locally, you can use the CircleCI Command Line Interface as described here:
-<https://circleci.com/docs/2.0/local-jobs/>
-
-After installing the `circleci` CLI, simply run one of the following:
-
-```sh
-circleci build --job lint
-circleci build --job node8
-circleci build --job node10
-circleci build --job node11
-circleci build --job node12
-circleci build --job node12-browsers
-```
-
 ## Docs
 
 We use [typedoc](https://www.npmjs.com/package/typedoc) to generate the api documentation.

--- a/doc/development-guide.md
+++ b/doc/development-guide.md
@@ -7,7 +7,7 @@ The code base is a monorepo. We use [Lerna](https://lerna.js.org/) for managing 
 ## Requirements
 
 Since this project supports multiple Node versions, using a version
-manager such as [nvm](https://github.com/creationix/nvm) is recommended.
+manager such as [nvm](https://github.com/nvm-sh/nvm) is recommended.
 
 To get started once you have Node installed, run:
 


### PR DESCRIPTION
## Which problem is this PR solving?

This PR addresses some documentation issues
- removes outdated information about the use of Circle CI, as it has been replaced by GitHub Actions in #1711
- updates the link to the `nvm` repository which has been moved to the nvm-sh organization.
- fixes a typo in `CONTRIBUTING.md`