### PR TITLE
fix(otlp-transformer): remove type dependency on Long

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(otlp-transformer): remove type dependency on Long #3022 @legendecas
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/otlp-transformer/src/common/types.ts
+++ b/experimental/packages/otlp-transformer/src/common/types.ts
@@ -41,7 +41,7 @@ export interface IAnyValue {
   boolValue?: (boolean | null);
 
   /** AnyValue intValue */
-  intValue?: (number | Long | null);
+  intValue?: (number | null);
 
   /** AnyValue doubleValue */
   doubleValue?: (number | null);


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/3020

## Short description of the changes

We have no usage on types of Long and its implementation. Removing the references in types should not break any usage.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Followed the style guidelines of this project
