### PR TITLE
fix(propagator-jaeger): 0-pad span-id to match 16-symbol validation

### DIFF
--- a/packages/opentelemetry-propagator-jaeger/src/JaegerPropagator.ts
+++ b/packages/opentelemetry-propagator-jaeger/src/JaegerPropagator.ts
@@ -141,9 +141,10 @@ function deserializeSpanContext(serializedString: string): SpanContext | null {
     return null;
   }
 
-  const [_traceId, spanId, , flags] = headers;
+  const [_traceId, _spanId, , flags] = headers;
 
   const traceId = _traceId.padStart(32, '0');
+  const spanId = _spanId.padStart(16, '0');
   const traceFlags = flags.match(/^[0-9a-f]{2}$/i) ? parseInt(flags) & 1 : 1;
 
   return { traceId, spanId, isRemote: true, traceFlags };

--- a/packages/opentelemetry-propagator-jaeger/test/JaegerPropagator.test.ts
+++ b/packages/opentelemetry-propagator-jaeger/test/JaegerPropagator.test.ts
@@ -299,6 +299,21 @@ describe('JaegerPropagator', () => {
       assert(typeof firstEntry !== 'undefined');
       assert(firstEntry.value === 'one');
     });
+
+    it('should 0-pad span and trace id from header', () => {
+      carrier[UBER_TRACE_ID_HEADER] = '4cda95b652f4a1592b449d5929fda1b:e0c63257de34c92:0:01';
+      const extractedSpanContext = trace.getSpanContext(
+        jaegerPropagator.extract(
+          ROOT_CONTEXT,
+          carrier,
+          defaultTextMapGetter
+        )
+      );
+
+      assert.ok(extractedSpanContext);
+      assert.equal(extractedSpanContext.spanId, '0e0c63257de34c92');
+      assert.equal(extractedSpanContext.traceId, '04cda95b652f4a1592b449d5929fda1b');
+    });
   });
 
   describe('.fields()', () => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

0-pad Span ID received from Carrier to 16-characters format according to [Jaeger Propagation Format](https://www.jaegertracing.io/docs/1.29/client-libraries/#propagation-format)

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [*] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [*] Can be verified by using [Jaeger Python Client](https://github.com/jaegertracing/jaeger-client-python) to generate _parent_ spans. Sometimes Python library generates 15-character-length Span ID so OpenTelemetry doesn't create reference to Parent Span

## Checklist:

- [*] Followed the style guidelines of this project
- [*] Unit tests have been added
- [-] Documentation has been updated
