### PR TITLE
chore: add Amir Blum as maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Approvers ([@open-telemetry/js-approvers](https://github.com/orgs/open-telemetry
 
 Maintainers ([@open-telemetry/js-maintainers](https://github.com/orgs/open-telemetry/teams/javascript-maintainers)):
 
+- [Amir Blum](https://github.com/blumamir), Aspecto
 - [Daniel Dyla](https://github.com/dyladan), Dynatrace
 - [Valentin Marchaud](https://github.com/vmarchaud), Open Source Contributor
 

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
     }
   ],
   "ignoreDeps": ["gcp-metadata", "got", "mocha", "husky", "karma-webpack"],
-  "assignees": ["@dyladan", "@vmarchaud"],
+  "assignees": ["@blumamir", "@dyladan", "@vmarchaud"],
   "schedule": ["before 3am on Friday"],
   "labels": ["dependencies"]
 }


### PR DESCRIPTION
Propose Amir Blum as maintainer of OpenTelemetry Javascript in recognition of his work on the project. Amir has been a long time contributor and has shown good judgement in all areas of the project including the API, SDK, and contrib repositories. He has been particularly helpful in the areas of tracing and instrumentation.