### PR TITLE
chore: release proposal 1.5.0 / 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project will be documented in this file.
 
 ### :house: (Internal)
 
+## 1.5.0
+
+### :rocket: (Enhancement)
+
+* feat(sdk-trace-base): Improve extensibility of BasicTracerProvider [#3023](https://github.com/open-telemetry/opentelemetry-js/pull/3023) @Rauno56
+
 ## 1.4.0
 
 ### :rocket: (Enhancement)

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-otlp-exporter-node",
   "private": true,
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
@@ -29,18 +29,18 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.1.0",
-    "@opentelemetry/api-metrics": "0.30.0",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.30.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.30.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "0.30.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.30.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.30.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.30.0",
-    "@opentelemetry/resources": "1.4.0",
-    "@opentelemetry/sdk-metrics-base": "0.30.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
-    "@opentelemetry/semantic-conventions": "1.4.0"
+    "@opentelemetry/api-metrics": "0.31.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.31.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.31.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "0.31.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.31.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.31.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.31.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/sdk-metrics-base": "0.31.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
+    "@opentelemetry/semantic-conventions": "1.5.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js#readme"
 }

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 All notable changes to experimental packages in this project will be documented in this file.
 
-## Unreleased
+# Unreleased
+
+### :boom: Breaking Change
+
+### :rocket: (Enhancement)
+
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 0.31.0
 
 ### :boom: Breaking Change
 
@@ -25,10 +37,6 @@ All notable changes to experimental packages in this project will be documented 
 * fix(histogram): fix maximum when only values < -1 are provided [#3086](https://github.com/open-telemetry/opentelemetry-js/pull/3086) @pichlermarc
 * fix(sdk-metrics-base): fix PeriodicExportingMetricReader keeping Node.js process from exiting
   [#3106](https://github.com/open-telemetry/opentelemetry-js/pull/3106) @seemk
-
-### :books: (Refine Doc)
-
-### :house: (Internal)
 
 ## 0.30.0
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to experimental packages in this project will be documented in this file.
 
-# Unreleased
+## Unreleased
 
 ### :boom: Breaking Change
 

--- a/experimental/backwards-compatability/node14/package.json
+++ b/experimental/backwards-compatability/node14/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node14",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "private": true,
   "description": "Backwards compatability app for node 14 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.30.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0"
+    "@opentelemetry/sdk-node": "0.31.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0"
   },
   "devDependencies": {
     "@types/node": "^14.0.0",

--- a/experimental/backwards-compatability/node16/package.json
+++ b/experimental/backwards-compatability/node16/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node16",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "private": true,
   "description": "Backwards compatability app for node 16 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.30.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0"
+    "@opentelemetry/sdk-node": "0.31.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0"
   },
   "devDependencies": {
     "@types/node": "^16.0.0",

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -73,7 +73,7 @@
     "@opentelemetry/otlp-grpc-exporter-base": "0.31.0",
     "@opentelemetry/otlp-transformer": "0.31.0",
     "@opentelemetry/resources": "1.5.0",
-    "@,opentelemetry/sdk-trace-base": "1.5.0"
-  }
+    "@opentelemetry/sdk-trace-base": "1.5.0"
+  },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-grpc"
 }

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-grpc",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/otlp-exporter-base": "0.30.0",
+    "@opentelemetry/otlp-exporter-base": "0.31.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -69,10 +69,10 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.5.9",
     "@grpc/proto-loader": "^0.6.9",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.30.0",
-    "@opentelemetry/otlp-transformer": "0.30.0",
-    "@opentelemetry/resources": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0"
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.31.0",
+    "@opentelemetry/otlp-transformer": "0.31.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0"
   }
 }

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-http",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry Collector Trace Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,10 +94,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/otlp-exporter-base": "0.30.0",
-    "@opentelemetry/otlp-transformer": "0.30.0",
-    "@opentelemetry/resources": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0"
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/otlp-exporter-base": "0.31.0",
+    "@opentelemetry/otlp-transformer": "0.31.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0"
   }
 }

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-proto",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -67,12 +67,12 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.6.9",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/otlp-exporter-base": "0.30.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.30.0",
-    "@opentelemetry/otlp-transformer": "0.30.0",
-    "@opentelemetry/resources": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/otlp-exporter-base": "0.31.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.31.0",
+    "@opentelemetry/otlp-transformer": "0.31.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
     "protobufjs": "^6.9.0"
   }
 }

