### PR TITLE
fix(sdk-trace-web): remove browsing context only api dependency on utils

### DIFF
--- a/doc/web-api.md
+++ b/doc/web-api.md
@@ -1,0 +1,21 @@
+# Web API Usages Guidance
+
+The packages of OpenTelemetry that targeting web platforms should be compatible
+with the following web environments:
+
+- [Browsing Context](https://developer.mozilla.org/en-US/docs/Glossary/Browsing_context),
+- [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers).
+
+As such, the usage of Web API that depends on APIs like [`window`],
+[`document`] and [`navigator`] is discouraged.
+
+If the use of the browsing context API is necessary, like adding `onload`
+listeners, an alternative code path for Web Worker environment should also be
+supported.
+
+It is an exception to above guidance if the package is instrumenting the
+browsing context only.
+
+[`window`]: https://developer.mozilla.org/en-US/docs/Web/API/window
+[`document`]: https://developer.mozilla.org/en-US/docs/Web/API/Document
+[`navigator]: https://developer.mozilla.org/en-US/docs/Web/API/Navigator

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/.eslintrc.js
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/.eslintrc.js
@@ -1,9 +1,7 @@
 module.exports = {
     "env": {
         "mocha": true,
-        "commonjs": true,
         "browser": true,
-        "jquery": true
     },
     ...require('../../../eslint.config.js')
 }

--- a/packages/opentelemetry-sdk-trace-web/.eslintrc.js
+++ b/packages/opentelemetry-sdk-trace-web/.eslintrc.js
@@ -1,9 +1,7 @@
 module.exports = {
     "env": {
         "mocha": true,
-        "commonjs": true,
         "browser": true,
-        "jquery": true
     },
     ...require('../../eslint.config.js')
 }

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -164,7 +164,7 @@ export function getResource(
   }
   const sorted = sortResources(filteredResources);
 
-  if (parsedSpanUrl.origin !== window.location.origin && sorted.length > 1) {
+  if (parsedSpanUrl.origin !== location.origin && sorted.length > 1) {
     let corsPreFlightRequest: PerformanceResourceTiming | undefined = sorted[0];
     let mainRequest: PerformanceResourceTiming = findMainRequest(
       sorted,
@@ -421,7 +421,7 @@ export function shouldPropagateTraceHeaders(
   }
   const parsedSpanUrl = parseUrl(spanUrl);
 
-  if (parsedSpanUrl.origin === window.location.origin) {
+  if (parsedSpanUrl.origin === location.origin) {
     return true;
   } else {
     return propagateTraceHeaderUrls.some(propagateTraceHeaderUrl =>


### PR DESCRIPTION

## Which problem is this PR solving?

sdk-trace-web should be compatible with web environments like web worker.

## Short description of the changes

1. Added guidance of Web API usages.
2. Removed `window` references in sdk-trace-web/src.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Existing tests with karma should continue to work. Worker integration tests should be introduced with https://github.com/open-telemetry/opentelemetry-js/pull/2659 or new karma configurations (for a full run of existing test suites on workers).

https://github.com/open-telemetry/opentelemetry-js/tree/main/selenium-tests is referencing experimental packages and it is not linked to the versions in the local repository, so testing with it is quite awkward. I'll continue to split it into two parts in https://github.com/open-telemetry/opentelemetry-js/pull/2659. However, if it is located in the `experimental/` subdirectory, it can not be linked to the latest un-published version of `sdk-trace-web`, and we can't get it passed without the changes in this PR :(. So I'm submitting this patch and hope to land it first to continue the setups in #2659.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] ~~Unit tests have been added~~
- [x] Documentation has been updated
