### PR TITLE
Add GraphQL schema attributes

### DIFF
--- a/packages/opentelemetry-semantic-conventions/src/trace/SemanticAttributes.ts
+++ b/packages/opentelemetry-semantic-conventions/src/trace/SemanticAttributes.ts
@@ -355,6 +355,21 @@ clear whether the exception will escape.
   CODE_LINENO: 'code.lineno',
 
   /**
+   * The GraphQL document being executed
+   */
+  GRAPHQL_DOCUMENT: 'graphql.document',
+
+  /**
+   * The name of the operation being executed.
+   */
+  GRAPHQL_OPERATION_NAME: 'graphql.operation.name',
+
+  /**
+   * The type of the operation being executed
+   */
+  GRAPHQL_OPERATION_TYPE: 'graphql.operation.type',
+
+  /**
   * HTTP request method.
   */
   HTTP_METHOD: 'http.method',

--- a/packages/opentelemetry-semantic-conventions/src/trace/SemanticAttributes.ts
+++ b/packages/opentelemetry-semantic-conventions/src/trace/SemanticAttributes.ts
@@ -355,7 +355,7 @@ clear whether the exception will escape.
   CODE_LINENO: 'code.lineno',
 
   /**
-   * The GraphQL document being executed
+   * The GraphQL document being executed.
    */
   GRAPHQL_DOCUMENT: 'graphql.document',
 
@@ -365,7 +365,7 @@ clear whether the exception will escape.
   GRAPHQL_OPERATION_NAME: 'graphql.operation.name',
 
   /**
-   * The type of the operation being executed
+   * The type of the operation being executed.
    */
   GRAPHQL_OPERATION_TYPE: 'graphql.operation.type',
 


### PR DESCRIPTION
## WHAT

I've added schema attributes for which was merged by https://github.com/open-telemetry/opentelemetry-specification/pull/2456 to help GraphQL OpenTelemetry uses to specify the attributes of there spans.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added: No unit tests as for not
- [x] Documentation has been updated: Not updates needed
