### PR TITLE
Use latest npm after setup node

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
 
+      - run: npm install -g npm@latest
+
       - name: restore lerna
         id: cache
         uses: actions/cache@v3


### PR DESCRIPTION
There have been several test failures on node 18 related to lerna running the version command in the wrong directory. This issue may be fixed by the latest version of npm. We should always make sure we are running the latest version when possible.