### PR TITLE
Fix docs deployment

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Build Docs
         run: npm run docs
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Deploy Documentation 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Build Docs
         run: npm run docs
         env:
-          NODE_OPTIONS: --max-old-space-size=4096
+          NODE_OPTIONS: --max-old-space-size=6144
 
       - name: Deploy Documentation 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Build Docs
         run: npm run docs
         env:
-          NODE_OPTIONS: --max-old-space-size=8192
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Deploy Documentation 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,5 +60,5 @@ jobs:
       - name: Lint doc files
         run: |
           npm run compile
-          NODE_OPTIONS=--max-old-space-size=4096 npm run docs
+          NODE_OPTIONS=--max-old-space-size=6144 npm run docs
           npm run docs:test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,5 +60,5 @@ jobs:
       - name: Lint doc files
         run: |
           npm run compile
-          NODE_OPTIONS=--max-old-space-size=8192 npm run docs
-          NODE_OPTIONS=--max-old-space-size=8192 npm run docs:test
+          NODE_OPTIONS=--max-old-space-size=4096 npm run docs
+          NODE_OPTIONS=--max-old-space-size=4096 npm run docs:test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,4 +61,4 @@ jobs:
         run: |
           npm run compile
           NODE_OPTIONS=--max-old-space-size=4096 npm run docs
-          NODE_OPTIONS=--max-old-space-size=4096 npm run docs:test
+          npm run docs:test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,5 +60,5 @@ jobs:
       - name: Lint doc files
         run: |
           npm run compile
-          NODE_OPTIONS=--max-old-space-size=4096 npm run docs
-          npm run docs:test
+          NODE_OPTIONS=--max-old-space-size=8192 npm run docs
+          NODE_OPTIONS=--max-old-space-size=8192 npm run docs:test


### PR DESCRIPTION
Docs deployment has failed for a while. We were also missing some of the packages now that we are back to a single monorepo.