### PR TITLE
GRPC instrumentation. Added new attributes according to the OpenTelemetry rpc convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### :rocket: (Enhancement)
 
-feat(sdk-trace-base): move Sampler declaration into sdk-trace-base [#3088](https://github.com/open-telemetry/opentelemetry-js/pull/3088) @legendecas
+* feat(sdk-trace-base): move Sampler declaration into sdk-trace-base [#3088](https://github.com/open-telemetry/opentelemetry-js/pull/3088) @legendecas
+* fix(grpc-instrumentation): added grpc attributes in instrumentation [#3127](https://github.com/open-telemetry/opentelemetry-js/pull/3127) @andrewzenkov
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/enums/AttributeValues.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/enums/AttributeValues.ts
@@ -14,16 +14,10 @@
  * limitations under the License.
  */
 
-/**
- * https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/http.md
- */
-
-interface AttributesType {
-  GRPC_ERROR_NAME: string;
-  GRPC_ERROR_MESSAGE: string;
+interface AttributeValuesType {
+  RPC_SYSTEM: string
 }
 
-export const AttributeNames: Readonly<AttributesType> = {
-  GRPC_ERROR_NAME: 'grpc.error_name',
-  GRPC_ERROR_MESSAGE: 'grpc.error_message',
+export const AttributeValues: Readonly<AttributeValuesType> = {
+  RPC_SYSTEM: 'grpc'
 };

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/clientUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/clientUtils.ts
@@ -17,7 +17,6 @@
 import { GrpcJsInstrumentation } from './';
 import type { GrpcClientFunc, SendUnaryDataCallback } from './types';
 import {
-  SpanKind,
   Span,
   SpanStatusCode,
   SpanStatus,
@@ -126,11 +125,6 @@ export function makeGrpcClientRemoteCall(
         );
       }
     }
-
-    span.setAttributes({
-      [AttributeNames.GRPC_METHOD]: original.path,
-      [AttributeNames.GRPC_KIND]: SpanKind.CLIENT,
-    });
 
     setSpanContext(metadata);
     const call = original.apply(self, args);

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/index.ts
@@ -49,7 +49,9 @@ import {
   getMetadata,
 } from './clientUtils';
 import { EventEmitter } from 'events';
-import { AttributeNames } from '../enums/AttributeNames';
+import { _extractMethodAndService } from '../utils';
+import { AttributeValues } from '../enums/AttributeValues';
+import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
 export class GrpcJsInstrumentation extends InstrumentationBase {
   constructor(
@@ -188,10 +190,14 @@ export class GrpcJsInstrumentation extends InstrumentationBase {
                   keys: carrier => Object.keys(carrier.getMap()),
                 }),
                 () => {
+                  const { service, method } = _extractMethodAndService(name);
+
                   const span = instrumentation.tracer
                     .startSpan(spanName, spanOptions)
                     .setAttributes({
-                      [AttributeNames.GRPC_KIND]: spanOptions.kind,
+                      [SemanticAttributes.RPC_SYSTEM]: AttributeValues.RPC_SYSTEM,
+                      [SemanticAttributes.RPC_METHOD]: method,
+                      [SemanticAttributes.RPC_SERVICE]: service,
                     });
 
                   context.with(trace.setSpan(context.active(), span), () => {
@@ -283,9 +289,15 @@ export class GrpcJsInstrumentation extends InstrumentationBase {
           original,
           args
         );
-        const span = instrumentation.tracer.startSpan(name, {
-          kind: SpanKind.CLIENT,
-        });
+        const { service, method } = _extractMethodAndService(original.path);
+
+        const span = instrumentation.tracer
+          .startSpan(name, { kind: SpanKind.CLIENT })
+          .setAttributes({
+            [SemanticAttributes.RPC_SYSTEM]: 'grpc',
+            [SemanticAttributes.RPC_METHOD]: method,
+            [SemanticAttributes.RPC_SERVICE]: service,
+          });
         return context.with(trace.setSpan(context.active(), span), () =>
           makeGrpcClientRemoteCall(original, args, metadata, this)(span)
         );

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/clientUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc/clientUtils.ts
@@ -22,7 +22,6 @@ import {
   context,
   Span,
   SpanStatusCode,
-  SpanKind,
   SpanStatus,
   propagation,
 } from '@opentelemetry/api';
@@ -99,10 +98,6 @@ export const makeGrpcClientRemoteCall = function (
     }
 
     span.addEvent('sent');
-    span.setAttributes({
-      [AttributeNames.GRPC_METHOD]: original.path,
-      [AttributeNames.GRPC_KIND]: SpanKind.CLIENT,
-    });
 
     setSpanContext(metadata);
     const call = original.apply(self, args);

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/utils.ts
@@ -95,3 +95,18 @@ export const _methodIsIgnored = (
 
   return false;
 };
+
+/**
+ * Return method and service values getting from grpc name/path
+ * @param name the grpc name/path
+ */
+export const _extractMethodAndService = (name: string): { service: string, method: string } => {
+  const serviceMethod = name.replace(/^\//, '').split('/');
+  const service = serviceMethod.shift() || '';
+  const method = serviceMethod.join('/');
+
+  return ({
+    service,
+    method
+  });
+};

--- a/experimental/packages/opentelemetry-instrumentation-grpc/test/utils/extractMethodAndServiceUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/test/utils/extractMethodAndServiceUtils.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { _extractMethodAndService } from '../../src/utils';
+import * as assert from 'assert';
+
+
+const cases = [
+  { value: 'readBooks/BookStorage.Book', result: { method: 'BookStorage.Book', service: 'readBooks' } },
+  { value: 'readBooks//BookStorage.Book', result: { method: '/BookStorage.Book', service: 'readBooks' } },
+  { value: 'readBooks/BookStorage/.Book', result: { method: 'BookStorage/.Book', service: 'readBooks' } },
+  { value: '/readBooks/BookStorage/.Book/Book', result: { method: 'BookStorage/.Book/Book', service: 'readBooks' } },
+];
+
+describe('ExtractMethodAndService Util', () => {
+
+  cases.forEach(({ value, result }) => {
+    it(`Should resolve use case correctly for: ${value}`, () => {
+      const { method, service } = _extractMethodAndService(value);
+
+      assert.deepStrictEqual({ method, service }, { method: result.method, service: result.service });
+    });
+  });
+});


### PR DESCRIPTION
This PR is extending [**old one**](https://github.com/open-telemetry/opentelemetry-js/pull/3089). Feel free to check it if needs comments

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Opentelemtry grpc instrumentation is not consistent in terms of creating grpc attributes in requests.
For example in Java/Python instrumentations it contains necessary attributes for grpc connection:
- rpc.method
- rpc.service
- rpc.system
<img width="786" alt="image" src="https://user-images.githubusercontent.com/81105315/178726002-4c3f4d64-e58b-4d7e-a01a-0054880688b2.png">

But these attributes are missed in js grpc instrumentation. It doesn't set attributes. 
Additionally, if compare Python/Java and Nodejs attributes.
Already existing attribute `rpc.method` is implemented incorrectly in Nodejs.
https://github.com/open-telemetry/opentelemetry-js/blob/747c404fb1295d54eb628a434ebf782d2f180bfb/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/clientUtils.ts#L131

Fixes # (issue)

## Short description of the changes

- Renamed `rpc.method` from `grpc.method` to `rpc.method` attribute (Client, Server)
- Added  `rpc.service` attribute (Client, Server)
- Added `rpc.system` attribute (Client, Server)
- Fixed`rpc.method` value calculating for some use case. (it should be method, but value is just full path)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Create GRPC example, run opentelemetry SDK using authoinstrumentation, or manually set `new GrpcInstrumentation()`, you will see that Grpc instrumentation detects grpc connection and creates spans but with missing attributes:
- rpc.method (server?/client?)
- rpc.system (server/client)
- rpc.service (server/client)

And for client rpc.method has incorrect value. https://github.com/open-telemetry/opentelemetry-js/blob/747c404fb1295d54eb628a434ebf782d2f180bfb/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/clientUtils.ts#L131

Before:
Client/server
<img width="1483" alt="image" src="https://user-images.githubusercontent.com/81105315/178730082-d5110e70-0d65-4435-b619-6aa7c510385b.png">

After:
Client/Server
<img width="1482" alt="image" src="https://user-images.githubusercontent.com/81105315/178750905-9ab533aa-254f-47bd-a514-38746ee8e8f6.png">
