### PR TITLE
fix(sdk-metrics-base): only record non-negative histogram values.

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(sdk-metrics-base): only record non-negative histogram values #3002 @pichlermarc
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/Instruments.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/Instruments.ts
@@ -72,6 +72,10 @@ export class HistogramInstrument extends SyncInstrument implements metrics.Histo
    * Records a measurement. Value of the measurement must not be negative.
    */
   record(value: number, attributes?: metrics.MetricAttributes, ctx?: api.Context): void {
+    if (value < 0) {
+      api.diag.warn(`negative value provided to histogram ${this._descriptor.name}: ${value}`);
+      return;
+    }
     this._record(value, attributes, ctx);
   }
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/Instruments.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/Instruments.test.ts
@@ -257,10 +257,10 @@ describe('Instruments', () => {
       });
 
       histogram.record(10);
-      // -0.1 should be trunc-ed to -0
-      histogram.record(-0.1);
+      // 0.1 should be trunc-ed to 0
+      histogram.record(0.1);
       histogram.record(100, { foo: 'bar' });
-      histogram.record(-0.1, { foo: 'bar' });
+      histogram.record(0.1, { foo: 'bar' });
       await validateExport(deltaReader, {
         descriptor: {
           name: 'test',
@@ -305,9 +305,9 @@ describe('Instruments', () => {
       });
 
       histogram.record(10);
-      histogram.record(-0.1);
+      histogram.record(0.1);
       histogram.record(100, { foo: 'bar' });
-      histogram.record(-0.1, { foo: 'bar' });
+      histogram.record(0.1, { foo: 'bar' });
       await validateExport(deltaReader, {
         dataPointType: DataPointType.HISTOGRAM,
         dataPoints: [
@@ -316,10 +316,10 @@ describe('Instruments', () => {
             value: {
               buckets: {
                 boundaries: [0, 5, 10, 25, 50, 75, 100, 250, 500, 1000],
-                counts: [1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
+                counts: [0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0],
               },
               count: 2,
-              sum: 9.9,
+              sum: 10.1,
             },
           },
           {
@@ -327,10 +327,10 @@ describe('Instruments', () => {
             value: {
               buckets: {
                 boundaries: [0, 5, 10, 25, 50, 75, 100, 250, 500, 1000],
-                counts: [1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0],
+                counts: [0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0],
               },
               count: 2,
-              sum: 99.9,
+              sum: 100.1,
             },
           },
         ],

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/Instruments.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/Instruments.test.ts
@@ -18,9 +18,24 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { InstrumentationScope } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
-import { AggregationTemporality, InstrumentDescriptor, InstrumentType, MeterProvider, MetricReader, DataPoint, DataPointType } from '../src';
+import {
+  AggregationTemporality,
+  InstrumentDescriptor,
+  InstrumentType,
+  MeterProvider,
+  MetricReader,
+  DataPoint,
+  DataPointType
+} from '../src';
 import { TestMetricReader } from './export/TestMetricReader';
-import { assertMetricData, assertDataPoint, commonValues, commonAttributes, defaultResource, defaultInstrumentationScope } from './util';
+import {
+  assertMetricData,
+  assertDataPoint,
+  commonValues,
+  commonAttributes,
+  defaultResource,
+  defaultInstrumentationScope
+} from './util';
 import { Histogram } from '../src/aggregator/types';
 import { ObservableResult, ValueType } from '@opentelemetry/api-metrics';
 
@@ -297,6 +312,18 @@ describe('Instruments', () => {
       });
     });
 
+    it('should not record negative INT values', async () => {
+      const { meter, deltaReader } = setup();
+      const histogram = meter.createHistogram('test', {
+        valueType: ValueType.DOUBLE,
+      });
+
+      histogram.record(-1, { foo: 'bar' });
+      await validateExport(deltaReader, {
+        dataPointType: DataPointType.HISTOGRAM,
+        dataPoints: [],
+      });
+    });
 
     it('should record DOUBLE values', async () => {
       const { meter, deltaReader } = setup();
@@ -334,6 +361,19 @@ describe('Instruments', () => {
             },
           },
         ],
+      });
+    });
+
+    it('should not record negative DOUBLE values', async () => {
+      const { meter, deltaReader } = setup();
+      const histogram = meter.createHistogram('test', {
+        valueType: ValueType.DOUBLE,
+      });
+
+      histogram.record(-0.5, { foo: 'bar' });
+      await validateExport(deltaReader, {
+        dataPointType: DataPointType.HISTOGRAM,
+        dataPoints: [],
       });
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

Currently, Histograms allow for negative values to be recorded. However, the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#record) states this for parameters of the Histogram `record()` function:

> Parameters:
>  - **The amount of the Measurement, which MUST be a non-negative numeric value.**
>  - Optional [attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute).

This PR changes the Histogram Implementation to drop negative values and to log when they are passed to `record()`. This behavior is in line with the [Python](https://github.com/open-telemetry/opentelemetry-python/blob/741389585b5d6d1af808a8939c5348113158f969/opentelemetry-sdk/src/opentelemetry/sdk/metrics/_internal/instrument.py#L169-L174) and [Java](https://github.com/open-telemetry/opentelemetry-java/blob/c2d8f6abd97376b94a7c1351ceb43b849ed0f7e5/sdk/metrics/src/main/java/io/opentelemetry/sdk/metrics/SdkDoubleHistogram.java#L36-L42) SDK implementations.

Fixes #3001

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Adapted existing Unit Tests
- [x] Added Unit Tests

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
