### PR TITLE
feat: warn when hooked module is already loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### :rocket: (Enhancement)
 
 * feat(ConsoleSpanExporter): export span links [#2917](https://github.com/open-telemetry/opentelemetry-js/pull/2917) @trentm
+* feat: warn when hooked module is already loaded [#2926](https://github.com/open-telemetry/opentelemetry-js/pull/2926) @nozik
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -52,8 +52,6 @@ export abstract class InstrumentationBase<T = any>
         'No modules instrumentation has been defined,' +
         ' nothing will be patched'
       );
-    } else {
-      this._warnOnPreloadedModules();
     }
 
     if (this._config.enabled) {
@@ -62,25 +60,18 @@ export abstract class InstrumentationBase<T = any>
   }
 
   private _warnOnPreloadedModules(): void {
-    const preloadedModules: string[] = [];
     this._modules.forEach((module: InstrumentationModuleDefinition<T>) => {
       const { name } = module;
       try {
         const resolvedModule = require.resolve(name);
         if (require.cache[resolvedModule]) {
           // Module is already cached, which means the instrumentation hook might not work
-          preloadedModules.push(name);
+          this._diag.warn(`Module ${name} has been loaded before ${this.instrumentationName} so it might not work, please initialize it before requiring ${name}`);
         }
       } catch {
         // Module isn't available, we can simply skip
       }
     });
-
-    if (!preloadedModules.length) {
-      return;
-    }
-
-    this._diag.warn(`Some modules (${preloadedModules.join(', ')}) were already required when their respective plugin was loaded, some plugins might not work. Make sure the SDK is setup before you require in other modules.`);
   }
 
   private _extractPackageVersion(baseDir: string): string | undefined {
@@ -158,6 +149,7 @@ export abstract class InstrumentationBase<T = any>
       return;
     }
 
+    this._warnOnPreloadedModules();
     for (const module of this._modules) {
       this._hooks.push(
         RequireInTheMiddle(


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

A common pitfall for OTEL JS is modules that are `required` before the require-in-the-middle hook is set. In many cases, the end users don't understand why certain instrumentations aren't working, while others do.

## Short description of the changes

Check the require cache when initializing each instrumentation, and alert if the module was already loaded. In case it was - log a warning.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manually

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
