### PR TITLE
fix(sdk-metrics-base): combine concurrent observable callback invocations

### DIFF
--- a/experimental/packages/opentelemetry-api-metrics/src/types/Meter.ts
+++ b/experimental/packages/opentelemetry-api-metrics/src/types/Meter.ts
@@ -80,6 +80,9 @@ export interface Meter {
 
   /**
    * Creates a new `ObservableGauge` metric.
+   *
+   * The callback SHOULD not be called concurrently.
+   *
    * @param name the name of the metric.
    * @param callback the observable callback
    * @param [options] the metric options.
@@ -92,6 +95,9 @@ export interface Meter {
 
   /**
    * Creates a new `ObservableCounter` metric.
+   *
+   * The callback SHOULD not be called concurrently.
+   *
    * @param name the name of the metric.
    * @param callback the observable callback
    * @param [options] the metric options.
@@ -104,6 +110,9 @@ export interface Meter {
 
   /**
    * Creates a new `ObservableUpDownCounter` metric.
+   *
+   * The callback SHOULD not be called concurrently.
+   *
    * @param name the name of the metric.
    * @param callback the observable callback
    * @param [options] the metric options.

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
@@ -16,26 +16,19 @@
 
 import * as metrics from '@opentelemetry/api-metrics-wip';
 import { InstrumentationLibrary } from '@opentelemetry/core';
-import { createInstrumentDescriptor, InstrumentDescriptor, InstrumentType } from './InstrumentDescriptor';
+import { createInstrumentDescriptor, InstrumentType } from './InstrumentDescriptor';
 import { Counter, Histogram, UpDownCounter } from './Instruments';
 import { MeterProviderSharedState } from './state/MeterProviderSharedState';
-import { MultiMetricStorage } from './state/MultiWritableMetricStorage';
-import { SyncMetricStorage } from './state/SyncMetricStorage';
-import { MetricStorage } from './state/MetricStorage';
-import { MetricData } from './export/MetricData';
-import { isNotNullish } from './utils';
-import { MetricCollectorHandle } from './state/MetricCollector';
-import { HrTime } from '@opentelemetry/api';
-import { AsyncMetricStorage } from './state/AsyncMetricStorage';
+import { MeterSharedState } from './state/MeterSharedState';
 
 /**
  * This class implements the {@link metrics.Meter} interface.
  */
 export class Meter implements metrics.Meter {
-  private _metricStorageRegistry = new Map<string, MetricStorage>();
+  private _meterSharedState: MeterSharedState;
 
-  constructor(private _meterProviderSharedState: MeterProviderSharedState, private _instrumentationLibrary: InstrumentationLibrary) {
-    this._meterProviderSharedState.meters.push(this);
+  constructor(meterProviderSharedState: MeterProviderSharedState, instrumentationLibrary: InstrumentationLibrary) {
+    this._meterSharedState = meterProviderSharedState.getMeterSharedState(instrumentationLibrary);
   }
 
   /**
@@ -43,7 +36,7 @@ export class Meter implements metrics.Meter {
    */
   createHistogram(name: string, options?: metrics.HistogramOptions): metrics.Histogram {
     const descriptor = createInstrumentDescriptor(name, InstrumentType.HISTOGRAM, options);
-    const storage = this._registerMetricStorage(descriptor);
+    const storage = this._meterSharedState.registerMetricStorage(descriptor);
     return new Histogram(storage, descriptor);
   }
 
@@ -52,7 +45,7 @@ export class Meter implements metrics.Meter {
    */
   createCounter(name: string, options?: metrics.CounterOptions): metrics.Counter {
     const descriptor = createInstrumentDescriptor(name, InstrumentType.COUNTER, options);
-    const storage = this._registerMetricStorage(descriptor);
+    const storage = this._meterSharedState.registerMetricStorage(descriptor);
     return new Counter(storage, descriptor);
   }
 
@@ -61,7 +54,7 @@ export class Meter implements metrics.Meter {
    */
   createUpDownCounter(name: string, options?: metrics.UpDownCounterOptions): metrics.UpDownCounter {
     const descriptor = createInstrumentDescriptor(name, InstrumentType.UP_DOWN_COUNTER, options);
-    const storage = this._registerMetricStorage(descriptor);
+    const storage = this._meterSharedState.registerMetricStorage(descriptor);
     return new UpDownCounter(storage, descriptor);
   }
 
@@ -74,7 +67,7 @@ export class Meter implements metrics.Meter {
     options?: metrics.ObservableGaugeOptions,
   ): void {
     const descriptor = createInstrumentDescriptor(name, InstrumentType.OBSERVABLE_GAUGE, options);
-    this._registerAsyncMetricStorage(descriptor, callback);
+    this._meterSharedState.registerAsyncMetricStorage(descriptor, callback);
   }
 
   /**
@@ -86,7 +79,7 @@ export class Meter implements metrics.Meter {
     options?: metrics.ObservableCounterOptions,
   ): void {
     const descriptor = createInstrumentDescriptor(name, InstrumentType.OBSERVABLE_COUNTER, options);
-    this._registerAsyncMetricStorage(descriptor, callback);
+    this._meterSharedState.registerAsyncMetricStorage(descriptor, callback);
   }
 
   /**
@@ -98,48 +91,6 @@ export class Meter implements metrics.Meter {
     options?: metrics.ObservableUpDownCounterOptions,
   ): void {
     const descriptor = createInstrumentDescriptor(name, InstrumentType.OBSERVABLE_UP_DOWN_COUNTER, options);
-    this._registerAsyncMetricStorage(descriptor, callback);
-  }
-
-  private _registerMetricStorage(descriptor: InstrumentDescriptor) {
-    const views = this._meterProviderSharedState.viewRegistry.findViews(descriptor, this._instrumentationLibrary);
-    const storages = views.map(view => {
-      const storage = SyncMetricStorage.create(view, descriptor);
-      // TODO: handle conflicts
-      this._metricStorageRegistry.set(descriptor.name, storage);
-      return storage;
-    });
-    if (storages.length === 1)  {
-      return storages[0];
-    }
-    return new MultiMetricStorage(storages);
-  }
-
-  private _registerAsyncMetricStorage(descriptor: InstrumentDescriptor, callback: metrics.ObservableCallback) {
-    const views = this._meterProviderSharedState.viewRegistry.findViews(descriptor, this._instrumentationLibrary);
-    views.forEach(view => {
-      const storage = AsyncMetricStorage.create(view, descriptor, callback);
-      // TODO: handle conflicts
-      this._metricStorageRegistry.set(descriptor.name, storage);
-    });
-  }
-
-  /**
-   * @internal
-   * @param collector opaque handle of {@link MetricCollector} which initiated the collection.
-   * @param collectionTime the HrTime at which the collection was initiated.
-   * @returns the list of {@link MetricData} collected.
-   */
-  async collect(collector: MetricCollectorHandle, collectionTime: HrTime): Promise<MetricData[]> {
-    const result = await Promise.all(Array.from(this._metricStorageRegistry.values()).map(metricStorage => {
-      return metricStorage.collect(
-        collector,
-        this._meterProviderSharedState.metricCollectors,
-        this._meterProviderSharedState.resource,
-        this._instrumentationLibrary,
-        this._meterProviderSharedState.sdkStartTime,
-        collectionTime);
-    }));
-    return result.filter(isNotNullish);
+    this._meterSharedState.registerAsyncMetricStorage(descriptor, callback);
   }
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MeterProviderSharedState.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MeterProviderSharedState.ts
@@ -15,10 +15,10 @@
  */
 
 import { HrTime } from '@opentelemetry/api';
-import { hrTime } from '@opentelemetry/core';
+import { hrTime, InstrumentationLibrary } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
-import { Meter } from '../Meter';
 import { ViewRegistry } from '../view/ViewRegistry';
+import { MeterSharedState } from './MeterSharedState';
 import { MetricCollector } from './MetricCollector';
 
 /**
@@ -30,7 +30,15 @@ export class MeterProviderSharedState {
 
   metricCollectors: MetricCollector[] = [];
 
-  meters: Meter[] = [];
+  meterSharedStates: MeterSharedState[] = [];
 
   constructor(public resource: Resource) {}
+
+  getMeterSharedState(instrumentationLibrary: InstrumentationLibrary) {
+    // TODO: meter identity
+    // https://github.com/open-telemetry/opentelemetry-specification/pull/2317
+    const meterSharedState = new MeterSharedState(this, instrumentationLibrary);
+    this.meterSharedStates.push(meterSharedState);
+    return meterSharedState;
+  }
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MeterSharedState.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MeterSharedState.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HrTime } from '@opentelemetry/api';
+import * as metrics from '@opentelemetry/api-metrics-wip';
+import { InstrumentationLibrary } from '@opentelemetry/core';
+import { MetricData } from '..';
+import { createInstrumentDescriptorWithView, InstrumentDescriptor } from '../InstrumentDescriptor';
+import { isNotNullish, promiseFinally } from '../utils';
+import { AsyncMetricStorage } from './AsyncMetricStorage';
+import { MeterProviderSharedState } from './MeterProviderSharedState';
+import { MetricCollectorHandle } from './MetricCollector';
+import { MetricStorage } from './MetricStorage';
+import { MultiMetricStorage } from './MultiWritableMetricStorage';
+import { ObservableRegistry } from './ObservableRegistry';
+import { SyncMetricStorage } from './SyncMetricStorage';
+
+/**
+ * An internal record for shared meter provider states.
+ */
+export class MeterSharedState {
+  private _metricStorageRegistry = new Map<string, MetricStorage>();
+  private _pendingCollectPromise: Promise<MetricData[]> | null = null;
+  private _observableRegistry = new ObservableRegistry();
+
+  constructor(private _meterProviderSharedState: MeterProviderSharedState, private _instrumentationLibrary: InstrumentationLibrary) {}
+
+  registerMetricStorage(descriptor: InstrumentDescriptor) {
+    const views = this._meterProviderSharedState.viewRegistry.findViews(descriptor, this._instrumentationLibrary);
+    const storages = views.map(view => {
+      const viewDescriptor = createInstrumentDescriptorWithView(view, descriptor);
+      const aggregator = view.aggregation.createAggregator(viewDescriptor);
+      const storage = new SyncMetricStorage(viewDescriptor, aggregator, view.attributesProcessor);
+      // TODO: handle conflicts
+      this._metricStorageRegistry.set(viewDescriptor.name, storage);
+      return storage;
+    });
+    if (storages.length === 1)  {
+      return storages[0];
+    }
+    return new MultiMetricStorage(storages);
+  }
+
+  registerAsyncMetricStorage(descriptor: InstrumentDescriptor, callback: metrics.ObservableCallback) {
+    const views = this._meterProviderSharedState.viewRegistry.findViews(descriptor, this._instrumentationLibrary);
+    views.forEach(view => {
+      const viewDescriptor = createInstrumentDescriptorWithView(view, descriptor);
+      const aggregator = view.aggregation.createAggregator(viewDescriptor);
+      const storage = new AsyncMetricStorage(viewDescriptor, aggregator, view.attributesProcessor, callback, this._observableRegistry);
+      this._observableRegistry.addCallback(callback, storage);
+      // TODO: handle conflicts
+      this._metricStorageRegistry.set(viewDescriptor.name, storage);
+    });
+  }
+
+  /**
+   * @param collector opaque handle of {@link MetricCollector} which initiated the collection.
+   * @param collectionTime the HrTime at which the collection was initiated.
+   * @returns the list of {@link MetricData} collected.
+   */
+  collect(collector: MetricCollectorHandle, collectionTime: HrTime): Promise<MetricData[]> {
+    if (this._pendingCollectPromise != null) {
+      return this._pendingCollectPromise;
+    }
+
+    /**
+     * 1. Call all observable callbacks first.
+     * 2. Collect metric result for the collector.
+     */
+    const promise = this._observableRegistry.observe()
+      .then(() => {
+        return Array.from(this._metricStorageRegistry.values()).map(metricStorage => {
+          return metricStorage.collect(
+            collector,
+            this._meterProviderSharedState.metricCollectors,
+            this._meterProviderSharedState.resource,
+            this._instrumentationLibrary,
+            this._meterProviderSharedState.sdkStartTime,
+            collectionTime);
+        })
+        .filter(isNotNullish);
+      });
+
+    this._pendingCollectPromise = promiseFinally(promise, () => {
+      this._pendingCollectPromise = null;
+    });
+    return this._pendingCollectPromise;
+  }
+}

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MetricCollector.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MetricCollector.ts
@@ -34,8 +34,8 @@ export class MetricCollector implements MetricProducer {
 
   async collect(): Promise<MetricData[]> {
     const collectionTime = hrTime();
-    const results = await Promise.all(this._sharedState.meters
-      .map(meter => meter.collect(this, collectionTime)));
+    const results = await Promise.all(this._sharedState.meterSharedStates
+      .map(meterSharedState => meterSharedState.collect(this, collectionTime)));
 
     return results.reduce((cumulation, current) => cumulation.concat(current), []);
   }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MetricStorage.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MetricStorage.ts
@@ -40,5 +40,5 @@ export interface MetricStorage {
     instrumentationLibrary: InstrumentationLibrary,
     sdkStartTime: HrTime,
     collectionTime: HrTime,
-  ): Promise<Maybe<MetricData>>;
+  ): Maybe<MetricData>;
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/ObservableRegistry.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/ObservableRegistry.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ObservableCallback } from '@opentelemetry/api-metrics-wip';
+import { MetricStorage } from './MetricStorage';
+import { ObservableResult } from '../ObservableResult';
+
+/**
+ * An internal state interface for ObservableCallbacks.
+ *
+ * An ObservableCallback can be bound to multiple AsyncMetricStorage at once.
+ * However they must not be called multiple times during a single collection
+ * operation.
+ */
+export class ObservableRegistry {
+  private _callbackMap = new Map<ObservableCallback, MetricStorage[]>();
+  private _observableResultMemo = new Map<ObservableCallback, ObservableResult>();
+
+  addCallback(callback: ObservableCallback, metricStorage: MetricStorage) {
+    let arr = this._callbackMap.get(callback);
+    if (arr == null) {
+      arr = [];
+      this._callbackMap.set(callback, arr);
+    }
+    arr.push(metricStorage);
+  }
+
+  getObservableResult(callback: ObservableCallback): ObservableResult | undefined {
+    const result = this._observableResultMemo.get(callback);
+    return result;
+  }
+
+  async observe(): Promise<void> {
+    this._observableResultMemo = new Map();
+    const promise = Promise.all(Array.from(this._callbackMap.keys()).map(observableCallback => {
+      const observableResult = new ObservableResult();
+      this._observableResultMemo.set(observableCallback, observableResult);
+      // TODO: timeout with callback
+      return observableCallback(observableResult);
+    }));
+
+    await promise;
+  }
+}

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/SyncMetricStorage.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/SyncMetricStorage.ts
@@ -18,8 +18,7 @@ import { Context, HrTime } from '@opentelemetry/api';
 import { Attributes } from '@opentelemetry/api-metrics-wip';
 import { WritableMetricStorage } from './WritableMetricStorage';
 import { Accumulation, Aggregator } from '../aggregator/types';
-import { View } from '../view/View';
-import { createInstrumentDescriptorWithView, InstrumentDescriptor } from '../InstrumentDescriptor';
+import { InstrumentDescriptor } from '../InstrumentDescriptor';
 import { AttributesProcessor } from '../view/AttributesProcessor';
 import { MetricStorage } from './MetricStorage';
 import { InstrumentationLibrary } from '@opentelemetry/core';
@@ -59,14 +58,14 @@ export class SyncMetricStorage<T extends Maybe<Accumulation>> implements Writabl
    * Note: This is a stateful operation and may reset any interval-related
    * state for the MetricCollector.
    */
-  async collect(
+  collect(
     collector: MetricCollectorHandle,
     collectors: MetricCollectorHandle[],
     resource: Resource,
     instrumentationLibrary: InstrumentationLibrary,
     sdkStartTime: HrTime,
     collectionTime: HrTime,
-  ): Promise<Maybe<MetricData>> {
+  ): Maybe<MetricData> {
     const accumulations = this._deltaMetricStorage.collect();
 
     return this._temporalMetricStorage.buildMetrics(
@@ -79,11 +78,5 @@ export class SyncMetricStorage<T extends Maybe<Accumulation>> implements Writabl
       sdkStartTime,
       collectionTime
     );
-  }
-
-  static create(view: View, instrument: InstrumentDescriptor): SyncMetricStorage<Maybe<Accumulation>> {
-    instrument = createInstrumentDescriptorWithView(view, instrument);
-    const aggregator = view.aggregation.createAggregator(instrument);
-    return new SyncMetricStorage(instrument, aggregator, view.attributesProcessor);
   }
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/utils.ts
@@ -82,3 +82,21 @@ export function callWithTimeout<T>(promise: Promise<T>, timeout: number): Promis
       throw reason;
     });
 }
+
+/**
+ * Compatibility helper for environments that don't support
+ * Promise.prototype.finally (like Node.js v8.x).
+ */
+export function promiseFinally<T>(promise: Promise<T>, onFinally: () => unknown): Promise<T> {
+  if (promise.finally) {
+    return promise.finally(onFinally);
+  }
+  return promise.then(value => {
+    return Promise.resolve(onFinally()).then(() => value);
+  }, error => {
+    return Promise.resolve(onFinally())
+      .then(() => {
+        throw error;
+      });
+  });
+}

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/export/TestMetricExporter.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/export/TestMetricExporter.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AggregationTemporality, MetricData, MetricExporter } from '../../src';
+
+export class TestMetricExporter extends MetricExporter {
+  metricDataList: MetricData[] = [];
+  async export(batch: MetricData[]): Promise<void> {
+    this.metricDataList.push(...batch);
+  }
+
+  async forceFlush(): Promise<void> {}
+
+  getPreferredAggregationTemporality(): AggregationTemporality {
+    return AggregationTemporality.CUMULATIVE;
+  }
+}
+
+export class TestDeltaMetricExporter extends TestMetricExporter {
+  override getPreferredAggregationTemporality(): AggregationTemporality {
+    return AggregationTemporality.DELTA;
+  }
+}

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/state/MeterSharedState.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/state/MeterSharedState.test.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { Meter, MeterProvider, MetricData, PointDataType } from '../../src';
+import { assertMetricData, defaultInstrumentationLibrary, defaultResource, sleep } from '../util';
+import { TestMetricReader } from '../export/TestMetricReader';
+import { TestDeltaMetricExporter, TestMetricExporter } from '../export/TestMetricExporter';
+import { MeterSharedState } from '../../src/state/MeterSharedState';
+import { View } from '../../src/view/View';
+import { InstrumentSelector } from '../../src/view/InstrumentSelector';
+import { MeterSelector } from '../../src/view/MeterSelector';
+
+describe('MeterSharedState', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('collect', () => {
+    function setupInstruments() {
+      const meterProvider = new MeterProvider({ resource: defaultResource });
+
+      const cumulativeReader = new TestMetricReader(new TestMetricExporter().getPreferredAggregationTemporality());
+      meterProvider.addMetricReader(cumulativeReader);
+      const cumulativeCollector = cumulativeReader.getMetricCollector();
+
+      const deltaReader = new TestMetricReader(new TestDeltaMetricExporter().getPreferredAggregationTemporality());
+      meterProvider.addMetricReader(deltaReader);
+      const deltaCollector = deltaReader.getMetricCollector();
+
+      const metricCollectors = [cumulativeCollector, deltaCollector];
+
+      const meter = meterProvider.getMeter(defaultInstrumentationLibrary.name, defaultInstrumentationLibrary.version, {
+        schemaUrl: defaultInstrumentationLibrary.schemaUrl,
+      }) as Meter;
+      const meterSharedState = meter['_meterSharedState'] as MeterSharedState;
+
+      return { metricCollectors, cumulativeCollector, deltaCollector, meter, meterSharedState, meterProvider };
+    }
+
+    it('should collect sync metrics', async () => {
+      /** preparing test instrumentations */
+      const { metricCollectors, meter } = setupInstruments();
+
+      /** creating metric events */
+      const counter = meter.createCounter('test');
+
+      /** collect metrics */
+      counter.add(1);
+      await Promise.all(metricCollectors.map(async collector => {
+        const result = await collector.collect();
+        assert.strictEqual(result.length, 1);
+        assertMetricData(result[0], PointDataType.SINGULAR, {
+          name: 'test',
+        });
+      }));
+    });
+
+    it('should collect sync metrics with views', async () => {
+      /** preparing test instrumentations */
+      const { metricCollectors, meter, meterProvider } = setupInstruments();
+
+      /** creating metric events */
+      meterProvider.addView(
+        new View({ name: 'foo' }),
+        new InstrumentSelector({ name: 'test' }),
+        new MeterSelector());
+      meterProvider.addView(
+        new View({ name: 'bar' }),
+        new InstrumentSelector({ name: 'test' }),
+        new MeterSelector());
+
+      const counter = meter.createCounter('test');
+
+      /** collect metrics */
+      counter.add(1);
+      await Promise.all(metricCollectors.map(async collector => {
+        const result = await collector.collect();
+        assert.strictEqual(result.length, 2);
+        assertMetricData(result[0], PointDataType.SINGULAR, {
+          name: 'foo',
+        });
+        assertMetricData(result[1], PointDataType.SINGULAR, {
+          name: 'bar',
+        });
+      }));
+    });
+
+    it('should collect async metrics without concurrent callback', async () => {
+      /** preparing test instrumentations */
+      const { metricCollectors, meter } = setupInstruments();
+
+      /** creating metric events */
+      let observableCalledCount = 0;
+      meter.createObservableCounter('test', observableResult => {
+        observableCalledCount++;
+        observableResult.observe(1);
+
+        // async observers.
+        return sleep(10);
+      });
+
+      /** collect metrics */
+      await Promise.all([
+        // initiate collection concurrently.
+        ...metricCollectors.map(collector => collector.collect()),
+        sleep(1).then(() => metricCollectors[0].collect()),
+      ]);
+      assert.strictEqual(observableCalledCount, 1);
+
+      /** collect metrics */
+      await Promise.all([
+        // initiate collection concurrently.
+        ...metricCollectors.map(collector => collector.collect()),
+        sleep(1).then(() => metricCollectors[0].collect()),
+      ]);
+      assert.strictEqual(observableCalledCount, 2);
+    });
+
+    it('should call one observable callback once with views', async () => {
+      /** preparing test instrumentations */
+      const { metricCollectors, meter, meterProvider } = setupInstruments();
+
+      /** creating metric events */
+      meterProvider.addView(
+        new View({ name: 'foo' }),
+        new InstrumentSelector({ name: 'test' }),
+        new MeterSelector());
+      meterProvider.addView(
+        new View({ name: 'bar' }),
+        new InstrumentSelector({ name: 'test' }),
+        new MeterSelector());
+
+      let observableCalledCount = 0;
+      meter.createObservableCounter('test', observableResult => {
+        observableCalledCount++;
+        observableResult.observe(1);
+
+        // async observers.
+        return sleep(10);
+      });
+
+      function verifyResult(metricData: MetricData[]) {
+        assert.strictEqual(metricData.length, 2);
+        assertMetricData(metricData[0], PointDataType.SINGULAR, {
+          name: 'foo'
+        });
+        assertMetricData(metricData[1], PointDataType.SINGULAR, {
+          name: 'bar'
+        });
+      }
+
+      /** collect metrics */
+      await Promise.all([
+        // initiate collection concurrently.
+        ...metricCollectors.map(collector => collector.collect().then(verifyResult)),
+        sleep(1).then(() => metricCollectors[0].collect().then(verifyResult)),
+      ]);
+      assert.strictEqual(observableCalledCount, 1);
+
+      /** collect metrics */
+      await Promise.all([
+        // initiate collection concurrently.
+        ...metricCollectors.map(collector => collector.collect().then(verifyResult)),
+        sleep(1).then(() => metricCollectors[0].collect().then(verifyResult)),
+      ]);
+      assert.strictEqual(observableCalledCount, 2);
+    });
+  });
+});

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/state/MetricCollector.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/state/MetricCollector.test.ts
@@ -17,32 +17,21 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { MeterProvider } from '../../src';
-import { AggregationTemporality } from '../../src/export/AggregationTemporality';
-import { MetricData, PointDataType } from '../../src/export/MetricData';
+import { PointDataType } from '../../src/export/MetricData';
 import { MetricExporter } from '../../src/export/MetricExporter';
 import { MeterProviderSharedState } from '../../src/state/MeterProviderSharedState';
 import { MetricCollector } from '../../src/state/MetricCollector';
-import { defaultInstrumentationLibrary, defaultResource, assertMetricData, assertPointData } from '../util';
+import {
+  defaultInstrumentationLibrary,
+  defaultResource,
+  assertMetricData,
+  assertPointData,
+} from '../util';
+import {
+  TestMetricExporter,
+  TestDeltaMetricExporter
+} from '../export/TestMetricExporter';
 import { TestMetricReader } from '../export/TestMetricReader';
-
-class TestMetricExporter extends MetricExporter {
-  metricDataList: MetricData[] = [];
-  async export(batch: MetricData[]): Promise<void> {
-    this.metricDataList.push(...batch);
-  }
-
-  async forceFlush(): Promise<void> {}
-
-  getPreferredAggregationTemporality(): AggregationTemporality {
-    return AggregationTemporality.CUMULATIVE;
-  }
-}
-
-class TestDeltaMetricExporter extends TestMetricExporter {
-  override getPreferredAggregationTemporality(): AggregationTemporality {
-    return AggregationTemporality.DELTA;
-  }
-}
 
 describe('MetricCollector', () => {
   afterEach(() => {

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/state/SyncMetricStorage.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/state/SyncMetricStorage.test.ts
@@ -58,7 +58,7 @@ describe('SyncMetricStorage', () => {
         metricStorage.record(2, {}, api.context.active());
         metricStorage.record(3, {}, api.context.active());
         {
-          const metric = await metricStorage.collect(
+          const metric = metricStorage.collect(
             deltaCollector,
             collectors,
             defaultResource,
@@ -73,7 +73,7 @@ describe('SyncMetricStorage', () => {
 
         // The attributes should not be memorized.
         {
-          const metric = await metricStorage.collect(
+          const metric = metricStorage.collect(
             deltaCollector,
             collectors,
             defaultResource,
@@ -87,7 +87,7 @@ describe('SyncMetricStorage', () => {
 
         metricStorage.record(1, {}, api.context.active());
         {
-          const metric = await metricStorage.collect(
+          const metric = metricStorage.collect(
             deltaCollector,
             [deltaCollector],
             defaultResource,
@@ -110,7 +110,7 @@ describe('SyncMetricStorage', () => {
         metricStorage.record(2, {}, api.context.active());
         metricStorage.record(3, {}, api.context.active());
         {
-          const metric = await metricStorage.collect(
+          const metric = metricStorage.collect(
             cumulativeCollector,
             collectors,
             defaultResource,
@@ -125,7 +125,7 @@ describe('SyncMetricStorage', () => {
 
         // The attributes should be memorized.
         {
-          const metric = await metricStorage.collect(
+          const metric = metricStorage.collect(
             cumulativeCollector,
             collectors,
             defaultResource,
@@ -140,7 +140,7 @@ describe('SyncMetricStorage', () => {
 
         metricStorage.record(1, {}, api.context.active());
         {
-          const metric = await metricStorage.collect(
+          const metric = metricStorage.collect(
             cumulativeCollector,
             collectors,
             defaultResource,

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/util.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/util.ts
@@ -49,7 +49,7 @@ a = '1';
 })];
 
 export const sleep = (time: number) =>
-  new Promise(resolve => {
+  new Promise<void>(resolve => {
     return setTimeout(resolve, time);
   });
 


### PR DESCRIPTION

## Which problem is this PR solving?

As https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#asynchronous-counter-creation states: 

> [OpenTelemetry API](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#api) authors SHOULD define whether this callback function needs to be reentrant safe / thread safe or not.

This PR documents that the async observable callbacks SHOULD not be called concurrently in JavaScript.

When multiple (or single) metric readers initiate `collect` operation concurrently, the invocation of the callback of async observables is merged.

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/2782

## Short description of the changes

- Add `ObservableRegistry` to combine `observableCallback`s for multiple async metrics.
- Call all `ObservableCallback`s at once before metric collections.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Concurrently collect (2 collectors) with 1 observableCallback and 1 async metrics.
- [x] Concurrently collect (2 collectors) with 1 observableCallback and multiple async metrics (renamed with views).

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
