### PR TITLE
feat(sdk-metrics-base): implement async instruments support

### DIFF
--- a/experimental/packages/opentelemetry-api-metrics/src/types/Meter.ts
+++ b/experimental/packages/opentelemetry-api-metrics/src/types/Meter.ts
@@ -18,15 +18,12 @@ import { CounterOptions, HistogramOptions, UpDownCounterOptions } from '..';
 import {
   Counter,
   Histogram,
-  ObservableCounter,
+  ObservableCallback,
   ObservableCounterOptions,
-  ObservableGauge,
   ObservableGaugeOptions,
-  ObservableUpDownCounter,
   ObservableUpDownCounterOptions,
   UpDownCounter,
 } from './Metric';
-import { ObservableResult } from './ObservableResult';
 
 /**
  * An interface describes additional metadata of a meter.
@@ -89,9 +86,9 @@ export interface Meter {
    */
   createObservableGauge(
     name: string,
-    callback: (observableResult: ObservableResult) => void,
+    callback: ObservableCallback,
     options?: ObservableGaugeOptions
-  ): ObservableGauge;
+  ): void;
 
   /**
    * Creates a new `ObservableCounter` metric.
@@ -101,9 +98,9 @@ export interface Meter {
    */
   createObservableCounter(
     name: string,
-    callback: (observableResult: ObservableResult) => void,
+    callback: ObservableCallback,
     options?: ObservableCounterOptions
-  ): ObservableCounter;
+  ): void;
 
   /**
    * Creates a new `ObservableUpDownCounter` metric.
@@ -113,7 +110,7 @@ export interface Meter {
    */
   createObservableUpDownCounter(
     name: string,
-    callback: (observableResult: ObservableResult) => void,
+    callback: ObservableCallback,
     options?: ObservableUpDownCounterOptions
-  ): ObservableUpDownCounter;
+  ): void;
 }

--- a/experimental/packages/opentelemetry-api-metrics/src/types/Metric.ts
+++ b/experimental/packages/opentelemetry-api-metrics/src/types/Metric.ts
@@ -15,6 +15,7 @@
  */
 
 import { Context } from '@opentelemetry/api';
+import { ObservableResult } from './ObservableResult';
 
 /**
  * Options needed for metric creation
@@ -88,21 +89,12 @@ export interface Histogram {
   record(value: number, attributes?: Attributes, context?: Context): void;
 }
 
-// ObservableBase has to be an Object but for now there is no field or method
-// declared.
-/** Base interface for the Observable metrics. */
-export type ObservableBase = Record<never, never>;
-
-/** Base interface for the ObservableGauge metrics. */
-export type ObservableGauge = ObservableBase;
-
-/** Base interface for the ObservableUpDownCounter metrics. */
-export type ObservableUpDownCounter = ObservableBase;
-
-/** Base interface for the ObservableCounter metrics. */
-export type ObservableCounter = ObservableBase;
-
 /**
  * key-value pairs passed by the user.
  */
 export type Attributes = { [key: string]: string };
+
+/**
+ * The observable callback for Observable instruments.
+ */
+export type ObservableCallback = (observableResult: ObservableResult) => void | Promise<void>;

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
@@ -26,6 +26,7 @@ import { MetricData } from './export/MetricData';
 import { isNotNullish } from './utils';
 import { MetricCollectorHandle } from './state/MetricCollector';
 import { HrTime } from '@opentelemetry/api';
+import { AsyncMetricStorage } from './state/AsyncMetricStorage';
 
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#meter
 
