### PR TITLE
fix(instrumentation-grpc): always set status code attribute with numeric value

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/clientUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/clientUtils.ts
@@ -93,7 +93,7 @@ export function makeGrpcClientRemoteCall(
           span.setStatus(_grpcStatusCodeToSpanStatus(err.code));
           span.setAttribute(
             SemanticAttributes.RPC_GRPC_STATUS_CODE,
-            err.code.toString()
+            err.code
           );
         }
         span.setAttributes({
@@ -104,7 +104,7 @@ export function makeGrpcClientRemoteCall(
         span.setStatus({ code: SpanStatusCode.UNSET });
         span.setAttribute(
           SemanticAttributes.RPC_GRPC_STATUS_CODE,
-          GRPC_STATUS_CODE_OK.toString()
+          GRPC_STATUS_CODE_OK
         );
       }
 

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/clientUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/clientUtils.ts
@@ -161,6 +161,7 @@ export function makeGrpcClientRemoteCall(
         span.setAttributes({
           [AttributeNames.GRPC_ERROR_NAME]: err.name,
           [AttributeNames.GRPC_ERROR_MESSAGE]: err.message,
+          [SemanticAttributes.RPC_GRPC_STATUS_CODE]: err.code,
         });
 
         endSpan();
@@ -173,6 +174,7 @@ export function makeGrpcClientRemoteCall(
         call[CALL_SPAN_ENDED] = true;
 
         span.setStatus(_grpcStatusCodeToSpanStatus(status.code));
+        span.setAttribute(SemanticAttributes.RPC_GRPC_STATUS_CODE, status.code);
 
         endSpan();
       });

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/clientUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/clientUtils.ts
@@ -34,6 +34,7 @@ import { CALL_SPAN_ENDED } from './serverUtils';
 import { EventEmitter } from 'events';
 import { AttributeNames } from '../enums/AttributeNames';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { GRPC_STATUS_CODE_OK } from '../status-code';
 
 /**
  * Parse a package method list and return a list of methods to patch
@@ -103,7 +104,7 @@ export function makeGrpcClientRemoteCall(
         span.setStatus({ code: SpanStatusCode.UNSET });
         span.setAttribute(
           SemanticAttributes.RPC_GRPC_STATUS_CODE,
-          SpanStatusCode.UNSET.toString()
+          GRPC_STATUS_CODE_OK.toString()
         );
       }
 

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/serverUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/serverUtils.ts
@@ -35,6 +35,7 @@ import {
 import { IgnoreMatcher } from '../types';
 import { AttributeNames } from '../enums/AttributeNames';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { GRPC_STATUS_CODE_OK } from '../status-code';
 
 export const CALL_SPAN_ENDED = Symbol('opentelemetry call span ended');
 
@@ -72,7 +73,7 @@ function serverStreamAndBidiHandler<RequestType, ResponseType>(
     });
     span.setAttribute(
       SemanticAttributes.RPC_GRPC_STATUS_CODE,
-      SpanStatusCode.OK.toString()
+      GRPC_STATUS_CODE_OK.toString()
     );
 
     endSpan();
@@ -135,7 +136,7 @@ function clientStreamAndUnaryHandler<RequestType, ResponseType>(
       span.setStatus({ code: SpanStatusCode.UNSET });
       span.setAttribute(
         SemanticAttributes.RPC_GRPC_STATUS_CODE,
-        SpanStatusCode.OK.toString()
+        GRPC_STATUS_CODE_OK.toString()
       );
     }
 

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/serverUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/serverUtils.ts
@@ -73,7 +73,7 @@ function serverStreamAndBidiHandler<RequestType, ResponseType>(
     });
     span.setAttribute(
       SemanticAttributes.RPC_GRPC_STATUS_CODE,
-      GRPC_STATUS_CODE_OK.toString()
+      GRPC_STATUS_CODE_OK
     );
 
     endSpan();
@@ -125,7 +125,7 @@ function clientStreamAndUnaryHandler<RequestType, ResponseType>(
         });
         span.setAttribute(
           SemanticAttributes.RPC_GRPC_STATUS_CODE,
-          err.code.toString()
+          err.code
         );
       }
       span.setAttributes({
@@ -136,7 +136,7 @@ function clientStreamAndUnaryHandler<RequestType, ResponseType>(
       span.setStatus({ code: SpanStatusCode.UNSET });
       span.setAttribute(
         SemanticAttributes.RPC_GRPC_STATUS_CODE,
-        GRPC_STATUS_CODE_OK.toString()
+        GRPC_STATUS_CODE_OK
       );
     }
 

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/serverUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/serverUtils.ts
@@ -94,6 +94,7 @@ function serverStreamAndBidiHandler<RequestType, ResponseType>(
     span.setAttributes({
       [AttributeNames.GRPC_ERROR_NAME]: err.name,
       [AttributeNames.GRPC_ERROR_MESSAGE]: err.message,
+      [SemanticAttributes.RPC_GRPC_STATUS_CODE]: err.code,
     });
     endSpan();
   });

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/clientUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/clientUtils.ts
@@ -58,7 +58,7 @@ export const makeGrpcClientRemoteCall = function (
           span.setStatus(_grpcStatusCodeToSpanStatus(err.code));
           span.setAttribute(
             SemanticAttributes.RPC_GRPC_STATUS_CODE,
-            err.code.toString()
+            err.code
           );
         }
         span.setAttributes({
@@ -69,7 +69,7 @@ export const makeGrpcClientRemoteCall = function (
         span.setStatus({ code: SpanStatusCode.UNSET });
         span.setAttribute(
           SemanticAttributes.RPC_GRPC_STATUS_CODE,
-          GRPC_STATUS_CODE_OK.toString()
+          GRPC_STATUS_CODE_OK
         );
       }
 
@@ -140,7 +140,7 @@ export const makeGrpcClientRemoteCall = function (
           span.setStatus({ code: SpanStatusCode.UNSET });
           span.setAttribute(
             SemanticAttributes.RPC_GRPC_STATUS_CODE,
-            status.code.toString()
+            status.code
           );
           endSpan();
         }

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/clientUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/clientUtils.ts
@@ -32,12 +32,12 @@ import {
   findIndex,
 } from '../utils';
 import { AttributeNames } from '../enums/AttributeNames';
+import { GRPC_STATUS_CODE_OK } from '../status-code';
 
 /**
  * This method handles the client remote call
  */
 export const makeGrpcClientRemoteCall = function (
-  grpcClient: typeof grpcTypes,
   original: GrpcClientFunc,
   args: any[],
   metadata: grpcTypes.Metadata,
@@ -69,7 +69,7 @@ export const makeGrpcClientRemoteCall = function (
         span.setStatus({ code: SpanStatusCode.UNSET });
         span.setAttribute(
           SemanticAttributes.RPC_GRPC_STATUS_CODE,
-          grpcClient.status.OK.toString()
+          GRPC_STATUS_CODE_OK.toString()
         );
       }
 

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/clientUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/clientUtils.ts
@@ -130,6 +130,9 @@ export const makeGrpcClientRemoteCall = function (
             [AttributeNames.GRPC_ERROR_NAME]: err.name,
             [AttributeNames.GRPC_ERROR_MESSAGE]: err.message,
           });
+          if(err.code != null) {
+            span.setAttribute(SemanticAttributes.RPC_GRPC_STATUS_CODE, err.code);
+          }
           endSpan();
         }
       );

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/index.ts
@@ -206,7 +206,6 @@ export class GrpcNativeInstrumentation extends InstrumentationBase<
                       case 'unary':
                       case 'client_stream':
                         return clientStreamAndUnaryHandler(
-                          grpcModule,
                           span,
                           call,
                           callback,
@@ -297,7 +296,6 @@ export class GrpcNativeInstrumentation extends InstrumentationBase<
         });
         return context.with(trace.setSpan(context.active(), span), () =>
           makeGrpcClientRemoteCall(
-            grpcClient,
             original,
             args,
             metadata,

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/index.ts
@@ -76,7 +76,7 @@ export class GrpcNativeInstrumentation extends InstrumentationBase<
           this._wrap(
             moduleExports.Server.prototype,
             'register',
-            this._patchServer(moduleExports) as any
+            this._patchServer() as any
           );
           // Wrap the externally exported client constructor
           if (isWrapped(moduleExports.makeGenericClientConstructor)) {
@@ -140,7 +140,7 @@ export class GrpcNativeInstrumentation extends InstrumentationBase<
     ];
   }
 
-  private _patchServer(grpcModule: typeof grpcTypes) {
+  private _patchServer() {
     const instrumentation = this;
     return (originalRegister: typeof grpcTypes.Server.prototype.register) => {
       instrumentation._diag.debug('patched gRPC server');

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/serverUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/serverUtils.ts
@@ -50,7 +50,7 @@ export const clientStreamAndUnaryHandler = function <RequestType, ResponseType>(
         });
         span.setAttribute(
           SemanticAttributes.RPC_GRPC_STATUS_CODE,
-          err.code.toString()
+          err.code
         );
       }
       span.setAttributes({
@@ -61,7 +61,7 @@ export const clientStreamAndUnaryHandler = function <RequestType, ResponseType>(
       span.setStatus({ code: SpanStatusCode.UNSET });
       span.setAttribute(
         SemanticAttributes.RPC_GRPC_STATUS_CODE,
-        GRPC_STATUS_CODE_OK.toString()
+        GRPC_STATUS_CODE_OK
       );
     }
     span.addEvent('received');
@@ -94,7 +94,7 @@ export const serverStreamAndBidiHandler = function <RequestType, ResponseType>(
     span.setStatus(_grpcStatusCodeToSpanStatus(call.status.code));
     span.setAttribute(
       SemanticAttributes.RPC_GRPC_STATUS_CODE,
-      call.status.code.toString()
+      call.status.code
     );
 
     // if there is an error, span will be ended on error event, otherwise end it here

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/serverUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/serverUtils.ts
@@ -114,6 +114,9 @@ export const serverStreamAndBidiHandler = function <RequestType, ResponseType>(
       [AttributeNames.GRPC_ERROR_NAME]: err.name,
       [AttributeNames.GRPC_ERROR_MESSAGE]: err.message,
     });
+    if(err.code != null) {
+      span.setAttribute(SemanticAttributes.RPC_GRPC_STATUS_CODE, err.code);
+    }
     endSpan();
   });
 

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/serverUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/serverUtils.ts
@@ -25,9 +25,9 @@ import {
 } from '../utils';
 import { AttributeNames } from '../enums/AttributeNames';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { GRPC_STATUS_CODE_OK } from '../status-code';
 
 export const clientStreamAndUnaryHandler = function <RequestType, ResponseType>(
-  grpcClient: typeof grpcTypes,
   span: Span,
   call: ServerCallWithMeta,
   callback: SendUnaryDataCallback,
@@ -61,7 +61,7 @@ export const clientStreamAndUnaryHandler = function <RequestType, ResponseType>(
       span.setStatus({ code: SpanStatusCode.UNSET });
       span.setAttribute(
         SemanticAttributes.RPC_GRPC_STATUS_CODE,
-        grpcClient.status.OK.toString()
+        GRPC_STATUS_CODE_OK.toString()
       );
     }
     span.addEvent('received');

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/status-code.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/status-code.ts
@@ -1,0 +1,2 @@
+
+export const GRPC_STATUS_CODE_OK = 0;

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/status-code.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/status-code.ts
@@ -1,2 +1,16 @@
-
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 export const GRPC_STATUS_CODE_OK = 0;

--- a/experimental/packages/opentelemetry-instrumentation-grpc/test/utils/assertionUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/test/utils/assertionUtils.ts
@@ -23,6 +23,7 @@ import {
   hrTimeToMilliseconds,
   hrTimeToMicroseconds,
 } from '@opentelemetry/core';
+import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
 export const grpcStatusCodeToOpenTelemetryStatusCode = (
   status: grpc.status | grpcJs.status
@@ -61,6 +62,7 @@ export const assertSpan = (
     span.status.code,
     grpcStatusCodeToOpenTelemetryStatusCode(validations.status)
   );
+  assert.strictEqual(span.attributes[SemanticAttributes.RPC_GRPC_STATUS_CODE], validations.status);
 };
 
 // Check if sourceSpan was propagated to targetSpan


### PR DESCRIPTION

## Which problem is this PR solving?

fixes #2984 
fixes #3052 
extends #2988 (which is not finalized: fixes an issue in one place out of 3 and no tests. no comment from the author for over a month).

## Short description of the changes

This PR fixes various issues with grpc instrumentation in the status code attribute.
1. `rpc.grpc.status_code` attribute was populated with string values which is not spec compliant. now it is filled with numbers #3054 
2. in some places, instrumentation used the `SpanStatus` enum to populate the attribute, instead of the gRPC status codes, which was incorrect. #2984
3. the `rpc.grpc.status_code` was not populated in some cases. Now it is always filled where known.
4. the attribute value was not asserted at all in any unittests. this PR adds the relevant assert to verify the attribute value.
5. grpc status code OK (===0) was read from `moduleExports` which made the code complicated and required to pass around the module exports just to read a constant value `0`. This pattern is removed in favor of instrumentation constant. Read more discussion [here](https://github.com/open-telemetry/opentelemetry-js/pull/2988#pullrequestreview-981993529) 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I added the relevant assert to unit tests. This revealed other places where the status code was not populated which I was not aware of and I also fixed them in this PR.

I am not deeply familiar with gRPC and this instrumentation, so please review it thoroughly :)

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
