### PR TITLE
chore: mark packages as side effects free for tree shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 ### :house: (Internal)
 
 * test: add node 18 and remove EoL node versions [#3048](https://github.com/open-telemetry/opentelemetry-js/pull/3048) @dyladan
+* chore: mark packages as side effects free for tree shaking []() @ogxd
 
 ## 1.3.1
 

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -74,5 +74,6 @@
     "@opentelemetry/otlp-transformer": "0.30.0",
     "@opentelemetry/resources": "1.4.0",
     "@opentelemetry/sdk-trace-base": "1.4.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -99,5 +99,6 @@
     "@opentelemetry/otlp-transformer": "0.30.0",
     "@opentelemetry/resources": "1.4.0",
     "@opentelemetry/sdk-trace-base": "1.4.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -74,5 +74,6 @@
     "@opentelemetry/resources": "1.4.0",
     "@opentelemetry/sdk-trace-base": "1.4.0",
     "protobufjs": "^6.9.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/opentelemetry-api-metrics/package.json
+++ b/experimental/packages/opentelemetry-api-metrics/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.0"
   },
+  "sideEffects": false,
   "devDependencies": {
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -75,5 +75,6 @@
     "@opentelemetry/otlp-transformer": "0.30.0",
     "@opentelemetry/resources": "1.4.0",
     "@opentelemetry/sdk-metrics-base": "0.30.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -100,5 +100,6 @@
     "@opentelemetry/otlp-transformer": "0.30.0",
     "@opentelemetry/resources": "1.4.0",
     "@opentelemetry/sdk-metrics-base": "0.30.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -76,5 +76,6 @@
     "@opentelemetry/resources": "1.4.0",
     "@opentelemetry/sdk-metrics-base": "0.30.0",
     "protobufjs": "^6.9.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -62,5 +62,6 @@
     "@opentelemetry/api-metrics": "0.30.0",
     "@opentelemetry/core": "1.4.0",
     "@opentelemetry/sdk-metrics-base": "0.30.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -91,5 +91,6 @@
     "@opentelemetry/instrumentation": "0.30.0",
     "@opentelemetry/sdk-trace-web": "1.4.0",
     "@opentelemetry/semantic-conventions": "1.4.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -74,5 +74,6 @@
     "@opentelemetry/api-metrics": "0.30.0",
     "@opentelemetry/instrumentation": "0.30.0",
     "@opentelemetry/semantic-conventions": "1.4.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -78,5 +78,6 @@
     "@opentelemetry/instrumentation": "0.30.0",
     "@opentelemetry/semantic-conventions": "1.4.0",
     "semver": "^7.3.5"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -91,5 +91,6 @@
     "@opentelemetry/instrumentation": "0.30.0",
     "@opentelemetry/sdk-trace-web": "1.4.0",
     "@opentelemetry/semantic-conventions": "1.4.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -73,6 +73,7 @@
     "semver": "^7.3.2",
     "shimmer": "^1.2.1"
   },
+  "sideEffects": false,
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"
   },

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -81,5 +81,6 @@
     "@opentelemetry/core": "1.4.0",
     "@opentelemetry/resources": "1.4.0",
     "lodash.merge": "4.6.2"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -72,5 +72,6 @@
     "ts-loader": "8.3.0",
     "ts-mocha": "9.0.2",
     "typescript": "4.4.4"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@opentelemetry/core": "1.4.0"
   },
+  "sideEffects": false,
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
     "@types/mocha": "8.2.3",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -75,5 +75,6 @@
     "@grpc/proto-loader": "^0.6.9",
     "@opentelemetry/core": "1.4.0",
     "@opentelemetry/otlp-exporter-base": "0.30.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -69,5 +69,6 @@
     "@opentelemetry/core": "1.4.0",
     "@opentelemetry/otlp-exporter-base": "0.30.0",
     "protobufjs": "^6.9.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -82,5 +82,6 @@
     "@opentelemetry/resources": "1.4.0",
     "@opentelemetry/sdk-metrics-base": "0.30.0",
     "@opentelemetry/sdk-trace-base": "1.4.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -56,5 +56,6 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -92,5 +92,6 @@
   },
   "dependencies": {
     "@opentelemetry/semantic-conventions": "1.4.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -66,5 +66,6 @@
     "@opentelemetry/sdk-trace-base": "1.4.0",
     "@opentelemetry/semantic-conventions": "1.4.0",
     "jaeger-client": "^3.15.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -95,5 +95,6 @@
     "@opentelemetry/resources": "1.4.0",
     "@opentelemetry/sdk-trace-base": "1.4.0",
     "@opentelemetry/semantic-conventions": "1.4.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@opentelemetry/core": "1.4.0"
   },
+  "sideEffects": false,
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -81,5 +81,6 @@
   },
   "dependencies": {
     "@opentelemetry/core": "1.4.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -91,5 +91,6 @@
   "dependencies": {
     "@opentelemetry/core": "1.4.0",
     "@opentelemetry/semantic-conventions": "1.4.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -94,5 +94,6 @@
     "@opentelemetry/core": "1.4.0",
     "@opentelemetry/resources": "1.4.0",
     "@opentelemetry/semantic-conventions": "1.4.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -94,5 +94,6 @@
     "@opentelemetry/core": "1.4.0",
     "@opentelemetry/sdk-trace-base": "1.4.0",
     "@opentelemetry/semantic-conventions": "1.4.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -60,5 +60,6 @@
     "sinon": "12.0.1",
     "ts-mocha": "9.0.2",
     "typescript": "4.4.4"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -62,5 +62,6 @@
     "@opentelemetry/core": "1.4.0",
     "@opentelemetry/semantic-conventions": "1.4.0",
     "opentracing": "^0.14.4"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #2855

For instance, when using the `exporter-trace-otlp-http` package for a simple create/send trace, having `sideEffects` set to false for all packages it depends on results in a 70kb smaller bundle (minified)

## Short description of the changes

Marked all package as side-effect free with `"sideEffects": false`.    
This is supposed to be safe:
> We talked about this in the SIG meeting and agreed that this is safe for us. Even our modules which have side-effects do not execute those side-effects at load time and require a user to explicitly call a function. This will cause the static analysis of webpack to realize the module is used and not tree-shake it out.
@dyladan 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change *could* benefit from a mention in the documentation

## How Has This Been Tested?

Tested manually using samples and setting `sideEffects: false` manually in `node_modules`

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] ~~Unit tests have been added~~
- [ ] Documentation has been updated
