### PR TITLE
fix(otlp-http-exporter): remove content length header

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to experimental packages in this project will be documented 
 
 * [#2707](https://github.com/open-telemetry/opentelemetry-js/pull/2707) feat(sdk-metrics-base): update metric exporter interfaces ([@srikanthccv](https://github.com/srikanthccv))
 * [#2687](https://github.com/open-telemetry/opentelemetry-js/pull/2687) feat(api-metrics): remove observable types ([@legendecas](https://github.com/legendecas))
+* [#2879](https://github.com/open-telemetry/opentelemetry-js/pull/2879) fix(otlp-http-exporter): remove content length header ([@svetlanabrennan](https://github.com/svetlanabrennan))
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/node/util.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/node/util.ts
@@ -50,7 +50,6 @@ export function sendWithHttp<ExportItem, ServiceRequest>(
     path: parsedUrl.pathname,
     method: 'POST',
     headers: {
-      'Content-Length': Buffer.byteLength(data),
       'Content-Type': contentType,
       ...collector.headers,
     },
@@ -88,7 +87,6 @@ export function sendWithHttp<ExportItem, ServiceRequest>(
         gzip = zlib.createGzip();
       }
       req.setHeader('Content-Encoding', 'gzip');
-      req.removeHeader('Content-Length');
       const dataStream = readableFromBuffer(data);
       dataStream.on('error', onError)
         .pipe(gzip).on('error', onError)
@@ -97,6 +95,7 @@ export function sendWithHttp<ExportItem, ServiceRequest>(
       break;
     }
     default:
+      req.setHeader('Content-Length', Buffer.byteLength(data));
       req.write(data);
       req.end();
 

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/node/util.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/node/util.ts
@@ -95,10 +95,7 @@ export function sendWithHttp<ExportItem, ServiceRequest>(
       break;
     }
     default:
-      req.setHeader('Content-Length', Buffer.byteLength(data));
-      req.write(data);
-      req.end();
-
+      req.end(data);
       break;
   }
 }

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/node/util.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/node/util.ts
@@ -88,6 +88,7 @@ export function sendWithHttp<ExportItem, ServiceRequest>(
         gzip = zlib.createGzip();
       }
       req.setHeader('Content-Encoding', 'gzip');
+      req.removeHeader('Content-Length');
       const dataStream = readableFromBuffer(data);
       dataStream.on('error', onError)
         .pipe(gzip).on('error', onError)

--- a/experimental/packages/exporter-trace-otlp-http/test/node/CollectorTraceExporter.test.ts
+++ b/experimental/packages/exporter-trace-otlp-http/test/node/CollectorTraceExporter.test.ts
@@ -287,6 +287,7 @@ describe('OTLPTraceExporter - node with json over http', () => {
       stubRequest = sinon.stub(http, 'request').returns(fakeRequest as any);
       spySetHeader = sinon.spy();
       (fakeRequest as any).setHeader = spySetHeader;
+      (fakeRequest as any).removeHeader = sinon.spy();
       collectorExporterConfig = {
         headers: {
           foo: 'bar',

--- a/experimental/packages/exporter-trace-otlp-http/test/node/CollectorTraceExporter.test.ts
+++ b/experimental/packages/exporter-trace-otlp-http/test/node/CollectorTraceExporter.test.ts
@@ -287,7 +287,6 @@ describe('OTLPTraceExporter - node with json over http', () => {
       stubRequest = sinon.stub(http, 'request').returns(fakeRequest as any);
       spySetHeader = sinon.spy();
       (fakeRequest as any).setHeader = spySetHeader;
-      (fakeRequest as any).removeHeader = sinon.spy();
       collectorExporterConfig = {
         headers: {
           foo: 'bar',

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/CollectorMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/CollectorMetricExporter.test.ts
@@ -148,7 +148,7 @@ describe('OTLPMetricExporter - node with json over http', () => {
   describe('export', () => {
     beforeEach(async () => {
       stubRequest = sinon.stub(http, 'request').returns(fakeRequest as any);
-      stubWrite = sinon.stub(fakeRequest, 'write');
+      stubWrite = sinon.stub(fakeRequest, 'end');
       collectorExporterConfig = {
         headers: {
           foo: 'bar',

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/OTLPMetricExporter.test.ts
@@ -179,9 +179,9 @@ describe('OTLPMetricExporter - node with proto over http', () => {
       collectorExporter.export(metrics, () => {});
 
       sinon.stub(http, 'request').returns({
-        end: () => {},
+        write: () => {},
         on: () => {},
-        write: (...writeArgs: any[]) => {
+        end: (...writeArgs: any[]) => {
           const ExportTraceServiceRequestProto = getExportRequestProto();
           const data = ExportTraceServiceRequestProto?.decode(writeArgs[0]);
           const json = data?.toJSON() as otlpTypes.opentelemetryProto.collector.metrics.v1.ExportMetricsServiceRequest;


### PR DESCRIPTION
Signed-off-by: Svetlana Brennan <svetlana.svn@gmail.com>

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

OTLP/HTTP and OLTP/PROTO trace exporters are unable to export when gzip compression is used. 

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #2876

## Short description of the changes

Removed `content-length` header when gzip is used. Content-length header was setting the uncompressed length which was causing a timeout export issue. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Updated existing unit test

## Checklist:

- [x] Followed the style guidelines of this project
