### PR TITLE
docs(exporters): replace 'collector' with 'OTLP compatible receivers'

### DIFF
--- a/experimental/packages/exporter-trace-otlp-grpc/README.md
+++ b/experimental/packages/exporter-trace-otlp-grpc/README.md
@@ -3,7 +3,7 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
-This module provides exporter for node to be used with [opentelemetry-collector][opentelemetry-collector-url].
+This module provides exporter for node to be used with OTLP (`grpc`) compatible receivers.
 Compatible with [opentelemetry-collector][opentelemetry-collector-url] versions `>=0.16 <=0.50`.
 
 ## Installation

--- a/experimental/packages/exporter-trace-otlp-http/README.md
+++ b/experimental/packages/exporter-trace-otlp-http/README.md
@@ -3,7 +3,7 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
-This module provides exporter for web and node to be used with [opentelemetry-collector][opentelemetry-collector-url]
+This module provides exporter for web and node to be used with OTLP (`http/json`) compatible receivers.
 Compatible with [opentelemetry-collector][opentelemetry-collector-url] versions `>=0.48 <=0.50`.
 
 ## Installation

--- a/experimental/packages/exporter-trace-otlp-proto/README.md
+++ b/experimental/packages/exporter-trace-otlp-proto/README.md
@@ -3,7 +3,7 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
-This module provides exporter for node to be used with [opentelemetry-collector][opentelemetry-collector-url].
+This module provides exporter for node to be used with OTLP (`http/protobuf`) compatible receivers.
 Compatible with [opentelemetry-collector][opentelemetry-collector-url] versions `>=0.32 <=0.50`.
 
 ## Installation

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/README.md
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/README.md
@@ -3,7 +3,7 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
-This module provides exporter for node to be used with [opentelemetry-collector][opentelemetry-collector-url].
+This module provides exporter for node to be used with OTLP (`grpc`) compatible receivers.
 Compatible with [opentelemetry-collector][opentelemetry-collector-url] versions `>=0.16 <=0.53`.
 
 ## Installation

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/README.md
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/README.md
@@ -3,7 +3,7 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
-This module provides exporter for web and node to be used with [opentelemetry-collector][opentelemetry-collector-url].
+This module provides exporter for web and node to be used with OTLP (`http/json`) compatible receivers.
 Compatible with [opentelemetry-collector][opentelemetry-collector-url] versions `>=0.52 <=0.53`.
 
 ## Installation

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/README.md
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/README.md
@@ -3,7 +3,7 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
-This module provides exporter for node to be used with [opentelemetry-collector][opentelemetry-collector-url].
+This module provides exporter for node to be used with OTLP (`http/protobuf`) compatible receivers.
 Compatible with [opentelemetry-collector][opentelemetry-collector-url] versions `>=0.32 <=0.53`.
 
 ## Installation


### PR DESCRIPTION
## Which problem is this PR solving?

Addresses comment
>Not related to this fix, but I think the wording should be "OTLP receiver" instead of "opentelemetry-collector", since the exporter >can send to any OTLP compatible receiver.

_Originally posted by @blumamir in https://github.com/open-telemetry/opentelemetry-js/pull/3070#discussion_r910294252_

## Checklist:

- [x] Documentation has been updated
