### PR TITLE
feat: remove -wip suffix in metrics packages

### DIFF
--- a/experimental/packages/opentelemetry-api-metrics/package.json
+++ b/experimental/packages/opentelemetry-api-metrics/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@opentelemetry/api-metrics-wip",
+  "name": "@opentelemetry/api-metrics",
   "version": "0.27.0",
   "private": true,
   "description": "Public metrics API for OpenTelemetry",

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -59,8 +59,8 @@
     "@opentelemetry/api": "^1.0.3"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics-wip": "0.27.0",
+    "@opentelemetry/api-metrics": "0.27.0",
     "@opentelemetry/core": "1.0.1",
-    "@opentelemetry/sdk-metrics-base-wip": "0.27.0"
+    "@opentelemetry/sdk-metrics-base": "0.27.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -18,7 +18,7 @@ import { diag } from '@opentelemetry/api';
 import {
   globalErrorHandler,
 } from '@opentelemetry/core';
-import { AggregationTemporality, MetricReader } from '@opentelemetry/sdk-metrics-base-wip';
+import { AggregationTemporality, MetricReader } from '@opentelemetry/sdk-metrics-base';
 import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
 import { ExporterConfig } from './export/types';
 import { PrometheusSerializer } from './PrometheusSerializer';

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -23,8 +23,8 @@ import {
   MetricData,
   DataPoint,
   Histogram,
-} from '@opentelemetry/sdk-metrics-base-wip';
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+} from '@opentelemetry/sdk-metrics-base';
+import { Attributes } from '@opentelemetry/api-metrics';
 import { hrTimeToMilliseconds } from '@opentelemetry/core';
 
 type PrometheusDataTypeLiteral =

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import { Meter, ObservableResult } from '@opentelemetry/api-metrics-wip';
+import { Meter, ObservableResult } from '@opentelemetry/api-metrics';
 import {
   MeterProvider,
-} from '@opentelemetry/sdk-metrics-base-wip';
+} from '@opentelemetry/sdk-metrics-base';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as http from 'http';
 import { PrometheusExporter } from '../src';
 import { mockedHrTimeMs, mockHrTime } from './util';
 import { SinonStubbedInstance } from 'sinon';
