### PR TITLE
fix: use api 1.1 in SDKs

### DIFF
--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -83,7 +83,7 @@
     "webpack": "4.46.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.2.0"
+    "@opentelemetry/api": ">=1.1.0 <1.2.0"
   },
   "dependencies": {
     "@opentelemetry/core": "1.0.1",

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.4.4"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.2.0"
+    "@opentelemetry/api": ">=1.1.0 <1.2.0"
   },
   "dependencies": {
     "@opentelemetry/context-async-hooks": "1.0.1",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -86,7 +86,7 @@
     "webpack-merge": "5.8.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.2.0"
+    "@opentelemetry/api": ">=1.1.0 <1.2.0"
   },
   "dependencies": {
     "@opentelemetry/core": "1.0.1",


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #2755

## Short description of the changes

Use API 1.1 in SDKs to avoid that SDKs register a TracerProvider,... using an older API then other OTel components.
This avoids the version check in API rejecting the use of API 1.1 but a peer may still use 1.0.x.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

CI was failing before

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