--- a/experimental/packages/opentelemetry-api-metrics/package.json
+++ b/experimental/packages/opentelemetry-api-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-metrics",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Public metrics API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/api-metrics": "0.30.0",
+    "@opentelemetry/api-metrics": "0.31.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -69,11 +69,11 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.5.9",
     "@grpc/proto-loader": "^0.6.9",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.30.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.30.0",
-    "@opentelemetry/otlp-transformer": "0.30.0",
-    "@opentelemetry/resources": "1.4.0",
-    "@opentelemetry/sdk-metrics-base": "0.30.0"
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.31.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.31.0",
+    "@opentelemetry/otlp-transformer": "0.31.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/sdk-metrics-base": "0.31.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-http",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,11 +94,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.30.0",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/otlp-exporter-base": "0.30.0",
-    "@opentelemetry/otlp-transformer": "0.30.0",
-    "@opentelemetry/resources": "1.4.0",
-    "@opentelemetry/sdk-metrics-base": "0.30.0"
+    "@opentelemetry/api-metrics": "0.31.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/otlp-exporter-base": "0.31.0",
+    "@opentelemetry/otlp-transformer": "0.31.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/sdk-metrics-base": "0.31.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-proto",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/api-metrics": "0.30.0",
+    "@opentelemetry/api-metrics": "0.31.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -68,13 +68,13 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "0.6.9",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.30.0",
-    "@opentelemetry/otlp-exporter-base": "0.30.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.30.0",
-    "@opentelemetry/otlp-transformer": "0.30.0",
-    "@opentelemetry/resources": "1.4.0",
-    "@opentelemetry/sdk-metrics-base": "0.30.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.31.0",
+    "@opentelemetry/otlp-exporter-base": "0.31.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.31.0",
+    "@opentelemetry/otlp-transformer": "0.31.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/sdk-metrics-base": "0.31.0",
     "protobufjs": "^6.9.0"
   }
 }

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -59,8 +59,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.30.0",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/sdk-metrics-base": "0.30.0"
+    "@opentelemetry/api-metrics": "0.31.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/sdk-metrics-base": "0.31.0"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-fetch",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry fetch automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-zone": "1.4.0",
-    "@opentelemetry/propagator-b3": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/context-zone": "1.5.0",
+    "@opentelemetry/propagator-b3": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -87,9 +87,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/instrumentation": "0.30.0",
-    "@opentelemetry/sdk-trace-web": "1.4.0",
-    "@opentelemetry/semantic-conventions": "1.4.0"
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/instrumentation": "0.31.0",
+    "@opentelemetry/sdk-trace-web": "1.5.0",
+    "@opentelemetry/semantic-conventions": "1.5.0"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-grpc",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry grpc automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -48,10 +48,10 @@
     "@grpc/grpc-js": "1.5.9",
     "@grpc/proto-loader": "0.6.9",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.4.0",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
-    "@opentelemetry/sdk-trace-node": "1.4.0",
+    "@opentelemetry/context-async-hooks": "1.5.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
+    "@opentelemetry/sdk-trace-node": "1.5.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/semver": "7.3.9",
@@ -71,8 +71,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.30.0",
-    "@opentelemetry/instrumentation": "0.30.0",
-    "@opentelemetry/semantic-conventions": "1.4.0"
+    "@opentelemetry/api-metrics": "0.31.0",
+    "@opentelemetry/instrumentation": "0.31.0",
+    "@opentelemetry/semantic-conventions": "1.5.0"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-http",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry http/https automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,9 +46,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
-    "@opentelemetry/sdk-trace-node": "1.4.0",
+    "@opentelemetry/context-async-hooks": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
+    "@opentelemetry/sdk-trace-node": "1.5.0",
     "@types/got": "9.6.12",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
@@ -74,9 +74,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/instrumentation": "0.30.0",
-    "@opentelemetry/semantic-conventions": "1.4.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/instrumentation": "0.31.0",
+    "@opentelemetry/semantic-conventions": "1.5.0",
     "semver": "^7.3.5"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-xml-http-request",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry XMLHttpRequest automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-zone": "1.4.0",
-    "@opentelemetry/propagator-b3": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/context-zone": "1.5.0",
+    "@opentelemetry/propagator-b3": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -87,9 +87,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/instrumentation": "0.30.0",
-    "@opentelemetry/sdk-trace-web": "1.4.0",
-    "@opentelemetry/semantic-conventions": "1.4.0"
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/instrumentation": "0.31.0",
+    "@opentelemetry/sdk-trace-web": "1.5.0",
+    "@opentelemetry/semantic-conventions": "1.5.0"
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Base class for node which OpenTelemetry instrumentation modules extend",
   "author": "OpenTelemetry Authors",
   "homepage": "https://github.com/open-telemetry/opentelemetry-js#readme",
@@ -68,7 +68,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.30.0",
+    "@opentelemetry/api-metrics": "0.31.0",
     "require-in-the-middle": "^5.0.3",
     "semver": "^7.3.2",
     "shimmer": "^1.2.1"

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics-base",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Work in progress OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -77,9 +77,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.30.0",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/api-metrics": "0.31.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/resources": "1.5.0",
     "lodash.merge": "4.6.2"
   }
 }

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-node",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry SDK for Node.js",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,21 +44,21 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.30.0",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/instrumentation": "0.30.0",
-    "@opentelemetry/resources": "1.4.0",
-    "@opentelemetry/sdk-metrics-base": "0.30.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
-    "@opentelemetry/sdk-trace-node": "1.4.0"
+    "@opentelemetry/api-metrics": "0.31.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/instrumentation": "0.31.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/sdk-metrics-base": "0.31.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
+    "@opentelemetry/sdk-trace-node": "1.5.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0",
-    "@opentelemetry/context-async-hooks": "1.4.0",
-    "@opentelemetry/semantic-conventions": "1.4.0",
+    "@opentelemetry/context-async-hooks": "1.5.0",
+    "@opentelemetry/semantic-conventions": "1.5.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/semver": "7.3.9",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-exporter-base",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry OTLP Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.4.0"
+    "@opentelemetry/core": "1.5.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-grpc-exporter-base",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry OTLP-gRPC Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -51,9 +51,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/otlp-transformer": "0.30.0",
-    "@opentelemetry/resources": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/otlp-transformer": "0.31.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -73,7 +73,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.5.9",
     "@grpc/proto-loader": "^0.6.9",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/otlp-exporter-base": "0.30.0"
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/otlp-exporter-base": "0.31.0"
   }
 }

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-proto-exporter-base",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "OpenTelemetry OTLP-HTTP-protobuf Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@grpc/proto-loader": "^0.6.9",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/otlp-exporter-base": "0.30.0"
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/otlp-exporter-base": "0.31.0"
   }
 }

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Transform OpenTelemetry SDK data into OTLP",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
@@ -77,10 +77,10 @@
     "webpack": "4.46.0"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "0.30.0",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/resources": "1.4.0",
-    "@opentelemetry/sdk-metrics-base": "0.30.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0"
+    "@opentelemetry/api-metrics": "0.31.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/sdk-metrics-base": "0.31.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0"
   }
 }

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.4.0",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/context-async-hooks": "1.5.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
     "axios": "0.24.0",
     "body-parser": "1.19.0",
     "express": "4.17.1"

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -74,7 +74,7 @@
     "webpack-merge": "5.8.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.4.0",
+    "@opentelemetry/context-zone-peer-dep": "1.5.0",
     "zone.js": "^0.11.0"
   },
   "sideEffects": true

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,6 +91,6 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.4.0"
+    "@opentelemetry/semantic-conventions": "1.5.0"
   }
 }

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/resources": "1.5.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/sinon": "10.0.6",
@@ -62,9 +62,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
-    "@opentelemetry/semantic-conventions": "1.4.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
+    "@opentelemetry/semantic-conventions": "1.5.0",
     "jaeger-client": "^3.15.0"
   }
 }

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,9 +91,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/resources": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
-    "@opentelemetry/semantic-conventions": "1.4.0"
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
+    "@opentelemetry/semantic-conventions": "1.5.0"
   }
 }

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.4.0"
+    "@opentelemetry/core": "1.5.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -80,6 +80,6 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.4.0"
+    "@opentelemetry/core": "1.5.0"
   }
 }

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -89,7 +89,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/semantic-conventions": "1.4.0"
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/semantic-conventions": "1.5.0"
   }
 }

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,8 +91,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/resources": "1.4.0",
-    "@opentelemetry/semantic-conventions": "1.4.0"
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/semantic-conventions": "1.5.0"
   }
 }

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0",
-    "@opentelemetry/resources": "1.4.0",
-    "@opentelemetry/semantic-conventions": "1.4.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/semantic-conventions": "1.5.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "@types/semver": "7.3.9",
@@ -64,11 +64,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.4.0",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/propagator-b3": "1.4.0",
-    "@opentelemetry/propagator-jaeger": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/context-async-hooks": "1.5.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/propagator-b3": "1.5.0",
+    "@opentelemetry/propagator-jaeger": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
     "semver": "^7.3.5"
   }
 }

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,9 +57,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": ">=1.0.0 <1.2.0",
-    "@opentelemetry/context-zone": "1.4.0",
-    "@opentelemetry/propagator-b3": "1.4.0",
-    "@opentelemetry/resources": "1.4.0",
+    "@opentelemetry/context-zone": "1.5.0",
+    "@opentelemetry/propagator-b3": "1.5.0",
+    "@opentelemetry/resources": "1.5.0",
     "@types/jquery": "3.5.8",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
@@ -91,8 +91,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
-    "@opentelemetry/semantic-conventions": "1.4.0"
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
+    "@opentelemetry/semantic-conventions": "1.5.0"
   }
 }

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -43,9 +43,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0",
-    "@opentelemetry/propagator-b3": "1.4.0",
-    "@opentelemetry/propagator-jaeger": "1.4.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
+    "@opentelemetry/propagator-b3": "1.5.0",
+    "@opentelemetry/propagator-jaeger": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.33",
     "codecov": "3.8.3",
@@ -59,8 +59,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/semantic-conventions": "1.4.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/semantic-conventions": "1.5.0",
     "opentracing": "^0.14.4"
   }
 }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
@@ -56,16 +56,16 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.4.0",
-    "@opentelemetry/core": "1.4.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.30.0",
-    "@opentelemetry/exporter-zipkin": "1.4.0",
-    "@opentelemetry/instrumentation": "0.30.0",
-    "@opentelemetry/instrumentation-fetch": "0.30.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.30.0",
-    "@opentelemetry/sdk-metrics-base": "0.30.0",
-    "@opentelemetry/sdk-trace-base": "1.4.0",
-    "@opentelemetry/sdk-trace-web": "1.4.0",
+    "@opentelemetry/context-zone-peer-dep": "1.5.0",
+    "@opentelemetry/core": "1.5.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.31.0",
+    "@opentelemetry/exporter-zipkin": "1.5.0",
+    "@opentelemetry/instrumentation": "0.31.0",
+    "@opentelemetry/instrumentation-fetch": "0.31.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.31.0",
+    "@opentelemetry/sdk-metrics-base": "0.31.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0",
+    "@opentelemetry/sdk-trace-web": "1.5.0",
     "zone.js": "0.11.4"
   }
 }


### PR DESCRIPTION
## 1.5.0

### :rocket: (Enhancement)

* feat(sdk-trace-base): Improve extensibility of BasicTracerProvider [#3023](https://github.com/open-telemetry/opentelemetry-js/pull/3023) @Rauno56

## 0.31.0

### :boom: Breaking Change

* feature(views): move views registration to MeterProvider constructor [#3066](https://github.com/open-telemetry/opentelemetry-js/pull/3066) @pichlermarc
* feat(sdk-metrics-base): split up Singular into Sum and Gauge in MetricData [#3079](https://github.com/open-telemetry/opentelemetry-js/pull/3079) @pichlermarc
  * removes `DataPointType.SINGULAR`, and replaces it with `DataPointType.SUM` and `DataPointType.GAUGE`
  * removes `SingularMetricData` and replaces it with `SumMetricData` (including an additional `isMonotonic` flag) and `GaugeMetricData`
* feat(histogram): align collection of optional Histogram properties with spec [#3102](https://github.com/open-telemetry/opentelemetry-js/pull/3079) @pichlermarc
  * changes type of `sum` property on `Histogram` to `number | undefined`
  * changes type of `min` and `max` properties on `Histogram` to `number | undefined`
  * removes `hasMinMax` flag on the exported `Histogram` - this is now indicated by `min` and `max` being `undefined`

### :rocket: (Enhancement)

* feat(metrics-api): use common attributes definitions #3038 @legendecas
* feat(otlp-proto): pre-compile proto files [#3098](https://github.com/open-telemetry/opentelemetry-js/pull/3098) @legendecas
* feat(opentelemetry-sdk-metrics-base): added InMemoryMetricExporter [#3039](https://github.com/open-telemetry/opentelemetry-js/pull/3039) @weyert

### :bug: (Bug Fix)

* fix(histogram): fix maximum when only values < -1 are provided [#3086](https://github.com/open-telemetry/opentelemetry-js/pull/3086) @pichlermarc
* fix(sdk-metrics-base): fix PeriodicExportingMetricReader keeping Node.js process from exiting
  [#3106](https://github.com/open-telemetry/opentelemetry-js/pull/3106) @seemk
* fix(otlp-proto): fixes [#2791](https://github.com/open-telemetry/opentelemetry-js/issues/2791) otlp proto exporters no longer share a single global proto definition
  [#3098](https://github.com/open-telemetry/opentelemetry-js/pull/3098) @legendecas