### PR TITLE
fix: pass same context to Sampler and SpanProcessor in root span case

### DIFF
--- a/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
@@ -71,19 +71,24 @@ export class Tracer implements api.Tracer {
       return api.trace.wrapSpanContext(api.INVALID_SPAN_CONTEXT);
     }
 
-    const parentContext = getParent(options, context);
+    // remove span from context in case a root span is requested via options
+    if (options.root) {
+      context = api.trace.deleteSpan(context);
+    }
+
+    const parentSpanContext = api.trace.getSpanContext(context);
     const spanId = this._idGenerator.generateSpanId();
     let traceId;
     let traceState;
     let parentSpanId;
-    if (!parentContext || !api.trace.isSpanContextValid(parentContext)) {
+    if (!parentSpanContext || !api.trace.isSpanContextValid(parentSpanContext)) {
       // New root span.
       traceId = this._idGenerator.generateTraceId();
     } else {
       // New child span.
-      traceId = parentContext.traceId;
-      traceState = parentContext.traceState;
-      parentSpanId = parentContext.spanId;
+      traceId = parentSpanContext.traceId;
+      traceState = parentSpanContext.traceState;
+      parentSpanId = parentSpanContext.spanId;
     }
 
     const spanKind = options.kind ?? api.SpanKind.INTERNAL;
@@ -91,9 +96,7 @@ export class Tracer implements api.Tracer {
     const attributes = sanitizeAttributes(options.attributes);
     // make sampling decision
     const samplingResult = this._sampler.shouldSample(
-      options.root
-        ? api.trace.setSpanContext(context, api.INVALID_SPAN_CONTEXT)
-        : context,
+      context,
       traceId,
       name,
       spanKind,
@@ -227,19 +230,4 @@ export class Tracer implements api.Tracer {
   getActiveSpanProcessor(): SpanProcessor {
     return this._tracerProvider.getActiveSpanProcessor();
   }
-}
-
-/**
- * Get the parent to assign to a started span. If options.parent is null,
- * do not assign a parent.
- *
- * @param options span options
- * @param context context to check for parent
- */
-function getParent(
-  options: api.SpanOptions,
-  context: api.Context
-): api.SpanContext | undefined {
-  if (options.root) return undefined;
-  return api.trace.getSpanContext(context);
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Currently `Sampler` gets a different context then `SpanProcessor` in case `option.root` is set to `true`. This is inconsistent and besides that the `SpanProcessor` might end up in a wrong conclusion regarding parent span which is not intended.

## Short description of the changes

If `options.root` is set the behavior is like no parent span is on context.
Delete a potential span from context and pass this new context to `onStart()` and `shouldSample()`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- see added tests

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
