### PR TITLE
chore: remove husky hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,6 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@commitlint/cli": "14.1.0",
-    "@commitlint/config-conventional": "14.1.0",
     "@typescript-eslint/eslint-plugin": "5.3.1",
     "@typescript-eslint/parser": "5.3.1",
     "eslint": "7.32.0",
@@ -58,7 +56,6 @@
     "eslint-plugin-import": "2.25.3",
     "eslint-plugin-node": "11.1.0",
     "gh-pages": "3.2.3",
-    "husky": "4.3.8",
     "lerna": "3.22.1",
     "lerna-changelog": "1.0.1",
     "linkinator": "3.0.3",
@@ -67,12 +64,6 @@
     "typedoc": "0.22.10",
     "typescript": "4.4.4",
     "update-ts-references": "2.4.1"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run lint:changed",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
   },
   "changelog": {
     "repo": "open-telemetry/opentelemetry-js",


### PR DESCRIPTION
Fixes #2078 

Remove husky and commitlint. Now that we're using manual changelogs, we don't need to enforce conventional commits so strictly in this repository. I still think we should strive to use them in PR titles, but I have found myself being mostly annoyed by the enforced hooks and using `--no-verify` flag most of the time.