### PR TITLE
release proposal 1.4.0/0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # CHANGELOG
 
 All notable changes to this project will be documented in this file.
-
 ## Unreleased
 
 ### :boom: Breaking Change
@@ -10,10 +9,18 @@ All notable changes to this project will be documented in this file.
 
 ### :bug: (Bug Fix)
 
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+
+## 1.4.0
+
+### :rocket: (Enhancement)
+
+
 * fix(resources): fix browser compatibility for host and os detectors [#3004](https://github.com/open-telemetry/opentelemetry-js/pull/3004) @legendecas
 * fix(sdk-trace-base): fix crash on environments without global document [#3000](https://github.com/open-telemetry/opentelemetry-js/pull/3000) @legendecas
-
-### :books: (Refine Doc)
 
 ### :house: (Internal)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 All notable changes to this project will be documented in this file.
+
 ## Unreleased
 
 ### :boom: Breaking Change
@@ -13,11 +14,9 @@ All notable changes to this project will be documented in this file.
 
 ### :house: (Internal)
 
-
 ## 1.4.0
 
 ### :rocket: (Enhancement)
-
 
 * fix(resources): fix browser compatibility for host and os detectors [#3004](https://github.com/open-telemetry/opentelemetry-js/pull/3004) @legendecas
 * fix(sdk-trace-base): fix crash on environments without global document [#3000](https://github.com/open-telemetry/opentelemetry-js/pull/3000) @legendecas

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ This is the JavaScript version of [OpenTelemetry](https://opentelemetry.io/), a 
 
 | API Version | Core version | Experimental Packages |
 | ----------- | ------------ | --------------------- |
+| 1.1.x       | 1.3.x        | 0.30.x                |
+| 1.1.x       | 1.2.x        | 0.29.x                |
 | 1.1.x       | 1.1.x        | 0.28.x                |
 | 1.0.x       | 1.0.x        | 0.26.x, 0.27.x        |
 | 1.0.x       | 0.26.x       | -----                 |

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-otlp-exporter-node",
   "private": true,
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
@@ -29,18 +29,18 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.1.0",
-    "@opentelemetry/api-metrics": "0.29.2",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.29.2",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.29.2",
-    "@opentelemetry/exporter-metrics-otlp-proto": "0.29.2",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.29.2",
-    "@opentelemetry/exporter-trace-otlp-http": "0.29.2",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.29.2",
-    "@opentelemetry/resources": "1.3.1",
-    "@opentelemetry/sdk-metrics-base": "0.29.2",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
-    "@opentelemetry/semantic-conventions": "1.3.1"
+    "@opentelemetry/api-metrics": "0.30.0",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.30.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.30.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "0.30.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.30.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.30.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.30.0",
+    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/sdk-metrics-base": "0.30.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/semantic-conventions": "1.4.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js#readme"
 }

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+### :rocket: (Enhancement)
+
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 0.30.0
+
+### :boom: Breaking Change
+
 * fix: remove aws and gcp detector from SDK #3024 @flarna
 * feat(sdk-metrics-base): implement min/max recording for Histograms #3032 @pichlermarc
   * adds `min`/`max` recording to Histograms
@@ -25,8 +37,6 @@ All notable changes to experimental packages in this project will be documented 
 * fix(otlp-transformer): remove type dependency on Long #3022 @legendecas
 * fix(grpc-exporter): use non-normalized URL to determine channel security #3019 @pichlermarc
 * fix(otlp-exporter-base): fix gzip output stream in http otlp export #3046 @mattolson
-
-### :books: (Refine Doc)
 
 ### :house: (Internal)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -18,8 +18,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
-* fix: remove aws and gcp detector from SDK #3024 @flarna
-* feat(sdk-metrics-base): implement min/max recording for Histograms #3032 @pichlermarc
+* fix: remove aws and gcp detector from SDK [#3024](https://github.com/open-telemetry/opentelemetry-js/pull/3024) @flarna
+* feat(sdk-metrics-base): implement min/max recording for Histograms [#3032](https://github.com/open-telemetry/opentelemetry-js/pull/3032) @pichlermarc
   * adds `min`/`max` recording to Histograms
   * updates [opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto) to `0.18` so that `min` and
     `max` can be exported. This change breaks the OTLP/JSON Metric Exporter for all collector versions `<0.52` due to
@@ -27,20 +27,20 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :rocket: (Enhancement)
 
-* feat(opentelemetry-instrumentation-fetch): optionally ignore network events #3028 @gregolsen
-* feat(http-instrumentation): record exceptions in http instrumentation #3008 @luismiramirez
-* feat(node-sdk): add serviceName config option #2867 @naseemkullah
-* feat(opentelemetry-exporter-prometheus): export PrometheusSerializer #3034 @matschaffer
-* feat(sdk-metrics-base): detect resets on async metrics #2990 @legendecas
+* feat(opentelemetry-instrumentation-fetch): optionally ignore network events [#3028](https://github.com/open-telemetry/opentelemetry-js/pull/3028) @gregolsen
+* feat(http-instrumentation): record exceptions in http instrumentation [#3008](https://github.com/open-telemetry/opentelemetry-js/pull/3008) @luismiramirez
+* feat(node-sdk): add serviceName config option [#2867](https://github.com/open-telemetry/opentelemetry-js/pull/2867) @naseemkullah
+* feat(opentelemetry-exporter-prometheus): export PrometheusSerializer [#3034](https://github.com/open-telemetry/opentelemetry-js/pull/3034) @matschaffer
+* feat(sdk-metrics-base): detect resets on async metrics [#2990](https://github.com/open-telemetry/opentelemetry-js/pull/2990) @legendecas
   * Added monotonicity support in SumAggregator.
   * Added reset and gaps detection for async metric instruments.
   * Fixed the start time and end time of an exported metric with regarding to resets and gaps.
 
 ### :bug: (Bug Fix)
 
-* fix(otlp-transformer): remove type dependency on Long #3022 @legendecas
-* fix(grpc-exporter): use non-normalized URL to determine channel security #3019 @pichlermarc
-* fix(otlp-exporter-base): fix gzip output stream in http otlp export #3046 @mattolson
+* fix(otlp-transformer): remove type dependency on Long [#3022](https://github.com/open-telemetry/opentelemetry-js/pull/3022) @legendecas
+* fix(grpc-exporter): use non-normalized URL to determine channel security [#3019](https://github.com/open-telemetry/opentelemetry-js/pull/3019) @pichlermarc
+* fix(otlp-exporter-base): fix gzip output stream in http otlp export [#3046](https://github.com/open-telemetry/opentelemetry-js/pull/3046) @mattolson
 
 ### :house: (Internal)
 
@@ -54,37 +54,37 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
-* fix(sdk-metrics-base): only record non-negative histogram values #3002 @pichlermarc
+* fix(sdk-metrics-base): only record non-negative histogram values [#3002](https://github.com/open-telemetry/opentelemetry-js/pull/3002) @pichlermarc
 * fix(otlp-transformer): include missing prepublishOnly script which ensures esm and esnext build files are created and packaged @dyladan
 
 ## 0.29.0
 
 ### :boom: Breaking Change
 
-* feat(metrics): metric readers and exporters now select aggregation temporality based on instrument type #2902 @seemk
-* refactor(metrics-sdk): rename InstrumentationLibrary -> InstrumentationScope #2959 @pichlermarc
-* feat(metrics): multi-instrument async callback support #2966 @legendecas
+* feat(metrics): metric readers and exporters now select aggregation temporality based on instrument type [#2902](https://github.com/open-telemetry/opentelemetry-js/pull/2902) @seemk
+* refactor(metrics-sdk): rename InstrumentationLibrary -> InstrumentationScope [#2959](https://github.com/open-telemetry/opentelemetry-js/pull/2959) @pichlermarc
+* feat(metrics): multi-instrument async callback support [#2966](https://github.com/open-telemetry/opentelemetry-js/pull/2966) @legendecas
   * changes on `meter.createObservableCounter`, `meter.createObservableGauge`, `meter.createObservableUpDownCounter`
     * removed the second parameter `callback`
     * returns an `Observable` object on which callbacks can be registered or unregistered.
   * added `meter.addBatchObservableCallback` and `meter.removeBatchObservableCallback`.
-* fix: remove attributes from OTLPExporterConfigBase #2991 @flarna
+* fix: remove attributes from OTLPExporterConfigBase [#2991](https://github.com/open-telemetry/opentelemetry-js/pull/2991) @flarna
 
 ### :rocket: (Enhancement)
 
-* feat(exporters): update proto version and use otlp-transformer #2929 @pichlermarc
-* fix(sdk-metrics-base): misbehaving aggregation temporality selector tolerance #2958 @legendecas
-* feat(trace-otlp-grpc): configure security with env vars #2827 @svetlanabrennan
-* feat(sdk-metrics-base): async instruments callback timeout #2742 @legendecas
+* feat(exporters): update proto version and use otlp-transformer [#2929](https://github.com/open-telemetry/opentelemetry-js/pull/2929) @pichlermarc
+* fix(sdk-metrics-base): misbehaving aggregation temporality selector tolerance [#2958](https://github.com/open-telemetry/opentelemetry-js/pull/2958) @legendecas
+* feat(trace-otlp-grpc): configure security with env vars [#2827](https://github.com/open-telemetry/opentelemetry-js/pull/2827) @svetlanabrennan
+* feat(sdk-metrics-base): async instruments callback timeout [#2742](https://github.com/open-telemetry/opentelemetry-js/pull/2742) @legendecas
 
 ### :bug: (Bug Fix)
 
-* fix(opentelemetry-instrumentation-http): use correct origin when port is `null` #2948 @danielgblanco
-* fix(otlp-exporter-base): include esm and esnext in package files #2952 @dyladan
-* fix(otlp-http-exporter): update endpoint to match spec #2895 @svetlanabrennan
-* fix(instrumentation): only patch core modules if enabled #2993 @santigimeno
-* fix(otlp-transformer): include esm and esnext in package files and update README #2992 @pichlermarc
-* fix(metrics): specification compliant default metric unit #2983 @andyfleming
+* fix(opentelemetry-instrumentation-http): use correct origin when port is `null` [#2948](https://github.com/open-telemetry/opentelemetry-js/pull/2948) @danielgblanco
+* fix(otlp-exporter-base): include esm and esnext in package files [#2952](https://github.com/open-telemetry/opentelemetry-js/pull/2952) @dyladan
+* fix(otlp-http-exporter): update endpoint to match spec [#2895](https://github.com/open-telemetry/opentelemetry-js/pull/2895) @svetlanabrennan
+* fix(instrumentation): only patch core modules if enabled [#2993](https://github.com/open-telemetry/opentelemetry-js/pull/2993) @santigimeno
+* fix(otlp-transformer): include esm and esnext in package files and update README [#2992](https://github.com/open-telemetry/opentelemetry-js/pull/2992) @pichlermarc
+* fix(metrics): specification compliant default metric unit [#2983](https://github.com/open-telemetry/opentelemetry-js/pull/2983) @andyfleming
 * fix(opentelemetry-instrumentation): use all provided patches for the same file [#2963](https://github.com/open-telemetry/opentelemetry-js/pull/2963) @Ugzuzg
 
 ### :books: (Refine Doc)
@@ -95,62 +95,62 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
-* feat(sdk-metrics-base): update metric exporter interfaces #2707 @srikanthccv
-* feat(api-metrics): remove observable types #2687 @legendecas
-* fix(otlp-http-exporter): remove content length header #2879 @svetlanabrennan
-* feat(experimental-packages): Update packages to latest SDK Version. #2871 @pichlermarc
+* feat(sdk-metrics-base): update metric exporter interfaces [#2707](https://github.com/open-telemetry/opentelemetry-js/pull/2707) @srikanthccv
+* feat(api-metrics): remove observable types [#2687](https://github.com/open-telemetry/opentelemetry-js/pull/2687) @legendecas
+* fix(otlp-http-exporter): remove content length header [#2879](https://github.com/open-telemetry/opentelemetry-js/pull/2879) @svetlanabrennan
+* feat(experimental-packages): Update packages to latest SDK Version. [#2871](https://github.com/open-telemetry/opentelemetry-js/pull/2871) @pichlermarc
   * removed the -wip suffix from api-metrics and metrics-sdk-base.
   * updated dependencies to stable packages to `1.1.1` for all "experimental" packages.
   * updated Metrics Exporters to the latest Metrics SDK (`exporter-metrics-otlp-grpc`, `exporter-metrics-otlp-http`, `exporter-metrics-otlp-proto`)
   * updated `opentelemetry-sdk-node` to the latest Metrics SDK.
   * updated `otlp-transformer` to the latest Metrics SDK.
   * updated all `instrumentation-*` packages to use local implementations of `parseUrl()` due to #2884
-* refactor(otlp-exporters) move base classes and associated types into their own packages #2893 @pichlermarc
+* refactor(otlp-exporters) move base classes and associated types into their own packages [#2893](https://github.com/open-telemetry/opentelemetry-js/pull/2893) @pichlermarc
   * `otlp-exporter-base` => `OTLPExporterBase`, `OTLPExporterBrowserBase`, `OTLPExporterNodeBase`
   * `otlp-grpc-exporter-base` => `OTLPGRPCExporterNodeBase`
   * `otlp-proto-exporter-base` => `OTLPProtoExporterNodeBase`
 
 ### :rocket: (Enhancement)
 
-* feat: spec compliant metric creation and sync instruments #2588 @dyladan
-* feat(api-metrics): async instruments spec compliance #2569 @legendecas
-* feat(sdk-metrics-base): add ValueType support for sync instruments #2776 @legendecas
-* feat(sdk-metrics-base): implement async instruments support #2686 @legendecas
-* feat(sdk-metrics-base): meter registration #2666 @legendecas
-* feat(sdk-metrics-base): bootstrap metrics exemplars #2641 @srikanthccv
-* feat(metrics-sdk): bootstrap aggregation support #2634 @legendecas
-* feat(metrics-sdk): bootstrap views api #2625 @legendecas
-* feat(sdk-metrics): bootstrap metric streams #2636 @legendecas
-* feat(views): add FilteringAttributesProcessor #2733 @pichlermarc
-* feat(metric-reader): add metric-reader #2681 @pichlermarc
-* feat(sdk-metrics-base): document and export basic APIs #2725 @legendecas
-* feat(views): Update addView() to disallow named views that select more than one instrument. #2820 @pichlermarc
-* feat(sdk-metrics-base): update exporting names #2829 @legendecas
-* Add grpc compression to trace-otlp-grpc exporter #2813 @svetlanabrennan
-* refactor: unifying shutdown once with BindOnceFuture #2695 @legendecas
-* feat(prometheus): update prometheus exporter with wip metrics sdk #2824 @legendecas
-* feat(instrumentation-xhr): add applyCustomAttributesOnSpan hook #2134 @mhennoch
-* feat(proto): add @opentelemetry/otlp-transformer package with hand-rolled transformation #2746 @dyladan
-* feat(sdk-metrics-base): shutdown and forceflush on MeterProvider #2890 @legendecas
-* feat(sdk-metrics-base): return the same meter for identical input to getMeter #2901 @legendecas
-* feat(otlp-exporter): add [OTEL_EXPORTER_OTLP_TIMEOUT](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options) env var to otlp exporters #2738 @svetlanabrennan
-* feat(sdk-metrics-base): hoist async instrument callback invocations #2822 @legendecas
+* feat: spec compliant metric creation and sync instruments [#2588](https://github.com/open-telemetry/opentelemetry-js/pull/2588) @dyladan
+* feat(api-metrics): async instruments spec compliance [#2569](https://github.com/open-telemetry/opentelemetry-js/pull/2569) @legendecas
+* feat(sdk-metrics-base): add ValueType support for sync instruments [#2776](https://github.com/open-telemetry/opentelemetry-js/pull/2776) @legendecas
+* feat(sdk-metrics-base): implement async instruments support [#2686](https://github.com/open-telemetry/opentelemetry-js/pull/2686) @legendecas
+* feat(sdk-metrics-base): meter registration [#2666](https://github.com/open-telemetry/opentelemetry-js/pull/2666) @legendecas
+* feat(sdk-metrics-base): bootstrap metrics exemplars [#2641](https://github.com/open-telemetry/opentelemetry-js/pull/2641) @srikanthccv
+* feat(metrics-sdk): bootstrap aggregation support [#2634](https://github.com/open-telemetry/opentelemetry-js/pull/2634) @legendecas
+* feat(metrics-sdk): bootstrap views api [#2625](https://github.com/open-telemetry/opentelemetry-js/pull/2625) @legendecas
+* feat(sdk-metrics): bootstrap metric streams [#2636](https://github.com/open-telemetry/opentelemetry-js/pull/2636) @legendecas
+* feat(views): add FilteringAttributesProcessor [#2733](https://github.com/open-telemetry/opentelemetry-js/pull/2733) @pichlermarc
+* feat(metric-reader): add metric-reader [#2681](https://github.com/open-telemetry/opentelemetry-js/pull/2681) @pichlermarc
+* feat(sdk-metrics-base): document and export basic APIs [#2725](https://github.com/open-telemetry/opentelemetry-js/pull/2725) @legendecas
+* feat(views): Update addView() to disallow named views that select more than one instrument. [#2820](https://github.com/open-telemetry/opentelemetry-js/pull/2820) @pichlermarc
+* feat(sdk-metrics-base): update exporting names [#2829](https://github.com/open-telemetry/opentelemetry-js/pull/2829) @legendecas
+* Add grpc compression to trace-otlp-grpc exporter [#2813](https://github.com/open-telemetry/opentelemetry-js/pull/2813) @svetlanabrennan
+* refactor: unifying shutdown once with BindOnceFuture [#2695](https://github.com/open-telemetry/opentelemetry-js/pull/2695) @legendecas
+* feat(prometheus): update prometheus exporter with wip metrics sdk [#2824](https://github.com/open-telemetry/opentelemetry-js/pull/2824) @legendecas
+* feat(instrumentation-xhr): add applyCustomAttributesOnSpan hook [#2134](https://github.com/open-telemetry/opentelemetry-js/pull/2134) @mhennoch
+* feat(proto): add @opentelemetry/otlp-transformer package with hand-rolled transformation [#2746](https://github.com/open-telemetry/opentelemetry-js/pull/2746) @dyladan
+* feat(sdk-metrics-base): shutdown and forceflush on MeterProvider [#2890](https://github.com/open-telemetry/opentelemetry-js/pull/2890) @legendecas
+* feat(sdk-metrics-base): return the same meter for identical input to getMeter [#2901](https://github.com/open-telemetry/opentelemetry-js/pull/2901) @legendecas
+* feat(otlp-exporter): add [OTEL_EXPORTER_OTLP_TIMEOUT](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options) env var to otlp exporters [#2738](https://github.com/open-telemetry/opentelemetry-js/pull/2738) @svetlanabrennan
+* feat(sdk-metrics-base): hoist async instrument callback invocations [#2822](https://github.com/open-telemetry/opentelemetry-js/pull/2822) @legendecas
 
 ### :bug: (Bug Fix)
 
-* fix(sdk-metrics-base): remove aggregator.toMetricData dependency on AggregationTemporality #2676 @legendecas
-* fix(sdk-metrics-base): coerce histogram boundaries to be implicit Infinity #2859 @legendecas
-* fix(instrumentation-http): HTTP 400 status code should not set span status to error on servers #2789 @nordfjord
+* fix(sdk-metrics-base): remove aggregator.toMetricData dependency on AggregationTemporality [#2676](https://github.com/open-telemetry/opentelemetry-js/pull/2676) @legendecas
+* fix(sdk-metrics-base): coerce histogram boundaries to be implicit Infinity [#2859](https://github.com/open-telemetry/opentelemetry-js/pull/2859) @legendecas
+* fix(instrumentation-http): HTTP 400 status code should not set span status to error on servers [#2789](https://github.com/open-telemetry/opentelemetry-js/pull/2789) @nordfjord
 
 ### :books: (Refine Doc)
 
-* Update metrics example #2658 @svetlanabrennan
-* docs(api-metrics): add notes on ObservableResult.observe #2712 @legendecas
+* Update metrics example [#2658](https://github.com/open-telemetry/opentelemetry-js/pull/2658) @svetlanabrennan
+* docs(api-metrics): add notes on ObservableResult.observe [#2712](https://github.com/open-telemetry/opentelemetry-js/pull/2712) @legendecas
 
 ### :house: (Internal)
 
-* chore: move trace exporters back to experimental #2835 @dyladan
-* refactor(sdk-metrics-base): meter shared states #2821 @legendecas
+* chore: move trace exporters back to experimental [#2835](https://github.com/open-telemetry/opentelemetry-js/pull/2835) @dyladan
+* refactor(sdk-metrics-base): meter shared states [#2821](https://github.com/open-telemetry/opentelemetry-js/pull/2821) @legendecas
 
 ## v0.27.0
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -31,6 +31,10 @@ All notable changes to experimental packages in this project will be documented 
 * feat(http-instrumentation): record exceptions in http instrumentation #3008 @luismiramirez
 * feat(node-sdk): add serviceName config option #2867 @naseemkullah
 * feat(opentelemetry-exporter-prometheus): export PrometheusSerializer #3034 @matschaffer
+* feat(sdk-metrics-base): detect resets on async metrics #2990 @legendecas
+  * Added monotonicity support in SumAggregator.
+  * Added reset and gaps detection for async metric instruments.
+  * Fixed the start time and end time of an exported metric with regarding to resets and gaps.
 
 ### :bug: (Bug Fix)
 
@@ -72,10 +76,6 @@ All notable changes to experimental packages in this project will be documented 
 * fix(sdk-metrics-base): misbehaving aggregation temporality selector tolerance #2958 @legendecas
 * feat(trace-otlp-grpc): configure security with env vars #2827 @svetlanabrennan
 * feat(sdk-metrics-base): async instruments callback timeout #2742 @legendecas
-* feat(sdk-metrics-base): detect resets on async metrics #2990 @legendecas
-  * Added monotonicity support in SumAggregator.
-  * Added reset and gaps detection for async metric instruments.
-  * Fixed the start time and end time of an exported metric with regarding to resets and gaps.
 
 ### :bug: (Bug Fix)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -41,7 +41,6 @@ All notable changes to experimental packages in this project will be documented 
 * fix(otlp-transformer): remove type dependency on Long [#3022](https://github.com/open-telemetry/opentelemetry-js/pull/3022) @legendecas
 * fix(grpc-exporter): use non-normalized URL to determine channel security [#3019](https://github.com/open-telemetry/opentelemetry-js/pull/3019) @pichlermarc
 * fix(otlp-exporter-base): fix gzip output stream in http otlp export [#3046](https://github.com/open-telemetry/opentelemetry-js/pull/3046) @mattolson
-
 * docs(grpc-exporters): remove 'web' as supported from README.md [#3070](https://github.com/open-telemetry/opentelemetry-js/pull/3070) @pichlermarc
 
 ### :house: (Internal)

--- a/experimental/backwards-compatability/node14/package.json
+++ b/experimental/backwards-compatability/node14/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node14",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "private": true,
   "description": "Backwards compatability app for node 14 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.29.2",
-    "@opentelemetry/sdk-trace-base": "1.3.1"
+    "@opentelemetry/sdk-node": "0.30.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0"
   },
   "devDependencies": {
     "@types/node": "^14.0.0",

--- a/experimental/backwards-compatability/node16/package.json
+++ b/experimental/backwards-compatability/node16/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node16",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "private": true,
   "description": "Backwards compatability app for node 16 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.29.2",
-    "@opentelemetry/sdk-trace-base": "1.3.1"
+    "@opentelemetry/sdk-node": "0.30.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-grpc",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/otlp-exporter-base": "0.29.2",
+    "@opentelemetry/otlp-exporter-base": "0.30.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -69,10 +69,10 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.5.9",
     "@grpc/proto-loader": "^0.6.9",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.29.2",
-    "@opentelemetry/otlp-transformer": "0.29.2",
-    "@opentelemetry/resources": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1"
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.30.0",
+    "@opentelemetry/otlp-transformer": "0.30.0",
+    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0"
   }
 }

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-http",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry Collector Trace Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,10 +94,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/otlp-exporter-base": "0.29.2",
-    "@opentelemetry/otlp-transformer": "0.29.2",
-    "@opentelemetry/resources": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1"
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/otlp-exporter-base": "0.30.0",
+    "@opentelemetry/otlp-transformer": "0.30.0",
+    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0"
   }
 }

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-proto",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -67,12 +67,12 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.6.9",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/otlp-exporter-base": "0.29.2",
-    "@opentelemetry/otlp-proto-exporter-base": "0.29.2",
-    "@opentelemetry/otlp-transformer": "0.29.2",
-    "@opentelemetry/resources": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/otlp-exporter-base": "0.30.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.30.0",
+    "@opentelemetry/otlp-transformer": "0.30.0",
+    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
     "protobufjs": "^6.9.0"
   }
 }

--- a/experimental/packages/opentelemetry-api-metrics/package.json
+++ b/experimental/packages/opentelemetry-api-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-metrics",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "Public metrics API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/api-metrics": "0.29.2",
+    "@opentelemetry/api-metrics": "0.30.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -69,11 +69,11 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.5.9",
     "@grpc/proto-loader": "^0.6.9",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.29.2",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.29.2",
-    "@opentelemetry/otlp-transformer": "0.29.2",
-    "@opentelemetry/resources": "1.3.1",
-    "@opentelemetry/sdk-metrics-base": "0.29.2"
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.30.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.30.0",
+    "@opentelemetry/otlp-transformer": "0.30.0",
+    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/sdk-metrics-base": "0.30.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-http",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,11 +94,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.29.2",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/otlp-exporter-base": "0.29.2",
-    "@opentelemetry/otlp-transformer": "0.29.2",
-    "@opentelemetry/resources": "1.3.1",
-    "@opentelemetry/sdk-metrics-base": "0.29.2"
+    "@opentelemetry/api-metrics": "0.30.0",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/otlp-exporter-base": "0.30.0",
+    "@opentelemetry/otlp-transformer": "0.30.0",
+    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/sdk-metrics-base": "0.30.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-proto",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/api-metrics": "0.29.2",
+    "@opentelemetry/api-metrics": "0.30.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -68,13 +68,13 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "0.6.9",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.29.2",
-    "@opentelemetry/otlp-exporter-base": "0.29.2",
-    "@opentelemetry/otlp-proto-exporter-base": "0.29.2",
-    "@opentelemetry/otlp-transformer": "0.29.2",
-    "@opentelemetry/resources": "1.3.1",
-    "@opentelemetry/sdk-metrics-base": "0.29.2",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.30.0",
+    "@opentelemetry/otlp-exporter-base": "0.30.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.30.0",
+    "@opentelemetry/otlp-transformer": "0.30.0",
+    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/sdk-metrics-base": "0.30.0",
     "protobufjs": "^6.9.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -59,8 +59,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.29.2",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/sdk-metrics-base": "0.29.2"
+    "@opentelemetry/api-metrics": "0.30.0",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/sdk-metrics-base": "0.30.0"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-fetch",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry fetch automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-zone": "1.3.1",
-    "@opentelemetry/propagator-b3": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
+    "@opentelemetry/context-zone": "1.4.0",
+    "@opentelemetry/propagator-b3": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -87,9 +87,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/instrumentation": "0.29.2",
-    "@opentelemetry/sdk-trace-web": "1.3.1",
-    "@opentelemetry/semantic-conventions": "1.3.1"
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/instrumentation": "0.30.0",
+    "@opentelemetry/sdk-trace-web": "1.4.0",
+    "@opentelemetry/semantic-conventions": "1.4.0"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-grpc",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry grpc automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -48,10 +48,10 @@
     "@grpc/grpc-js": "1.5.9",
     "@grpc/proto-loader": "0.6.9",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.3.1",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
-    "@opentelemetry/sdk-trace-node": "1.3.1",
+    "@opentelemetry/context-async-hooks": "1.4.0",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/sdk-trace-node": "1.4.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/semver": "7.3.9",
@@ -71,8 +71,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.29.2",
-    "@opentelemetry/instrumentation": "0.29.2",
-    "@opentelemetry/semantic-conventions": "1.3.1"
+    "@opentelemetry/api-metrics": "0.30.0",
+    "@opentelemetry/instrumentation": "0.30.0",
+    "@opentelemetry/semantic-conventions": "1.4.0"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-http",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry http/https automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,9 +46,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
-    "@opentelemetry/sdk-trace-node": "1.3.1",
+    "@opentelemetry/context-async-hooks": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/sdk-trace-node": "1.4.0",
     "@types/got": "9.6.12",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
@@ -74,9 +74,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/instrumentation": "0.29.2",
-    "@opentelemetry/semantic-conventions": "1.3.1",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/instrumentation": "0.30.0",
+    "@opentelemetry/semantic-conventions": "1.4.0",
     "semver": "^7.3.5"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-xml-http-request",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry XMLHttpRequest automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-zone": "1.3.1",
-    "@opentelemetry/propagator-b3": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
+    "@opentelemetry/context-zone": "1.4.0",
+    "@opentelemetry/propagator-b3": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -87,9 +87,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/instrumentation": "0.29.2",
-    "@opentelemetry/sdk-trace-web": "1.3.1",
-    "@opentelemetry/semantic-conventions": "1.3.1"
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/instrumentation": "0.30.0",
+    "@opentelemetry/sdk-trace-web": "1.4.0",
+    "@opentelemetry/semantic-conventions": "1.4.0"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "Base class for node which OpenTelemetry instrumentation modules extend",
   "author": "OpenTelemetry Authors",
   "homepage": "https://github.com/open-telemetry/opentelemetry-js#readme",
@@ -68,7 +68,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.29.2",
+    "@opentelemetry/api-metrics": "0.30.0",
     "require-in-the-middle": "^5.0.3",
     "semver": "^7.3.2",
     "shimmer": "^1.2.1"

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics-base",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "Work in progress OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -77,9 +77,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.29.2",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/resources": "1.3.1",
+    "@opentelemetry/api-metrics": "0.30.0",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/resources": "1.4.0",
     "lodash.merge": "4.6.2"
   }
 }

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-node",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry SDK for Node.js",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,21 +44,21 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.29.2",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/instrumentation": "0.29.2",
-    "@opentelemetry/resources": "1.3.1",
-    "@opentelemetry/sdk-metrics-base": "0.29.2",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
-    "@opentelemetry/sdk-trace-node": "1.3.1"
+    "@opentelemetry/api-metrics": "0.30.0",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/instrumentation": "0.30.0",
+    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/sdk-metrics-base": "0.30.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/sdk-trace-node": "1.4.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0",
-    "@opentelemetry/context-async-hooks": "1.3.1",
-    "@opentelemetry/semantic-conventions": "1.3.1",
+    "@opentelemetry/context-async-hooks": "1.4.0",
+    "@opentelemetry/semantic-conventions": "1.4.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/semver": "7.3.9",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-exporter-base",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry OTLP Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.3.1"
+    "@opentelemetry/core": "1.4.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-grpc-exporter-base",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry OTLP-gRPC Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -51,9 +51,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/otlp-transformer": "0.29.2",
-    "@opentelemetry/resources": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
+    "@opentelemetry/otlp-transformer": "0.30.0",
+    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -73,7 +73,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.5.9",
     "@grpc/proto-loader": "^0.6.9",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/otlp-exporter-base": "0.29.2"
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/otlp-exporter-base": "0.30.0"
   }
 }

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-proto-exporter-base",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "OpenTelemetry OTLP-HTTP-protobuf Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -66,8 +66,8 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.6.9",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/otlp-exporter-base": "0.29.2",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/otlp-exporter-base": "0.30.0",
     "protobufjs": "^6.9.0"
   }
 }

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "Transform OpenTelemetry SDK data into OTLP",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
@@ -77,10 +77,10 @@
     "webpack": "4.46.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.29.2",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/resources": "1.3.1",
-    "@opentelemetry/sdk-metrics-base": "0.29.2",
-    "@opentelemetry/sdk-trace-base": "1.3.1"
+    "@opentelemetry/api-metrics": "0.30.0",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/sdk-metrics-base": "0.30.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0"
   }
 }

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.3.1",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
+    "@opentelemetry/context-async-hooks": "1.4.0",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
     "axios": "0.24.0",
     "body-parser": "1.19.0",
     "express": "4.17.1"

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -74,7 +74,7 @@
     "webpack-merge": "5.8.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.3.1",
+    "@opentelemetry/context-zone-peer-dep": "1.4.0",
     "zone.js": "^0.11.0"
   },
   "sideEffects": true

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,6 +91,6 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.3.1"
+    "@opentelemetry/semantic-conventions": "1.4.0"
   }
 }

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/resources": "1.3.1",
+    "@opentelemetry/resources": "1.4.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -62,9 +62,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
-    "@opentelemetry/semantic-conventions": "1.3.1",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/semantic-conventions": "1.4.0",
     "jaeger-client": "^3.15.0"
   }
 }

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,9 +91,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/resources": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
-    "@opentelemetry/semantic-conventions": "1.3.1"
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/semantic-conventions": "1.4.0"
   }
 }

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.3.1"
+    "@opentelemetry/core": "1.4.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -80,6 +80,6 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.3.1"
+    "@opentelemetry/core": "1.4.0"
   }
 }

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -89,7 +89,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/semantic-conventions": "1.3.1"
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/semantic-conventions": "1.4.0"
   }
 }

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,8 +91,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/resources": "1.3.1",
-    "@opentelemetry/semantic-conventions": "1.3.1"
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/semantic-conventions": "1.4.0"
   }
 }

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0",
-    "@opentelemetry/resources": "1.3.1",
-    "@opentelemetry/semantic-conventions": "1.3.1",
+    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/semantic-conventions": "1.4.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/semver": "7.3.9",
@@ -64,11 +64,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.3.1",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/propagator-b3": "1.3.1",
-    "@opentelemetry/propagator-jaeger": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
+    "@opentelemetry/context-async-hooks": "1.4.0",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/propagator-b3": "1.4.0",
+    "@opentelemetry/propagator-jaeger": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
     "semver": "^7.3.5"
   }
 }

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,9 +57,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": ">=1.0.0 <1.2.0",
-    "@opentelemetry/context-zone": "1.3.1",
-    "@opentelemetry/propagator-b3": "1.3.1",
-    "@opentelemetry/resources": "1.3.1",
+    "@opentelemetry/context-zone": "1.4.0",
+    "@opentelemetry/propagator-b3": "1.4.0",
+    "@opentelemetry/resources": "1.4.0",
     "@types/jquery": "3.5.8",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
@@ -91,8 +91,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
-    "@opentelemetry/semantic-conventions": "1.3.1"
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/semantic-conventions": "1.4.0"
   }
 }

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -43,9 +43,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0",
-    "@opentelemetry/propagator-b3": "1.3.1",
-    "@opentelemetry/propagator-jaeger": "1.3.1",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
+    "@opentelemetry/propagator-b3": "1.4.0",
+    "@opentelemetry/propagator-jaeger": "1.4.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "codecov": "3.8.3",
@@ -59,8 +59,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/semantic-conventions": "1.3.1",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/semantic-conventions": "1.4.0",
     "opentracing": "^0.14.4"
   }
 }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
@@ -56,16 +56,16 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.3.1",
-    "@opentelemetry/core": "1.3.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.29.2",
-    "@opentelemetry/exporter-zipkin": "1.3.1",
-    "@opentelemetry/instrumentation": "0.29.2",
-    "@opentelemetry/instrumentation-fetch": "0.29.2",
-    "@opentelemetry/instrumentation-xml-http-request": "0.29.2",
-    "@opentelemetry/sdk-metrics-base": "0.29.2",
-    "@opentelemetry/sdk-trace-base": "1.3.1",
-    "@opentelemetry/sdk-trace-web": "1.3.1",
+    "@opentelemetry/context-zone-peer-dep": "1.4.0",
+    "@opentelemetry/core": "1.4.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.30.0",
+    "@opentelemetry/exporter-zipkin": "1.4.0",
+    "@opentelemetry/instrumentation": "0.30.0",
+    "@opentelemetry/instrumentation-fetch": "0.30.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.30.0",
+    "@opentelemetry/sdk-metrics-base": "0.30.0",
+    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/sdk-trace-web": "1.4.0",
     "zone.js": "0.11.4"
   }
 }


### PR DESCRIPTION
## 1.4.0

### :rocket: (Enhancement)


* fix(resources): fix browser compatibility for host and os detectors [#3004](https://github.com/open-telemetry/opentelemetry-js/pull/3004) @legendecas
* fix(sdk-trace-base): fix crash on environments without global document [#3000](https://github.com/open-telemetry/opentelemetry-js/pull/3000) @legendecas

### :house: (Internal)

* test: add node 18 and remove EoL node versions [#3048](https://github.com/open-telemetry/opentelemetry-js/pull/3048) @dyladan

## Experimental 0.30.0

### :boom: Breaking Change

* fix: remove aws and gcp detector from SDK [#3024](https://github.com/open-telemetry/opentelemetry-js/pull/3024) @flarna
* feat(sdk-metrics-base): implement min/max recording for Histograms [#3032](https://github.com/open-telemetry/opentelemetry-js/pull/3032) @pichlermarc
  * adds `min`/`max` recording to Histograms
  * updates [opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto) to `0.18` so that `min` and
    `max` can be exported. This change breaks the OTLP/JSON Metric Exporter for all collector versions `<0.52` due to
    [open-telemetry/opentelemetry-collector#5312](https://github.com/open-telemetry/opentelemetry-collector/issues/5312).

### :rocket: (Enhancement)

* feat(opentelemetry-instrumentation-fetch): optionally ignore network events [#3028](https://github.com/open-telemetry/opentelemetry-js/pull/3028) @gregolsen
* feat(http-instrumentation): record exceptions in http instrumentation [#3008](https://github.com/open-telemetry/opentelemetry-js/pull/3008) @luismiramirez
* feat(node-sdk): add serviceName config option [#2867](https://github.com/open-telemetry/opentelemetry-js/pull/2867) @naseemkullah
* feat(opentelemetry-exporter-prometheus): export PrometheusSerializer [#3034](https://github.com/open-telemetry/opentelemetry-js/pull/3034) @matschaffer
* feat(sdk-metrics-base): detect resets on async metrics [#2990](https://github.com/open-telemetry/opentelemetry-js/pull/2990) @legendecas
  * Added monotonicity support in SumAggregator.
  * Added reset and gaps detection for async metric instruments.
  * Fixed the start time and end time of an exported metric with regarding to resets and gaps.

### :bug: (Bug Fix)

* fix(otlp-transformer): remove type dependency on Long [#3022](https://github.com/open-telemetry/opentelemetry-js/pull/3022) @legendecas
* fix(grpc-exporter): use non-normalized URL to determine channel security [#3019](https://github.com/open-telemetry/opentelemetry-js/pull/3019) @pichlermarc
* fix(otlp-exporter-base): fix gzip output stream in http otlp export [#3046](https://github.com/open-telemetry/opentelemetry-js/pull/3046) @mattolson
* docs(grpc-exporters): remove 'web' as supported from README.md [#3070](https://github.com/open-telemetry/opentelemetry-js/pull/3070) @pichlermarc

### :house: (Internal)

* test: add node 18 and remove EoL node versions [#3048](https://github.com/open-telemetry/opentelemetry-js/pull/3048) @dyladan