### PR TITLE
fix(opentelemetry-js): Adding headers set from code to grpc call metadata in exporter-trace-otlp-grpc

### DIFF
--- a/packages/exporter-trace-otlp-grpc/src/OTLPExporterNodeBase.ts
+++ b/packages/exporter-trace-otlp-grpc/src/OTLPExporterNodeBase.ts
@@ -46,13 +46,15 @@ export abstract class OTLPExporterNodeBase<
 
   constructor(config: OTLPExporterConfigNode = {}) {
     super(config);
-    if (config.headers) {
-      diag.warn('Headers cannot be set when using grpc');
-    }
     const headers = baggageUtils.parseKeyPairsIntoRecord(getEnv().OTEL_EXPORTER_OTLP_HEADERS);
     this.metadata = config.metadata || new Metadata();
     for (const [k, v] of Object.entries(headers)) {
       this.metadata.set(k, v)
+    }
+    if (config.headers) {
+      for (const [k, v] of Object.entries(config.headers)) {
+        this.metadata.set(k, v)
+      }
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Nikhil Shrivastav <nikhil.shrivastav@live.com>

## Which problem is this PR solving?
Headers added in code do not get sent in the grpc metadata in exporter-trace-otlp-grpc.

## Short description of the changes
Adding headers set from code to the grpc metadata. This will override headers set from OTEL_EXPORTER_OTLP_HEADERS if there is a conflict.

## Type of change
- [✓] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Not tested.

## Checklist:
- [✓] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
