### PR TITLE
fix(metrics): updates unit option behavior to be spec-compliant

### DIFF
--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/InstrumentDescriptor.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/InstrumentDescriptor.ts
@@ -42,7 +42,7 @@ export function createInstrumentDescriptor(name: string, type: InstrumentType, o
     name,
     type,
     description: options?.description ?? '',
-    unit: options?.unit ?? '1',
+    unit: options?.unit === '' ? '1' : options?.unit ?? '',
     valueType: options?.valueType ?? ValueType.DOUBLE,
   };
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/InstrumentDescriptor.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/InstrumentDescriptor.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import {createInstrumentDescriptor, InstrumentType} from '../src/InstrumentDescriptor';
+
+describe('InstrumentDescriptor', () => {
+
+  describe('createInstrumentDescriptor', () => {
+
+    // Spec compliance: https://github.com/open-telemetry/opentelemetry-js/issues/2910
+    it('should interpret a null unit value as a blank string', () => {
+      const result = createInstrumentDescriptor('example', InstrumentType.COUNTER, {
+        unit: null as any,
+      });
+
+      assert.strictEqual(result.unit, '');
+    });
+
+    // Spec compliance: https://github.com/open-telemetry/opentelemetry-js/issues/2910
+    it('should interpret an undefined unit value as a blank string', () => {
+      const result = createInstrumentDescriptor('example', InstrumentType.COUNTER, {
+        unit: undefined,
+      });
+
+      assert.strictEqual(result.unit, '');
+    });
+
+    // Spec compliance: https://github.com/open-telemetry/opentelemetry-js/issues/2910
+    it('should interpret a null unit value as a blank string', () => {
+      const result = createInstrumentDescriptor('example', InstrumentType.COUNTER, {
+        unit: '',
+      });
+
+      assert.strictEqual(result.unit, '1');
+    });
+
+  });
+
+});


### PR DESCRIPTION
Fixes #2910

## Short description of the changes

Changes the behavior of the unit option for an instrument descriptor to be compliant with the specification. See additional discussion on issue.

## How Has This Been Tested?

Unit tests were added to confirm behavior.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] ~~Documentation has been updated~~
