### PR TITLE
fix(otlp-proto-exporter-base): spawn pbjs without node

### DIFF
--- a/experimental/packages/otlp-proto-exporter-base/scripts/protos.js
+++ b/experimental/packages/otlp-proto-exporter-base/scripts/protos.js
@@ -18,7 +18,7 @@ const protos = [
 
 function exec(command, argv) {
   return new Promise((resolve, reject) => {
-    const child = cp.spawn(process.execPath, [command, ...argv], {
+    const child = cp.spawn(command, argv, {
       stdio: ['ignore', 'inherit', 'inherit'],
     });
     child.on('exit', (code, signal) => {
@@ -27,7 +27,7 @@ function exec(command, argv) {
         return;
       }
       resolve();
-    })
+    });
   });
 }
 
@@ -35,7 +35,7 @@ function pbts(pbjsOutFile) {
   const pbtsPath = path.resolve(__dirname, '../node_modules/.bin/pbts');
   const pbtsOptions = [
     '-o', path.join(generatedPath, 'root.d.ts'),
-  ]
+  ];
   return exec(pbtsPath, [...pbtsOptions, pbjsOutFile]);
 }
 

--- a/experimental/packages/otlp-proto-exporter-base/scripts/protos.js
+++ b/experimental/packages/otlp-proto-exporter-base/scripts/protos.js
@@ -19,6 +19,7 @@ const protos = [
 function exec(command, argv) {
   return new Promise((resolve, reject) => {
     const child = cp.spawn(command, argv, {
+      shell: true,
       stdio: ['ignore', 'inherit', 'inherit'],
     });
     child.on('exit', (code, signal) => {


### PR DESCRIPTION


## Which problem is this PR solving?

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/3121

The scripts in `node_modules/.bin` can be a script wrapper on Windows. Run the executable directly instead of running it with node to circumvent the problem.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] I don't have a windows environment. Better to set up a GitHub action with windows?

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
