### PR TITLE
feat: allow Resource to be created with some attributes resolving asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### :rocket: (Enhancement)
 
+* feat: allow Resource to be created with some attributes resolving asynchronously [#2933](https://github.com/open-telemetry/opentelemetry-js/pull/2933) @aabmass
+
 ### :bug: (Bug Fix)
 
 * fix(resources): fix browser compatibility for host and os detectors [#3004](https://github.com/open-telemetry/opentelemetry-js/pull/3004) @legendecas

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -24,7 +24,7 @@ import {
 } from '@opentelemetry/instrumentation';
 import { NodeTracerConfig, NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import {
-  detectResources,
+  detectResourcesSync,
   envDetector,
   processDetector,
   Resource,
@@ -113,13 +113,13 @@ export class NodeSDK {
   }
 
   /** Detect resource attributes */
-  public async detectResources(config?: ResourceDetectionConfig): Promise<void> {
+  public detectResources(config?: ResourceDetectionConfig): void {
     const internalConfig: ResourceDetectionConfig = {
       detectors: [ envDetector, processDetector],
       ...config,
     };
 
-    this.addResource(await detectResources(internalConfig));
+    this.addResource(detectResourcesSync(internalConfig));
   }
 
   /** Manually add a resource */
@@ -130,9 +130,9 @@ export class NodeSDK {
   /**
    * Once the SDK has been configured, call this method to construct SDK components and register them with the OpenTelemetry API.
    */
-  public async start(): Promise<void> {
+  public start(): void {
     if (this._autoDetectResources) {
-      await this.detectResources();
+      this.detectResources();
     }
 
     if (this._tracerProviderConfig) {

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -70,7 +70,7 @@ describe('Node SDK', () => {
         autoDetectResources: false,
       });
 
-      await sdk.start();
+      sdk.start();
 
       assert.strictEqual(context['_getContextManager'](), ctxManager, 'context manager should not change');
       assert.strictEqual(propagation['_getGlobalPropagator'](), propagator, 'propagator should not change');
@@ -85,7 +85,7 @@ describe('Node SDK', () => {
         autoDetectResources: false,
       });
 
-      await sdk.start();
+      sdk.start();
 
       assert.ok(metrics.getMeterProvider() instanceof NoopMeterProvider);
 
@@ -108,7 +108,7 @@ describe('Node SDK', () => {
         autoDetectResources: false,
       });
 
-      await sdk.start();
+      sdk.start();
 
       assert.ok(metrics.getMeterProvider() instanceof NoopMeterProvider);
 
@@ -135,7 +135,7 @@ describe('Node SDK', () => {
         autoDetectResources: false,
       });
 
-      await sdk.start();
+      sdk.start();
 
       assert.strictEqual(context['_getContextManager'](), ctxManager, 'context manager should not change');
       assert.strictEqual(propagation['_getGlobalPropagator'](), propagator, 'propagator should not change');
@@ -162,7 +162,7 @@ describe('Node SDK', () => {
         const sdk = new NodeSDK({
           autoDetectResources: true,
         });
-        await sdk.detectResources({
+        sdk.detectResources({
           detectors: [ processDetector, {
             detect() {
               throw new Error('Buggy detector');
@@ -171,6 +171,7 @@ describe('Node SDK', () => {
           envDetector ]
         });
         const resource = sdk['_resource'];
+        await resource.waitForAsyncAttributes();
 
         assertServiceResource(resource, {
           instanceId: '627cc493',
@@ -217,7 +218,8 @@ describe('Node SDK', () => {
           DiagLogLevel.VERBOSE
         );
 
-        await sdk.detectResources();
+        sdk.detectResources();
+        await sdk['_resource'].waitForAsyncAttributes().catch(() => {});
 
         // Test that the Env Detector successfully found its resource and populated it with the right values.
         assert.ok(
@@ -249,7 +251,7 @@ describe('Node SDK', () => {
             DiagLogLevel.DEBUG
           );
 
-          await sdk.detectResources();
+          sdk.detectResources();
 
           assert.ok(
             callArgsContains(

--- a/packages/opentelemetry-resources/src/platform/browser/detect-resources.ts
+++ b/packages/opentelemetry-resources/src/platform/browser/detect-resources.ts
@@ -19,9 +19,11 @@ import { ResourceDetectionConfig } from '../../config';
 import { diag } from '@opentelemetry/api';
 
 /**
- * Runs all resource detectors and returns the results merged into a single
- * Resource.
+ * Runs all resource detectors and returns the results merged into a single Resource. Promise
+ * does not resolve until all of the underlying detectors have resolved, unlike
+ * detectResourcesSync.
  *
+ * @deprecated use detectResourceSync() instead.
  * @param config Configuration for resource detection
  */
 export const detectResources = async (
@@ -46,4 +48,52 @@ export const detectResources = async (
     (acc, resource) => acc.merge(resource),
     Resource.empty()
   );
+};
+
+/**
+ * Runs all resource detectors synchronously, merging their results. Any asynchronous
+ * attributes will be merged together in-order after they resolve.
+ *
+ * @param config Configuration for resource detection
+ */
+export const detectResourcesSync = (
+  config: ResourceDetectionConfig = {}
+): Resource => {
+  const internalConfig: ResourceDetectionConfig = Object.assign(config);
+
+  const resources: Resource[] = (internalConfig.detectors ?? []).map(d => {
+    try {
+      const resourceOrPromise = d.detect(internalConfig);
+      let resource: Resource;
+      if (resourceOrPromise instanceof Promise) {
+        diag.info('Resource detector %s should return a Resource directly instead of a promise.', d.constructor.name);
+        const createPromise = async () => {
+          const resolved = await resourceOrPromise;
+          await resolved.waitForAsyncAttributes();
+          return resolved.attributes;
+        };
+        resource = new Resource({}, createPromise());
+      } else {
+        resource = resourceOrPromise;
+      }
+
+      resource.waitForAsyncAttributes().then(() => {
+        diag.debug(`${d.constructor.name} found resource.`, resource);
+      }).catch(e => {
+        diag.debug(`${d.constructor.name} failed: ${e.message}`);
+      });
+
+      return resource;
+    } catch (e) {
+      diag.debug(`${d.constructor.name} failed: ${e.message}`);
+      return Resource.empty();
+    }
+  });
+
+
+  const mergedResources = resources.reduce(
+    (acc, resource) => acc.merge(resource),
+    Resource.empty()
+  );
+  return mergedResources;
 };

--- a/packages/opentelemetry-resources/src/types.ts
+++ b/packages/opentelemetry-resources/src/types.ts
@@ -26,9 +26,10 @@ import { SpanAttributes } from '@opentelemetry/api';
 export type ResourceAttributes = SpanAttributes;
 
 /**
- * Interface for a Resource Detector. In order to detect resources in parallel
- * a detector returns a Promise containing a Resource.
+ * Interface for a Resource Detector. In order to detect resources asynchronously, a detector
+ * can pass a Promise as the second parameter to the Resource constructor. Returning a
+ * Promise<Resource> is deprecated in favor of this approach.
  */
 export interface Detector {
-  detect(config?: ResourceDetectionConfig): Promise<Resource>;
+  detect(config?: ResourceDetectionConfig): Promise<Resource> | Resource;
 }

--- a/packages/opentelemetry-resources/test/detect-resources.test.ts
+++ b/packages/opentelemetry-resources/test/detect-resources.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { diag } from '@opentelemetry/api';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { Resource, Detector, detectResourcesSync } from '../src';
+import { describeNode } from './util';
+
+describe('detectResourcesSync', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('handles resource detectors which return Promise<Resource>', async () => {
+    const detector: Detector = {
+      async detect() {
+        return new Resource(
+          { 'sync': 'fromsync', 'async': 'fromasync' },
+        );
+      },
+    };
+    const resource = detectResourcesSync({
+      detectors: [detector],
+    });
+
+    await resource.waitForAsyncAttributes();
+    assert.deepStrictEqual(resource.attributes, {'sync': 'fromsync', 'async': 'fromasync'});
+  });
+
+  it('handles resource detectors which return Resource with a promise inside', async () => {
+    const detector: Detector = {
+      detect() {
+        return new Resource(
+          { 'sync': 'fromsync' },
+          Promise.resolve({ 'async': 'fromasync'})
+        );
+      },
+    };
+    const resource = detectResourcesSync({
+      detectors: [detector],
+    });
+
+    // before waiting, it should already have the sync resources
+    assert.deepStrictEqual(resource.attributes, {'sync': 'fromsync'});
+    await resource.waitForAsyncAttributes();
+    assert.deepStrictEqual(resource.attributes, {'sync': 'fromsync', 'async': 'fromasync'});
+  });
+
+  describeNode('logging', () => {
+    it("logs when a detector's async attributes promise rejects or resolves", async () => {
+      const debugStub = sinon.spy(diag, 'debug');
+
+      // use a class so it has a name
+      class DetectorRejects implements Detector {
+        detect() {
+          return new Resource(
+            { 'sync': 'fromsync' },
+            Promise.reject(new Error('reject')),
+          );
+        }
+      }
+      class DetectorOk implements Detector {
+        detect() {
+          return new Resource(
+            { 'sync': 'fromsync' },
+            Promise.resolve({'async': 'fromasync'}),
+          );
+        }
+      }
+      class DetectorAsync implements Detector {
+        async detect() {
+          return new Resource(
+            { 'sync': 'fromsync', 'async': 'fromasync' },
+          );
+        }
+      }
+
+      const resource = detectResourcesSync({
+        detectors: [
+          new DetectorRejects(),
+          new DetectorOk(),
+          new DetectorAsync(),
+        ],
+      });
+
+      await resource.waitForAsyncAttributes();
+      assert.ok(debugStub.calledWithMatch('DetectorRejects failed: reject'));
+      assert.ok(debugStub.calledWithMatch('DetectorOk found resource.'));
+      assert.ok(debugStub.calledWithMatch('DetectorAsync found resource.'));
+    });
+  });
+});


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes #2912

## Short description of the changes

- In `@opentelemetry/sdk-node`
  - Adds an optional `Promise<ResourceAttributes>` to the Resource constructor which can asynchronously resolve some attributes. When this promise resolves, the attributes will be merged with the "synchronous" attributes.
  - Deprecated `detectResources()` in favor of a new method `detectResourcesSync()` which defers promises into the resource to be resolved later
  - Update `Detector.detect()` signature to allow it to be synchronous and updated documentation that the synchronous variant should be used
- In `@opentelemetry/sdk-node`, updated `NodeSDK.start()` and its dependencies to now be synchronous (doesn't return a promise). This is a breaking change, but that package is experimental.
- Updated `BatchSpanProcessorBase` and `SimpleSpanProcessor` to await the resource promise before calling exporters, if the resource has asynchronous attributes AND they have not already resolved. I.e. if there is no promise in the Resource (the case for existing detectors and code), the behavior is unchanged.

There may be some test breakages in contrib because of the nature of asynchronous tests on fire-and-forget `span.end()`. Users shouldn't see any behavior change.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) **I don't think so?**

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Existing tests pass with no modification
- [x] Added new tests to `Resource.test.ts`
- [x] Added `detect-resources.test.ts`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
