### PR TITLE
chore: add Rauno Viskus as maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Approvers ([@open-telemetry/js-approvers](https://github.com/orgs/open-telemetry
 Maintainers ([@open-telemetry/js-maintainers](https://github.com/orgs/open-telemetry/teams/javascript-maintainers)):
 
 - [Daniel Dyla](https://github.com/dyladan), Dynatrace
+- [Rauno Viskus](https://github.com/Rauno56), Splunk
 - [Valentin Marchaud](https://github.com/vmarchaud), Open Source Contributor
 
 *Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).*

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     }
   ],
   "ignoreDeps": ["gcp-metadata", "got", "mocha", "husky", "karma-webpack"],
-  "assignees": ["@dyladan", "@vmarchaud"],
+  "assignees": ["@dyladan", "@Rauno56", "@vmarchaud"],
   "schedule": ["before 3am on Friday"],
   "labels": ["dependencies"]
 }


### PR DESCRIPTION
Propose Rauno Viskus as maintainer of OpenTelemetry Javascript in recognition of his work on the project. Rauno has shown good judgement in all areas of the project including the API, SDK, and contrib respositories, and has been particularly helpful with maintenance of the contrib repository.