### PR TITLE
feat(histogram): align collection of optional `Histogram` properties with spec

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to experimental packages in this project will be documented 
 * feat(histogram): align collection of optional Histogram properties with spec [#3102](https://github.com/open-telemetry/opentelemetry-js/pull/3079) @pichlermarc
   * changes type of `sum` property on `Histogram` to `number | undefined`
   * changes type of `min` and `max` properties on `Histogram` to `number | undefined`
-  * removes `hasMinMax` flag on `Histogram`
+  * removes `hasMinMax` flag on the exported `Histogram` - this is now indicated by `min` and `max` being `undefined`
 
 ### :rocket: (Enhancement)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to experimental packages in this project will be documented 
 * feat(sdk-metrics-base): split up Singular into Sum and Gauge in MetricData [#3079](https://github.com/open-telemetry/opentelemetry-js/pull/3079) @pichlermarc
   * removes `DataPointType.SINGULAR`, and replaces it with `DataPointType.SUM` and `DataPointType.GAUGE`
   * removes `SingularMetricData` and replaces it with `SumMetricData` (including an additional `isMonotonic` flag) and `GaugeMetricData`
+* feat(histogram): align collection of optional Histogram properties with spec [#3102](https://github.com/open-telemetry/opentelemetry-js/pull/3079) @pichlermarc
+  * changes type of `sum` property on `Histogram` to `number | undefined`
+  * changes type of `min` and `max` properties on `Histogram` to `number | undefined`
+  * removes `hasMinMax` flag on `Histogram`
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -255,7 +255,7 @@ export class PrometheusSerializer {
       results += stringify(
         name + '_' + key,
         attributes,
-        value[key],
+        value[key] ?? 0,
         this._appendTimestamp ? timestamp : undefined,
         undefined
       );

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -24,7 +24,10 @@ import {
   DataPoint,
   Histogram,
 } from '@opentelemetry/sdk-metrics-base';
-import type { MetricAttributes, MetricAttributeValue } from '@opentelemetry/api-metrics';
+import type {
+  MetricAttributes,
+  MetricAttributeValue
+} from '@opentelemetry/api-metrics';
 import { hrTimeToMilliseconds } from '@opentelemetry/core';
 
 type PrometheusDataTypeLiteral =
@@ -52,6 +55,7 @@ function escapeAttributeValue(str: MetricAttributeValue = '') {
 }
 
 const invalidCharacterRegex = /[^a-z0-9_]/gi;
+
 /**
  * Ensures metric names are valid Prometheus metric names by removing
  * characters allowed by OpenTelemetry but disallowed by Prometheus.
@@ -254,25 +258,28 @@ export class PrometheusSerializer {
     let results = '';
 
     name = enforcePrometheusNamingConvention(name, type);
-    const { value, attributes } = dataPoint;
+    const attributes = dataPoint.attributes;
+    const histogram = dataPoint.value;
     const timestamp = hrTimeToMilliseconds(dataPoint.endTime);
     /** Histogram["bucket"] is not typed with `number` */
     for (const key of ['count', 'sum'] as ('count' | 'sum')[]) {
-      results += stringify(
-        name + '_' + key,
-        attributes,
-        value[key] ?? 0,
-        this._appendTimestamp ? timestamp : undefined,
-        undefined
-      );
+      const value = histogram[key];
+      if (value != null)
+        results += stringify(
+          name + '_' + key,
+          attributes,
+          value,
+          this._appendTimestamp ? timestamp : undefined,
+          undefined
+        );
     }
 
     let cumulativeSum = 0;
-    const countEntries = value.buckets.counts.entries();
+    const countEntries = histogram.buckets.counts.entries();
     let infiniteBoundaryDefined = false;
     for (const [idx, val] of countEntries) {
       cumulativeSum += val;
-      const upperBound = value.buckets.boundaries[idx];
+      const upperBound = histogram.buckets.boundaries[idx];
       /** HistogramAggregator is producing different boundary output -
        * in one case not including infinity values, in other -
        * full, e.g. [0, 100] and [0, 100, Infinity]

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -412,15 +412,11 @@ describe('PrometheusSerializer', () => {
           '# HELP test foobar\n' +
           '# TYPE test histogram\n' +
           `test_count{val="1"} 3 ${mockedHrTimeMs}\n` +
-          // undefined sum should be 0 (mimics collector exporter)
-          `test_sum{val="1"} 0 ${mockedHrTimeMs}\n` +
           `test_bucket{val="1",le="1"} 0 ${mockedHrTimeMs}\n` +
           `test_bucket{val="1",le="10"} 1 ${mockedHrTimeMs}\n` +
           `test_bucket{val="1",le="100"} 2 ${mockedHrTimeMs}\n` +
           `test_bucket{val="1",le="+Inf"} 3 ${mockedHrTimeMs}\n` +
           `test_count{val="2"} 1 ${mockedHrTimeMs}\n` +
-          // undefined sum should be 0 (mimics collector exporter)
-          `test_sum{val="2"} 0 ${mockedHrTimeMs}\n` +
           `test_bucket{val="2",le="1"} 0 ${mockedHrTimeMs}\n` +
           `test_bucket{val="2",le="10"} 1 ${mockedHrTimeMs}\n` +
           `test_bucket{val="2",le="100"} 1 ${mockedHrTimeMs}\n` +

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -355,7 +355,7 @@ describe('PrometheusSerializer', () => {
         return result;
       }
 
-      it('serialize metric record with ExplicitHistogramAggregation aggregator, cumulative', async () => {
+      it('serialize cumulative metric record', async () => {
         const serializer = new PrometheusSerializer();
         const result = await testSerializer(serializer);
         assert.strictEqual(
@@ -374,6 +374,57 @@ describe('PrometheusSerializer', () => {
             `test_bucket{val="2",le="10"} 1 ${mockedHrTimeMs}\n` +
             `test_bucket{val="2",le="100"} 1 ${mockedHrTimeMs}\n` +
             `test_bucket{val="2",le="+Inf"} 1 ${mockedHrTimeMs}\n`
+        );
+      });
+
+      it('serialize cumulative metric record on instrument that allows negative values', async () => {
+        const serializer = new PrometheusSerializer();
+        const reader = new TestMetricReader();
+        const meterProvider = new MeterProvider({
+          views: [
+            new View({
+              aggregation: new ExplicitBucketHistogramAggregation([1, 10, 100]),
+              instrumentName: '*'
+            })
+          ]
+        });
+        meterProvider.addMetricReader(reader);
+        const meter = meterProvider.getMeter('test');
+
+        const upDownCounter = meter.createUpDownCounter('test', {
+          description: 'foobar',
+        });
+        upDownCounter.add(5, { val: '1' });
+        upDownCounter.add(50, { val: '1' });
+        upDownCounter.add(120, { val: '1' });
+
+        upDownCounter.add(5, { val: '2' });
+
+        const { resourceMetrics, errors } = await reader.collect();
+        assert.strictEqual(errors.length, 0);
+        assert.strictEqual(resourceMetrics.scopeMetrics.length, 1);
+        assert.strictEqual(resourceMetrics.scopeMetrics[0].metrics.length, 1);
+        const scopeMetrics = resourceMetrics.scopeMetrics[0];
+
+        const result = serializer['_serializeScopeMetrics'](scopeMetrics);
+        assert.strictEqual(
+          result,
+          '# HELP test foobar\n' +
+          '# TYPE test histogram\n' +
+          `test_count{val="1"} 3 ${mockedHrTimeMs}\n` +
+          // undefined sum should be 0 (mimics collector exporter)
+          `test_sum{val="1"} 0 ${mockedHrTimeMs}\n` +
+          `test_bucket{val="1",le="1"} 0 ${mockedHrTimeMs}\n` +
+          `test_bucket{val="1",le="10"} 1 ${mockedHrTimeMs}\n` +
+          `test_bucket{val="1",le="100"} 2 ${mockedHrTimeMs}\n` +
+          `test_bucket{val="1",le="+Inf"} 3 ${mockedHrTimeMs}\n` +
+          `test_count{val="2"} 1 ${mockedHrTimeMs}\n` +
+          // undefined sum should be 0 (mimics collector exporter)
+          `test_sum{val="2"} 0 ${mockedHrTimeMs}\n` +
+          `test_bucket{val="2",le="1"} 0 ${mockedHrTimeMs}\n` +
+          `test_bucket{val="2",le="10"} 1 ${mockedHrTimeMs}\n` +
+          `test_bucket{val="2",le="100"} 1 ${mockedHrTimeMs}\n` +
+          `test_bucket{val="2",le="+Inf"} 1 ${mockedHrTimeMs}\n`
         );
       });
     });

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/aggregator/types.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/aggregator/types.ts
@@ -57,11 +57,10 @@ export interface Histogram {
     boundaries: number[];
     counts: number[];
   };
-  sum: number;
+  sum?: number;
   count: number;
-  hasMinMax: boolean;
-  min: number;
-  max: number;
+  min?: number;
+  max?: number;
 }
 
 /**

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/export/MetricData.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/export/MetricData.ts
@@ -19,8 +19,8 @@ import { MetricAttributes } from '@opentelemetry/api-metrics';
 import { InstrumentationScope } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
 import { InstrumentDescriptor } from '../InstrumentDescriptor';
-import { Histogram } from '../aggregator/types';
 import { AggregationTemporality } from './AggregationTemporality';
+import { Histogram } from '../aggregator/types';
 
 /**
  * Basic metric data fields.

--- a/experimental/packages/opentelemetry-sdk-metrics-base/test/Instruments.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/test/Instruments.test.ts
@@ -25,7 +25,8 @@ import {
   MeterProvider,
   MetricReader,
   DataPoint,
-  DataPointType
+  DataPointType,
+  Histogram
 } from '../src';
 import { TestMetricReader } from './export/TestMetricReader';
 import {
@@ -36,7 +37,6 @@ import {
   defaultResource,
   defaultInstrumentationScope
 } from './util';
-import { Histogram } from '../src/aggregator/types';
 import { ObservableResult, ValueType } from '@opentelemetry/api-metrics';
 
 describe('Instruments', () => {
@@ -301,7 +301,6 @@ describe('Instruments', () => {
               },
               count: 2,
               sum: 10,
-              hasMinMax: true,
               max: 10,
               min: 0
             },
@@ -315,7 +314,6 @@ describe('Instruments', () => {
               },
               count: 2,
               sum: 100,
-              hasMinMax: true,
               max: 100,
               min: 0
             },
@@ -358,7 +356,6 @@ describe('Instruments', () => {
               },
               count: 2,
               sum: 110,
-              hasMinMax: true,
               min: 20,
               max: 90
             },
@@ -386,7 +383,6 @@ describe('Instruments', () => {
               },
               count: 4,
               sum: 220,
-              hasMinMax: true,
               min: 10,
               max: 100
             },
@@ -430,7 +426,6 @@ describe('Instruments', () => {
               },
               count: 2,
               sum: 10.1,
-              hasMinMax: true,
               max: 10,
               min: 0.1
             },
@@ -444,7 +439,6 @@ describe('Instruments', () => {
               },
               count: 2,
               sum: 100.1,
-              hasMinMax: true,
               max: 100,
               min: 0.1
             },

--- a/experimental/packages/otlp-transformer/src/metrics/internal.ts
+++ b/experimental/packages/otlp-transformer/src/metrics/internal.ts
@@ -128,8 +128,8 @@ function toHistogramDataPoints(
       explicitBounds: histogram.buckets.boundaries,
       count: histogram.count,
       sum: histogram.sum,
-      min: histogram.hasMinMax ? histogram.min : undefined,
-      max: histogram.hasMinMax ? histogram.max : undefined,
+      min: histogram.min,
+      max: histogram.max,
       startTimeUnixNano: hrTimeToNanoseconds(dataPoint.startTime),
       timeUnixNano: hrTimeToNanoseconds(
         dataPoint.endTime

--- a/experimental/packages/otlp-transformer/test/metrics.test.ts
+++ b/experimental/packages/otlp-transformer/test/metrics.test.ts
@@ -179,9 +179,8 @@ describe('Metrics', () => {
       sum: number,
       boundaries: number[],
       counts: number[], aggregationTemporality: AggregationTemporality,
-      hasMinMax: boolean,
-      min: number,
-      max: number): MetricData {
+      min?: number,
+      max?: number): MetricData {
       return {
         descriptor: {
           description: 'this is a description',
@@ -197,7 +196,6 @@ describe('Metrics', () => {
             value: {
               sum: sum,
               count: count,
-              hasMinMax: hasMinMax,
               min: min,
               max: max,
               buckets: {
@@ -437,7 +435,7 @@ describe('Metrics', () => {
     describe('serializes a histogram metric record', () => {
       it('with min/max', () => {
         const exportRequest = createExportMetricsServiceRequest(
-          [createResourceMetrics([createHistogramMetrics(2, 9, [5], [1, 1], AggregationTemporality.CUMULATIVE, true,1, 8)])]
+          [createResourceMetrics([createHistogramMetrics(2, 9, [5], [1, 1], AggregationTemporality.CUMULATIVE, 1, 8)])]
         );
         assert.ok(exportRequest);
 
@@ -482,7 +480,7 @@ describe('Metrics', () => {
 
       it('without min/max', () => {
         const exportRequest = createExportMetricsServiceRequest(
-          [createResourceMetrics([createHistogramMetrics(2, 9, [5], [1, 1], AggregationTemporality.CUMULATIVE, false, Infinity, -1)])]
+          [createResourceMetrics([createHistogramMetrics(2, 9, [5], [1, 1], AggregationTemporality.CUMULATIVE)])]
         );
         assert.ok(exportRequest);
 


### PR DESCRIPTION
## Which problem is this PR solving?

With a Histogram Aggregation, `sum` was collected even when using it with instruments like `UpDownCounter` or `ObservableGauge`, which allow negative measurements. However, the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/0b8aa6a375c60d7ed0a5cd4f99263f4800faca3a/specification/metrics/sdk.md?plain=1#L418-L419) states this:

>Arithmetic sum of `Measurement` values in population. This SHOULD NOT be collected when used with
instruments that record negative measurements (e.g. `UpDownCounter` or `ObservableGauge`).

This PR changes the Aggregation so that `sum` is only exported when used with instruments that only allow non-negative values. With the previous approach this would be indicated with a flag. This approach became unwieldy, so instead the type for `sum` is changed to `number | undefined`. To prevent a mix of approaches for the same problem, `min` and `max`'s types are also changed to `number | undefined` and the `hasMinMax` field is dropped. 

Fixes #3090

## Short description of the changes

- Changes the `Histogram` type's fields `sum`, `min` and `max` to be of type `number | undefined`
- Removes `hasMinMax` field from the `Histogram` type.
- Aligns the Prometheus Exporter's behavior on undefined Histogram sum with the exporter in collector-contrib (exports `sum = 0`).

## Type of change

Please delete options that are not relevant.

- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - `sum` is now optional on `Histogram` and might be `undefined`
  - `min` and `max` are now optional on `Histogram` and might be `undefined`
  - `hasMinMax` has been removed on `Histogram`

## How Has This Been Tested?

- [x] Added unit tests
- [x] Adapted existing unit tests

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
