### PR TITLE
feat(views): Update addView() to disallow named views that select more than one instrument.

### DIFF
--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
@@ -134,23 +134,17 @@ export class MeterProvider implements metrics.MeterProvider {
       throw new Error('Cannot create view with no view arguments supplied');
     }
 
-    // the SDK MUST NOT allow Views with a specified name to be declared with instrument selectors that select by instrument type or wildcard
-    if (options.name !== undefined) {
-      if (selectorOptions === undefined ||
-        (selectorOptions.instrument?.name === undefined && selectorOptions.instrument?.type === undefined)) {
-        throw new Error('Views with a specified name must be declared with an instrument selector that selects at most one instrument.');
-      }
-      if (selectorOptions?.instrument?.type !== undefined) {
-        throw new Error('Views with a specified name must not be declared with instrument selectors that select by instrument type.');
-      }
-      if (selectorOptions?.instrument?.name !== undefined && PatternPredicate.hasWildcard(selectorOptions.instrument.name)) {
-        throw new Error('Views with a specified name must not be declared with instrument selectors that select by wildcard.');
-      }
+    // the SDK SHOULD NOT allow Views with a specified name to be declared with instrument selectors that
+    // may select more than one instrument (e.g. wild card instrument name) in the same Meter.
+    if (options.name != null &&
+      (selectorOptions?.instrument?.name == null ||
+        PatternPredicate.hasWildcard(selectorOptions.instrument.name))) {
+      throw new Error('Views with a specified name must be declared with an instrument selector that selects at most one instrument per meter.');
     }
 
     // Create AttributesProcessor if attributeKeys are defined set.
     let attributesProcessor = undefined;
-    if (options.attributeKeys !== undefined) {
+    if (options.attributeKeys != null) {
       attributesProcessor = new FilteringAttributesProcessor(options.attributeKeys);
     }
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/index.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/index.ts
@@ -16,6 +16,7 @@
 
 export * from './export/AggregationTemporality';
 export * from './export/MetricData';
+export { MeterProvider, MeterProviderOptions } from './MeterProvider';
 export * from './export/MetricExporter';
 export * from './export/MetricProducer';
 export * from './export/MetricReader';
@@ -26,3 +27,4 @@ export * from './Meter';
 export * from './MeterProvider';
 export * from './ObservableResult';
 export { TimeoutError } from './utils';
+export { FilteringAttributesProcessor } from './view/AttributesProcessor';

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MetricStorageRegistry.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MetricStorageRegistry.ts
@@ -26,6 +26,10 @@ import { getConflictResolutionRecipe, getIncompatibilityDetails } from '../view/
 export class MetricStorageRegistry {
   private readonly _metricStorageRegistry = new Map<string, MetricStorage[]>();
 
+  static create(){
+    return new MetricStorageRegistry();
+  }
+
   getStorages(): MetricStorage[] {
     let storages: MetricStorage[] = [];
     for (const metricStorages of this._metricStorageRegistry.values()) {

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/view/Predicate.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/view/Predicate.ts
@@ -51,6 +51,10 @@ export class PatternPredicate implements Predicate {
   static escapePattern(pattern: string): string {
     return `^${pattern.replace(ESCAPE, '\\$&').replace('*', '.*')}$`;
   }
+
+  static hasWildcard(pattern: string): boolean{
+    return pattern.includes('*');
+  }
 }
 
 export class ExactPredicate implements Predicate {

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
@@ -16,9 +16,9 @@
 
 import * as assert from 'assert';
 import { NOOP_METER } from '@opentelemetry/api-metrics-wip';
-import { Meter } from '../src/Meter';
-import { MeterProvider } from '../src/MeterProvider';
-import { defaultResource } from './util';
+import { Meter, MeterProvider, InstrumentType, PointDataType } from '../src';
+import { assertMetricData, defaultResource } from './util';
+import { TestMetricReader } from './export/TestMetricReader';
 
 describe('MeterProvider', () => {
   describe('constructor', () => {
@@ -45,6 +45,194 @@ describe('MeterProvider', () => {
       meterProvider.shutdown();
       const meter = meterProvider.getMeter('meter1', '1.0.0');
       assert.strictEqual(meter, NOOP_METER);
+    });
+  });
+
+  describe('getView', () => {
+    it('with existing instrument should rename', async () => {
+      const meterProvider = new MeterProvider({ resource: defaultResource });
+
+      const reader = new TestMetricReader();
+      meterProvider.addMetricReader(reader);
+
+      meterProvider.addView({
+        name: 'renamed-instrument',
+        instrument: {
+          name: 'non-renamed-instrument',
+        },
+        stream: {
+          description: 'my renamed instrument',
+          attributeKeys: ['attrib1']
+        }
+      });
+
+      const myMeter = meterProvider.getMeter('meter1', '1.0.0');
+      const counter = myMeter.createCounter('non-renamed-instrument');
+      counter.add(1, { attrib1: 'attrib_value1', attrib2: 'attrib_value2' });
+
+      const result = await reader.collect();
+
+      assert.strictEqual(result?.instrumentationLibraryMetrics.length, 1);
+      assert.strictEqual(result?.instrumentationLibraryMetrics[0].instrumentationLibrary.name, 'meter1');
+
+      assertMetricData(result?.instrumentationLibraryMetrics[0].metrics[0], PointDataType.SINGULAR, {
+          name: 'renamed-instrument',
+          type: InstrumentType.COUNTER
+        });
+    });
+
+    it('with named view and instrument wildcard should throw', () => {
+      const meterProvider = new MeterProvider({ resource: defaultResource });
+
+      assert.throws(() => meterProvider.addView({
+        name: 'renamed-instrument',
+        instrument: {
+          name: '*'
+        }
+      }));
+
+      assert.throws(() => meterProvider.addView({
+        name: 'renamed-instrument',
+        instrument: {
+          name: 'other.instrument.*'
+        }
+      }));
+    });
+
+    it('with named view and instrument type selector should throw', () => {
+      const meterProvider = new MeterProvider({ resource: defaultResource });
+
+      assert.throws(() => meterProvider.addView({
+        name: 'renamed-instrument',
+        instrument: {
+          type: InstrumentType.COUNTER
+        }
+      }));
+    });
+
+    it('with no meter name should apply view to instruments of all meters', async () => {
+      const meterProvider = new MeterProvider({ resource: defaultResource });
+
+      const reader = new TestMetricReader();
+      meterProvider.addMetricReader(reader);
+
+      meterProvider.addView({
+        name: 'renamed-instrument',
+        instrument: {
+          name: 'test-counter'
+        }
+      });
+
+      const meter1 = meterProvider.getMeter('meter1', 'v1.0.0');
+      const meter2 = meterProvider.getMeter('meter2', 'v1.0.0');
+
+      const counter1 = meter1.createCounter('test-counter', { unit: 'ms' });
+      const counter2 = meter2.createCounter('test-counter', { unit: 'ms' });
+
+      counter1.add(1);
+      counter2.add(2);
+
+      const result = await reader.collect();
+
+      assert.strictEqual(result?.instrumentationLibraryMetrics.length, 2);
+
+      assert.strictEqual(result?.instrumentationLibraryMetrics[0].instrumentationLibrary.name, 'meter1');
+      assertMetricData(result?.instrumentationLibraryMetrics[0].metrics[0], PointDataType.SINGULAR, {
+        name: 'renamed-instrument',
+        type: InstrumentType.COUNTER,
+      });
+
+      assert.strictEqual(result?.instrumentationLibraryMetrics[1].instrumentationLibrary.name, 'meter2');
+      assertMetricData(result?.instrumentationLibraryMetrics[1].metrics[0], PointDataType.SINGULAR, {
+        name: 'renamed-instrument',
+        type: InstrumentType.COUNTER
+      });
+    });
+
+    it('with no meter name should apply view to only the selected meter', async () => {
+      const meterProvider = new MeterProvider({ resource: defaultResource });
+
+      const reader = new TestMetricReader();
+      meterProvider.addMetricReader(reader);
+
+      meterProvider.addView({
+        name: 'renamed-instrument',
+        instrument: {
+          name: 'test-counter'
+        },
+        meter: {
+          name: 'meter1'
+        }
+      });
+
+      const meter1 = meterProvider.getMeter('meter1', 'v1.0.0');
+      const meter2 = meterProvider.getMeter('meter2', 'v1.0.0');
+
+      const counter1 = meter1.createCounter('test-counter', { unit: 'ms' });
+      const counter2 = meter2.createCounter('test-counter', { unit: 'ms' });
+
+      counter1.add(1);
+      counter2.add(2);
+
+      const result = await reader.collect();
+
+      assert.strictEqual(result?.instrumentationLibraryMetrics.length, 2);
+      assert.strictEqual(result?.instrumentationLibraryMetrics[0].instrumentationLibrary.name, 'meter1');
+      assertMetricData(result?.instrumentationLibraryMetrics[0].metrics[0], PointDataType.SINGULAR, {
+          name: 'renamed-instrument',
+          type: InstrumentType.COUNTER
+        });
+
+      assert.strictEqual(result?.instrumentationLibraryMetrics[1].instrumentationLibrary.name, 'meter2');
+      assertMetricData(result?.instrumentationLibraryMetrics[1].metrics[0], PointDataType.SINGULAR, {
+          name: 'test-counter',
+          type: InstrumentType.COUNTER
+        });
+    });
+
+    it('with different instrument types does not throw', async () => {
+      const meterProvider = new MeterProvider({ resource: defaultResource });
+      const reader = new TestMetricReader();
+      meterProvider.addMetricReader(reader);
+
+      meterProvider.addView({
+        name: 'renamed-instrument',
+        instrument: {
+          name: 'test-counter'
+        },
+        meter: {
+          name: 'meter1'
+        }
+      });
+
+      meterProvider.addView({
+        name: 'renamed-instrument',
+        instrument: {
+          name: 'test-histogram'
+        },
+        meter: {
+          name: 'meter1'
+        }
+      });
+
+      const meter = meterProvider.getMeter('meter1', 'v1.0.0');
+
+      const counter = meter.createCounter('test-counter', { unit: 'ms' });
+      assert.doesNotThrow(() => meter.createHistogram('test-histogram', { unit: 'ms' }));
+
+      counter.add(1);
+
+      const result = await reader.collect();
+
+      assert.strictEqual(result?.instrumentationLibraryMetrics.length, 1);
+      assertMetricData(result?.instrumentationLibraryMetrics[0].metrics[0], PointDataType.SINGULAR, {
+          name: 'renamed-instrument',
+          type: InstrumentType.COUNTER
+        });
+      assertMetricData(result?.instrumentationLibraryMetrics[0].metrics[1], PointDataType.HISTOGRAM, {
+        name: 'renamed-instrument',
+        type: InstrumentType.HISTOGRAM
+      });
     });
   });
 });

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
@@ -53,7 +53,7 @@ describe('MeterProvider', () => {
     });
   });
 
-  describe('getView', () => {
+  describe('addView', () => {
     it('with named view and instrument wildcard should throw', () => {
       const meterProvider = new MeterProvider({ resource: defaultResource });
 
@@ -322,7 +322,7 @@ describe('MeterProvider', () => {
       counter.add(1);
       histogram.record(1);
 
-      // Collect.
+      // Perform collection.
       const result = await reader.collect();
 
       // Results came only from one Meter.

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
@@ -94,12 +94,16 @@ describe('MeterProvider', () => {
       const meterProvider = new MeterProvider({ resource: defaultResource });
 
       assert.throws(() => meterProvider.addView({
+        name: 'renamed-instrument'
+      }));
+
+      assert.throws(() => meterProvider.addView({
           name: 'renamed-instrument'
         },
         {}));
     });
 
-    it('with no parameters should throw', () => {
+    it('with no view parameters should throw', () => {
       const meterProvider = new MeterProvider({ resource: defaultResource });
 
       assert.throws(() => meterProvider.addView({}));

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
@@ -59,15 +59,18 @@ describe('MeterProvider', () => {
 
       // Throws with wildcard character only.
       assert.throws(() => meterProvider.addView({
-        name: 'renamed-instrument',
-        instrument: {
-          name: '*'
-        }
-      }));
+          name: 'renamed-instrument'
+        },
+        {
+          instrument: {
+            name: '*'
+          }
+        }));
 
       // Throws with wildcard character in instrument name.
       assert.throws(() => meterProvider.addView({
-        name: 'renamed-instrument',
+        name: 'renamed-instrument'
+      }, {
         instrument: {
           name: 'other.instrument.*'
         }
@@ -78,24 +81,28 @@ describe('MeterProvider', () => {
       const meterProvider = new MeterProvider({ resource: defaultResource });
 
       assert.throws(() => meterProvider.addView({
-        name: 'renamed-instrument',
-        instrument: {
-          type: InstrumentType.COUNTER
-        }
-      }));
+          name: 'renamed-instrument'
+        },
+        {
+          instrument: {
+            type: InstrumentType.COUNTER
+          }
+        }));
+    });
+
+    it('with named view and no instrument selector should throw', () => {
+      const meterProvider = new MeterProvider({ resource: defaultResource });
+
+      assert.throws(() => meterProvider.addView({
+          name: 'renamed-instrument'
+        },
+        {}));
     });
 
     it('with no parameters should throw', () => {
       const meterProvider = new MeterProvider({ resource: defaultResource });
 
       assert.throws(() => meterProvider.addView({}));
-      assert.throws(() => meterProvider.addView({ instrument: {} }));
-      assert.throws(() => meterProvider.addView({ instrument: {}, meter: {} }));
-      assert.throws(() => meterProvider.addView({ instrument: {}, meter: {}, stream: {} }));
-      assert.throws(() => meterProvider.addView({ instrument: {}, stream: {} }));
-      assert.throws(() => meterProvider.addView({ meter: {}, stream: {} }));
-      assert.throws(() => meterProvider.addView({ meter: {} }));
-      assert.throws(() => meterProvider.addView({ stream: {} }));
     });
 
     it('with existing instrument should rename', async () => {
@@ -106,14 +113,14 @@ describe('MeterProvider', () => {
 
       // Add view to rename 'non-renamed-instrument' to 'renamed-instrument'
       meterProvider.addView({
-        name: 'renamed-instrument',
-        instrument: {
-          name: 'non-renamed-instrument',
-        },
-        stream: {
+          name: 'renamed-instrument',
           description: 'my renamed instrument'
-        }
-      });
+        },
+        {
+          instrument: {
+            name: 'non-renamed-instrument',
+          },
+        });
 
       // Create meter and instrument.
       const myMeter = meterProvider.getMeter('meter1', 'v1.0.0');
@@ -165,13 +172,13 @@ describe('MeterProvider', () => {
 
       // Add view to drop all attributes except 'attrib1'
       meterProvider.addView({
-        instrument: {
-          name: 'non-renamed-instrument',
-        },
-        stream: {
           attributeKeys: ['attrib1']
-        }
-      });
+        },
+        {
+          instrument: {
+            name: 'non-renamed-instrument',
+          }
+        });
 
       // Create meter and instrument.
       const myMeter = meterProvider.getMeter('meter1', 'v1.0.0');
@@ -221,11 +228,13 @@ describe('MeterProvider', () => {
 
       // Add view that renames 'test-counter' to 'renamed-instrument'
       meterProvider.addView({
-        name: 'renamed-instrument',
-        instrument: {
-          name: 'test-counter'
-        }
-      });
+          name: 'renamed-instrument'
+        },
+        {
+          instrument: {
+            name: 'test-counter'
+          }
+        });
 
       // Create two meters.
       const meter1 = meterProvider.getMeter('meter1', 'v1.0.0');
@@ -284,14 +293,16 @@ describe('MeterProvider', () => {
 
       // Add view that renames 'test-counter' to 'renamed-instrument' on 'meter1'
       meterProvider.addView({
-        name: 'renamed-instrument',
-        instrument: {
-          name: 'test-counter'
+          name: 'renamed-instrument'
         },
-        meter: {
-          name: 'meter1'
-        }
-      });
+        {
+          instrument: {
+            name: 'test-counter'
+          },
+          meter: {
+            name: 'meter1'
+          }
+        });
 
       // Create two meters.
       const meter1 = meterProvider.getMeter('meter1', 'v1.0.0');
@@ -349,24 +360,28 @@ describe('MeterProvider', () => {
 
       // Add Views to rename both instruments (of different types) to the same name.
       meterProvider.addView({
-        name: 'renamed-instrument',
-        instrument: {
-          name: 'test-counter'
+          name: 'renamed-instrument'
         },
-        meter: {
-          name: 'meter1'
-        }
-      });
+        {
+          instrument: {
+            name: 'test-counter'
+          },
+          meter: {
+            name: 'meter1'
+          }
+        });
 
       meterProvider.addView({
-        name: 'renamed-instrument',
-        instrument: {
-          name: 'test-histogram'
+          name: 'renamed-instrument'
         },
-        meter: {
-          name: 'meter1'
-        }
-      });
+        {
+          instrument: {
+            name: 'test-histogram'
+          },
+          meter: {
+            name: 'meter1'
+          }
+        });
 
       // Create meter and instruments.
       const meter = meterProvider.getMeter('meter1', 'v1.0.0');

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
@@ -347,7 +347,6 @@ describe('MeterProvider', () => {
       const reader = new TestMetricReader();
       meterProvider.addMetricReader(reader);
 
-
       // Add Views to rename both instruments (of different types) to the same name.
       meterProvider.addView({
         name: 'renamed-instrument',

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/util.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/util.ts
@@ -18,9 +18,15 @@ import { Attributes, ValueType } from '@opentelemetry/api-metrics';
 import { InstrumentationLibrary } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
 import * as assert from 'assert';
-import { InstrumentDescriptor, InstrumentType } from '../src/InstrumentDescriptor';
-import { Histogram } from '../src/Instruments';
-import { MetricData, PointData, PointDataType } from '../src/export/MetricData';
+import {
+  InstrumentDescriptor,
+  InstrumentType,
+  Histogram,
+  MetricData,
+  PointData,
+  PointDataType,
+  InstrumentationLibraryMetrics
+} from '../src';
 import { Measurement } from '../src/Measurement';
 import { isNotNullish } from '../src/utils';
 import { HrTime } from '@opentelemetry/api';
@@ -44,14 +50,23 @@ export const defaultInstrumentationLibrary: InstrumentationLibrary = {
 };
 
 export const commonValues: number[] = [1, -1, 1.0, Infinity, -Infinity, NaN];
-export const commonAttributes: Attributes[] = [{}, {1: '1'}, {a: '2'}, new (class Foo{
-a = '1';
+export const commonAttributes: Attributes[] = [{}, { 1: '1' }, { a: '2' }, new (class Foo {
+  a = '1';
 })];
 
 export const sleep = (time: number) =>
   new Promise(resolve => {
     return setTimeout(resolve, time);
   });
+
+export function assertInstrumentationLibraryMetrics(
+  actual: unknown,
+  instrumentationLibrary: Partial<InstrumentationLibrary>
+): asserts actual is InstrumentationLibraryMetrics {
+  const it = actual as InstrumentationLibraryMetrics;
+  assertPartialDeepStrictEqual(it.instrumentationLibrary, instrumentationLibrary);
+  assert(Array.isArray(it.metrics));
+}
 
 export function assertMetricData(
   actual: unknown,


### PR DESCRIPTION
## Which problem is this PR solving?

This PR simplifies the the public API for `MeterProvider.addView()` as mentioned in #2592 and makes `addView()` adhere to the following spec statement:

> In order to avoid conflicts, views which specify a name SHOULD have an instrument selector that selects at most one instrument.  

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Unit tests

## Checklist:

- [ ] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