@@ -60,27 +61,30 @@ export class Meter implements metrics.Meter {
   }
 
   createObservableGauge(
-    _name: string,
-    _callback: (observableResult: metrics.ObservableResult) => void,
-    _options?: metrics.ObservableGaugeOptions,
-  ): metrics.ObservableGauge {
-    throw new Error('Method not implemented.');
+    name: string,
+    callback: metrics.ObservableCallback,
+    options?: metrics.ObservableGaugeOptions,
+  ): void {
+    const descriptor = createInstrumentDescriptor(name, InstrumentType.OBSERVABLE_GAUGE, options);
+    this._registerAsyncMetricStorage(descriptor, callback);
   }
 
   createObservableCounter(
-    _name: string,
-    _callback: (observableResult: metrics.ObservableResult) => void,
-    _options?: metrics.ObservableCounterOptions,
-  ): metrics.ObservableCounter {
-    throw new Error('Method not implemented.');
+    name: string,
+    callback: metrics.ObservableCallback,
+    options?: metrics.ObservableCounterOptions,
+  ): void {
+    const descriptor = createInstrumentDescriptor(name, InstrumentType.OBSERVABLE_COUNTER, options);
+    this._registerAsyncMetricStorage(descriptor, callback);
   }
 
   createObservableUpDownCounter(
-    _name: string,
-    _callback: (observableResult: metrics.ObservableResult) => void,
-    _options?: metrics.ObservableUpDownCounterOptions,
-  ): metrics.ObservableUpDownCounter {
-    throw new Error('Method not implemented.');
+    name: string,
+    callback: metrics.ObservableCallback,
+    options?: metrics.ObservableUpDownCounterOptions,
+  ): void {
+    const descriptor = createInstrumentDescriptor(name, InstrumentType.OBSERVABLE_UP_DOWN_COUNTER, options);
+    this._registerAsyncMetricStorage(descriptor, callback);
   }
 
   private _registerMetricStorage(descriptor: InstrumentDescriptor) {
@@ -95,6 +99,15 @@ export class Meter implements metrics.Meter {
       return storages[0];
     }
     return new MultiMetricStorage(storages);
+  }
+
+  private _registerAsyncMetricStorage(descriptor: InstrumentDescriptor, callback: metrics.ObservableCallback) {
+    const views = this._meterProviderSharedState.viewRegistry.findViews(descriptor, this._instrumentationLibrary);
+    views.forEach(view => {
+      const storage = AsyncMetricStorage.create(view, descriptor, callback);
+      // TODO: handle conflicts
+      this._metricStorageRegistry.set(descriptor.name, storage);
+    });
   }
 
   async collect(collector: MetricCollectorHandle, collectionTime: HrTime): Promise<MetricData[]> {

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/ObservableResult.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/ObservableResult.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as metrics from '@opentelemetry/api-metrics-wip';
+import { AttributeHashMap } from './state/HashMap';
+
+export class ObservableResult implements metrics.ObservableResult {
+  buffer = new AttributeHashMap<number>()
+
+  observe(value: number, attributes: metrics.Attributes = {}): void {
+    this.buffer.set(attributes, value);
+  }
+}

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/AsyncMetricStorage.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/AsyncMetricStorage.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import { Context, HrTime } from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics-wip';
-import { WritableMetricStorage } from './WritableMetricStorage';
+import { HrTime } from '@opentelemetry/api';
+import { ObservableCallback } from '@opentelemetry/api-metrics-wip';
 import { Accumulation, Aggregator } from '../aggregator/types';
 import { View } from '../view/View';
 import { createInstrumentDescriptorWithView, InstrumentDescriptor } from '../InstrumentDescriptor';
@@ -29,28 +28,34 @@ import { DeltaMetricProcessor } from './DeltaMetricProcessor';
 import { TemporalMetricProcessor } from './TemporalMetricProcessor';
 import { Maybe } from '../utils';
 import { MetricCollectorHandle } from './MetricCollector';
+import { ObservableResult } from '../ObservableResult';
+import { AttributeHashMap } from './HashMap';
 
 /**
  * Internal interface.
  *
  * Stores and aggregates {@link MetricData} for synchronous instruments.
  */
-export class SyncMetricStorage<T extends Maybe<Accumulation>> implements WritableMetricStorage, MetricStorage {
+export class AsyncMetricStorage<T extends Maybe<Accumulation>> implements MetricStorage {
   private _deltaMetricStorage: DeltaMetricProcessor<T>;
   private _temporalMetricStorage: TemporalMetricProcessor<T>;
 
   constructor(
     private _instrumentDescriptor: InstrumentDescriptor,
     aggregator: Aggregator<T>,
-    private _attributesProcessor: AttributesProcessor
+    private _attributesProcessor: AttributesProcessor,
+    private _callback: ObservableCallback
   ) {
     this._deltaMetricStorage = new DeltaMetricProcessor(aggregator);
     this._temporalMetricStorage = new TemporalMetricProcessor(aggregator);
   }
 
-  record(value: number, attributes: Attributes, context: Context) {
-    attributes = this._attributesProcessor.process(attributes, context);
-    this._deltaMetricStorage.record(value, attributes, context);
+  private _record(measurements: AttributeHashMap<number>) {
+    const processed = new AttributeHashMap<number>();
+    for (const [attributes, value] of measurements.entries()) {
+      processed.set(this._attributesProcessor.process(attributes), value);
+    }
+    this._deltaMetricStorage.batchCumulate(processed);
   }
 
   /**
@@ -67,6 +72,11 @@ export class SyncMetricStorage<T extends Maybe<Accumulation>> implements Writabl
     sdkStartTime: HrTime,
     collectionTime: HrTime,
   ): Promise<Maybe<MetricData>> {
+    const observableResult = new ObservableResult();
+    // TODO: timeout with callback
+    await this._callback(observableResult);
+    this._record(observableResult.buffer);
+
     const accumulations = this._deltaMetricStorage.collect();
 
     return this._temporalMetricStorage.buildMetrics(
@@ -81,9 +91,9 @@ export class SyncMetricStorage<T extends Maybe<Accumulation>> implements Writabl
     );
   }
 
-  static create(view: View, instrument: InstrumentDescriptor): SyncMetricStorage<Maybe<Accumulation>> {
+  static create(view: View, instrument: InstrumentDescriptor, callback: ObservableCallback): AsyncMetricStorage<Maybe<Accumulation>> {
     instrument = createInstrumentDescriptorWithView(view, instrument);
     const aggregator = view.aggregation.createAggregator(instrument);
-    return new SyncMetricStorage(instrument, aggregator, view.attributesProcessor);
+    return new AsyncMetricStorage(instrument, aggregator, view.attributesProcessor, callback);
   }
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/DeltaMetricProcessor.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/DeltaMetricProcessor.ts
@@ -28,11 +28,12 @@ import { AttributeHashMap } from './HashMap';
  * recording to delta data points.
  */
 export class DeltaMetricProcessor<T extends Maybe<Accumulation>> {
-  private _activeCollectionStorage: AttributeHashMap<T>;
+  private _activeCollectionStorage = new AttributeHashMap<T>();
+  // TODO: find a reasonable mean to clean the memo;
+  // https://github.com/open-telemetry/opentelemetry-specification/pull/2208
+  private _cumulativeMemoStorage = new AttributeHashMap<T>();
 
-  constructor(private _aggregator: Aggregator<T>) {
-    this._activeCollectionStorage = new AttributeHashMap();
-  }
+  constructor(private _aggregator: Aggregator<T>) {}
 
   /** Bind an efficient storage handle for a set of attributes. */
   private bind(attributes: Attributes) {
@@ -42,6 +43,20 @@ export class DeltaMetricProcessor<T extends Maybe<Accumulation>> {
   record(value: number, attributes: Attributes, _context: Context) {
     const accumulation = this.bind(attributes);
     accumulation?.record(value);
+  }
+
+  batchCumulate(measurements: AttributeHashMap<number>) {
+    for (const [attributes, value, hashCode] of measurements.entries()) {
+      let accumulation = this._aggregator.createAccumulation();
+      accumulation?.record(value);
+      if (this._cumulativeMemoStorage.has(attributes, hashCode)) {
+        const previous = this._cumulativeMemoStorage.get(attributes, hashCode)!;
+        accumulation = this._aggregator.diff(previous, accumulation);
+      }
+
+      this._cumulativeMemoStorage.set(attributes, accumulation, hashCode);
+      this._activeCollectionStorage.set(attributes, accumulation, hashCode);
+    }
   }
 
   collect() {

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/HashMap.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/HashMap.ts
@@ -53,6 +53,11 @@ export class HashMap<KeyType, ValueType, HashCodeType> {
     this._valueMap.set(hashCode, value);
   }
 
+  has(key: KeyType, hashCode?: HashCodeType) {
+    hashCode ??= this._hash(key);
+    return this._valueMap.has(hashCode);
+  }
+
   *entries(): IterableIterator<[KeyType, ValueType, HashCodeType]> {
     const valueIterator = this._valueMap.entries();
     let next = valueIterator.next();

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/view/AttributesProcessor.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/view/AttributesProcessor.ts
@@ -23,7 +23,7 @@ import { Attributes } from '@opentelemetry/api-metrics-wip';
  * additional dimension(s) from the {@link Context}.
  */
 export abstract class AttributesProcessor {
-  abstract process(incoming: Attributes, context: Context): Attributes;
+  abstract process(incoming: Attributes, context?: Context): Attributes;
 
   static Noop() {
     return NOOP;
@@ -31,7 +31,7 @@ export abstract class AttributesProcessor {
 }
 
 export class NoopAttributesProcessor extends AttributesProcessor {
-  process(incoming: Attributes, _context: Context) {
+  process(incoming: Attributes, _context?: Context) {
     return incoming;
   }
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/Meter.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/Meter.test.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
+import { ObservableCallback } from '@opentelemetry/api-metrics-wip';
 import * as assert from 'assert';
 import { Counter, Histogram, UpDownCounter } from '../src/Instruments';
 import { Meter } from '../src/Meter';
 import { MeterProviderSharedState } from '../src/state/MeterProviderSharedState';
 import { defaultInstrumentationLibrary, defaultResource } from './util';
+
+const noopObservableCallback: ObservableCallback = _observableResult => {};
 
 describe('Meter', () => {
   describe('createCounter', () => {
@@ -42,6 +45,27 @@ describe('Meter', () => {
       const meter = new Meter(new MeterProviderSharedState(defaultResource), defaultInstrumentationLibrary);
       const counter = meter.createHistogram('foobar');
       assert(counter instanceof Histogram);
+    });
+  });
+
+  describe('createObservableGauge', () => {
+    it('should create observable gauge', () => {
+      const meter = new Meter(new MeterProviderSharedState(defaultResource), defaultInstrumentationLibrary);
+      meter.createObservableGauge('foobar', noopObservableCallback);
+    });
+  });
+
+  describe('createObservableCounter', () => {
+    it('should create observable counter', () => {
+      const meter = new Meter(new MeterProviderSharedState(defaultResource), defaultInstrumentationLibrary);
+      meter.createObservableCounter('foobar', noopObservableCallback);
+    });
+  });
+
+  describe('createObservableUpDownCounter', () => {
+    it('should create observable up-down-counter', () => {
+      const meter = new Meter(new MeterProviderSharedState(defaultResource), defaultInstrumentationLibrary);
+      meter.createObservableUpDownCounter('foobar', noopObservableCallback);
     });
   });
 });

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/ObservableResult.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/ObservableResult.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { ObservableResult } from '../src/ObservableResult';
+import { commonAttributes, commonValues } from './util';
+
+describe('ObservableResult', () => {
+  describe('observe', () => {
+    it('should observe', () => {
+      const observableResult = new ObservableResult();
+      for (const value of commonValues) {
+        for (const attributes of commonAttributes) {
+          observableResult.observe(value, attributes);
+        }
+      }
+    });
+
+    it('should deduplicate observations', () => {
+      const observableResult = new ObservableResult();
+      observableResult.observe(1, {});
+      observableResult.observe(2, {});
+
+      assert.strictEqual(observableResult.buffer.size, 1);
+      assert(observableResult.buffer.has({}));
+      assert.strictEqual(observableResult.buffer.get({}), 2);
+    });
+  });
+});

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/state/AsyncMetricStorage.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/state/AsyncMetricStorage.test.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { hrTime } from '@opentelemetry/core';
+import * as assert from 'assert';
+
+import { SumAggregator } from '../../src/aggregator';
+import { AggregationTemporality } from '../../src/export/AggregationTemporality';
+import { PointDataType } from '../../src/export/MetricData';
+import { MetricCollectorHandle } from '../../src/state/MetricCollector';
+import { AsyncMetricStorage } from '../../src/state/AsyncMetricStorage';
+import { NoopAttributesProcessor } from '../../src/view/AttributesProcessor';
+import { assertMetricData, assertPointData, defaultInstrumentationLibrary, defaultInstrumentDescriptor, defaultResource } from '../util';
+import { ObservableCallback } from '@opentelemetry/api-metrics-wip';
+
+const deltaCollector: MetricCollectorHandle = {
+  aggregatorTemporality: AggregationTemporality.DELTA,
+};
+
+const cumulativeCollector: MetricCollectorHandle = {
+  aggregatorTemporality: AggregationTemporality.CUMULATIVE,
+};
+
+const sdkStartTime = hrTime();
+
+class ObservableCallbackDelegate {
+  private _delegate?: ObservableCallback;
+  setDelegate(delegate: ObservableCallback) {
+    this._delegate = delegate;
+  }
+
+  getCallback(): ObservableCallback {
+    return observableResult => {
+      this._delegate?.(observableResult);
+    };
+  }
+}
+
+describe('AsyncMetricStorage', () => {
+  describe('collect', () => {
+    describe('Delta Collector', () => {
+      const collectors = [deltaCollector];
+      it('should collect and reset memos', async () => {
+        const delegate = new ObservableCallbackDelegate();
+        const metricStorage = new AsyncMetricStorage(
+          defaultInstrumentDescriptor,
+          new SumAggregator(),
+          new NoopAttributesProcessor(),
+          delegate.getCallback(),
+        );
+
+        delegate.setDelegate(observableResult => {
+          observableResult.observe(1, { key: '1' });
+          observableResult.observe(2, { key: '2' });
+          observableResult.observe(3, { key: '3' });
+        });
+        {
+          const metric = await metricStorage.collect(
+            deltaCollector,
+            collectors,
+            defaultResource,
+            defaultInstrumentationLibrary,
+            sdkStartTime,
+            hrTime());
+
+          assertMetricData(metric, PointDataType.SINGULAR);
+          assert.strictEqual(metric.pointData.length, 3);
+          assertPointData(metric.pointData[0], { key: '1' }, 1);
+          assertPointData(metric.pointData[1], { key: '2' }, 2);
+          assertPointData(metric.pointData[2], { key: '3' }, 3);
+        }
+
+        delegate.setDelegate(observableResult => {});
+        // The attributes should not be memorized if no measurement was reported.
+        {
+          const metric = await metricStorage.collect(
+            deltaCollector,
+            collectors,
+            defaultResource,
+            defaultInstrumentationLibrary,
+            sdkStartTime,
+            hrTime());
+
+          assertMetricData(metric, PointDataType.SINGULAR);
+          assert.strictEqual(metric.pointData.length, 0);
+        }
+
+        delegate.setDelegate(observableResult => {
+          observableResult.observe(4, { key: '1' });
+          observableResult.observe(5, { key: '2' });
+          observableResult.observe(6, { key: '3' });
+        });
+        {
+          const metric = await metricStorage.collect(
+            deltaCollector,
+            [deltaCollector],
+            defaultResource,
+            defaultInstrumentationLibrary,
+            sdkStartTime,
+            hrTime());
+
+          assertMetricData(metric, PointDataType.SINGULAR);
+          assert.strictEqual(metric.pointData.length, 3);
+          // all values were diffed.
+          assertPointData(metric.pointData[0], { key: '1' }, 3);
+          assertPointData(metric.pointData[1], { key: '2' }, 3);
+          assertPointData(metric.pointData[2], { key: '3' }, 3);
+        }
+      });
+    });
+
+    describe('Cumulative Collector', () => {
+      const collectors = [cumulativeCollector];
+      it('should collect cumulative metrics', async () => {
+        const delegate = new ObservableCallbackDelegate();
+        const metricStorage = new AsyncMetricStorage(
+          defaultInstrumentDescriptor,
+          new SumAggregator(),
+          new NoopAttributesProcessor(),
+          delegate.getCallback(),
+        );
+
+        delegate.setDelegate(observableResult => {
+          observableResult.observe(1, { key: '1' });
+          observableResult.observe(2, { key: '2' });
+          observableResult.observe(3, { key: '3' });
+        });
+        {
+          const metric = await metricStorage.collect(
+            cumulativeCollector,
+            collectors,
+            defaultResource,
+            defaultInstrumentationLibrary,
+            sdkStartTime,
+            hrTime());
+
+          assertMetricData(metric, PointDataType.SINGULAR);
+          assert.strictEqual(metric.pointData.length, 3);
+          assertPointData(metric.pointData[0], { key: '1' }, 1);
+          assertPointData(metric.pointData[1], { key: '2' }, 2);
+          assertPointData(metric.pointData[2], { key: '3' }, 3);
+        }
+
+        delegate.setDelegate(observableResult => {});
+        // The attributes should be memorized even if no measurement was reported.
+        {
+          const metric = await metricStorage.collect(
+            cumulativeCollector,
+            collectors,
+            defaultResource,
+            defaultInstrumentationLibrary,
+            sdkStartTime,
+            hrTime());
+
+          assertMetricData(metric, PointDataType.SINGULAR);
+          assert.strictEqual(metric.pointData.length, 3);
+          assertPointData(metric.pointData[0], { key: '1' }, 1);
+          assertPointData(metric.pointData[1], { key: '2' }, 2);
+          assertPointData(metric.pointData[2], { key: '3' }, 3);
+        }
+
+        delegate.setDelegate(observableResult => {
+          observableResult.observe(4, { key: '1' });
+          observableResult.observe(5, { key: '2' });
+          observableResult.observe(6, { key: '3' });
+        });
+        {
+          const metric = await metricStorage.collect(
+            cumulativeCollector,
+            collectors,
+            defaultResource,
+            defaultInstrumentationLibrary,
+            sdkStartTime,
+            hrTime());
+
+          assertMetricData(metric, PointDataType.SINGULAR);
+          assert.strictEqual(metric.pointData.length, 3);
+          assertPointData(metric.pointData[0], { key: '1' }, 4);
+          assertPointData(metric.pointData[1], { key: '2' }, 5);
+          assertPointData(metric.pointData[2], { key: '3' }, 6);
+        }
+      });
+    });
+  });
+});

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/state/DeltaMetricProcessor.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/state/DeltaMetricProcessor.test.ts
@@ -18,40 +18,89 @@ import * as api from '@opentelemetry/api';
 import * as assert from 'assert';
 import { DropAggregator, SumAggregator } from '../../src/aggregator';
 import { DeltaMetricProcessor } from '../../src/state/DeltaMetricProcessor';
+import { AttributeHashMap } from '../../src/state/HashMap';
 import { commonAttributes, commonValues } from '../util';
 
 describe('DeltaMetricProcessor', () => {
   describe('record', () => {
     it('no exceptions on record with DropAggregator', () => {
-      const metricStorage = new DeltaMetricProcessor(new DropAggregator());
+      const metricProcessor = new DeltaMetricProcessor(new DropAggregator());
 
       for (const value of commonValues) {
         for (const attributes of commonAttributes) {
-          metricStorage.record(value, attributes, api.context.active());
+          metricProcessor.record(value, attributes, api.context.active());
         }
       }
     });
 
     it('no exceptions on record with no-drop aggregator', () => {
-      const metricStorage = new DeltaMetricProcessor(new SumAggregator());
+      const metricProcessor = new DeltaMetricProcessor(new SumAggregator());
 
       for (const value of commonValues) {
         for (const attributes of commonAttributes) {
-          metricStorage.record(value, attributes, api.context.active());
+          metricProcessor.record(value, attributes, api.context.active());
         }
+      }
+    });
+  });
+
+  describe('batchCumulate', () => {
+    it('no exceptions on batchCumulate with DropAggregator', () => {
+      const metricProcessor = new DeltaMetricProcessor(new DropAggregator());
+
+      const measurements = new AttributeHashMap<number>();
+      for (const value of commonValues) {
+        for (const attributes of commonAttributes) {
+          measurements.set(attributes, value);
+        }
+      }
+      metricProcessor.batchCumulate(measurements);
+    });
+
+    it('no exceptions on record with no-drop aggregator', () => {
+      const metricProcessor = new DeltaMetricProcessor(new SumAggregator());
+
+      const measurements = new AttributeHashMap<number>();
+      for (const value of commonValues) {
+        for (const attributes of commonAttributes) {
+          measurements.set(attributes, value);
+        }
+      }
+      metricProcessor.batchCumulate(measurements);
+    });
+
+    it('should compute the diff of accumulations', () => {
+      const metricProcessor = new DeltaMetricProcessor(new SumAggregator());
+
+      {
+        const measurements = new AttributeHashMap<number>();
+        measurements.set({}, 10);
+        metricProcessor.batchCumulate(measurements);
+        const accumulations = metricProcessor.collect();
+        const accumulation = accumulations.get({});
+        assert.strictEqual(accumulation?.toPoint(), 10);
+      }
+
+      {
+        const measurements = new AttributeHashMap<number>();
+        measurements.set({}, 21);
+        metricProcessor.batchCumulate(measurements);
+        const accumulations = metricProcessor.collect();
+        const accumulation = accumulations.get({});
+        assert.strictEqual(accumulation?.toPoint(), 11);
       }
     });
   });
 
   describe('collect', () => {
     it('should export', () => {
-      const metricStorage = new DeltaMetricProcessor(new SumAggregator());
+      const metricProcessor = new DeltaMetricProcessor(new SumAggregator());
 
-      metricStorage.record(1, { attribute: '1' }, api.ROOT_CONTEXT);
-      metricStorage.record(2, { attribute: '1' }, api.ROOT_CONTEXT);
-      metricStorage.record(1, { attribute: '2' }, api.ROOT_CONTEXT);
+      metricProcessor.record(1, { attribute: '1' }, api.ROOT_CONTEXT);
+      metricProcessor.record(2, { attribute: '1' }, api.ROOT_CONTEXT);
+      metricProcessor.record(1, { attribute: '2' }, api.ROOT_CONTEXT);
 
-      let accumulations = metricStorage.collect();
+      let accumulations = metricProcessor.collect();
       assert.strictEqual(accumulations.size, 2);
       {
         const accumulation = accumulations.get({ attribute: '1' });
@@ -63,7 +112,7 @@ describe('DeltaMetricProcessor', () => {
       }
 
       /** the accumulations shall be reset. */
-      accumulations = metricStorage.collect();
+      accumulations = metricProcessor.collect();
       assert.strictEqual(accumulations.size, 0);
     });
   });

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/state/HashMap.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/state/HashMap.test.ts
@@ -39,6 +39,23 @@ describe('HashMap', () => {
     });
   });
 
+  describe('has', () => {
+    it('should return if the key exists in the value map', () => {
+      const map = new HashMap<Attributes, number, string>(hashAttributes);
+      const hash = hashAttributes({ foo: 'bar' });
+
+      // with pinned hash code
+      assert.strictEqual(map.has({}, hash), false);
+      assert.strictEqual(map.has({ foo: 'bar' }, hash), false);
+
+      map.set({ foo: 'bar' }, 1);
+      // with pinned hash code
+      assert.strictEqual(map.has({}, hash), true);
+      // with attributes object.
+      assert.strictEqual(map.has({ foo: 'bar' }), true);
+    });
+  });
+
   describe('entries', () => {
     it('iterating with entries', () => {
       const map = new HashMap<Attributes, number, string>(hashAttributes);


### PR DESCRIPTION

## Which problem is this PR solving?

This is the continuation part of https://github.com/open-telemetry/opentelemetry-js/pull/2636 for async instruments metric streams.

This is a prototype implementation described in https://docs.google.com/document/d/1EluDhj5UanNATS3hR8xx30sv55Se7uYjsGYslvNWHtc/edit#.

## Short description of the changes

1. Add AsyncMetricStorage for async instruments.
2. Add support for handling cumulative measurements recording in DeltaMetricProcessor.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] AsyncMetricStorage
- [x] DeltaMetricProcessor.batchCumulate
- [x] Meter.createObservableGauge
- [x] Meter.createObservableCounter
- [x] Meter.createObservableUpDownCounter

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
