### PR TITLE
chore: retry link checks on code 429 with 'retry-after' header

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "predocs-test": "npm run docs",
     "docs": "typedoc && touch docs/.nojekyll",
     "docs-deploy": "gh-pages --dotfiles --dist docs",
-    "docs:test": "linkinator docs --silent && linkinator doc/*.md --silent",
+    "docs:test": "linkinator docs --silent --retry && linkinator doc/*.md --silent --retry",
     "lint": "lerna run lint",
     "lint:changed": "lerna run --concurrency 1 --stream lint --since HEAD --exclude-dependents",
     "lint:fix": "lerna run lint:fix",


### PR DESCRIPTION
## Which problem is this PR solving?

There are chances that link checks get code 429 on github action. Allow the linkinator to retry with respecting the 'retry-after' header to suppress the "too many requests" code.

Links: https://github.com/open-telemetry/opentelemetry-js/runs/4653698160?check_suite_focus=true

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Followed the style guidelines of this project
