### PR TITLE
chore(deps): upgrade lerna to 5.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-node": "11.1.0",
     "gh-pages": "3.2.3",
-    "lerna": "3.22.1",
+    "lerna": "5.1.8",
     "lerna-changelog": "1.0.1",
     "linkinator": "3.0.3",
     "markdownlint-cli": "0.29.0",


### PR DESCRIPTION
## Which problem is this PR solving?

Noticed that `lerna run version` failed more often than not with Node 18 and npm `8.13.2` on the main branch of the repository. Also saw a the same error in CI [here](https://github.com/open-telemetry/opentelemetry-js/runs/7356025057?check_suite_focus=true) in another branch.

Using `lerna` version `5.1.8` seems to make a difference. 
Still trying to figure out the root cause, keeping as draft for now.

## Short description of the changes
upgrade lerna to 5.1.8

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
