### PR TITLE
Add node 18 to tests and remove EoL node versions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ["8", "10", "12", "14", "16"]
+        node_version: ["14", "16", "18"]
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_UNSAFE_PERM: true


### PR DESCRIPTION
Based on discussions we've had in several SIG meetings.

- API will continue to support old runtimes as long as is practical
- Allows us to update our CI tooling to versions which no longer support these deprecated runtimes