### PR TITLE
Add missing compiled browser entry points to package

### DIFF
--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -38,6 +38,12 @@
     "node": ">=8.12.0"
   },
   "files": [
+    "build/esm/**/*.js",
+    "build/esm/**/*.js.map",
+    "build/esm/**/*.d.ts",
+    "build/esnext/**/*.js",
+    "build/esnext/**/*.js.map",
+    "build/esnext/**/*.d.ts",
     "build/src/**/*.js",
     "build/src/**/*.js.map",
     "build/src/**/*.d.ts",


### PR DESCRIPTION
## Which problem is this PR solving?

This PR fixes some missing `files` entries in `package.json` files. The missing entries would cause the module and esnext entry points to be excluded from the built NPM packages.


## Short description of the changes

Some projects have "module" and "esnext" entries in their `package.json`, but the referenced files were not being included in their respective package due to them having been left out of the `files` section.

The issue applies to `@opentelemetry/otlp-exporter-base` and `@opentelemetry/otlp-transformer` and was causing problems under Webpack bundling for us.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

- [x] Building the package locally using the corrected package.json generates a package that includes the missing files.
- [x] Using this corrected package fixes the Webpack bundling problem I described above.


## Checklist:

- [x] Followed the style guidelines of this project
