### PR TITLE
chore: update `https` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 
 ### :books: (Refine Doc)
 
-*  chore: update https example [#3152](https://github.com/open-telemetry/opentelemetry-js/pull/3152) @pichlermarc
+* chore: update https example [#3152](https://github.com/open-telemetry/opentelemetry-js/pull/3152) @pichlermarc
 
 ### :house: (Internal)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file.
 
 ### :books: (Refine Doc)
 
+*  chore: update https example [#3152](https://github.com/open-telemetry/opentelemetry-js/pull/3152) @pichlermarc
+
 ### :house: (Internal)
 
 ## 1.5.0

--- a/examples/https/README.md
+++ b/examples/https/README.md
@@ -24,6 +24,7 @@ Setup [Zipkin Tracing](https://zipkin.io/pages/quickstart.html)
 or
 Setup [Jaeger Tracing](https://www.jaegertracing.io/docs/latest/getting-started/#all-in-one)
 or
+
 ```sh
 # from this directory, requires docker and docker-compose
 npm run docker:start

--- a/examples/https/README.md
+++ b/examples/https/README.md
@@ -1,6 +1,7 @@
 # Overview
 
-OpenTelemetry HTTPS Instrumentation allows the user to automatically collect trace data and export them to the backend of choice (we can use Zipkin or Jaeger for this example), to give observability to distributed systems.
+OpenTelemetry HTTPS Instrumentation allows the user to automatically collect trace data and export them to the backend
+of choice. This example exports directly to Zipkin or Jaeger.
 
 This is a simple example that demonstrates tracing HTTPS request from client to server. The example
 shows key aspects of tracing such as
@@ -22,6 +23,13 @@ npm install
 Setup [Zipkin Tracing](https://zipkin.io/pages/quickstart.html)
 or
 Setup [Jaeger Tracing](https://www.jaegertracing.io/docs/latest/getting-started/#all-in-one)
+or
+```sh
+# from this directory, requires docker and docker-compose
+npm run docker:start
+# Zipkin UI will be available at http://localhost:9411/zipkin/
+# Jaeger UI will be available at http://localhost:16686/
+```
 
 ## Run the Application
 
@@ -44,7 +52,8 @@ Setup [Jaeger Tracing](https://www.jaegertracing.io/docs/latest/getting-started/
 #### Zipkin UI
 
 `zipkin:server` script should output the `traceid` in the terminal (e.g `traceid: 4815c3d576d930189725f1f1d1bdfcc6`).
-Go to Zipkin with your browser <http://localhost:9411/zipkin/traces/(your-trace-id)> (e.g <http://localhost:9411/zipkin/traces/4815c3d576d930189725f1f1d1bdfcc6)>
+Go to Zipkin with your browser <http://localhost:9411/zipkin/traces/(your-trace-id)> (
+e.g <http://localhost:9411/zipkin/traces/4815c3d576d930189725f1f1d1bdfcc6)>
 
 <p align="center"><img src="./images/zipkin-ui.png?raw=true"/></p>
 
@@ -67,14 +76,16 @@ Go to Zipkin with your browser <http://localhost:9411/zipkin/traces/(your-trace-
 #### Jaeger UI
 
 `jaeger:server` script should output the `traceid` in the terminal (e.g `traceid: 4815c3d576d930189725f1f1d1bdfcc6`).
-Go to Jaeger with your browser <http://localhost:16686/trace/(your-trace-id)> (e.g <http://localhost:16686/trace/4815c3d576d930189725f1f1d1bdfcc6)>
+Go to Jaeger with your browser <http://localhost:16686/trace/(your-trace-id)> (
+e.g <http://localhost:16686/trace/4815c3d576d930189725f1f1d1bdfcc6)>
 
 <p align="center"><img src="images/jaeger-ui.png?raw=true"/></p>
 
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
-- For more information on OpenTelemetry for Node.js, visit: <https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node>
+- For more information on OpenTelemetry for Node.js,
+  visit: <https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node>
 
 ## LICENSE
 

--- a/examples/https/client.js
+++ b/examples/https/client.js
@@ -13,7 +13,7 @@ function makeRequest() {
   api.context.with(api.trace.setSpan(api.context.active(), span), () => {
     https.get({
       host: 'localhost',
-      port: 443,
+      port: 8443,
       path: '/helloworld',
     }, (response) => {
       const body = [];

--- a/examples/https/docker/docker-compose.yml
+++ b/examples/https/docker/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+services:
+  # Jaeger
+  jaeger-all-in-one:
+    image: jaegertracing/all-in-one:1.37.0
+    ports:
+      - "16686:16686" # frontend
+      - "14268:14268" # jaeger.thrift via HTTP
+      - "6832:6832/udp"   # jaeger.thrift via UDP (binary)
+  # Zipkin
+  zipkin-all-in-one:
+    image: openzipkin/zipkin:latest
+    ports:
+      - "9411:9411"

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,7 +1,7 @@
 {
   "name": "https-example",
   "private": true,
-  "version": "0.25.0",
+  "version": "0.31.0",
   "description": "Example of HTTPs integration with OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -9,7 +9,10 @@
     "zipkin:server": "cross-env EXPORTER=zipkin node ./server.js",
     "zipkin:client": "cross-env EXPORTER=zipkin node ./client.js",
     "jaeger:server": "cross-env EXPORTER=jaeger node ./server.js",
-    "jaeger:client": "cross-env EXPORTER=jaeger node ./client.js"
+    "jaeger:client": "cross-env EXPORTER=jaeger node ./client.js",
+    "docker:start": "cd ./docker && docker-compose down && docker-compose up",
+    "docker:startd": "cd ./docker && docker-compose down && docker-compose up -d",
+    "docker:stop": "cd ./docker && docker-compose down"
   },
   "repository": {
     "type": "git",
@@ -30,14 +33,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.2",
-    "@opentelemetry/exporter-jaeger": "0.25.0",
-    "@opentelemetry/exporter-zipkin": "0.25.0",
-    "@opentelemetry/instrumentation": "0.25.0",
-    "@opentelemetry/instrumentation-http": "0.25.0",
-    "@opentelemetry/resources": "0.25.0",
-    "@opentelemetry/semantic-conventions": "0.25.0",
-    "@opentelemetry/sdk-trace-node": "0.25.0",
-    "@opentelemetry/sdk-trace-base": "0.25.0"
+    "@opentelemetry/exporter-jaeger": "1.5.0",
+    "@opentelemetry/exporter-zipkin": "1.5.0",
+    "@opentelemetry/instrumentation": "0.31.0",
+    "@opentelemetry/instrumentation-http": "0.31.0",
+    "@opentelemetry/resources": "1.5.0",
+    "@opentelemetry/semantic-conventions": "1.5.0",
+    "@opentelemetry/sdk-trace-node": "1.5.0",
+    "@opentelemetry/sdk-trace-base": "1.5.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.2",
+    "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/exporter-jaeger": "1.5.0",
     "@opentelemetry/exporter-zipkin": "1.5.0",
     "@opentelemetry/instrumentation": "0.31.0",

--- a/examples/https/server.js
+++ b/examples/https/server.js
@@ -46,4 +46,4 @@ function handleRequest(request, response) {
   });
 }
 
-startServer(443);
+startServer(8443);

--- a/lerna.json
+++ b/lerna.json
@@ -7,6 +7,7 @@
     "experimental/backwards-compatability/*",
     "integration-tests/*",
     "selenium-tests",
-    "examples/otlp-exporter-node"
+    "examples/otlp-exporter-node",
+    "examples/https"
   ]
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Versions on the `https` example were outdated. The example server needed to be run as root, as it was using port `443`. This PR
- changes the port used to `8443` so it can be used with non-root users
- also adds `npm` scripts to easily start Zipkin and Jaeger via docker and docker-compose.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing with new version of packages.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
