### PR TITLE
fix: don't let PeriodicExportingMetricReader block process exit

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to experimental packages in this project will be documented 
 ### :bug: (Bug Fix)
 
 * fix(histogram): fix maximum when only values < -1 are provided [#3086](https://github.com/open-telemetry/opentelemetry-js/pull/3086) @pichlermarc
+* fix(sdk-metrics-base): fix PeriodicExportingMetricReader keeping Node.js process from exiting
+  [#3106](https://github.com/open-telemetry/opentelemetry-js/pull/3106) @seemk
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-sdk-metrics-base/src/export/PeriodicExportingMetricReader.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/src/export/PeriodicExportingMetricReader.ts
@@ -15,7 +15,11 @@
  */
 
 import * as api from '@opentelemetry/api';
-import { ExportResultCode, globalErrorHandler } from '@opentelemetry/core';
+import {
+  ExportResultCode,
+  globalErrorHandler,
+  unrefTimer
+} from '@opentelemetry/core';
 import { MetricReader } from './MetricReader';
 import { AggregationTemporality } from './AggregationTemporality';
 import { InstrumentType } from '../InstrumentDescriptor';
@@ -100,6 +104,7 @@ export class PeriodicExportingMetricReader extends MetricReader {
         globalErrorHandler(err);
       }
     }, this._exportInterval);
+    unrefTimer(this._interval);
   }
 
   protected async onForceFlush(): Promise<void> {


### PR DESCRIPTION
`PeriodicExportingMetricReader` currently keeps the Node.js process from exiting when not doing an explicit shutdown.