-import { Counter } from '@opentelemetry/api-metrics-wip';
+import { Counter } from '@opentelemetry/api-metrics';
 
 describe('PrometheusExporter', () => {
   beforeEach(() => {

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -15,7 +15,7 @@
  */
 
 import * as assert from 'assert';
-import { Attributes, UpDownCounter } from '@opentelemetry/api-metrics-wip';
+import { Attributes, UpDownCounter } from '@opentelemetry/api-metrics';
 import {
   AggregationTemporality,
   MeterProvider,
@@ -25,7 +25,7 @@ import {
   HistogramAggregation,
   SumAggregation,
   Histogram,
-} from '@opentelemetry/sdk-metrics-base-wip';
+} from '@opentelemetry/sdk-metrics-base';
 import * as sinon from 'sinon';
 import { PrometheusSerializer } from '../src/PrometheusSerializer';
 import { mockedHrTimeMs, mockHrTime } from './util';

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@opentelemetry/sdk-metrics-base-wip",
+  "name": "@opentelemetry/sdk-metrics-base",
   "version": "0.27.0",
   "private": true,
   "description": "Work in progress OpenTelemetry metrics SDK",
@@ -78,7 +78,7 @@
   },
   "todo": "Move API metrics to peer dependencies. While it is using an unpublished name, lerna doesn't properly link it if it is in peer dependencies",
   "dependencies": {
-    "@opentelemetry/api-metrics-wip": "0.27.0",
+    "@opentelemetry/api-metrics": "0.27.0",
     "@opentelemetry/core": "1.0.1",
     "@opentelemetry/resources": "1.0.1",
     "lodash.merge": "4.6.2"

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/InstrumentDescriptor.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/InstrumentDescriptor.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { MetricOptions, ValueType } from '@opentelemetry/api-metrics-wip';
+import { MetricOptions, ValueType } from '@opentelemetry/api-metrics';
 import { View } from './view/View';
 
 /**

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Instruments.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Instruments.ts
@@ -15,7 +15,7 @@
  */
 
 import * as api from '@opentelemetry/api';
-import * as metrics from '@opentelemetry/api-metrics-wip';
+import * as metrics from '@opentelemetry/api-metrics';
 import { InstrumentDescriptor } from './InstrumentDescriptor';
 import { WritableMetricStorage } from './state/WritableMetricStorage';
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Measurement.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Measurement.ts
@@ -15,7 +15,7 @@
  */
 
 import * as api from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#measurement
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Meter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as metrics from '@opentelemetry/api-metrics-wip';
+import * as metrics from '@opentelemetry/api-metrics';
 import { InstrumentationLibrary } from '@opentelemetry/core';
 import { createInstrumentDescriptor, InstrumentDescriptor, InstrumentType } from './InstrumentDescriptor';
 import { CounterInstrument, HistogramInstrument, UpDownCounterInstrument } from './Instruments';

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/MeterProvider.ts
@@ -15,7 +15,7 @@
  */
 
 import * as api from '@opentelemetry/api';
-import * as metrics from '@opentelemetry/api-metrics-wip';
+import * as metrics from '@opentelemetry/api-metrics';
 import { Resource } from '@opentelemetry/resources';
 import { Meter } from './Meter';
 import { MetricReader } from './export/MetricReader';

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/ObservableResult.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/ObservableResult.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as metrics from '@opentelemetry/api-metrics-wip';
+import * as metrics from '@opentelemetry/api-metrics';
 import { AttributeHashMap } from './state/HashMap';
 
 /**

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/AlignedHistogramBucketExemplarReservoir.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/AlignedHistogramBucketExemplarReservoir.ts
@@ -16,7 +16,7 @@
 
 
 import { Context, HrTime } from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 import { FixedSizeExemplarReservoirBase } from './ExemplarReservoir';
 
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/AlwaysSampleExemplarFilter.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/AlwaysSampleExemplarFilter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 import { Context, HrTime } from '@opentelemetry/api';
 import { ExemplarFilter } from './ExemplarFilter';
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/Exemplar.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/Exemplar.ts
@@ -15,7 +15,7 @@
  */
 
 import { HrTime } from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 
 /**
  * A representation of an exemplar, which is a sample input measurement.

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/ExemplarFilter.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/ExemplarFilter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 import { Context, HrTime } from '@opentelemetry/api';
 
 /**

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/ExemplarReservoir.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/ExemplarReservoir.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 import { Context, HrTime, isSpanContextValid, trace } from '@opentelemetry/api';
 import { Exemplar } from './Exemplar';
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/NeverSampleExemplarFilter.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/NeverSampleExemplarFilter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 import { Context, HrTime } from '@opentelemetry/api';
 import { ExemplarFilter } from './ExemplarFilter';
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/SimpleFixedSizeExemplarReservoir.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/SimpleFixedSizeExemplarReservoir.ts
@@ -15,7 +15,7 @@
  */
 
 import { Context, HrTime } from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 import { FixedSizeExemplarReservoirBase } from './ExemplarReservoir';
 
 /**

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/WithTraceExemplarFilter.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/exemplar/WithTraceExemplarFilter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 import { Context, HrTime, isSpanContextValid, trace, TraceFlags } from '@opentelemetry/api';
 import { ExemplarFilter } from './ExemplarFilter';
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/AsyncMetricStorage.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/AsyncMetricStorage.ts
@@ -15,7 +15,7 @@
  */
 
 import { HrTime } from '@opentelemetry/api';
-import { ObservableCallback } from '@opentelemetry/api-metrics-wip';
+import { ObservableCallback } from '@opentelemetry/api-metrics';
 import { Accumulation, Aggregator } from '../aggregator/types';
 import { View } from '../view/View';
 import {

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/DeltaMetricProcessor.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/DeltaMetricProcessor.ts
@@ -15,7 +15,7 @@
  */
 
 import { Context } from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 import { Maybe } from '../utils';
 import { Accumulation, Aggregator } from '../aggregator/types';
 import { AttributeHashMap } from './HashMap';

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/HashMap.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/HashMap.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 import { hashAttributes } from '../utils';
 
 export interface Hash<ValueType, HashCodeType> {

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MultiWritableMetricStorage.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MultiWritableMetricStorage.ts
@@ -15,7 +15,7 @@
  */
 
 import { Context } from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 import { WritableMetricStorage } from './WritableMetricStorage';
 
 /**

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/SyncMetricStorage.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/SyncMetricStorage.ts
@@ -15,7 +15,7 @@
  */
 
 import { Context, HrTime } from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 import { WritableMetricStorage } from './WritableMetricStorage';
 import { Accumulation, Aggregator } from '../aggregator/types';
 import { View } from '../view/View';

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/WritableMetricStorage.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/WritableMetricStorage.ts
@@ -15,7 +15,7 @@
  */
 
 import { Context } from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 
 /**
  * Internal interface.

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 
 export type Maybe<T> = T | undefined;
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/view/AttributesProcessor.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/view/AttributesProcessor.ts
@@ -15,7 +15,7 @@
  */
 
 import { Context } from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 
 /**
  * The {@link AttributesProcessor} is responsible for customizing which

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/Instruments.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/Instruments.test.ts
@@ -22,7 +22,7 @@ import { AggregationTemporality, InstrumentDescriptor, InstrumentType, MeterProv
 import { TestMetricReader } from './export/TestMetricReader';
 import { assertMetricData, assertDataPoint, commonValues, commonAttributes, defaultResource, defaultInstrumentationLibrary } from './util';
 import { Histogram } from '../src/aggregator/types';
-import { ObservableResult, ValueType } from '@opentelemetry/api-metrics-wip';
+import { ObservableResult, ValueType } from '@opentelemetry/api-metrics';
 
 describe('Instruments', () => {
   describe('Counter', () => {

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/Meter.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/Meter.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ObservableCallback } from '@opentelemetry/api-metrics-wip';
+import { ObservableCallback } from '@opentelemetry/api-metrics';
 import * as assert from 'assert';
 import { CounterInstrument, HistogramInstrument, UpDownCounterInstrument } from '../src/Instruments';
 import { Meter } from '../src/Meter';

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
@@ -15,7 +15,7 @@
  */
 
 import * as assert from 'assert';
-import { NOOP_METER } from '@opentelemetry/api-metrics-wip';
+import { NOOP_METER } from '@opentelemetry/api-metrics';
 import { Meter, MeterProvider, InstrumentType, DataPointType } from '../src';
 import {
   assertInstrumentationLibraryMetrics,

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/state/AsyncMetricStorage.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/state/AsyncMetricStorage.test.ts
@@ -24,7 +24,7 @@ import { MetricCollectorHandle } from '../../src/state/MetricCollector';
 import { AsyncMetricStorage } from '../../src/state/AsyncMetricStorage';
 import { NoopAttributesProcessor } from '../../src/view/AttributesProcessor';
 import { assertMetricData, assertDataPoint, defaultInstrumentDescriptor } from '../util';
-import { ObservableCallback } from '@opentelemetry/api-metrics-wip';
+import { ObservableCallback } from '@opentelemetry/api-metrics';
 
 const deltaCollector: MetricCollectorHandle = {
   aggregatorTemporality: AggregationTemporality.DELTA,

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/state/HashMap.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/state/HashMap.test.ts
@@ -15,7 +15,7 @@
  */
 
 import * as assert from 'assert';
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 import { HashMap } from '../../src/state/HashMap';
 import { hashAttributes } from '../../src/utils';
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/state/MetricStorageRegistry.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/state/MetricStorageRegistry.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { MetricStorageRegistry } from '../../src/state/MetricStorageRegistry';
-import { ValueType } from '@opentelemetry/api-metrics-wip';
+import { ValueType } from '@opentelemetry/api-metrics';
 import { MetricStorage } from '../../src/state/MetricStorage';
 import { HrTime } from '@opentelemetry/api';
 import { MetricCollectorHandle } from '../../src/state/MetricCollector';

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/state/MultiWritableMetricStorage.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/state/MultiWritableMetricStorage.test.ts
@@ -15,7 +15,7 @@
  */
 
 import * as api from '@opentelemetry/api';
-import { Attributes } from '@opentelemetry/api-metrics-wip';
+import { Attributes } from '@opentelemetry/api-metrics';
 import * as assert from 'assert';
 import { Measurement } from '../../src/Measurement';
 import { MultiMetricStorage } from '../../src/state/MultiWritableMetricStorage';


### PR DESCRIPTION

## Which problem is this PR solving?

These packages are already been marked as private, so they don't get published before they are ready to go.

Refs: https://github.com/open-telemetry/opentelemetry-js/pull/2871#discussion_r836905154

## Type of change

- [x] New feature (non-breaking change which adds functionality)

Not really a new feature. This is breaking but we have not published these packages yet so I just marking it as new-feature as it is kinda significant.

## Checklist:

- [x] Followed the style guidelines of this project
