### PR TITLE
feat: record exceptions in http instrumentation

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :rocket: (Enhancement)
 
+* feat(http-instrumentation): record exceptions in http instrumentation #3008 @luismiramirez
+
 ### :bug: (Bug Fix)
 
 * fix(otlp-transformer): remove type dependency on Long #3022 @legendecas

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -150,6 +150,7 @@ export const setSpanWithError = (
   });
 
   span.setStatus({ code: SpanStatusCode.ERROR, message });
+  span.recordException(error);
 };
 
 /**

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
@@ -570,6 +570,7 @@ describe('HttpInstrumentation', () => {
             },
             component: 'http',
             noNetPeer: true,
+            error: err,
           };
           assertSpan(spans[0], SpanKind.CLIENT, validations);
           return true;

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -259,6 +259,8 @@ describe('Utility', () => {
         attributes[AttributeNames.HTTP_ERROR_MESSAGE],
         errorMessage
       );
+      assert.strictEqual(span.events.length, 1);
+      assert.strictEqual(span.events[0].name, 'exception');
       assert.ok(attributes[AttributeNames.HTTP_ERROR_NAME]);
     });
   });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

When an error is captured, it is now recorded as an event using [recordException()](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#record-exception).

## Short description of the changes

Added the `recordException` call right after the status setup in `setSpanWithError()`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Updated the helper that compares spans so it supports errors being passed and checks if they've been recorded.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
