### PR TITLE
fix(instrumentation-http): do not overwrite span error status if already set

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :bug: (Bug Fix)
 
 * fix(instrumentation-http): add `http.host` attribute before sending the request #3054 @cuichenli
+* fix(instrumentation-http): don't overwrite span error status if already set [](https://github.com/open-telemetry/opentelemetry-js/pull/) @luismiramirez
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -18,9 +18,9 @@ import {
   INVALID_SPAN_CONTEXT,
   propagation,
   ROOT_CONTEXT,
-  Span,
   SpanKind,
   SpanOptions,
+  Span,
   SpanStatus,
   SpanStatusCode,
   trace,
@@ -307,7 +307,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
           this._diag.debug('outgoingRequest on end()');
           let status: SpanStatus;
 
-          if (response.aborted && !response.complete) {
+          if (response.aborted && !response.complete && span.status['code'] !== SpanStatusCode.ERROR) {
             status = { code: SpanStatusCode.ERROR };
           } else {
             status = { code: utils.parseResponseStatus(SpanKind.CLIENT, response.statusCode) };

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -332,9 +332,8 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
         });
         response.on('error', (error: Err) => {
           this._diag.debug('outgoingRequest on error()', error);
-          utils.setSpanWithError(span, error);
           const code = utils.parseResponseStatus(SpanKind.CLIENT, response.statusCode);
-          span.setStatus({ code, message: error.message });
+          utils.setSpanWithError(span, error, code);
           this._closeHttpSpan(span);
         });
       }

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -137,10 +137,13 @@ export const isIgnored = (
  * Sets the span with the error passed in params
  * @param {Span} span the span that need to be set
  * @param {Error} error error that will be set to span
+ * @param {SpanStatusCode} [statusCode] The status code to set up if the default error
+ *     one is not wanted
  */
 export const setSpanWithError = (
   span: Span,
-  error: Err
+  error: Err,
+  statusCode?: SpanStatusCode
 ): void => {
   const message = error.message;
 
@@ -149,7 +152,9 @@ export const setSpanWithError = (
     [AttributeNames.HTTP_ERROR_MESSAGE]: message,
   });
 
-  span.setStatus({ code: SpanStatusCode.ERROR, message });
+  const code = statusCode || SpanStatusCode.ERROR;
+
+  span.setStatus({ code, message });
   span.recordException(error);
 };
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -152,9 +152,11 @@ export const setSpanWithError = (
     [AttributeNames.HTTP_ERROR_MESSAGE]: message,
   });
 
-  const code = statusCode || SpanStatusCode.ERROR;
+  if (span.status['code'] !== SpanStatusCode.ERROR) {
+    const code = statusCode || SpanStatusCode.ERROR;
+    span.setStatus({ code, message });
+  }
 
-  span.setStatus({ code, message });
   span.recordException(error);
 };
 


### PR DESCRIPTION
## Which problem is this PR solving?

If a span has already set its status as Error (2), it shouldn't be overwritten as this may result in its status changing to Ok even with exceptions recorded in the `events` attribute.

## Short description of the changes

- Small refactor to make `setSpanWithError()` accept a new optional parameter (`statusCode`) to set the desired status if the default error one is not wanted.
- Check if the given span has already set the error status before trying to overwrite the status.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit tests

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
