### PR TITLE
feat(node-sdk): add serviceName config option

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to experimental packages in this project will be documented 
 
 * feat(opentelemetry-instrumentation-fetch): optionally ignore network events #3028 @gregolsen
 * feat(http-instrumentation): record exceptions in http instrumentation #3008 @luismiramirez
+* feat(node-sdk): add serviceName config option #2867 @naseemkullah
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -128,6 +128,10 @@ Configure a trace exporter. If an exporter OR span processor is not configured, 
 
 Configure tracing parameters. These are the same trace parameters used to [configure a tracer](../../../packages/opentelemetry-sdk-trace-base/src/types.ts#L71).
 
+### serviceName
+
+Configure the [service name](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service).
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/experimental/packages/opentelemetry-sdk-node/src/types.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/types.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import { SpanAttributes, TextMapPropagator, Sampler } from '@opentelemetry/api';
-import type { ContextManager } from '@opentelemetry/api';
+import type { ContextManager, SpanAttributes } from '@opentelemetry/api';
+import { Sampler, TextMapPropagator } from '@opentelemetry/api';
 import { InstrumentationOption } from '@opentelemetry/instrumentation';
-import { MetricReader } from '@opentelemetry/sdk-metrics-base';
 import { Resource } from '@opentelemetry/resources';
+import { MetricReader } from '@opentelemetry/sdk-metrics-base';
 import {
   SpanExporter,
-  SpanProcessor,
   SpanLimits,
+  SpanProcessor
 } from '@opentelemetry/sdk-trace-base';
 
 export interface NodeSDKConfiguration {
@@ -34,6 +34,7 @@ export interface NodeSDKConfiguration {
   instrumentations: InstrumentationOption[];
   resource: Resource;
   sampler: Sampler;
+  serviceName?: string;
   spanProcessor: SpanProcessor;
   traceExporter: SpanExporter;
   spanLimits: SpanLimits;

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -261,4 +261,76 @@ describe('Node SDK', () => {
       });
     });
   });
+
+  describe('configureServiceName', async () => {
+    it('should configure service name via config', async () => {
+      const sdk = new NodeSDK({
+        serviceName: 'config-set-name',
+      });
+
+      await sdk.start();
+      const resource = sdk['_resource'];
+
+      assertServiceResource(resource, {
+        name: 'config-set-name',
+      });
+    });
+
+    it('should configure service name via OTEL_SERVICE_NAME env var', async () => {
+      process.env.OTEL_SERVICE_NAME='env-set-name';
+      const sdk = new NodeSDK();
+
+      await sdk.start();
+      const resource = sdk['_resource'];
+
+      assertServiceResource(resource, {
+        name: 'env-set-name',
+      });
+      delete process.env.OTEL_SERVICE_NAME;
+    });
+
+    it('should favor config set service name over OTEL_SERVICE_NAME env set service name', async () => {
+      process.env.OTEL_SERVICE_NAME='env-set-name';
+      const sdk = new NodeSDK({
+        serviceName: 'config-set-name',
+      });
+
+      await sdk.start();
+      const resource = sdk['_resource'];
+
+      assertServiceResource(resource, {
+        name: 'config-set-name',
+      });
+      delete process.env.OTEL_SERVICE_NAME;
+    });
+
+
+    it('should configure service name via OTEL_RESOURCE_ATTRIBUTES env var', async () => {
+      process.env.OTEL_RESOURCE_ATTRIBUTES = 'service.name=resource-env-set-name';
+      const sdk = new NodeSDK();
+
+      await sdk.start();
+      const resource = sdk['_resource'];
+
+      assertServiceResource(resource, {
+        name: 'resource-env-set-name',
+      });
+      delete process.env.OTEL_RESOURCE_ATTRIBUTES;
+    });
+
+    it('should favor config set service name over OTEL_RESOURCE_ATTRIBUTES env set service name', async () => {
+      process.env.OTEL_RESOURCE_ATTRIBUTES = 'service.name=resource-env-set-name';
+      const sdk = new NodeSDK({
+        serviceName: 'config-set-name',
+      });
+
+      await sdk.start();
+      const resource = sdk['_resource'];
+
+      assertServiceResource(resource, {
+        name: 'config-set-name',
+      });
+      delete process.env.OTEL_RESOURCE_ATTRIBUTES;
+    });
+  });
 });

--- a/experimental/packages/opentelemetry-sdk-node/test/util/resource-assertions.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/util/resource-assertions.ts
@@ -232,7 +232,7 @@ export const assertServiceResource = (
   resource: Resource,
   validations: {
     name: string;
-    instanceId: string;
+    instanceId?: string;
     namespace?: string;
     version?: string;
   }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes #2799

configure service name directly in the node SDK config

## Short description of the changes

add optional serviceName option in node SDK constructor, which behind the scenes creates another resource that is merged with any one that may have been passed in. this occurs after autoDetectResources so that the in code config set service name trumps any env set service name

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] unit tests

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
