### PR TITLE
fix(grpc-exporter): use non-normalized URL to determine channel security

### DIFF
--- a/experimental/packages/exporter-trace-otlp-grpc/src/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-grpc/src/OTLPTraceExporter.ts
@@ -48,13 +48,7 @@ export class OTLPTraceExporter
   }
 
   getDefaultUrl(config: OTLPGRPCExporterConfigNode) {
-    return typeof config.url === 'string'
-      ? validateAndNormalizeUrl(config.url)
-      : getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT.length > 0
-        ? validateAndNormalizeUrl(getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
-        : getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0
-          ? validateAndNormalizeUrl(getEnv().OTEL_EXPORTER_OTLP_ENDPOINT)
-          : validateAndNormalizeUrl(DEFAULT_COLLECTOR_URL);
+    return validateAndNormalizeUrl(this.getUrlFromConfig(config));
   }
 
   getServiceClientType() {
@@ -63,5 +57,17 @@ export class OTLPTraceExporter
 
   getServiceProtoPath(): string {
     return 'opentelemetry/proto/collector/trace/v1/trace_service.proto';
+  }
+
+  getUrlFromConfig(config: OTLPGRPCExporterConfigNode): string {
+    if (typeof config.url === 'string') {
+      return config.url;
+    } else if (getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT.length > 0) {
+      return getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    } else if (getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0) {
+      return getEnv().OTEL_EXPORTER_OTLP_ENDPOINT;
+    } else {
+      return DEFAULT_COLLECTOR_URL;
+    }
   }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/OTLPMetricExporter.ts
@@ -51,17 +51,23 @@ class OTLPMetricExporterProxy extends OTLPGRPCExporterNodeBase<ResourceMetrics, 
   }
 
   getDefaultUrl(config: OTLPGRPCExporterConfigNode): string {
-    return typeof config.url === 'string'
-      ? validateAndNormalizeUrl(config.url)
-      : getEnv().OTEL_EXPORTER_OTLP_METRICS_ENDPOINT.length > 0
-        ? validateAndNormalizeUrl(getEnv().OTEL_EXPORTER_OTLP_METRICS_ENDPOINT)
-        : getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0
-          ? validateAndNormalizeUrl(getEnv().OTEL_EXPORTER_OTLP_ENDPOINT)
-          : validateAndNormalizeUrl(DEFAULT_COLLECTOR_URL);
+    return validateAndNormalizeUrl(this.getUrlFromConfig(config));
   }
 
   convert(metrics: ResourceMetrics[]): IExportMetricsServiceRequest {
     return createExportMetricsServiceRequest(metrics);
+  }
+
+  getUrlFromConfig(config: OTLPGRPCExporterConfigNode): string {
+    if (typeof config.url === 'string') {
+      return config.url;
+    } else if (getEnv().OTEL_EXPORTER_OTLP_METRICS_ENDPOINT.length > 0) {
+      return getEnv().OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
+    } else if (getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0) {
+      return getEnv().OTEL_EXPORTER_OTLP_ENDPOINT;
+    } else {
+      return DEFAULT_COLLECTOR_URL;
+    }
   }
 }
 

--- a/experimental/packages/otlp-grpc-exporter-base/src/OTLPGRPCExporterNodeBase.ts
+++ b/experimental/packages/otlp-grpc-exporter-base/src/OTLPGRPCExporterNodeBase.ts
@@ -116,4 +116,5 @@ export abstract class OTLPGRPCExporterNodeBase<
 
   abstract getServiceProtoPath(): string;
   abstract getServiceClientType(): ServiceClientType;
+  abstract getUrlFromConfig(config: OTLPGRPCExporterConfigNode): string;
 }

--- a/experimental/packages/otlp-grpc-exporter-base/src/util.ts
+++ b/experimental/packages/otlp-grpc-exporter-base/src/util.ts
@@ -33,7 +33,7 @@ export function onInit<ExportItem, ServiceRequest>(
 ): void {
   collector.grpcQueue = [];
 
-  const credentials: grpc.ChannelCredentials = configureSecurity(config.credentials, collector.url);
+  const credentials: grpc.ChannelCredentials = configureSecurity(config.credentials, collector.getUrlFromConfig(config));
 
   const includeDirs = [path.resolve(__dirname, '..', 'protos')];
 
@@ -92,7 +92,7 @@ export function send<ExportItem, ServiceRequest>(
     collector.serviceClient.export(
       serviceRequest,
       collector.metadata || new grpc.Metadata(),
-      {deadline: deadline},
+      { deadline: deadline },
       (err: ExportServiceError) => {
         if (err) {
           diag.error('Service request', serviceRequest);
@@ -225,7 +225,7 @@ function retrieveCertChain(): Buffer | undefined {
 }
 
 function toGrpcCompression(compression: CompressionAlgorithm): GrpcCompressionAlgorithm {
-  if(compression === CompressionAlgorithm.NONE)
+  if (compression === CompressionAlgorithm.NONE)
     return GrpcCompressionAlgorithm.NONE;
   else if (compression === CompressionAlgorithm.GZIP)
     return GrpcCompressionAlgorithm.GZIP;
@@ -246,6 +246,6 @@ export function configureCompression(compression: CompressionAlgorithm | undefin
   } else {
     const definedCompression = getEnv().OTEL_EXPORTER_OTLP_TRACES_COMPRESSION || getEnv().OTEL_EXPORTER_OTLP_COMPRESSION;
 
-    return definedCompression === 'gzip' ? GrpcCompressionAlgorithm.GZIP: GrpcCompressionAlgorithm.NONE;
+    return definedCompression === 'gzip' ? GrpcCompressionAlgorithm.GZIP : GrpcCompressionAlgorithm.NONE;
   }
 }

--- a/experimental/packages/otlp-grpc-exporter-base/test/OTLPGRPCExporterNodeBase.test.ts
+++ b/experimental/packages/otlp-grpc-exporter-base/test/OTLPGRPCExporterNodeBase.test.ts
@@ -52,6 +52,10 @@ class MockCollectorExporter extends OTLPGRPCExporterNodeBase<
   getServiceProtoPath(): string {
     return 'opentelemetry/proto/collector/trace/v1/trace_service.proto';
   }
+
+  getUrlFromConfig(config: OTLPGRPCExporterConfigNode): string {
+    return '';
+  }
 }
 
 // Mocked _send which just saves the callbacks for later


### PR DESCRIPTION
## Which problem is this PR solving?

In #2675, @mplachter brought up that the gRPC exporter is currently not working as intended. Investigating this bug revealed that the `collector.url` passed to `configureSecurity()` was already stripped of its protocol (`http://` or `https://`) which is used to in `configureSecurity()` to determine the security mode (implemented in #2827).

This caused all gRPC exporters configured with URLs containing `http://` to be configured with a secure gRPC channel, and therefore did not work with the collector.

This PR fixes this issue by passing a URL that still contains the protocol to `configureSecurity()`  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing using the `otlp-exporter-node` example

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
