### PR TITLE
fix(sdk-node): add no-op logger to fix failing tests.

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -59,7 +59,7 @@ export abstract class InstrumentationBase<T = any>
     }
   }
 
-  private _warnOnPreloadedModules(): void {
+  protected _warnOnPreloadedModules(): void {
     this._modules.forEach((module: InstrumentationModuleDefinition<T>) => {
       const { name } = module;
       try {

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -363,11 +363,16 @@ describe('Node SDK', () => {
         // This test depends on the env detector to be functioning as intended
         const mockedLoggerMethod = Sinon.fake();
         const mockedVerboseLoggerMethod = Sinon.fake();
+        const nop = () => {
+        };
         diag.setLogger(
           {
             debug: mockedLoggerMethod,
             verbose: mockedVerboseLoggerMethod,
-          } as any,
+            warn: nop,
+            error: nop,
+            info: nop
+          },
           DiagLogLevel.VERBOSE
         );
 


### PR DESCRIPTION
## Which problem is this PR solving?

#2926 introduced `warn` logs in the `@opentelemetry/instrumentation` package. The current tests in `@opentelemetry/sdk-node` are failing as they did not add a `warn` logger. This PR adds all required loggers so that `warn` can be called safely.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Existing tests run in CI

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
