### PR TITLE
Use interface for span in span processor

### DIFF
--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { SDK_INFO } from '@opentelemetry/core';
-import { ResourceAttributes } from './types';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { defaultServiceName } from './platform';
+import { IResource, ResourceAttributes } from './types';
 
 /**
  * A Resource describes the entity for which a signals (metrics or trace) are
  * collected.
  */
-export class Resource {
+export class Resource implements IResource {
   static readonly EMPTY = new Resource({});
 
   /**

--- a/packages/opentelemetry-resources/src/types.ts
+++ b/packages/opentelemetry-resources/src/types.ts
@@ -17,6 +17,11 @@
 import { Resource } from './Resource';
 import { ResourceDetectionConfig } from './config';
 
+export interface IResource {
+  readonly attributes: ResourceAttributes
+  merge(other: IResource | null): IResource
+}
+
 /** Interface for Resource attributes  */
 export interface ResourceAttributes {
   [key: string]: number | string | boolean;

--- a/packages/opentelemetry-sdk-trace-base/src/MultiSpanProcessor.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/MultiSpanProcessor.ts
@@ -17,7 +17,7 @@
 import { Context } from '@opentelemetry/api';
 import { globalErrorHandler } from '@opentelemetry/core';
 import { ReadableSpan } from './export/ReadableSpan';
-import { Span } from './Span';
+import { WriteableSpan } from './export/WriteableSpan';
 import { SpanProcessor } from './SpanProcessor';
 
 /**
@@ -47,7 +47,7 @@ export class MultiSpanProcessor implements SpanProcessor {
     });
   }
 
-  onStart(span: Span, context: Context): void {
+  onStart(span: WriteableSpan, context: Context): void {
     for (const spanProcessor of this._spanProcessors) {
       spanProcessor.onStart(span, context);
     }

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -15,29 +15,30 @@
  */
 
 import * as api from '@opentelemetry/api';
+import { Context, SpanAttributeValue } from '@opentelemetry/api';
 import {
-  isAttributeValue,
   hrTime,
   hrTimeDuration,
   InstrumentationLibrary,
+  isAttributeValue,
   isTimeInput,
-  timeInputToHrTime,
   sanitizeAttributes,
+  timeInputToHrTime
 } from '@opentelemetry/core';
-import { Resource } from '@opentelemetry/resources';
+import { IResource } from '@opentelemetry/resources';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { ExceptionEventName } from './enums';
 import { ReadableSpan } from './export/ReadableSpan';
+import { WriteableSpan } from './export/WriteableSpan';
+import { SpanProcessor } from './SpanProcessor';
 import { TimedEvent } from './TimedEvent';
 import { Tracer } from './Tracer';
-import { SpanProcessor } from './SpanProcessor';
 import { SpanLimits } from './types';
-import { SpanAttributeValue, Context } from '@opentelemetry/api';
-import { ExceptionEventName } from './enums';
 
 /**
  * This class represents a span.
  */
-export class Span implements api.Span, ReadableSpan {
+export class Span implements api.Span, ReadableSpan, WriteableSpan {
   // Below properties are included to implement ReadableSpan for export
   // purposes but are not intended to be written-to directly.
   private readonly _spanContext: api.SpanContext;
@@ -47,7 +48,7 @@ export class Span implements api.Span, ReadableSpan {
   readonly links: api.Link[] = [];
   readonly events: TimedEvent[] = [];
   readonly startTime: api.HrTime;
-  readonly resource: Resource;
+  readonly resource: IResource;
   readonly instrumentationLibrary: InstrumentationLibrary;
   name: string;
   status: api.SpanStatus = {
@@ -103,7 +104,7 @@ export class Span implements api.Span, ReadableSpan {
 
     if (
       Object.keys(this.attributes).length >=
-        this._spanLimits.attributeCountLimit! &&
+      this._spanLimits.attributeCountLimit! &&
       !Object.prototype.hasOwnProperty.call(this.attributes, key)
     ) {
       return this;

--- a/packages/opentelemetry-sdk-trace-base/src/SpanProcessor.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/SpanProcessor.ts
@@ -16,7 +16,7 @@
 
 import { Context } from '@opentelemetry/api';
 import { ReadableSpan } from './export/ReadableSpan';
-import { Span } from './Span';
+import { WriteableSpan } from './export/WriteableSpan';
 
 /**
  * SpanProcessor is the interface Tracer SDK uses to allow synchronous hooks
@@ -33,7 +33,7 @@ export interface SpanProcessor {
    * returns true.
    * @param span the Span that just started.
    */
-  onStart(span: Span, parentContext: Context): void;
+  onStart(span: WriteableSpan, parentContext: Context): void;
 
   /**
    * Called when a {@link ReadableSpan} is ended, if the `span.isRecording()`

--- a/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
@@ -21,13 +21,13 @@ import {
   getEnv,
   globalErrorHandler,
   suppressTracing,
-  unrefTimer,
+  unrefTimer
 } from '@opentelemetry/core';
-import { Span } from '../Span';
 import { SpanProcessor } from '../SpanProcessor';
 import { BufferConfig } from '../types';
 import { ReadableSpan } from './ReadableSpan';
 import { SpanExporter } from './SpanExporter';
+import { WriteableSpan } from './WriteableSpan';
 
 /**
  * Implementation of the {@link SpanProcessor} that batches spans exported by
@@ -73,7 +73,7 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig> implements 
   }
 
   // does nothing.
-  onStart(_span: Span, _parentContext: Context): void {}
+  onStart(_span: WriteableSpan, _parentContext: Context): void {}
 
   onEnd(span: ReadableSpan): void {
     if (this._shutdownOnce.isCalled) {

--- a/packages/opentelemetry-sdk-trace-base/src/export/NoopSpanProcessor.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/NoopSpanProcessor.ts
@@ -15,13 +15,13 @@
  */
 
 import { Context } from '@opentelemetry/api';
-import { ReadableSpan } from './ReadableSpan';
-import { Span } from '../Span';
 import { SpanProcessor } from '../SpanProcessor';
+import { ReadableSpan } from './ReadableSpan';
+import { WriteableSpan } from './WriteableSpan';
 
 /** No-op implementation of SpanProcessor */
 export class NoopSpanProcessor implements SpanProcessor {
-  onStart(_span: Span, _context: Context): void {}
+  onStart(_span: WriteableSpan, _context: Context): void {}
   onEnd(_span: ReadableSpan): void {}
   shutdown(): Promise<void> {
     return Promise.resolve();

--- a/packages/opentelemetry-sdk-trace-base/src/export/SimpleSpanProcessor.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/SimpleSpanProcessor.ts
@@ -16,15 +16,14 @@
 
 import { context, Context, TraceFlags } from '@opentelemetry/api';
 import {
-  ExportResultCode,
+  BindOnceFuture, ExportResultCode,
   globalErrorHandler,
-  suppressTracing,
-  BindOnceFuture,
+  suppressTracing
 } from '@opentelemetry/core';
-import { Span } from '../Span';
 import { SpanProcessor } from '../SpanProcessor';
 import { ReadableSpan } from './ReadableSpan';
 import { SpanExporter } from './SpanExporter';
+import { WriteableSpan } from './WriteableSpan';
 
 /**
  * An implementation of the {@link SpanProcessor} that converts the {@link Span}
@@ -45,7 +44,7 @@ export class SimpleSpanProcessor implements SpanProcessor {
   }
 
   // does nothing.
-  onStart(_span: Span, _parentContext: Context): void {}
+  onStart(_span: WriteableSpan, _parentContext: Context): void {}
 
   onEnd(span: ReadableSpan): void {
     if (this._shutdownOnce.isCalled) {

--- a/packages/opentelemetry-sdk-trace-base/src/export/WriteableSpan.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/WriteableSpan.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as api from '@opentelemetry/api';
+import { SpanAttributeValue } from '@opentelemetry/api';
+import {
+  InstrumentationLibrary
+} from '@opentelemetry/core';
+import { IResource } from '@opentelemetry/resources';
+import { TimedEvent } from '../TimedEvent';
+
+export interface WriteableSpan extends api.Span {
+    readonly kind: api.SpanKind;
+    readonly parentSpanId?: string;
+    readonly attributes: api.SpanAttributes;
+    readonly links: api.Link[];
+    readonly events: TimedEvent[];
+    readonly startTime: api.HrTime;
+    readonly resource: IResource;
+    readonly instrumentationLibrary: InstrumentationLibrary;
+    name: string;
+    status: api.SpanStatus;
+    endTime: api.HrTime;
+
+    spanContext(): api.SpanContext
+
+    setAttribute(key: string, value?: SpanAttributeValue): this;
+
+    setAttributes(attributes: api.SpanAttributes): this
+
+    addEvent(
+      name: string,
+      attributesOrStartTime?: api.SpanAttributes | api.TimeInput,
+      startTime?: api.TimeInput
+    ): this
+
+    setStatus(status: api.SpanStatus): this
+
+    updateName(name: string): this
+
+    end(endTime?: api.TimeInput): void
+
+    isRecording(): boolean
+
+    recordException(exception: api.Exception, time?: api.TimeInput): void;
+
+    get duration(): api.HrTime
+
+    get ended(): boolean
+  }


### PR DESCRIPTION
This prevents compilation errors when differing versions of the sdk-trace-base package are in the node_modules tree