### PR TITLE
docs: simplify contrib part in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,25 +45,25 @@ This is the JavaScript version of [OpenTelemetry](https://opentelemetry.io/), a 
 
 ## Compatibility Matrix
 
-| API Version | Core version | Experimental Packages | Contrib Version         |
-| ----------- |--------------| --------------------- |-------------------------|
-| 1.0.x       | 1.x          | 0.26.x                | 0.26.x                  |
-| 1.0.x       | 0.26.x       | -----                 | ------                  |
-| 1.0.x       | 0.25.x       | -----                 | ------                  |
-| 1.0.x       | 0.24.x       | -----                 | 0.24.x                  |
-| 1.0.x       | 0.23.x       | -----                 | 0.23.x                  |
-| 1.0.x       | 0.22.x       | -----                 | 0.22.x                  |
-| 0.21.x      | 0.21.x       | -----                 | 0.21.x                  |
-| 0.20.x      | 0.20.x       | -----                 | 0.20.x                  |
-| v1.0.0-rc.3 | 0.19.x       | -----                 | 0.16.x                  |
-| 0.18.x      | 0.18.x       | -----                 | 0.14.x                  |
-|             | 0.17.x       | -----                 | ------                  |
-|             | 0.16.x       | -----                 | ------                  |
-|             | 0.15.x       | -----                 | 0.13.x                  |
-|             | 0.14.x       | -----                 | 0.12.x                  |
-|             | 0.13.x       | -----                 | ------                  |
-|             | 0.12.x       | -----                 | 0.11.x                  |
-|             | 0.11.x       | -----                 | 0.10.x                  |
+| API Version | Core version | Experimental Packages |
+| ----------- |--------------| --------------------- |
+| 1.0.x       | 1.x          | 0.26.x                |
+| 1.0.x       | 0.26.x       | -----                 |
+| 1.0.x       | 0.25.x       | -----                 |
+| 1.0.x       | 0.24.x       | -----                 |
+| 1.0.x       | 0.23.x       | -----                 |
+| 1.0.x       | 0.22.x       | -----                 |
+| 0.21.x      | 0.21.x       | -----                 |
+| 0.20.x      | 0.20.x       | -----                 |
+| v1.0.0-rc.3 | 0.19.x       | -----                 |
+| 0.18.x      | 0.18.x       | -----                 |
+|             | 0.17.x       | -----                 |
+|             | 0.16.x       | -----                 |
+|             | 0.15.x       | -----                 |
+|             | 0.14.x       | -----                 |
+|             | 0.13.x       | -----                 |
+|             | 0.12.x       | -----                 |
+|             | 0.11.x       | -----                 |
 
 ## Versioning
 
@@ -239,7 +239,11 @@ See the [OpenTelemetry registry](https://opentelemetry.io/registry/?language=js&
 
 ### Instrumentations
 
-OpenTelemetry can collect tracing data automatically using instrumentations. Vendors/Users can also create and use their own. Currently, OpenTelemetry supports automatic tracing for:
+OpenTelemetry can collect tracing data automatically using instrumentations.
+
+To request automatic tracing support for a module not on this list, please [file an issue](https://github.com/open-telemetry/opentelemetry-js/issues). Alternatively, Vendor/Users can [write an instrumentation yourself](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/instrumentation-guide.md).
+
+Currently, OpenTelemetry supports automatic tracing for:
 
 #### Node Instrumentations
 
@@ -250,17 +254,7 @@ OpenTelemetry can collect tracing data automatically using instrumentations. Ven
 
 ##### Contrib
 
-These plugins are hosted at <https://github.com/open-telemetry/opentelemetry-js-contrib/tree/master/plugins/node>
-
-- [@opentelemetry/instrumentation-mongodb][otel-contrib-instrumentation-mongodb]
-- [@opentelemetry/instrumentation-mysql][otel-contrib-instrumentation-mysql]
-- [@opentelemetry/instrumentation-pg][otel-contrib-instrumentation-pg]
-- [@opentelemetry/instrumentation-redis][otel-contrib-instrumentation-redis]
-- [@opentelemetry/instrumentation-ioredis][otel-contrib-instrumentation-ioredis]
-- [@opentelemetry/instrumentation-express][otel-contrib-instrumentation-express]
-- [@opentelemetry/instrumentation-dns][otel-contrib-instrumentation-dns]
-- [@opentelemetry/instrumentation-hapi][otel-contrib-instrumentation-hapi]
-- [@opentelemetry/instrumentation-koa][otel-contrib-instrumentation-koa]
+These instrumentations are hosted at <https://github.com/open-telemetry/opentelemetry-js-contrib/tree/master/plugins/node>
 
 #### Web Instrumentations
 
@@ -272,11 +266,6 @@ These plugins are hosted at <https://github.com/open-telemetry/opentelemetry-js-
 ##### Contrib
 
 These instrumentations are hosted at <https://github.com/open-telemetry/opentelemetry-js-contrib/tree/master/plugins/web>
-
-- [@opentelemetry/instrumentation-document-load][otel-contrib-instrumentation-document-load]
-- [@opentelemetry/instrumentation-user-interaction][otel-contrib-instrumentation-user-interaction]
-
-To request automatic tracing support for a module not on this list, please [file an issue](https://github.com/open-telemetry/opentelemetry-js/issues). Alternatively, you can [write an instrumentation yourself](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/instrumentation-guide.md).
 
 ### Shims
 
@@ -552,17 +541,5 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [otel-core]: https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core
 [otel-propagator-b3]: https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-b3
 [generate-api-documentation]: https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md#generating-api-documentation
-
-[otel-contrib-instrumentation-dns]: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-dns
-[otel-contrib-instrumentation-ioredis]: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-ioredis
-[otel-contrib-instrumentation-mongodb]: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mongodb
-[otel-contrib-instrumentation-mysql]: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mysql
-[otel-contrib-instrumentation-pg]: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pg
-[otel-contrib-instrumentation-redis]: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-redis
-[otel-contrib-instrumentation-express]: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express
-[otel-contrib-instrumentation-user-interaction]: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-instrumentation-user-interaction
-[otel-contrib-instrumentation-document-load]: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-instrumentation-document-load
-[otel-contrib-instrumentation-hapi]: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-hapi
-[otel-contrib-instrumentation-koa]: https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-koa
 
 [spec-versioning]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/versioning-and-stability.md


### PR DESCRIPTION
## Which problem is this PR solving?

## Short description of the changes

Removed the contrib version column from compatibility matrix because contrib packages
no longer use a common version and release happens quite independent of core.
Therefore having this at a single place in this repo would result in mostly
incomplete/outdated information.

Removed links to individual contrib packages as the list was outdated already and it's
a maintenance pain to keep core repo up to date with unrelated contrib changes.

## Type of change

- [x] This change requires a documentation update


