### PR TITLE
chore: remove unused InstrumentationConfig#path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### :boom: Breaking Change
 
+* chore: remove unused InstrumentationConfig#path [#2944](https://github.com/open-telemetry/opentelemetry-js/pull/2944) @flarna
+
 ### :rocket: (Enhancement)
 
 * feat(ConsoleSpanExporter): export span links [#2917](https://github.com/open-telemetry/opentelemetry-js/pull/2917) @trentm

--- a/experimental/packages/opentelemetry-instrumentation/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/types.ts
@@ -65,12 +65,6 @@ export interface InstrumentationConfig {
    * @default true
    */
   enabled?: boolean;
-
-  /**
-   * Path of the trace plugin to load.
-   * @default '@opentelemetry/plugin-http' in case of http.
-   */
-  path?: string;
 }
 
 /**


### PR DESCRIPTION
## Which problem is this PR solving?

## Short description of the changes

Removed the unused field `InstrumentationConfig#path` as it seems it's not used anywhere. The comment there is also outdated so can't tell if it was ever used.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

CI 

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
