### PR TITLE
deps(otlp-transformer): move sdk-trace-base and sdk-metrics-base to dev-dependencies

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to experimental packages in this project will be documented 
 * feat(exporters): update proto version and use otlp-transformer #2929 @pichlermarc
 * fix(sdk-metrics-base): misbehaving aggregation temporality selector tolerance #2958 @legendecas
 * feat(sdk-metrics-base): async instruments callback timeout #2742 @legendecas
+* deps(otlp-transformer): move sdk-trace-base and sdk-metrics-base to dev-dependencies #2973 @pichlermarc
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/otlp-transformer/README.md
+++ b/experimental/packages/otlp-transformer/README.md
@@ -3,9 +3,9 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
-This package provides everything needed to serialize [OpenTelemetry SDK][sdk] traces and metrics into the [OpenTelemetry Protocol][otlp] format using [protocol buffers][protobuf] or JSON.
-It also contains service clients for exporting traces and metrics to the OpenTelemetry Collector or a compatible receiver using using OTLP over [gRPC][grpc].
-This module uses [`protobufjs`][protobufjs] for serialization and is compatible with [`@grpc/grpc-js`][grpc-js].
+**NOTE: This package is intended for internal use only.**
+
+This package provides everything needed to serialize [OpenTelemetry SDK][sdk] traces and metrics into the [OpenTelemetry Protocol][otlp] format.
 
 ## Quick Start
 
@@ -15,8 +15,7 @@ To get started you will need to install a compatible OpenTelemetry API.
 
 ```sh
 npm install \
-    @opentelemetry/api \
-    @grpc/grpc-js # only required if you are using gRPC
+    @opentelemetry/api
 ```
 
 ### Serialize Traces and Metrics
@@ -28,65 +27,6 @@ import { createExportTraceServiceRequest, createExportMetricsServiceRequest } fr
 
 const serializedSpans = createExportTraceServiceRequest(readableSpans);
 const serializedMetrics = createExportMetricsServiceRequest(readableMetrics);
-```
-
-### Create gRPC Service Clients
-
-This module also contains gRPC service clients for exporting traces and metrics to an OpenTelemetry collector or compatible receiver over gRPC.
-In order to avoid bundling a gRPC module with this module, it is required to construct an RPC implementation to pass to the constructor of the service clients.
-Any RPC implementation compatible with `grpc` or `@grpc/grpc-js` may be used, but `@grpc/grpc-js` is recommended.
-
-```typescript
-import type { RPCImpl } from 'protobufjs';
-import { makeGenericClientConstructor, credentials } from '@gprc/grpc-js';
-import { MetricServiceClient, TraceServiceClient } from "@opentelemetry/otlp-transformer";
-
-// Construct a RPC Implementation according to protobufjs docs
-const GrpcClientConstructor = makeGenericClientConstructor({});
-
-const metricGRPCClient = new GrpcClientConstructor(
-    "http://localhost:4317/v1/metrics", // default collector metrics endpoint
-    credentials.createInsecure(),
-);
-
-const traceGRPCClient = new GrpcClientConstructor(
-    "http://localhost:4317/v1/traces", // default collector traces endpoint
-    credentials.createInsecure(),
-);
-
-const metricRpc: RPCImpl = function(method, requestData, callback) {
-  metricGRPCClient.makeUnaryRequest(
-    method.name,
-    arg => arg,
-    arg => arg,
-    requestData,
-    callback
-  );
-}
-
-const traceRpc: RPCImpl = function(method, requestData, callback) {
-  traceGRPCClient.makeUnaryRequest(
-    method.name,
-    arg => arg,
-    arg => arg,
-    requestData,
-    callback
-  );
-}
-
-// Construct service clients to use RPC Implementations
-const metricServiceClient = new MetricServiceClient({
-    rpcImpl: metricRpc,
-    startTime: Date.now(), // exporter start time in milliseconds
-});
-
-const traceServiceClient = new TraceServiceClient({
-    rpcImpl: traceRpc,
-});
-
-// Export ReadableSpan[] and ReadableMetric[] over gRPC
-await metricServiceClient.export(readableMetrics);
-await traceServiceClient.export(readableSpans);
 ```
 
 ## Useful links

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -38,6 +38,12 @@
     "node": ">=8.12.0"
   },
   "files": [
+    "build/esm/**/*.js",
+    "build/esm/**/*.js.map",
+    "build/esm/**/*.d.ts",
+    "build/esnext/**/*.js",
+    "build/esnext/**/*.js.map",
+    "build/esnext/**/*.d.ts",
     "build/src/**/*.js",
     "build/src/**/*.js.map",
     "build/src/**/*.d.ts",
@@ -49,6 +55,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0",
+    "@opentelemetry/resources": "1.2.0",
+    "@opentelemetry/sdk-metrics-base": "0.28.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/mocha": "8.2.3",
     "@types/webpack-env": "1.16.3",
     "codecov": "3.8.3",
@@ -62,7 +71,6 @@
     "mkdirp": "1.0.4",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
-    "protobufjs": "6.11.2",
     "rimraf": "3.0.2",
     "ts-loader": "8.3.0",
     "ts-mocha": "9.0.2",
@@ -71,9 +79,6 @@
   },
   "dependencies": {
     "@opentelemetry/api-metrics": "0.28.0",
-    "@opentelemetry/core": "1.2.0",
-    "@opentelemetry/resources": "1.2.0",
-    "@opentelemetry/sdk-metrics-base": "0.28.0",
-    "@opentelemetry/sdk-trace-base": "1.2.0"
+    "@opentelemetry/core": "1.2.0"
   }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

The `@opentelemetry/otlp-transformer` package currently depends on `@opentelemetry/sdk-metrics-base` and `@opentelemetry/sdk-trace-base`. The OTLP exporters are split between signal lines (currently metrics and traces), but via  `@opentelemetry/otlp-transformer`, all exporters depend on both `@opentelemetry/sdk-metrics-base` and `@opentelemetry/sdk-trace-base`. 

However, the `@opentelemetry/otlp-transformer` package currently only uses types from `@opentelemetry/sdk-metrics-base` and `@opentelemetry/sdk-trace-base` which means that they can be `devDependencies` instead. 

This PR converts these dependencies to `dev-dependencies` and removes some outdated information from the README file.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing with the `otlp-exporter-node` example.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated
