### PR TITLE
chore: update changelog to reflect #3098 fixed #2791

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable changes to experimental packages in this project will be documented 
 * fix(histogram): fix maximum when only values < -1 are provided [#3086](https://github.com/open-telemetry/opentelemetry-js/pull/3086) @pichlermarc
 * fix(sdk-metrics-base): fix PeriodicExportingMetricReader keeping Node.js process from exiting
   [#3106](https://github.com/open-telemetry/opentelemetry-js/pull/3106) @seemk
+* fix(otlp-proto): fixes [#2791](https://github.com/open-telemetry/opentelemetry-js/issues/2791) otlp proto exporters no longer share a single global proto definition
+  [#3098](https://github.com/open-telemetry/opentelemetry-js/pull/3098) @legendecas
 
 ### :books: (Refine Doc)
 


### PR DESCRIPTION
This is simply updating the changelog to reflect that a bug was fixed while implementing another feature.