### PR TITLE
test(integration-w3c): fix inconsistent api versions loaded

### DIFF
--- a/.github/workflows/w3c-integration-test.yml
+++ b/.github/workflows/w3c-integration-test.yml
@@ -31,13 +31,13 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           npm install --ignore-scripts
-          npx lerna bootstrap --no-ci --scope=propagation-validation-server --include-dependencies
+          npx lerna bootstrap --no-ci --hoist --scope=propagation-validation-server --include-dependencies
 
       - name: Install and Bootstrap (cache hit) 🔧
         if: steps.cache.outputs.cache-hit == 'true'
         run: |
           npm ci --ignore-scripts
-          npx lerna bootstrap --scope=propagation-validation-server --include-dependencies
+          npx lerna bootstrap --hoist --scope=propagation-validation-server --include-dependencies
 
       - name: Generate version.ts files
         run: lerna run version

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -11,7 +11,7 @@
     "compile": "tsc --build"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.3",
+    "@opentelemetry/api": "~1.0.3",
     "@opentelemetry/context-async-hooks": "1.0.1",
     "@opentelemetry/core": "1.0.1",
     "@opentelemetry/sdk-trace-base": "1.0.1",


### PR DESCRIPTION
## Which problem is this PR solving?

In the latest changes, one of the package.json is changed and triggered cache invalidations at https://github.com/open-telemetry/opentelemetry-js/blob/main/.github/workflows/w3c-integration-test.yml#L28 and installed @opentelemtry/api with different versions for private package propagation-validation-server (^1.0.3) and lerna package @opentelemtry/sdk-trace-base (~1.0.3 in dev dependencies). Lerna treats this inconsistent semver mark as incompatible semvers and installs different versions for each package.

This leads to the failure of registration of BasicTracerProvider for https://github.com/open-telemetry/opentelemetry-js-api/blob/main/src/internal/global-utils.ts#L53.

## Short description of the changes

- Pin the @opentelemetry/api version in private package `propagation-validation-server` to `~1.0.3`. 
- Hoist all dependencies to align the dependencies versions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Documentation has been updated
