### PR TITLE
refactor(metrics-sdk): rename InstrumentationLibrary -> InstrumentationScope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 * feat: warn when hooked module is already loaded [#2926](https://github.com/open-telemetry/opentelemetry-js/pull/2926) @nozik
 * feat: implement OSDetector [#2927](https://github.com/open-telemetry/opentelemetry-js/pull/2927) @rauno56
 * feat: implement HostDetector [#2921](https://github.com/open-telemetry/opentelemetry-js/pull/2921) @rauno56
+* refactor(metrics-sdk): rename InstrumentationLibrary -> InstrumentationScope [#2959](https://github.com/open-telemetry/opentelemetry-js/pull/2959) @pichlermarc
 
 ### :bug: (Bug Fix)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 * feat: warn when hooked module is already loaded [#2926](https://github.com/open-telemetry/opentelemetry-js/pull/2926) @nozik
 * feat: implement OSDetector [#2927](https://github.com/open-telemetry/opentelemetry-js/pull/2927) @rauno56
 * feat: implement HostDetector [#2921](https://github.com/open-telemetry/opentelemetry-js/pull/2921) @rauno56
-* refactor(metrics-sdk): rename InstrumentationLibrary -> InstrumentationScope [#2959](https://github.com/open-telemetry/opentelemetry-js/pull/2959) @pichlermarc
+* feat(opentelemetry-core): add InstrumentationScope [#2959](https://github.com/open-telemetry/opentelemetry-js/pull/2959) @pichlermarc
 
 ### :bug: (Bug Fix)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+* refactor(metrics-sdk): rename InstrumentationLibrary -> InstrumentationScope #2959 @pichlermarc
+
 ### :rocket: (Enhancement)
 
 * feat(exporters): update proto version and use otlp-transformer #2929 @pichlermarc

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/CollectorMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/CollectorMetricExporter.test.ts
@@ -115,8 +115,8 @@ describe('OTLPMetricExporter - web', () => {
 
           ensureCounterIsCorrect(
             metric1,
-            hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[0].dataPoints[0].endTime),
-            hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[0].dataPoints[0].startTime)
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[0].dataPoints[0].endTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[0].dataPoints[0].startTime)
           );
 
 
@@ -126,8 +126,8 @@ describe('OTLPMetricExporter - web', () => {
           );
           ensureObservableGaugeIsCorrect(
             metric2,
-            hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[1].dataPoints[0].endTime),
-            hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[1].dataPoints[0].startTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].endTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].startTime),
             6,
             'double-observable-gauge2'
           );
@@ -138,8 +138,8 @@ describe('OTLPMetricExporter - web', () => {
           );
           ensureHistogramIsCorrect(
             metric3,
-            hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[2].dataPoints[0].endTime),
-            hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[2].dataPoints[0].startTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[2].dataPoints[0].endTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[2].dataPoints[0].startTime),
             [0, 100],
             [0, 2, 0]
           );
@@ -221,8 +221,8 @@ describe('OTLPMetricExporter - web', () => {
           assert.ok(typeof metric1 !== 'undefined', "metric doesn't exist");
           ensureCounterIsCorrect(
             metric1,
-            hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[0].dataPoints[0].endTime),
-            hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[0].dataPoints[0].startTime)
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[0].dataPoints[0].endTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[0].dataPoints[0].startTime)
           );
 
           assert.ok(
@@ -231,8 +231,8 @@ describe('OTLPMetricExporter - web', () => {
           );
           ensureObservableGaugeIsCorrect(
             metric2,
-            hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[1].dataPoints[0].endTime),
-            hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[1].dataPoints[0].startTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].endTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].startTime),
             6,
             'double-observable-gauge2'
           );
@@ -243,8 +243,8 @@ describe('OTLPMetricExporter - web', () => {
           );
           ensureHistogramIsCorrect(
             metric3,
-            hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[2].dataPoints[0].endTime),
-            hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[2].dataPoints[0].startTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[2].dataPoints[0].endTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[2].dataPoints[0].startTime),
             [0, 100],
             [0, 2, 0]
           );

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/metricsHelper.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/metricsHelper.ts
@@ -22,7 +22,7 @@ import {
 } from '@opentelemetry/api-metrics';
 import { Resource } from '@opentelemetry/resources';
 import * as assert from 'assert';
