### PR TITLE
Include metrics in release

### DIFF
--- a/experimental/packages/opentelemetry-api-metrics/package.json
+++ b/experimental/packages/opentelemetry-api-metrics/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@opentelemetry/api-metrics",
   "version": "0.28.0",
-  "private": true,
   "description": "Public metrics API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
   "version": "0.28.0",
-  "private": true,
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics-base",
   "version": "0.28.0",
-  "private": true,
   "description": "Work in progress OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",


### PR DESCRIPTION
Metrics packages were left out of the release on friday because they were marked private