### PR TITLE
Prevent double wrapping event emitter listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.
 
 ### :bug: (Bug Fix)
 
+* fix(context-async-hooks): Ensure listeners added using `once` can be removed using `removeListener`
+  [#3133](https://github.com/open-telemetry/opentelemetry-js/pull/3133)
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/packages/opentelemetry-context-async-hooks/src/AbstractAsyncHooksContextManager.ts
+++ b/packages/opentelemetry-context-async-hooks/src/AbstractAsyncHooksContextManager.ts
@@ -195,9 +195,11 @@ export abstract class AbstractAsyncHooksContextManager
       listeners.set(listener, patchedListener);
       
       contextManager._wrapped = true;
-      const val = original.call(this, event, patchedListener);
-      contextManager._wrapped = false;
-      return val;
+      try {
+        return original.call(this, event, patchedListener);;
+      } finally {
+        contextManager._wrapped = false;
+      }
     };
   }
 

--- a/packages/opentelemetry-context-async-hooks/src/AbstractAsyncHooksContextManager.ts
+++ b/packages/opentelemetry-context-async-hooks/src/AbstractAsyncHooksContextManager.ts
@@ -201,7 +201,7 @@ implements ContextManager {
       // store a weak reference of the user listener to ours
       listeners.set(listener, patchedListener);
 
-      /** 
+      /**
        * See comment at the start of this function for the explanation of this property.
        */
       contextManager._wrapped = true;

--- a/packages/opentelemetry-context-async-hooks/src/AbstractAsyncHooksContextManager.ts
+++ b/packages/opentelemetry-context-async-hooks/src/AbstractAsyncHooksContextManager.ts
@@ -37,7 +37,7 @@ const ADD_LISTENER_METHODS = [
 ];
 
 export abstract class AbstractAsyncHooksContextManager
-  implements ContextManager {
+implements ContextManager {
   abstract active(): Context;
 
   abstract with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
@@ -193,10 +193,10 @@ export abstract class AbstractAsyncHooksContextManager
       const patchedListener = contextManager.bind(context, listener);
       // store a weak reference of the user listener to ours
       listeners.set(listener, patchedListener);
-      
+
       contextManager._wrapped = true;
       try {
-        return original.call(this, event, patchedListener);;
+        return original.call(this, event, patchedListener);
       } finally {
         contextManager._wrapped = false;
       }

--- a/packages/opentelemetry-context-async-hooks/test/AsyncHooksContextManager.test.ts
+++ b/packages/opentelemetry-context-async-hooks/test/AsyncHooksContextManager.test.ts
@@ -415,6 +415,28 @@ for (const contextManagerClass of [
         patchedEE.emit('test');
       });
 
+      it('should remove event handler enabled by .once using removeListener (when enabled)', () => {
+        const ee = new EventEmitter();
+        const context = ROOT_CONTEXT.setValue(key1, 1);
+        const patchedEE = contextManager.bind(context, ee);
+        function handler() {}
+        patchedEE.once('test', handler);
+        assert.strictEqual(patchedEE.listeners('test').length, 1);
+        patchedEE.removeListener('test', handler);
+        assert.strictEqual(patchedEE.listeners('test').length, 0);
+      });
+
+      it('should remove event handler enabled by .once using off (when enabled)', () => {
+        const ee = new EventEmitter();
+        const context = ROOT_CONTEXT.setValue(key1, 1);
+        const patchedEE = contextManager.bind(context, ee);
+        const handler = () => { };
+        patchedEE.once('test', handler);
+        assert.strictEqual(patchedEE.listeners('test').length, 1);
+        patchedEE.off('test', handler);
+        assert.strictEqual(patchedEE.listeners('test').length, 0);
+      });
+
       it('should return current context and removeAllListeners (when enabled)', done => {
         const ee = new EventEmitter();
         const context = ROOT_CONTEXT.setValue(key1, 1);


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-js/issues/2971

This is an alternative solution to https://github.com/open-telemetry/opentelemetry-js/pull/3132