### PR TITLE
refactor(fetch): revert to original code in endSpanOnSuccess

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -321,22 +321,15 @@ export class FetchInstrumentation extends InstrumentationBase<Promise<Response>>
 
         function endSpanOnSuccess(span: api.Span, response: Response) {
           plugin._applyAttributesAfterFetch(span, options, response);
-          const spanResponse = {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-            url
-          };
           if (response.status >= 200 && response.status < 400) {
-            if (response.url != null && response.url !== '') {
-              spanResponse.url = url;
-            }
+            plugin._endSpan(span, spanData, response);
+          } else {
+            plugin._endSpan(span, spanData, {
+              status: response.status,
+              statusText: response.statusText,
+              url,
+            });
           }
-          plugin._endSpan(span, spanData, {
-            status: response.status,
-            statusText: response.statusText,
-            url,
-          });
         }
 
         function onSuccess(


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This `spanResponse` object is not used for anything, and I can't figure out its purpose:
https://github.com/open-telemetry/opentelemetry-js/blob/0213d829dc6ab4f7181212bb6f99ebb6538aaabb/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts#L324-L334

The override doesn't make sense, as it sets the same value already present in the initialised object:
https://github.com/open-telemetry/opentelemetry-js/blob/0213d829dc6ab4f7181212bb6f99ebb6538aaabb/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts#L330-L334

I have amended the code to what I think makes sense and was the original intention. Opening a PR to have a discussion.

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
