### PR TITLE
chore: add Chengzhong Wu as maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Approvers ([@open-telemetry/js-approvers](https://github.com/orgs/open-telemetry
 Maintainers ([@open-telemetry/js-maintainers](https://github.com/orgs/open-telemetry/teams/javascript-maintainers)):
 
 - [Daniel Dyla](https://github.com/dyladan), Dynatrace
+- [Chengzhong Wu](https://github.com/legendecas), Alibaba
 - [Valentin Marchaud](https://github.com/vmarchaud), Open Source Contributor
 
 *Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).*

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     }
   ],
   "ignoreDeps": ["gcp-metadata", "got", "mocha", "husky", "karma-webpack"],
-  "assignees": ["@dyladan", "@vmarchaud"],
+  "assignees": ["@dyladan", "@legendecas", "@vmarchaud"],
   "schedule": ["before 3am on Friday"],
   "labels": ["dependencies"]
 }


### PR DESCRIPTION
Propose Chengzhong Wu as maintainer of OpenTelemetry Javascript in recognition of his work on the project. Chengzhong has show good judgement in all areas of the project, and has been especially helpful in development the API and the metrics SDK.