-import { InstrumentationLibrary, VERSION } from '@opentelemetry/core';
+import { InstrumentationScope, VERSION } from '@opentelemetry/core';
 import {
   AggregationTemporality,
   ExplicitBucketHistogramAggregation,
@@ -171,7 +171,7 @@ export const mockedResources: Resource[] = [
   new Resource({ name: 'resource 2' }),
 ];
 
-export const mockedInstrumentationLibraries: InstrumentationLibrary[] = [
+export const mockedInstrumentationLibraries: InstrumentationScope[] = [
   {
     name: 'lib1',
     version: '0.0.1',

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/CollectorMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/CollectorMetricExporter.test.ts
@@ -238,22 +238,22 @@ describe('OTLPMetricExporter - node with json over http', () => {
         assert.ok(typeof metric1 !== 'undefined', "counter doesn't exist");
         ensureCounterIsCorrect(
           metric1,
-          core.hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[0].dataPoints[0].endTime),
-          core.hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[0].dataPoints[0].startTime)
+          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[0].dataPoints[0].endTime),
+          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[0].dataPoints[0].startTime)
         );
         assert.ok(typeof metric2 !== 'undefined', "observable gauge doesn't exist");
         ensureObservableGaugeIsCorrect(
           metric2,
-          core.hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[1].dataPoints[0].endTime),
-          core.hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[1].dataPoints[0].startTime),
+          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].endTime),
+          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].startTime),
           6,
           'double-observable-gauge2'
         );
         assert.ok(typeof metric3 !== 'undefined', "histogram doesn't exist");
         ensureHistogramIsCorrect(
           metric3,
-          core.hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[1].dataPoints[0].endTime),
-          core.hrTimeToNanoseconds(metrics.instrumentationLibraryMetrics[0].metrics[1].dataPoints[0].startTime),
+          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].endTime),
+          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].startTime),
           [0, 100],
           [0, 2, 0]
         );

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -19,7 +19,7 @@ import {
   ResourceMetrics,
   InstrumentType,
   DataPointType,
-  InstrumentationLibraryMetrics,
+  ScopeMetrics,
   MetricData,
   DataPoint,
   Histogram,
@@ -178,15 +178,15 @@ export class PrometheusSerializer {
 
   serialize(resourceMetrics: ResourceMetrics): string {
     let str = '';
-    for (const instrumentationLibraryMetrics of resourceMetrics.instrumentationLibraryMetrics) {
-      str += this.serializeInstrumentationLibraryMetrics(instrumentationLibraryMetrics);
+    for (const scopeMetrics of resourceMetrics.scopeMetrics) {
+      str += this.serializeScopeMetrics(scopeMetrics);
     }
     return str;
   }
 
-  serializeInstrumentationLibraryMetrics(instrumentationLibraryMetrics: InstrumentationLibraryMetrics) {
+  serializeScopeMetrics(scopeMetrics: ScopeMetrics) {
     let str = '';
-    for (const metric of instrumentationLibraryMetrics.metrics) {
+    for (const metric of scopeMetrics.metrics) {
       str += this.serializeMetricData(metric) + '\n';
     }
     return str;

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -79,9 +79,9 @@ describe('PrometheusSerializer', () => {
 
         const resourceMetrics = await reader.collect();
         assert(resourceMetrics != null);
-        assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics.length, 1);
-        assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics[0].metrics.length, 1);
-        const metric = resourceMetrics.instrumentationLibraryMetrics[0].metrics[0];
+        assert.strictEqual(resourceMetrics.scopeMetrics.length, 1);
+        assert.strictEqual(resourceMetrics.scopeMetrics[0].metrics.length, 1);
+        const metric = resourceMetrics.scopeMetrics[0].metrics[0];
         assert.strictEqual(metric.dataPointType, DataPointType.SINGULAR);
         const pointData = metric.dataPoints as DataPoint<number>[];
         assert.strictEqual(pointData.length, 1);
@@ -122,9 +122,9 @@ describe('PrometheusSerializer', () => {
 
         const resourceMetrics = await reader.collect();
         assert(resourceMetrics != null);
-        assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics.length, 1);
-        assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics[0].metrics.length, 1);
-        const metric = resourceMetrics.instrumentationLibraryMetrics[0].metrics[0];
+        assert.strictEqual(resourceMetrics.scopeMetrics.length, 1);
+        assert.strictEqual(resourceMetrics.scopeMetrics[0].metrics.length, 1);
+        const metric = resourceMetrics.scopeMetrics[0].metrics[0];
         assert.strictEqual(metric.dataPointType, DataPointType.HISTOGRAM);
         const pointData = metric.dataPoints as DataPoint<Histogram>[];
         assert.strictEqual(pointData.length, 1);
@@ -180,11 +180,11 @@ describe('PrometheusSerializer', () => {
 
         const resourceMetrics = await reader.collect();
         assert(resourceMetrics != null);
-        assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics.length, 1);
-        assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics[0].metrics.length, 1);
-        const instrumentationLibraryMetrics = resourceMetrics.instrumentationLibraryMetrics[0];
+        assert.strictEqual(resourceMetrics.scopeMetrics.length, 1);
+        assert.strictEqual(resourceMetrics.scopeMetrics[0].metrics.length, 1);
+        const scopeMetrics = resourceMetrics.scopeMetrics[0];
 
-        const result = serializer.serializeInstrumentationLibraryMetrics(instrumentationLibraryMetrics);
+        const result = serializer.serializeScopeMetrics(scopeMetrics);
         return result;
       }
 
@@ -232,11 +232,11 @@ describe('PrometheusSerializer', () => {
 
         const resourceMetrics = await reader.collect();
         assert(resourceMetrics != null);
-        assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics.length, 1);
-        assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics[0].metrics.length, 1);
-        const instrumentationLibraryMetrics = resourceMetrics.instrumentationLibraryMetrics[0];
+        assert.strictEqual(resourceMetrics.scopeMetrics.length, 1);
+        assert.strictEqual(resourceMetrics.scopeMetrics[0].metrics.length, 1);
+        const scopeMetrics = resourceMetrics.scopeMetrics[0];
 
-        const result = serializer.serializeInstrumentationLibraryMetrics(instrumentationLibraryMetrics);
+        const result = serializer.serializeScopeMetrics(scopeMetrics);
         return result;
       }
 
@@ -277,9 +277,9 @@ describe('PrometheusSerializer', () => {
 
       const resourceMetrics = await reader.collect();
       assert(resourceMetrics != null);
-      assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics.length, 1);
-      assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics[0].metrics.length, 1);
-      const metric = resourceMetrics.instrumentationLibraryMetrics[0].metrics[0];
+      assert.strictEqual(resourceMetrics.scopeMetrics.length, 1);
+      assert.strictEqual(resourceMetrics.scopeMetrics[0].metrics.length, 1);
+      const metric = resourceMetrics.scopeMetrics[0].metrics[0];
       assert.strictEqual(metric.dataPointType, DataPointType.SINGULAR);
       const pointData = metric.dataPoints as DataPoint<number>[];
       assert.strictEqual(pointData.length, 1);
@@ -316,9 +316,9 @@ describe('PrometheusSerializer', () => {
 
       const resourceMetrics = await reader.collect();
       assert(resourceMetrics != null);
-      assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics.length, 1);
-      assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics[0].metrics.length, 1);
-      const metric = resourceMetrics.instrumentationLibraryMetrics[0].metrics[0];
+      assert.strictEqual(resourceMetrics.scopeMetrics.length, 1);
+      assert.strictEqual(resourceMetrics.scopeMetrics[0].metrics.length, 1);
+      const metric = resourceMetrics.scopeMetrics[0].metrics[0];
       assert.strictEqual(metric.dataPointType, DataPointType.SINGULAR);
       const pointData = metric.dataPoints as DataPoint<number>[];
       assert.strictEqual(pointData.length, 1);

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/export/MetricData.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/export/MetricData.ts
@@ -16,7 +16,7 @@
 
 import { HrTime } from '@opentelemetry/api';
 import { MetricAttributes } from '@opentelemetry/api-metrics';
-import { InstrumentationLibrary } from '@opentelemetry/core';
+import { InstrumentationScope } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
 import { InstrumentDescriptor } from '../InstrumentDescriptor';
 import { Histogram } from '../aggregator/types';
@@ -56,14 +56,14 @@ export interface HistogramMetricData extends BaseMetricData {
  */
 export type MetricData = SingularMetricData | HistogramMetricData;
 
-export interface InstrumentationLibraryMetrics {
-  instrumentationLibrary: InstrumentationLibrary;
+export interface ScopeMetrics {
+  scope: InstrumentationScope;
   metrics: MetricData[];
 }
 
 export interface ResourceMetrics {
   resource: Resource;
-  instrumentationLibraryMetrics: InstrumentationLibraryMetrics[];
+  scopeMetrics: ScopeMetrics[];
 }
 
 /**

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MeterProviderSharedState.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MeterProviderSharedState.ts
@@ -15,9 +15,9 @@
  */
 
 import { HrTime } from '@opentelemetry/api';
-import { hrTime, InstrumentationLibrary } from '@opentelemetry/core';
+import { hrTime, InstrumentationScope } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
-import { instrumentationLibraryId } from '../utils';
+import { instrumentationScopeId } from '../utils';
 import { ViewRegistry } from '../view/ViewRegistry';
 import { MeterSharedState } from './MeterSharedState';
 import { MetricCollector } from './MetricCollector';
@@ -35,11 +35,11 @@ export class MeterProviderSharedState {
 
   constructor(public resource: Resource) {}
 
-  getMeterSharedState(instrumentationLibrary: InstrumentationLibrary) {
-    const id = instrumentationLibraryId(instrumentationLibrary);
+  getMeterSharedState(instrumentationScope: InstrumentationScope) {
+    const id = instrumentationScopeId(instrumentationScope);
     let meterSharedState = this.meterSharedStates.get(id);
     if (meterSharedState == null) {
-      meterSharedState = new MeterSharedState(this, instrumentationLibrary);
+      meterSharedState = new MeterSharedState(this, instrumentationScope);
       this.meterSharedStates.set(id, meterSharedState);
     }
     return meterSharedState;

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MeterSharedState.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MeterSharedState.ts
@@ -16,8 +16,8 @@
 
 import { HrTime } from '@opentelemetry/api';
 import * as metrics from '@opentelemetry/api-metrics';
-import { InstrumentationLibrary } from '@opentelemetry/core';
-import { InstrumentationLibraryMetrics } from '../export/MetricData';
+import { InstrumentationScope } from '@opentelemetry/core';
+import { ScopeMetrics } from '../export/MetricData';
 import { createInstrumentDescriptorWithView, InstrumentDescriptor } from '../InstrumentDescriptor';
 import { Meter } from '../Meter';
 import { isNotNullish } from '../utils';
@@ -37,12 +37,12 @@ export class MeterSharedState {
   private _observableRegistry = new ObservableRegistry();
   meter: Meter;
 
-  constructor(private _meterProviderSharedState: MeterProviderSharedState, private _instrumentationLibrary: InstrumentationLibrary) {
+  constructor(private _meterProviderSharedState: MeterProviderSharedState, private _instrumentationScope: InstrumentationScope) {
     this.meter = new Meter(this);
   }
 
   registerMetricStorage(descriptor: InstrumentDescriptor) {
-    const views = this._meterProviderSharedState.viewRegistry.findViews(descriptor, this._instrumentationLibrary);
+    const views = this._meterProviderSharedState.viewRegistry.findViews(descriptor, this._instrumentationScope);
     const storages = views
       .map(view => {
         const viewDescriptor = createInstrumentDescriptorWithView(view, descriptor);
@@ -58,7 +58,7 @@ export class MeterSharedState {
   }
 
   registerAsyncMetricStorage(descriptor: InstrumentDescriptor, callback: metrics.ObservableCallback) {
-    const views = this._meterProviderSharedState.viewRegistry.findViews(descriptor, this._instrumentationLibrary);
+    const views = this._meterProviderSharedState.viewRegistry.findViews(descriptor, this._instrumentationScope);
     views.forEach(view => {
       const viewDescriptor = createInstrumentDescriptorWithView(view, descriptor);
       const aggregator = view.aggregation.createAggregator(viewDescriptor);
@@ -76,7 +76,7 @@ export class MeterSharedState {
    * @param collectionTime the HrTime at which the collection was initiated.
    * @returns the list of {@link MetricData} collected.
    */
-  async collect(collector: MetricCollectorHandle, collectionTime: HrTime): Promise<InstrumentationLibraryMetrics> {
+  async collect(collector: MetricCollectorHandle, collectionTime: HrTime): Promise<ScopeMetrics> {
     /**
      * 1. Call all observable callbacks first.
      * 2. Collect metric result for the collector.
@@ -93,7 +93,7 @@ export class MeterSharedState {
       .filter(isNotNullish);
 
     return {
-      instrumentationLibrary: this._instrumentationLibrary,
+      scope: this._instrumentationScope,
       metrics: metricDataList.filter(isNotNullish),
     };
   }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MetricCollector.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/MetricCollector.ts
@@ -36,11 +36,11 @@ export class MetricCollector implements MetricProducer {
     const collectionTime = hrTime();
     const meterCollectionPromises = Array.from(this._sharedState.meterSharedStates.values())
       .map(meterSharedState => meterSharedState.collect(this, collectionTime));
-    const instrumentationLibraryMetrics = await Promise.all(meterCollectionPromises);
+    const scopeMetrics = await Promise.all(meterCollectionPromises);
 
     return {
       resource: this._sharedState.resource,
-      instrumentationLibraryMetrics,
+      scopeMetrics,
     };
   }
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/state/TemporalMetricProcessor.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/state/TemporalMetricProcessor.ts
@@ -54,7 +54,7 @@ export class TemporalMetricProcessor<T> {
    * @param collector The information of the MetricCollector.
    * @param collectors The registered collectors.
    * @param resource The resource to attach these metrics against.
-   * @param instrumentationLibrary The instrumentation library that generated these metrics.
+   * @param instrumentationScope The instrumentation scope that generated these metrics.
    * @param instrumentDescriptor The instrumentation descriptor that these metrics generated with.
    * @param currentAccumulations The current accumulation of metric data from instruments.
    * @param sdkStartTime The sdk start timestamp.

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/utils.ts
@@ -15,7 +15,7 @@
  */
 
 import { MetricAttributes } from '@opentelemetry/api-metrics';
-import { InstrumentationLibrary } from '@opentelemetry/core';
+import { InstrumentationScope } from '@opentelemetry/core';
 
 export type Maybe<T> = T | undefined;
 
@@ -41,11 +41,11 @@ export function hashAttributes(attributes: MetricAttributes): string {
 }
 
 /**
- * Converting the instrumentation library object to a unique identifier string.
- * @param instrumentationLibrary
+ * Converting the instrumentation scope object to a unique identifier string.
+ * @param instrumentationScope
  */
-export function instrumentationLibraryId(instrumentationLibrary: InstrumentationLibrary): string {
-  return `${instrumentationLibrary.name}:${instrumentationLibrary.version ?? ''}:${instrumentationLibrary.schemaUrl ?? ''}`;
+export function instrumentationScopeId(instrumentationScope: InstrumentationScope): string {
+  return `${instrumentationScope.name}:${instrumentationScope.version ?? ''}:${instrumentationScope.schemaUrl ?? ''}`;
 }
 
 /**

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/view/ViewRegistry.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/view/ViewRegistry.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { InstrumentationLibrary } from '@opentelemetry/core';
+import { InstrumentationScope } from '@opentelemetry/core';
 import { InstrumentDescriptor } from '../InstrumentDescriptor';
 import { InstrumentSelector } from './InstrumentSelector';
 import { MeterSelector } from './MeterSelector';
@@ -38,7 +38,7 @@ export class ViewRegistry {
     });
   }
 
-  findViews(instrument: InstrumentDescriptor, meter: InstrumentationLibrary): View[] {
+  findViews(instrument: InstrumentDescriptor, meter: InstrumentationScope): View[] {
     const views = this._registeredViews
       .filter(registeredView => {
         return this._matchInstrument(registeredView.instrumentSelector, instrument) &&
@@ -57,7 +57,7 @@ export class ViewRegistry {
       selector.getNameFilter().match(instrument.name);
   }
 
-  private _matchMeter(selector: MeterSelector, meter: InstrumentationLibrary): boolean {
+  private _matchMeter(selector: MeterSelector, meter: InstrumentationScope): boolean {
     return selector.getNameFilter().match(meter.name) &&
       (meter.version === undefined || selector.getVersionFilter().match(meter.version)) &&
       (meter.schemaUrl === undefined || selector.getSchemaUrlFilter().match(meter.schemaUrl));

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/Instruments.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/Instruments.test.ts
@@ -16,11 +16,11 @@
 
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { InstrumentationLibrary } from '@opentelemetry/core';
+import { InstrumentationScope } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
 import { AggregationTemporality, InstrumentDescriptor, InstrumentType, MeterProvider, MetricReader, DataPoint, DataPointType } from '../src';
 import { TestMetricReader } from './export/TestMetricReader';
-import { assertMetricData, assertDataPoint, commonValues, commonAttributes, defaultResource, defaultInstrumentationLibrary } from './util';
+import { assertMetricData, assertDataPoint, commonValues, commonAttributes, defaultResource, defaultInstrumentationScope } from './util';
 import { Histogram } from '../src/aggregator/types';
 import { ObservableResult, ValueType } from '@opentelemetry/api-metrics';
 
@@ -518,8 +518,8 @@ describe('Instruments', () => {
 
 function setup() {
   const meterProvider = new MeterProvider({ resource: defaultResource });
-  const meter = meterProvider.getMeter(defaultInstrumentationLibrary.name, defaultInstrumentationLibrary.version, {
-    schemaUrl: defaultInstrumentationLibrary.schemaUrl,
+  const meter = meterProvider.getMeter(defaultInstrumentationScope.name, defaultInstrumentationScope.version, {
+    schemaUrl: defaultInstrumentationScope.schemaUrl,
   });
   const deltaReader = new TestMetricReader(() => AggregationTemporality.DELTA);
   meterProvider.addMetricReader(deltaReader);
@@ -536,7 +536,7 @@ function setup() {
 
 interface ValidateMetricData {
   resource?: Resource;
-  instrumentationLibrary?: InstrumentationLibrary;
+  instrumentationScope?: InstrumentationScope;
   descriptor?: InstrumentDescriptor;
   dataPointType?: DataPointType,
   dataPoints?: Partial<DataPoint<number | Partial<Histogram>>>[];
@@ -547,12 +547,12 @@ async function validateExport(reader: MetricReader, expected: ValidateMetricData
 
   assert.notStrictEqual(resourceMetrics, undefined);
 
-  const { resource, instrumentationLibraryMetrics } = resourceMetrics!;
+  const { resource, scopeMetrics } = resourceMetrics!;
 
-  const { instrumentationLibrary, metrics } = instrumentationLibraryMetrics[0];
+  const { scope, metrics } = scopeMetrics[0];
 
   assert.deepStrictEqual(resource, defaultResource);
-  assert.deepStrictEqual(instrumentationLibrary, defaultInstrumentationLibrary);
+  assert.deepStrictEqual(scope, defaultInstrumentationScope);
 
   const metric = metrics[0];
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/Meter.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/Meter.test.ts
@@ -20,7 +20,7 @@ import { CounterInstrument, HistogramInstrument, UpDownCounterInstrument } from 
 import { Meter } from '../src/Meter';
 import { MeterProviderSharedState } from '../src/state/MeterProviderSharedState';
 import { MeterSharedState } from '../src/state/MeterSharedState';
-import { defaultInstrumentationLibrary, defaultResource } from './util';
+import { defaultInstrumentationScope, defaultResource } from './util';
 
 const noopObservableCallback: ObservableCallback = _observableResult => {};
 
@@ -29,7 +29,7 @@ describe('Meter', () => {
     it('should create counter', () => {
       const meterSharedState = new MeterSharedState(
         new MeterProviderSharedState(defaultResource),
-        defaultInstrumentationLibrary);
+        defaultInstrumentationScope);
       const meter = new Meter(meterSharedState);
       const counter = meter.createCounter('foobar');
       assert(counter instanceof CounterInstrument);
@@ -40,7 +40,7 @@ describe('Meter', () => {
     it('should create up down counter', () => {
       const meterSharedState = new MeterSharedState(
         new MeterProviderSharedState(defaultResource),
-        defaultInstrumentationLibrary);
+        defaultInstrumentationScope);
       const meter = new Meter(meterSharedState);
       const counter = meter.createUpDownCounter('foobar');
       assert(counter instanceof UpDownCounterInstrument);
@@ -51,7 +51,7 @@ describe('Meter', () => {
     it('should create histogram', () => {
       const meterSharedState = new MeterSharedState(
         new MeterProviderSharedState(defaultResource),
-        defaultInstrumentationLibrary);
+        defaultInstrumentationScope);
       const meter = new Meter(meterSharedState);
       const counter = meter.createHistogram('foobar');
       assert(counter instanceof HistogramInstrument);
@@ -62,7 +62,7 @@ describe('Meter', () => {
     it('should create observable gauge', () => {
       const meterSharedState = new MeterSharedState(
         new MeterProviderSharedState(defaultResource),
-        defaultInstrumentationLibrary);
+        defaultInstrumentationScope);
       const meter = new Meter(meterSharedState);
       meter.createObservableGauge('foobar', noopObservableCallback);
     });
@@ -72,7 +72,7 @@ describe('Meter', () => {
     it('should create observable counter', () => {
       const meterSharedState = new MeterSharedState(
         new MeterProviderSharedState(defaultResource),
-        defaultInstrumentationLibrary);
+        defaultInstrumentationScope);
       const meter = new Meter(meterSharedState);
       meter.createObservableCounter('foobar', noopObservableCallback);
     });
@@ -82,7 +82,7 @@ describe('Meter', () => {
     it('should create observable up-down-counter', () => {
       const meterSharedState = new MeterSharedState(
         new MeterProviderSharedState(defaultResource),
-        defaultInstrumentationLibrary);
+        defaultInstrumentationScope);
       const meter = new Meter(meterSharedState);
       meter.createObservableUpDownCounter('foobar', noopObservableCallback);
     });

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/MeterProvider.test.ts
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 import { NOOP_METER } from '@opentelemetry/api-metrics';
 import { Meter, MeterProvider, InstrumentType, DataPointType } from '../src';
 import {
-  assertInstrumentationLibraryMetrics,
+  assertScopeMetrics,
   assertMetricData,
   assertPartialDeepStrictEqual,
   defaultResource
@@ -87,22 +87,22 @@ describe('MeterProvider', () => {
       const result = await reader.collect();
 
       // Results came only from de-duplicated meters.
-      assert.strictEqual(result?.instrumentationLibraryMetrics.length, 4);
+      assert.strictEqual(result?.scopeMetrics.length, 4);
 
-      // InstrumentationLibrary matches from de-duplicated meters.
-      assertInstrumentationLibraryMetrics(result?.instrumentationLibraryMetrics[0], {
+      // InstrumentationScope matches from de-duplicated meters.
+      assertScopeMetrics(result?.scopeMetrics[0], {
         name: 'meter1',
         version: 'v1.0.0'
       });
-      assertInstrumentationLibraryMetrics(result?.instrumentationLibraryMetrics[1], {
+      assertScopeMetrics(result?.scopeMetrics[1], {
         name: 'meter2',
         version: 'v1.0.0'
       });
-      assertInstrumentationLibraryMetrics(result?.instrumentationLibraryMetrics[2], {
+      assertScopeMetrics(result?.scopeMetrics[2], {
         name: 'meter1',
         version: 'v1.0.1'
       });
-      assertInstrumentationLibraryMetrics(result?.instrumentationLibraryMetrics[3], {
+      assertScopeMetrics(result?.scopeMetrics[3], {
         name: 'meter1',
         version: 'v1.0.1',
         schemaUrl: 'https://opentelemetry.io/schemas/1.4.0',
@@ -192,29 +192,29 @@ describe('MeterProvider', () => {
       const result = await reader.collect();
 
       // Results came only from one Meter.
-      assert.strictEqual(result?.instrumentationLibraryMetrics.length, 1);
+      assert.strictEqual(result?.scopeMetrics.length, 1);
 
-      // InstrumentationLibrary matches the only created Meter.
-      assertInstrumentationLibraryMetrics(result?.instrumentationLibraryMetrics[0], {
+      // InstrumentationScope matches the only created Meter.
+      assertScopeMetrics(result?.scopeMetrics[0], {
         name: 'meter1',
         version: 'v1.0.0'
       });
 
       // Collected only one Metric.
-      assert.strictEqual(result?.instrumentationLibraryMetrics[0].metrics.length, 1);
+      assert.strictEqual(result?.scopeMetrics[0].metrics.length, 1);
 
       // View updated name and description.
-      assertMetricData(result?.instrumentationLibraryMetrics[0].metrics[0], DataPointType.SINGULAR, {
+      assertMetricData(result?.scopeMetrics[0].metrics[0], DataPointType.SINGULAR, {
         name: 'renamed-instrument',
         type: InstrumentType.COUNTER,
         description: 'my renamed instrument'
       });
 
       // Only one DataPoint added.
-      assert.strictEqual(result?.instrumentationLibraryMetrics[0].metrics[0].dataPoints.length, 1);
+      assert.strictEqual(result?.scopeMetrics[0].metrics[0].dataPoints.length, 1);
 
       // DataPoint matches attributes and point.
-      assertPartialDeepStrictEqual(result?.instrumentationLibraryMetrics[0].metrics[0].dataPoints[0], {
+      assertPartialDeepStrictEqual(result?.scopeMetrics[0].metrics[0].dataPoints[0], {
         // MetricAttributes are still there.
         attributes: {
           attrib1: 'attrib_value1',
@@ -250,28 +250,28 @@ describe('MeterProvider', () => {
       const result = await reader.collect();
 
       // Results came only from one Meter.
-      assert.strictEqual(result?.instrumentationLibraryMetrics.length, 1);
+      assert.strictEqual(result?.scopeMetrics.length, 1);
 
-      // InstrumentationLibrary matches the only created Meter.
-      assertInstrumentationLibraryMetrics(result?.instrumentationLibraryMetrics[0], {
+      // InstrumentationScope matches the only created Meter.
+      assertScopeMetrics(result?.scopeMetrics[0], {
         name: 'meter1',
         version: 'v1.0.0'
       });
 
       // Collected only one Metric.
-      assert.strictEqual(result?.instrumentationLibraryMetrics[0].metrics.length, 1);
+      assert.strictEqual(result?.scopeMetrics[0].metrics.length, 1);
 
       // View updated name and description.
-      assertMetricData(result?.instrumentationLibraryMetrics[0].metrics[0], DataPointType.SINGULAR, {
+      assertMetricData(result?.scopeMetrics[0].metrics[0], DataPointType.SINGULAR, {
         name: 'non-renamed-instrument',
         type: InstrumentType.COUNTER,
       });
 
       // Only one DataPoint added.
-      assert.strictEqual(result?.instrumentationLibraryMetrics[0].metrics[0].dataPoints.length, 1);
+      assert.strictEqual(result?.scopeMetrics[0].metrics[0].dataPoints.length, 1);
 
       // DataPoint matches attributes and point.
-      assertPartialDeepStrictEqual(result?.instrumentationLibraryMetrics[0].metrics[0].dataPoints[0], {
+      assertPartialDeepStrictEqual(result?.scopeMetrics[0].metrics[0].dataPoints[0], {
         // 'attrib_1' is still here but 'attrib_2' is not.
         attributes: {
           attrib1: 'attrib_value1'
@@ -313,34 +313,34 @@ describe('MeterProvider', () => {
       const result = await reader.collect();
 
       // Results came from two Meters.
-      assert.strictEqual(result?.instrumentationLibraryMetrics.length, 2);
+      assert.strictEqual(result?.scopeMetrics.length, 2);
 
-      // First InstrumentationLibrary matches the first created Meter.
-      assertInstrumentationLibraryMetrics(result?.instrumentationLibraryMetrics[0], {
+      // First InstrumentationScope matches the first created Meter.
+      assertScopeMetrics(result?.scopeMetrics[0], {
         name: 'meter1',
         version: 'v1.0.0'
       });
 
       // Collected one Metric on 'meter1'
-      assert.strictEqual(result?.instrumentationLibraryMetrics[0].metrics.length, 1);
+      assert.strictEqual(result?.scopeMetrics[0].metrics.length, 1);
 
       // View updated the name to 'renamed-instrument' and instrument is still a Counter
-      assertMetricData(result?.instrumentationLibraryMetrics[0].metrics[0], DataPointType.SINGULAR, {
+      assertMetricData(result?.scopeMetrics[0].metrics[0], DataPointType.SINGULAR, {
         name: 'renamed-instrument',
         type: InstrumentType.COUNTER,
       });
 
-      // Second InstrumentationLibrary matches the second created Meter.
-      assertInstrumentationLibraryMetrics(result?.instrumentationLibraryMetrics[1], {
+      // Second InstrumentationScope matches the second created Meter.
+      assertScopeMetrics(result?.scopeMetrics[1], {
         name: 'meter2',
         version: 'v1.0.0'
       });
 
       // Collected one Metric on 'meter2'
-      assert.strictEqual(result?.instrumentationLibraryMetrics[1].metrics.length, 1);
+      assert.strictEqual(result?.scopeMetrics[1].metrics.length, 1);
 
       // View updated the name to 'renamed-instrument' and instrument is still a Counter
-      assertMetricData(result?.instrumentationLibraryMetrics[1].metrics[0], DataPointType.SINGULAR, {
+      assertMetricData(result?.scopeMetrics[1].metrics[0], DataPointType.SINGULAR, {
         name: 'renamed-instrument',
         type: InstrumentType.COUNTER
       });
@@ -381,34 +381,34 @@ describe('MeterProvider', () => {
       const result = await reader.collect();
 
       // Results came from two Meters.
-      assert.strictEqual(result?.instrumentationLibraryMetrics.length, 2);
+      assert.strictEqual(result?.scopeMetrics.length, 2);
 
-      // First InstrumentationLibrary matches the first created Meter.
-      assertInstrumentationLibraryMetrics(result?.instrumentationLibraryMetrics[0], {
+      // First InstrumentationScope matches the first created Meter.
+      assertScopeMetrics(result?.scopeMetrics[0], {
         name: 'meter1',
         version: 'v1.0.0'
       });
 
       // Collected one Metric on 'meter1'
-      assert.strictEqual(result?.instrumentationLibraryMetrics[0].metrics.length, 1);
+      assert.strictEqual(result?.scopeMetrics[0].metrics.length, 1);
 
       // View updated the name to 'renamed-instrument' and instrument is still a Counter
-      assertMetricData(result?.instrumentationLibraryMetrics[0].metrics[0], DataPointType.SINGULAR, {
+      assertMetricData(result?.scopeMetrics[0].metrics[0], DataPointType.SINGULAR, {
         name: 'renamed-instrument',
         type: InstrumentType.COUNTER
       });
 
-      // Second InstrumentationLibrary matches the second created Meter.
-      assertInstrumentationLibraryMetrics(result?.instrumentationLibraryMetrics[1], {
+      // Second InstrumentationScope matches the second created Meter.
+      assertScopeMetrics(result?.scopeMetrics[1], {
         name: 'meter2',
         version: 'v1.0.0'
       });
 
       // Collected one Metric on 'meter2'
-      assert.strictEqual(result?.instrumentationLibraryMetrics[1].metrics.length, 1);
+      assert.strictEqual(result?.scopeMetrics[1].metrics.length, 1);
 
       // No updated name on 'test-counter'.
-      assertMetricData(result?.instrumentationLibraryMetrics[1].metrics[0], DataPointType.SINGULAR, {
+      assertMetricData(result?.scopeMetrics[1].metrics[0], DataPointType.SINGULAR, {
         name: 'test-counter',
         type: InstrumentType.COUNTER
       });
@@ -457,23 +457,23 @@ describe('MeterProvider', () => {
       const result = await reader.collect();
 
       // Results came only from one Meter.
-      assert.strictEqual(result?.instrumentationLibraryMetrics.length, 1);
+      assert.strictEqual(result?.scopeMetrics.length, 1);
 
-      // InstrumentationLibrary matches the only created Meter.
-      assertInstrumentationLibraryMetrics(result?.instrumentationLibraryMetrics[0], {
+      // InstrumentationScope matches the only created Meter.
+      assertScopeMetrics(result?.scopeMetrics[0], {
         name: 'meter1',
         version: 'v1.0.0'
       });
 
       // Two metrics are collected ('renamed-instrument'-Counter and 'renamed-instrument'-Histogram)
-      assert.strictEqual(result?.instrumentationLibraryMetrics[0].metrics.length, 2);
+      assert.strictEqual(result?.scopeMetrics[0].metrics.length, 2);
 
       // Both 'renamed-instrument' are still exported with their types.
-      assertMetricData(result?.instrumentationLibraryMetrics[0].metrics[0], DataPointType.SINGULAR, {
+      assertMetricData(result?.scopeMetrics[0].metrics[0], DataPointType.SINGULAR, {
         name: 'renamed-instrument',
         type: InstrumentType.COUNTER
       });
-      assertMetricData(result?.instrumentationLibraryMetrics[0].metrics[1], DataPointType.HISTOGRAM, {
+      assertMetricData(result?.scopeMetrics[0].metrics[1], DataPointType.HISTOGRAM, {
         name: 'renamed-instrument',
         type: InstrumentType.HISTOGRAM
       });

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/export/PeriodicExportingMetricReader.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/export/PeriodicExportingMetricReader.test.ts
@@ -88,14 +88,14 @@ class TestDeltaMetricExporter extends TestMetricExporter {
   }
 }
 
-const emptyResourceMetrics = { resource: defaultResource, instrumentationLibraryMetrics: [] };
+const emptyResourceMetrics = { resource: defaultResource, scopeMetrics: [] };
 
 class TestMetricProducer implements MetricProducer {
   public collectionTime = 0;
 
   async collect(): Promise<ResourceMetrics> {
     await new Promise(resolve => setTimeout(resolve, this.collectionTime));
-    return { resource: defaultResource, instrumentationLibraryMetrics: [] };
+    return { resource: defaultResource, scopeMetrics: [] };
   }
 }
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/state/MeterSharedState.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/state/MeterSharedState.test.ts
@@ -23,7 +23,7 @@ import {
   DataPointType,
   ResourceMetrics
 } from '../../src';
-import { assertMetricData, defaultInstrumentationLibrary, defaultResource, sleep } from '../util';
+import { assertMetricData, defaultInstrumentationScope, defaultResource, sleep } from '../util';
 import { TestMetricReader } from '../export/TestMetricReader';
 import { MeterSharedState } from '../../src/state/MeterSharedState';
 
@@ -46,8 +46,8 @@ describe('MeterSharedState', () => {
 
       const metricCollectors = [cumulativeCollector, deltaCollector];
 
-      const meter = meterProvider.getMeter(defaultInstrumentationLibrary.name, defaultInstrumentationLibrary.version, {
-        schemaUrl: defaultInstrumentationLibrary.schemaUrl,
+      const meter = meterProvider.getMeter(defaultInstrumentationScope.name, defaultInstrumentationScope.version, {
+        schemaUrl: defaultInstrumentationScope.schemaUrl,
       }) as Meter;
       const meterSharedState = meter['_meterSharedState'] as MeterSharedState;
 
@@ -65,9 +65,9 @@ describe('MeterSharedState', () => {
       counter.add(1);
       await Promise.all(metricCollectors.map(async collector => {
         const result = await collector.collect();
-        assert.strictEqual(result.instrumentationLibraryMetrics.length, 1);
-        assert.strictEqual(result.instrumentationLibraryMetrics[0].metrics.length, 1);
-        assertMetricData(result.instrumentationLibraryMetrics[0].metrics[0], DataPointType.SINGULAR, {
+        assert.strictEqual(result.scopeMetrics.length, 1);
+        assert.strictEqual(result.scopeMetrics[0].metrics.length, 1);
+        assertMetricData(result.scopeMetrics[0].metrics[0], DataPointType.SINGULAR, {
           name: 'test',
         });
       }));
@@ -87,12 +87,12 @@ describe('MeterSharedState', () => {
       counter.add(1);
       await Promise.all(metricCollectors.map(async collector => {
         const result = await collector.collect();
-        assert.strictEqual(result.instrumentationLibraryMetrics.length, 1);
-        assert.strictEqual(result.instrumentationLibraryMetrics[0].metrics.length, 2);
-        assertMetricData(result.instrumentationLibraryMetrics[0].metrics[0], DataPointType.SINGULAR, {
+        assert.strictEqual(result.scopeMetrics.length, 1);
+        assert.strictEqual(result.scopeMetrics[0].metrics.length, 2);
+        assertMetricData(result.scopeMetrics[0].metrics[0], DataPointType.SINGULAR, {
           name: 'foo',
         });
-        assertMetricData(result.instrumentationLibraryMetrics[0].metrics[1], DataPointType.SINGULAR, {
+        assertMetricData(result.scopeMetrics[0].metrics[1], DataPointType.SINGULAR, {
           name: 'bar',
         });
       }));
@@ -156,12 +156,12 @@ describe('MeterSharedState', () => {
       });
 
       function verifyResult(resourceMetrics: ResourceMetrics) {
-        assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics.length, 1);
-        assert.strictEqual(resourceMetrics.instrumentationLibraryMetrics[0].metrics.length, 2);
-        assertMetricData(resourceMetrics.instrumentationLibraryMetrics[0].metrics[0], DataPointType.SINGULAR, {
+        assert.strictEqual(resourceMetrics.scopeMetrics.length, 1);
+        assert.strictEqual(resourceMetrics.scopeMetrics[0].metrics.length, 2);
+        assertMetricData(resourceMetrics.scopeMetrics[0].metrics[0], DataPointType.SINGULAR, {
           name: 'foo'
         });
-        assertMetricData(resourceMetrics.instrumentationLibraryMetrics[0].metrics[1], DataPointType.SINGULAR, {
+        assertMetricData(resourceMetrics.scopeMetrics[0].metrics[1], DataPointType.SINGULAR, {
           name: 'bar'
         });
       }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/state/MetricCollector.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/state/MetricCollector.test.ts
@@ -21,7 +21,7 @@ import { DataPointType } from '../../src/export/MetricData';
 import { PushMetricExporter } from '../../src/export/MetricExporter';
 import { MeterProviderSharedState } from '../../src/state/MeterProviderSharedState';
 import { MetricCollector } from '../../src/state/MetricCollector';
-import { defaultInstrumentationLibrary, defaultResource, assertMetricData, assertDataPoint } from '../util';
+import { defaultInstrumentationScope, defaultResource, assertMetricData, assertDataPoint } from '../util';
 import { TestMetricReader } from '../export/TestMetricReader';
 import { TestDeltaMetricExporter, TestMetricExporter } from '../export/TestMetricExporter';
 
@@ -50,8 +50,8 @@ describe('MetricCollector', () => {
       meterProvider.addMetricReader(reader);
       const metricCollector = reader.getMetricCollector();
 
-      const meter = meterProvider.getMeter(defaultInstrumentationLibrary.name, defaultInstrumentationLibrary.version, {
-        schemaUrl: defaultInstrumentationLibrary.schemaUrl,
+      const meter = meterProvider.getMeter(defaultInstrumentationScope.name, defaultInstrumentationScope.version, {
+        schemaUrl: defaultInstrumentationScope.schemaUrl,
       });
 
       return { metricCollector, meter };
@@ -71,8 +71,8 @@ describe('MetricCollector', () => {
       counter2.add(3);
 
       /** collect metrics */
-      const { instrumentationLibraryMetrics } = await metricCollector.collect();
-      const { metrics } = instrumentationLibraryMetrics[0];
+      const { scopeMetrics } = await metricCollector.collect();
+      const { metrics } = scopeMetrics[0];
       assert.strictEqual(metrics.length, 2);
 
       /** checking batch[0] */

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/util.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/util.ts
@@ -15,7 +15,7 @@
  */
 
 import { MetricAttributes, ValueType } from '@opentelemetry/api-metrics';
-import { InstrumentationLibrary } from '@opentelemetry/core';
+import { InstrumentationScope } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import { InstrumentDescriptor, InstrumentType } from '../src/InstrumentDescriptor';
@@ -23,7 +23,7 @@ import {
   MetricData,
   DataPoint,
   DataPointType,
-  InstrumentationLibraryMetrics
+  ScopeMetrics
 } from '../src/export/MetricData';
 import { Measurement } from '../src/Measurement';
 import { isNotNullish } from '../src/utils';
@@ -42,7 +42,7 @@ export const defaultInstrumentDescriptor: InstrumentDescriptor = {
   valueType: ValueType.DOUBLE,
 };
 
-export const defaultInstrumentationLibrary: InstrumentationLibrary = {
+export const defaultInstrumentationScope: InstrumentationScope = {
   name: 'default',
   version: '1.0.0',
   schemaUrl: 'https://opentelemetry.io/schemas/1.7.0'
@@ -58,12 +58,12 @@ export const sleep = (time: number) =>
     return setTimeout(resolve, time);
   });
 
-export function assertInstrumentationLibraryMetrics(
+export function assertScopeMetrics(
   actual: unknown,
-  instrumentationLibrary: Partial<InstrumentationLibrary>
-): asserts actual is InstrumentationLibraryMetrics {
-  const it = actual as InstrumentationLibraryMetrics;
-  assertPartialDeepStrictEqual(it.instrumentationLibrary, instrumentationLibrary);
+  instrumentationScope: Partial<InstrumentationScope>
+): asserts actual is ScopeMetrics {
+  const it = actual as ScopeMetrics;
+  assertPartialDeepStrictEqual(it.scope, instrumentationScope);
   assert(Array.isArray(it.metrics));
 }
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/view/ViewRegistry.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/view/ViewRegistry.test.ts
@@ -20,14 +20,14 @@ import { ViewRegistry } from '../../src/view/ViewRegistry';
 import { View } from '../../src/view/View';
 import { InstrumentSelector } from '../../src/view/InstrumentSelector';
 import { MeterSelector } from '../../src/view/MeterSelector';
-import { defaultInstrumentationLibrary, defaultInstrumentDescriptor } from '../util';
+import { defaultInstrumentationScope, defaultInstrumentDescriptor } from '../util';
 
 
 describe('ViewRegistry', () => {
   describe('findViews', () => {
     it('should return default view if no view registered', () => {
       const registry = new ViewRegistry();
-      const views = registry.findViews(defaultInstrumentDescriptor, defaultInstrumentationLibrary);
+      const views = registry.findViews(defaultInstrumentDescriptor, defaultInstrumentationScope);
       assert.strictEqual(views.length, 1);
       assert.strictEqual(views[0], ViewRegistry['DEFAULT_VIEW']);
     });
@@ -47,7 +47,7 @@ describe('ViewRegistry', () => {
           const views = registry.findViews({
             ...defaultInstrumentDescriptor,
             name: 'foo'
-          }, defaultInstrumentationLibrary);
+          }, defaultInstrumentationScope);
 
           assert.strictEqual(views.length, 2);
           assert.strictEqual(views[0].name, 'no-filter');
@@ -58,7 +58,7 @@ describe('ViewRegistry', () => {
           const views = registry.findViews({
             ...defaultInstrumentDescriptor,
             name: 'bar'
-          }, defaultInstrumentationLibrary);
+          }, defaultInstrumentationScope);
 
           assert.strictEqual(views.length, 2);
           assert.strictEqual(views[0].name, 'no-filter');
@@ -80,7 +80,7 @@ describe('ViewRegistry', () => {
           const views = registry.findViews({
             ...defaultInstrumentDescriptor,
             type: InstrumentType.COUNTER
-          }, defaultInstrumentationLibrary);
+          }, defaultInstrumentationScope);
 
           assert.strictEqual(views.length, 2);
           assert.strictEqual(views[0].name, 'no-filter');
@@ -91,7 +91,7 @@ describe('ViewRegistry', () => {
           const views = registry.findViews({
             ...defaultInstrumentDescriptor,
             type: InstrumentType.HISTOGRAM
-          }, defaultInstrumentationLibrary);
+          }, defaultInstrumentationScope);
 
           assert.strictEqual(views.length, 2);
           assert.strictEqual(views[0].name, 'no-filter');
@@ -113,7 +113,7 @@ describe('ViewRegistry', () => {
 
         {
           const views = registry.findViews(defaultInstrumentDescriptor, {
-            ...defaultInstrumentationLibrary,
+            ...defaultInstrumentationScope,
             name: 'foo',
           });
 
@@ -124,7 +124,7 @@ describe('ViewRegistry', () => {
 
         {
           const views = registry.findViews(defaultInstrumentDescriptor, {
-            ...defaultInstrumentationLibrary,
+            ...defaultInstrumentationScope,
             name: 'bar'
           });
 

--- a/experimental/packages/otlp-transformer/src/metrics/internal.ts
+++ b/experimental/packages/otlp-transformer/src/metrics/internal.ts
@@ -20,7 +20,7 @@ import {
   DataPoint,
   DataPointType,
   Histogram,
-  InstrumentationLibraryMetrics,
+  ScopeMetrics,
   InstrumentType,
   MetricData,
   ResourceMetrics
@@ -42,19 +42,19 @@ export function toResourceMetrics(resourceMetrics: ResourceMetrics): IResourceMe
       droppedAttributesCount: 0
     },
     schemaUrl: undefined, // TODO: Schema Url does not exist yet in the SDK.
-    scopeMetrics: toScopeMetrics(resourceMetrics.instrumentationLibraryMetrics)
+    scopeMetrics: toScopeMetrics(resourceMetrics.scopeMetrics)
   };
 }
 
-export function toScopeMetrics(instrumentationLibraryMetrics: InstrumentationLibraryMetrics[]): IScopeMetrics[]{
-  return Array.from(instrumentationLibraryMetrics.map(metrics => {
+export function toScopeMetrics(scopeMetrics: ScopeMetrics[]): IScopeMetrics[]{
+  return Array.from(scopeMetrics.map(metrics => {
     const scopeMetrics : IScopeMetrics = {
       scope: {
-        name: metrics.instrumentationLibrary.name,
-        version: metrics.instrumentationLibrary.version,
+        name: metrics.scope.name,
+        version: metrics.scope.version,
       },
       metrics: metrics.metrics.map(metricData => toMetric(metricData)),
-      schemaUrl: metrics.instrumentationLibrary.schemaUrl
+      schemaUrl: metrics.scope.schemaUrl
     };
     return scopeMetrics;
   }));

--- a/experimental/packages/otlp-transformer/test/metrics.test.ts
+++ b/experimental/packages/otlp-transformer/test/metrics.test.ts
@@ -133,10 +133,10 @@ describe('Metrics', () => {
       });
       return {
         resource: resource,
-        instrumentationLibraryMetrics:
+        scopeMetrics:
           [
             {
-              instrumentationLibrary: {
+              scope: {
                 name: 'mylib',
                 version: '0.1.0',
                 schemaUrl: 'http://url.to.schema'

--- a/packages/opentelemetry-core/src/common/types.ts
+++ b/packages/opentelemetry-core/src/common/types.ts
@@ -40,11 +40,23 @@ export interface ShimWrapped extends Function {
 }
 
 /**
- * An instrumentation library consists of the name and and optional version
+ * An instrumentation library consists of the name and optional version
+ * used to obtain a tracer or meter from a provider. This metadata is made
+ * available on ReadableSpan and MetricRecord for use by the export pipeline.
+ * @deprecated Use {@link InstrumentationScope} instead.
+ */
+export interface InstrumentationLibrary {
+  readonly name: string;
+  readonly version?: string;
+  readonly schemaUrl?: string;
+}
+
+/**
+ * An instrumentation scope consists of the name and optional version
  * used to obtain a tracer or meter from a provider. This metadata is made
  * available on ReadableSpan and MetricRecord for use by the export pipeline.
  */
-export interface InstrumentationLibrary {
+export interface InstrumentationScope {
   readonly name: string;
   readonly version?: string;
   readonly schemaUrl?: string;


### PR DESCRIPTION
## Which problem is this PR solving?

The spec renamed `InstrumentationLibrary` to `InstrumentationScope`. This PR renames `InstrumentationLibrary` to `InstrumentationScope` to match the spec (**Metrics ONLY**)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - breaking change for experimental packages

## How Has This Been Tested?

- [x] Unit Tests

## Checklist:

- [ ] Followed the style guidelines of this project
- [x] Unit tests have been ~~added~~ updated
- [ ] Documentation has been updated
