### PR TITLE
docs(grpc-exporters): remove 'web' as supported from README.md.

### DIFF
--- a/experimental/packages/exporter-trace-otlp-grpc/README.md
+++ b/experimental/packages/exporter-trace-otlp-grpc/README.md
@@ -3,7 +3,7 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
-This module provides exporter for web and node to be used with [opentelemetry-collector][opentelemetry-collector-url].
+This module provides exporter for node to be used with [opentelemetry-collector][opentelemetry-collector-url].
 Compatible with [opentelemetry-collector][opentelemetry-collector-url] versions `>=0.16 <=0.50`.
 
 ## Installation
@@ -121,7 +121,7 @@ The OTLPTraceExporter has a timeout configuration option which is the maximum ti
     url: '<collector-hostname>:<port>',
     metadata, // // an optional grpc.Metadata object to be sent with each request
   };
-    
+
   const exporter = new OTLPTraceExporter(collectorOptions);
   ```
 

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/README.md
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/README.md
@@ -3,7 +3,7 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
-This module provides exporter for web and node to be used with [opentelemetry-collector][opentelemetry-collector-url].
+This module provides exporter for node to be used with [opentelemetry-collector][opentelemetry-collector-url].
 Compatible with [opentelemetry-collector][opentelemetry-collector-url] versions `>=0.16 <=0.53`.
 
 ## Installation


### PR DESCRIPTION
## Which problem is this PR solving?

The gRPC exporters for both trace and metrics listed 'web and node' as supported targets, but only 'node' is actually supported.
This PR removes 'web' from the respective `README.md`s.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
