### PR TITLE
feat(sdk-metrics-base): per metric-reader aggregation

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to experimental packages in this project will be documented 
 * feature(add-console-metrics-exporter): add ConsoleMetricExporter [#3120](https://github.com/open-telemetry/opentelemetry-js/pull/3120) @weyert
 * feature(prometheus-serialiser): export the unit block when unit is set in metric descriptor [#3066](https://github.com/open-telemetry/opentelemetry-js/pull/3041) @weyert
 * feat: support latest `@opentelemetry/api` [#3177](https://github.com/open-telemetry/opentelemetry-js/pull/3177) @dyladan
+* feat(sdk-metrics-base): add per metric-reader aggregation support [#3153](https://github.com/open-telemetry/opentelemetry-js/pull/3153) @legendecas
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/test/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/test/OTLPMetricExporter.test.ts
@@ -214,13 +214,18 @@ const testOTLPMetricExporter = (params: TestParams) =>
 
           assert.ok(exportedData, 'exportedData does not exist');
 
+          // The order of the metrics is not guaranteed.
+          const counterIndex = exportedData[0].scopeMetrics[0].metrics.findIndex(it => it.name === 'int-counter');
+          const observableIndex = exportedData[0].scopeMetrics[0].metrics.findIndex(it => it.name === 'double-observable-gauge');
+          const histogramIndex = exportedData[0].scopeMetrics[0].metrics.findIndex(it => it.name === 'int-histogram');
+
           const resource = exportedData[0].resource;
           const counter =
-            exportedData[0].scopeMetrics[0].metrics[0];
+            exportedData[0].scopeMetrics[0].metrics[counterIndex];
           const observableGauge =
-            exportedData[0].scopeMetrics[0].metrics[1];
+            exportedData[0].scopeMetrics[0].metrics[observableIndex];
           const histogram =
-            exportedData[0].scopeMetrics[0].metrics[2];
+            exportedData[0].scopeMetrics[0].metrics[histogramIndex];
           ensureExportedCounterIsCorrect(
             counter,
             counter.sum?.dataPoints[0].timeUnixNano,

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/test/metricsHelper.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/test/metricsHelper.ts
@@ -20,6 +20,7 @@ import * as assert from 'assert';
 import * as grpc from '@grpc/grpc-js';
 import { VERSION } from '@opentelemetry/core';
 import {
+  Aggregation,
   AggregationTemporality,
   ExplicitBucketHistogramAggregation,
   MeterProvider,
@@ -29,6 +30,10 @@ import {
 import { IKeyValue, IMetric, IResource } from '@opentelemetry/otlp-transformer';
 
 class TestMetricReader extends MetricReader {
+  selectAggregation() {
+    return Aggregation.Default();
+  }
+
   selectAggregationTemporality() {
     return AggregationTemporality.CUMULATIVE;
   }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/CollectorMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/CollectorMetricExporter.test.ts
@@ -99,6 +99,7 @@ describe('OTLPMetricExporter - web', () => {
           temporalityPreference: AggregationTemporality.CUMULATIVE
         });
       });
+
       it('should successfully send metrics using sendBeacon', done => {
         collectorExporter.export(metrics, () => {
         });
@@ -109,16 +110,22 @@ describe('OTLPMetricExporter - web', () => {
           const blob: Blob = args[1];
           const body = await blob.text();
           const json = JSON.parse(body) as IExportMetricsServiceRequest;
-          const metric1 = json.resourceMetrics[0].scopeMetrics[0].metrics[0];
-          const metric2 = json.resourceMetrics[0].scopeMetrics[0].metrics[1];
-          const metric3 = json.resourceMetrics[0].scopeMetrics[0].metrics[2];
+
+          // The order of the metrics is not guaranteed.
+          const counterIndex = metrics.scopeMetrics[0].metrics.findIndex(it => it.descriptor.name === 'int-counter');
+          const observableIndex = metrics.scopeMetrics[0].metrics.findIndex(it => it.descriptor.name === 'double-observable-gauge2');
+          const histogramIndex = metrics.scopeMetrics[0].metrics.findIndex(it => it.descriptor.name === 'int-histogram');
+
+          const metric1 = json.resourceMetrics[0].scopeMetrics[0].metrics[counterIndex];
+          const metric2 = json.resourceMetrics[0].scopeMetrics[0].metrics[observableIndex];
+          const metric3 = json.resourceMetrics[0].scopeMetrics[0].metrics[histogramIndex];
 
           assert.ok(typeof metric1 !== 'undefined', "metric doesn't exist");
 
           ensureCounterIsCorrect(
             metric1,
-            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[0].dataPoints[0].endTime),
-            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[0].dataPoints[0].startTime)
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[counterIndex].dataPoints[0].endTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[counterIndex].dataPoints[0].startTime)
           );
 
 
@@ -128,8 +135,8 @@ describe('OTLPMetricExporter - web', () => {
           );
           ensureObservableGaugeIsCorrect(
             metric2,
-            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].endTime),
-            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].startTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[observableIndex].dataPoints[0].endTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[observableIndex].dataPoints[0].startTime),
             6,
             'double-observable-gauge2'
           );
@@ -140,8 +147,8 @@ describe('OTLPMetricExporter - web', () => {
           );
           ensureHistogramIsCorrect(
             metric3,
-            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[2].dataPoints[0].endTime),
-            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[2].dataPoints[0].startTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[histogramIndex].dataPoints[0].endTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[histogramIndex].dataPoints[0].startTime),
             [0, 100],
             [0, 2, 0]
           );
@@ -216,15 +223,20 @@ describe('OTLPMetricExporter - web', () => {
 
           const body = request.requestBody;
           const json = JSON.parse(body) as IExportMetricsServiceRequest;
-          const metric1 = json.resourceMetrics[0].scopeMetrics[0].metrics[0];
-          const metric2 = json.resourceMetrics[0].scopeMetrics[0].metrics[1];
-          const metric3 = json.resourceMetrics[0].scopeMetrics[0].metrics[2];
+          // The order of the metrics is not guaranteed.
+          const counterIndex = metrics.scopeMetrics[0].metrics.findIndex(it => it.descriptor.name === 'int-counter');
+          const observableIndex = metrics.scopeMetrics[0].metrics.findIndex(it => it.descriptor.name === 'double-observable-gauge2');
+          const histogramIndex = metrics.scopeMetrics[0].metrics.findIndex(it => it.descriptor.name === 'int-histogram');
+
+          const metric1 = json.resourceMetrics[0].scopeMetrics[0].metrics[counterIndex];
+          const metric2 = json.resourceMetrics[0].scopeMetrics[0].metrics[observableIndex];
+          const metric3 = json.resourceMetrics[0].scopeMetrics[0].metrics[histogramIndex];
 
           assert.ok(typeof metric1 !== 'undefined', "metric doesn't exist");
           ensureCounterIsCorrect(
             metric1,
-            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[0].dataPoints[0].endTime),
-            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[0].dataPoints[0].startTime)
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[counterIndex].dataPoints[0].endTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[counterIndex].dataPoints[0].startTime)
           );
 
           assert.ok(
@@ -233,8 +245,8 @@ describe('OTLPMetricExporter - web', () => {
           );
           ensureObservableGaugeIsCorrect(
             metric2,
-            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].endTime),
-            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].startTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[observableIndex].dataPoints[0].endTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[observableIndex].dataPoints[0].startTime),
             6,
             'double-observable-gauge2'
           );
@@ -245,8 +257,8 @@ describe('OTLPMetricExporter - web', () => {
           );
           ensureHistogramIsCorrect(
             metric3,
-            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[2].dataPoints[0].endTime),
-            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[2].dataPoints[0].startTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[histogramIndex].dataPoints[0].endTime),
+            hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[histogramIndex].dataPoints[0].startTime),
             [0, 100],
             [0, 2, 0]
           );

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/metricsHelper.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/metricsHelper.ts
@@ -27,6 +27,7 @@ import { Resource } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import { InstrumentationScope, VERSION } from '@opentelemetry/core';
 import {
+  Aggregation,
   AggregationTemporality,
   ExplicitBucketHistogramAggregation,
   MeterProvider,
@@ -55,6 +56,10 @@ class TestMetricReader extends MetricReader {
 
   protected onShutdown(): Promise<void> {
     return Promise.resolve(undefined);
+  }
+
+  selectAggregation() {
+    return Aggregation.Default();
   }
 
   selectAggregationTemporality() {

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/CollectorMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/CollectorMetricExporter.test.ts
@@ -288,29 +288,34 @@ describe('OTLPMetricExporter - node with json over http', () => {
         const responseBody = buff.toString();
 
         const json = JSON.parse(responseBody) as IExportMetricsServiceRequest;
-        const metric1 = json.resourceMetrics[0].scopeMetrics[0].metrics[0];
-        const metric2 = json.resourceMetrics[0].scopeMetrics[0].metrics[1];
-        const metric3 = json.resourceMetrics[0].scopeMetrics[0].metrics[2];
+        // The order of the metrics is not guaranteed.
+        const counterIndex = metrics.scopeMetrics[0].metrics.findIndex(it => it.descriptor.name === 'int-counter');
+        const observableIndex = metrics.scopeMetrics[0].metrics.findIndex(it => it.descriptor.name === 'double-observable-gauge2');
+        const histogramIndex = metrics.scopeMetrics[0].metrics.findIndex(it => it.descriptor.name === 'int-histogram');
+
+        const metric1 = json.resourceMetrics[0].scopeMetrics[0].metrics[counterIndex];
+        const metric2 = json.resourceMetrics[0].scopeMetrics[0].metrics[observableIndex];
+        const metric3 = json.resourceMetrics[0].scopeMetrics[0].metrics[histogramIndex];
 
         assert.ok(typeof metric1 !== 'undefined', "counter doesn't exist");
         ensureCounterIsCorrect(
           metric1,
-          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[0].dataPoints[0].endTime),
-          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[0].dataPoints[0].startTime)
+          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[counterIndex].dataPoints[0].endTime),
+          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[counterIndex].dataPoints[0].startTime)
         );
         assert.ok(typeof metric2 !== 'undefined', "observable gauge doesn't exist");
         ensureObservableGaugeIsCorrect(
           metric2,
-          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].endTime),
-          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[1].dataPoints[0].startTime),
+          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[observableIndex].dataPoints[0].endTime),
+          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[observableIndex].dataPoints[0].startTime),
           6,
           'double-observable-gauge2'
         );
         assert.ok(typeof metric3 !== 'undefined', "histogram doesn't exist");
         ensureHistogramIsCorrect(
           metric3,
-          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[2].dataPoints[0].endTime),
-          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[2].dataPoints[0].startTime),
+          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[histogramIndex].dataPoints[0].endTime),
+          core.hrTimeToNanoseconds(metrics.scopeMetrics[0].metrics[histogramIndex].dataPoints[0].startTime),
           [0, 100],
           [0, 2, 0]
         );

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/OTLPMetricExporter.test.ts
@@ -240,9 +240,14 @@ describe('OTLPMetricExporter - node with proto over http', () => {
         const data = ExportTraceServiceRequestProto.decode(buff);
         const json = data?.toJSON() as IExportMetricsServiceRequest;
 
-        const metric1 = json.resourceMetrics[0].scopeMetrics[0].metrics[0];
-        const metric2 = json.resourceMetrics[0].scopeMetrics[0].metrics[1];
-        const metric3 = json.resourceMetrics[0].scopeMetrics[0].metrics[2];
+        // The order of the metrics is not guaranteed.
+        const counterIndex = metrics.scopeMetrics[0].metrics.findIndex(it => it.descriptor.name === 'int-counter');
+        const observableIndex = metrics.scopeMetrics[0].metrics.findIndex(it => it.descriptor.name === 'double-observable-gauge');
+        const histogramIndex = metrics.scopeMetrics[0].metrics.findIndex(it => it.descriptor.name === 'int-histogram');
+
+        const metric1 = json.resourceMetrics[0].scopeMetrics[0].metrics[counterIndex];
+        const metric2 = json.resourceMetrics[0].scopeMetrics[0].metrics[observableIndex];
+        const metric3 = json.resourceMetrics[0].scopeMetrics[0].metrics[histogramIndex];
 
         assert.ok(typeof metric1 !== 'undefined', "counter doesn't exist");
         ensureExportedCounterIsCorrect(

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/metricsHelper.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/metricsHelper.ts
@@ -24,6 +24,7 @@ import {
 import { Resource } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import {
+  Aggregation,
   AggregationTemporality,
   ExplicitBucketHistogramAggregation,
   MeterProvider,
@@ -34,6 +35,10 @@ import { IExportMetricsServiceRequest, IKeyValue, IMetric } from '@opentelemetry
 import { Stream } from 'stream';
 
 export class TestMetricReader extends MetricReader {
+  selectAggregation() {
+    return Aggregation.Default();
+  }
+
   selectAggregationTemporality() {
     return AggregationTemporality.CUMULATIVE;
   }

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -18,7 +18,7 @@ import { diag } from '@opentelemetry/api';
 import {
   globalErrorHandler,
 } from '@opentelemetry/core';
-import { AggregationTemporality, MetricReader } from '@opentelemetry/sdk-metrics';
+import { Aggregation, AggregationTemporality, MetricReader } from '@opentelemetry/sdk-metrics';
 import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
 import { ExporterConfig } from './export/types';
 import { PrometheusSerializer } from './PrometheusSerializer';
@@ -88,6 +88,10 @@ export class PrometheusExporter extends MetricReader {
     } else if (callback) {
       callback();
     }
+  }
+
+  selectAggregation(): Aggregation {
+    return Aggregation.Default();
   }
 
   selectAggregationTemporality(): AggregationTemporality {

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -17,6 +17,7 @@
 import * as assert from 'assert';
 import { MetricAttributes, UpDownCounter } from '@opentelemetry/api-metrics';
 import {
+  Aggregation,
   AggregationTemporality,
   DataPoint,
   DataPointType,
@@ -44,6 +45,10 @@ class TestMetricReader extends MetricReader {
 
   selectAggregationTemporality() {
     return AggregationTemporality.CUMULATIVE;
+  }
+
+  selectAggregation() {
+    return Aggregation.Default();
   }
 
   async onForceFlush() {}

--- a/experimental/packages/opentelemetry-sdk-metrics/src/export/AggregationSelector.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/export/AggregationSelector.ts
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
+import { InstrumentType } from '../InstrumentDescriptor';
+import { Aggregation } from '../view/Aggregation';
+import { AggregationTemporality } from './AggregationTemporality';
+
 /**
- * AggregationTemporality indicates the way additive quantities are expressed.
+ * Aggregation selector based on metric instrument types.
  */
-export enum AggregationTemporality {
-  DELTA,
-  CUMULATIVE,
-}
+export type AggregationSelector = (instrumentType: InstrumentType) => Aggregation;
+
+/**
+  * Aggregation temporality selector based on metric instrument types.
+  */
+export type AggregationTemporalitySelector = (instrumentType: InstrumentType) => AggregationTemporality;

--- a/experimental/packages/opentelemetry-sdk-metrics/src/export/MetricReader.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/export/MetricReader.ts
@@ -21,6 +21,7 @@ import { CollectionResult } from './MetricData';
 import { callWithTimeout } from '../utils';
 import { InstrumentType } from '../InstrumentDescriptor';
 import { CollectionOptions, ForceFlushOptions, ShutdownOptions } from '../types';
+import { Aggregation } from '../view/Aggregation';
 
 /**
  * A registered reader of metrics that, when linked to a {@link MetricProducer}, offers global
@@ -45,6 +46,12 @@ export abstract class MetricReader {
     this._metricProducer = metricProducer;
     this.onInitialized();
   }
+
+  /**
+   * Select the {@link Aggregation} for the given {@link InstrumentType} for this
+   * reader.
+   */
+  abstract selectAggregation(instrumentType: InstrumentType): Aggregation;
 
   /**
    * Select the {@link AggregationTemporality} for the given

--- a/experimental/packages/opentelemetry-sdk-metrics/src/index.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/index.ts
@@ -15,6 +15,7 @@
  */
 
 export { Sum, LastValue, Histogram } from './aggregator/types';
+export * from './export/AggregationSelector';
 export * from './export/AggregationTemporality';
 export * from './export/MetricData';
 export * from './export/MetricExporter';

--- a/experimental/packages/opentelemetry-sdk-metrics/src/state/MeterProviderSharedState.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/state/MeterProviderSharedState.ts
@@ -16,10 +16,11 @@
 
 import { InstrumentationScope } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
+import { Aggregation, InstrumentType } from '..';
 import { instrumentationScopeId } from '../utils';
 import { ViewRegistry } from '../view/ViewRegistry';
 import { MeterSharedState } from './MeterSharedState';
-import { MetricCollector } from './MetricCollector';
+import { MetricCollector, MetricCollectorHandle } from './MetricCollector';
 
 /**
  * An internal record for shared meter provider states.
@@ -41,5 +42,13 @@ export class MeterProviderSharedState {
       this.meterSharedStates.set(id, meterSharedState);
     }
     return meterSharedState;
+  }
+
+  selectAggregations(instrumentType: InstrumentType) {
+    const result: [MetricCollectorHandle, Aggregation][] = [];
+    for (const collector of this.metricCollectors) {
+      result.push([collector, collector.selectAggregation(instrumentType)]);
+    }
+    return result;
   }
 }

--- a/experimental/packages/opentelemetry-sdk-metrics/src/state/MeterSharedState.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/state/MeterSharedState.ts
@@ -20,7 +20,7 @@ import { MetricCollectOptions } from '../export/MetricProducer';
 import { ScopeMetrics } from '../export/MetricData';
 import { createInstrumentDescriptorWithView, InstrumentDescriptor } from '../InstrumentDescriptor';
 import { Meter } from '../Meter';
-import { isNotNullish } from '../utils';
+import { isNotNullish, Maybe } from '../utils';
 import { AsyncMetricStorage } from './AsyncMetricStorage';
 import { MeterProviderSharedState } from './MeterProviderSharedState';
 import { MetricCollectorHandle } from './MetricCollector';
@@ -28,12 +28,15 @@ import { MetricStorageRegistry } from './MetricStorageRegistry';
 import { MultiMetricStorage } from './MultiWritableMetricStorage';
 import { ObservableRegistry } from './ObservableRegistry';
 import { SyncMetricStorage } from './SyncMetricStorage';
+import { Accumulation, Aggregator } from '../aggregator/types';
+import { AttributesProcessor } from '../view/AttributesProcessor';
+import { MetricStorage } from './MetricStorage';
 
 /**
  * An internal record for shared meter provider states.
  */
 export class MeterSharedState {
-  private _metricStorageRegistry = new MetricStorageRegistry();
+  metricStorageRegistry = new MetricStorageRegistry();
   observableRegistry = new ObservableRegistry();
   meter: Meter;
 
@@ -42,15 +45,8 @@ export class MeterSharedState {
   }
 
   registerMetricStorage(descriptor: InstrumentDescriptor) {
-    const views = this._meterProviderSharedState.viewRegistry.findViews(descriptor, this._instrumentationScope);
-    const storages = views
-      .map(view => {
-        const viewDescriptor = createInstrumentDescriptorWithView(view, descriptor);
-        const aggregator = view.aggregation.createAggregator(viewDescriptor);
-        const storage = new SyncMetricStorage(viewDescriptor, aggregator, view.attributesProcessor);
-        return this._metricStorageRegistry.register(storage);
-      })
-      .filter(isNotNullish);
+    const storages = this._registerMetricStorage(descriptor, SyncMetricStorage);
+
     if (storages.length === 1)  {
       return storages[0];
     }
@@ -58,15 +54,8 @@ export class MeterSharedState {
   }
 
   registerAsyncMetricStorage(descriptor: InstrumentDescriptor) {
-    const views = this._meterProviderSharedState.viewRegistry.findViews(descriptor, this._instrumentationScope);
-    const storages = views
-      .map(view => {
-        const viewDescriptor = createInstrumentDescriptorWithView(view, descriptor);
-        const aggregator = view.aggregation.createAggregator(viewDescriptor);
-        const viewStorage = new AsyncMetricStorage(viewDescriptor, aggregator, view.attributesProcessor);
-        return this._metricStorageRegistry.register(viewStorage);
-      })
-      .filter(isNotNullish);
+    const storages = this._registerMetricStorage(descriptor, AsyncMetricStorage);
+
     return storages;
   }
 
@@ -81,7 +70,7 @@ export class MeterSharedState {
      * 2. Collect metric result for the collector.
      */
     const errors = await this.observableRegistry.observe(collectionTime, options?.timeoutMillis);
-    const metricDataList = Array.from(this._metricStorageRegistry.getStorages())
+    const metricDataList = Array.from(this.metricStorageRegistry.getStorages(collector))
       .map(metricStorage => {
         return metricStorage.collect(
           collector,
@@ -98,9 +87,49 @@ export class MeterSharedState {
       errors,
     };
   }
+
+  private _registerMetricStorage<MetricStorageType extends MetricStorageConstructor, R extends InstanceType<MetricStorageType>>(descriptor: InstrumentDescriptor, MetricStorageType: MetricStorageType): R[] {
+    const views = this._meterProviderSharedState.viewRegistry.findViews(descriptor, this._instrumentationScope);
+    let storages = views
+      .map(view => {
+        const viewDescriptor = createInstrumentDescriptorWithView(view, descriptor);
+        const compatibleStorage = this.metricStorageRegistry.findOrUpdateCompatibleStorage<R>(viewDescriptor);
+        if (compatibleStorage != null) {
+          return compatibleStorage;
+        }
+        const aggregator = view.aggregation.createAggregator(viewDescriptor);
+        const viewStorage = new MetricStorageType(viewDescriptor, aggregator, view.attributesProcessor) as R;
+        this.metricStorageRegistry.register(viewStorage);
+        return viewStorage;
+      });
+
+    // Fallback to the per-collector aggregations if no view is configured for the instrument.
+    if (storages.length === 0) {
+      const perCollectorAggregations = this._meterProviderSharedState.selectAggregations(descriptor.type);
+      const collectorStorages = perCollectorAggregations.map(([collector, aggregation]) => {
+        const compatibleStorage = this.metricStorageRegistry.findOrUpdateCompatibleCollectorStorage<R>(collector, descriptor);
+        if (compatibleStorage != null) {
+          return compatibleStorage;
+        }
+        const aggregator = aggregation.createAggregator(descriptor);
+        const storage = new MetricStorageType(descriptor, aggregator, AttributesProcessor.Noop()) as R;
+        this.metricStorageRegistry.registerForCollector(collector, storage);
+        return storage;
+      });
+      storages = storages.concat(collectorStorages);
+    }
+
+    return storages;
+  }
 }
 
 interface ScopeMetricsResult {
   scopeMetrics: ScopeMetrics;
   errors: unknown[];
+}
+
+interface MetricStorageConstructor {
+  new (instrumentDescriptor: InstrumentDescriptor,
+    aggregator: Aggregator<Maybe<Accumulation>>,
+    attributesProcessor: AttributesProcessor): MetricStorage;
 }

--- a/experimental/packages/opentelemetry-sdk-metrics/src/state/MetricCollector.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/state/MetricCollector.ts
@@ -15,7 +15,7 @@
  */
 
 import { hrTime } from '@opentelemetry/core';
-import { AggregationTemporalitySelector } from '../export/AggregationTemporality';
+import { AggregationTemporalitySelector } from '../export/AggregationSelector';
 import { CollectionResult } from '../export/MetricData';
 import { MetricProducer, MetricCollectOptions } from '../export/MetricProducer';
 import { MetricReader } from '../export/MetricReader';
@@ -64,6 +64,10 @@ export class MetricCollector implements MetricProducer {
 
   selectAggregationTemporality(instrumentType: InstrumentType) {
     return this._metricReader.selectAggregationTemporality(instrumentType);
+  }
+
+  selectAggregation(instrumentType: InstrumentType) {
+    return this._metricReader.selectAggregation(instrumentType);
   }
 }
 

--- a/experimental/packages/opentelemetry-sdk-metrics/src/state/MetricStorage.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/state/MetricStorage.ts
@@ -41,7 +41,7 @@ export abstract class MetricStorage {
     collectionTime: HrTime,
   ): Maybe<MetricData>;
 
-  getInstrumentDescriptor(): InstrumentDescriptor{
+  getInstrumentDescriptor(): Readonly<InstrumentDescriptor> {
     return this._instrumentDescriptor;
   }
 

--- a/experimental/packages/opentelemetry-sdk-metrics/src/view/ViewRegistry.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/view/ViewRegistry.ts
@@ -21,9 +21,6 @@ import { MeterSelector } from './MeterSelector';
 import { View } from './View';
 
 export class ViewRegistry {
-  private static DEFAULT_VIEW = new View({
-    instrumentName: '*'
-  });
   private _registeredViews: View[] = [];
 
   addView(view: View) {
@@ -37,9 +34,6 @@ export class ViewRegistry {
           this._matchMeter(registeredView.meterSelector, meter);
       });
 
-    if (views.length === 0) {
-      return [ViewRegistry.DEFAULT_VIEW];
-    }
     return views;
   }
 

--- a/experimental/packages/opentelemetry-sdk-metrics/test/Instruments.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/test/Instruments.test.ts
@@ -19,7 +19,6 @@ import * as sinon from 'sinon';
 import { InstrumentationScope } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
 import {
-  AggregationTemporality,
   InstrumentDescriptor,
   InstrumentType,
   MeterProvider,
@@ -28,7 +27,7 @@ import {
   DataPointType,
   Histogram
 } from '../src';
-import { TestMetricReader } from './export/TestMetricReader';
+import { TestDeltaMetricReader, TestMetricReader } from './export/TestMetricReader';
 import {
   assertMetricData,
   assertDataPoint,
@@ -654,9 +653,9 @@ function setup() {
   const meter = meterProvider.getMeter(defaultInstrumentationScope.name, defaultInstrumentationScope.version, {
     schemaUrl: defaultInstrumentationScope.schemaUrl,
   });
-  const deltaReader = new TestMetricReader(() => AggregationTemporality.DELTA);
+  const deltaReader = new TestDeltaMetricReader();
   meterProvider.addMetricReader(deltaReader);
-  const cumulativeReader = new TestMetricReader(() => AggregationTemporality.CUMULATIVE);
+  const cumulativeReader = new TestMetricReader();
   meterProvider.addMetricReader(cumulativeReader);
 
   return {

--- a/experimental/packages/opentelemetry-sdk-metrics/test/export/TestMetricProducer.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/test/export/TestMetricProducer.ts
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 
-/**
- * AggregationTemporality indicates the way additive quantities are expressed.
- */
-export enum AggregationTemporality {
-  DELTA,
-  CUMULATIVE,
+import { CollectionResult } from '../../src/export/MetricData';
+import { MetricProducer } from '../../src/export/MetricProducer';
+import { defaultResource } from '../util';
+
+export const emptyResourceMetrics = { resource: defaultResource, scopeMetrics: [] };
+
+export class TestMetricProducer implements MetricProducer {
+  async collect(): Promise<CollectionResult> {
+    return {
+      resourceMetrics: { resource: defaultResource, scopeMetrics: [] },
+      errors: [],
+    };
+  }
 }

--- a/experimental/packages/opentelemetry-sdk-metrics/test/state/MeterSharedState.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/test/state/MeterSharedState.test.ts
@@ -17,15 +17,17 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import {
-  AggregationTemporality,
   Meter,
   MeterProvider,
   DataPointType,
   CollectionResult,
-  View
+  View,
+  Aggregation,
+  MetricReader,
+  InstrumentType
 } from '../../src';
 import { assertMetricData, defaultInstrumentationScope, defaultResource, sleep } from '../util';
-import { TestMetricReader } from '../export/TestMetricReader';
+import { TestDeltaMetricReader, TestMetricReader } from '../export/TestMetricReader';
 import { MeterSharedState } from '../../src/state/MeterSharedState';
 
 describe('MeterSharedState', () => {
@@ -33,15 +35,122 @@ describe('MeterSharedState', () => {
     sinon.restore();
   });
 
+  describe('registerMetricStorage', () => {
+    function setupMeter(views?: View[], readers?: MetricReader[]) {
+      const meterProvider = new MeterProvider({
+        resource: defaultResource,
+        views,
+      });
+      readers?.forEach(reader => meterProvider.addMetricReader(reader));
+
+      const meter = meterProvider.getMeter('test-meter');
+
+      return {
+        meter,
+        meterSharedState: meterProvider['_sharedState'].getMeterSharedState({ name: 'test-meter' }),
+        collectors: Array.from(meterProvider['_sharedState'].metricCollectors),
+      };
+    }
+
+    it('should register metric storages with views', () => {
+      const reader = new TestMetricReader({
+        aggregationSelector: () => {
+          throw new Error('should not be called');
+        },
+      });
+      const { meter, meterSharedState, collectors } = setupMeter(
+        [ new View({ instrumentName: 'test-counter' }) ],
+        [reader],
+      );
+
+      meter.createCounter('test-counter');
+      const metricStorages = meterSharedState.metricStorageRegistry.getStorages(collectors[0]);
+
+      assert.strictEqual(metricStorages.length, 1);
+      assert.strictEqual(metricStorages[0].getInstrumentDescriptor().name, 'test-counter');
+    });
+
+    it('should register metric storages with views', () => {
+      const reader = new TestMetricReader({
+        aggregationSelector: () => {
+          throw new Error('should not be called');
+        },
+      });
+      const { meter, meterSharedState, collectors } = setupMeter(
+        [ new View({ instrumentName: 'test-counter' }) ],
+        [reader],
+      );
+
+      meter.createCounter('test-counter');
+      const metricStorages = meterSharedState.metricStorageRegistry.getStorages(collectors[0]);
+
+      assert.strictEqual(metricStorages.length, 1);
+      assert.strictEqual(metricStorages[0].getInstrumentDescriptor().name, 'test-counter');
+    });
+
+    it('should register metric storages with the collector', () => {
+      const reader = new TestMetricReader({
+        aggregationSelector: (instrumentType: InstrumentType) => {
+          return Aggregation.Drop();
+        },
+      });
+      const readerAggregationSelectorSpy = sinon.spy(reader, 'selectAggregation');
+
+      const { meter, meterSharedState, collectors } = setupMeter(
+        [], /** no views registered */
+        [reader],
+      );
+
+      meter.createCounter('test-counter');
+      const metricStorages = meterSharedState.metricStorageRegistry.getStorages(collectors[0]);
+
+      // Should select aggregation with the metric reader.
+      assert.strictEqual(readerAggregationSelectorSpy.callCount, 1);
+      assert.strictEqual(metricStorages.length, 1);
+      assert.strictEqual(metricStorages[0].getInstrumentDescriptor().name, 'test-counter');
+    });
+
+    it('should register metric storages with collectors', () => {
+      const reader = new TestMetricReader({
+        aggregationSelector: (instrumentType: InstrumentType) => {
+          return Aggregation.Drop();
+        },
+      });
+      const reader2 = new TestMetricReader({
+        aggregationSelector: (instrumentType: InstrumentType) => {
+          return Aggregation.LastValue();
+        },
+      });
+
+      const { meter, meterSharedState, collectors } = setupMeter(
+        [], /** no views registered */
+        [reader, reader2],
+      );
+
+      meter.createCounter('test-counter');
+      const metricStorages = meterSharedState.metricStorageRegistry.getStorages(collectors[0]);
+      const metricStorages2 = meterSharedState.metricStorageRegistry.getStorages(collectors[1]);
+
+      // Should select aggregation with the metric reader.
+      assert.strictEqual(metricStorages.length, 1);
+      assert.strictEqual(metricStorages[0].getInstrumentDescriptor().name, 'test-counter');
+
+      assert.strictEqual(metricStorages2.length, 1);
+      assert.strictEqual(metricStorages2[0].getInstrumentDescriptor().name, 'test-counter');
+
+      assert.notStrictEqual(metricStorages[0], metricStorages2[0], 'should create a distinct metric storage for each metric reader');
+    });
+  });
+
   describe('collect', () => {
     function setupInstruments(views?: View[]) {
       const meterProvider = new MeterProvider({ resource: defaultResource, views: views });
 
-      const cumulativeReader = new TestMetricReader(() => AggregationTemporality.CUMULATIVE);
+      const cumulativeReader = new TestMetricReader();
       meterProvider.addMetricReader(cumulativeReader);
       const cumulativeCollector = cumulativeReader.getMetricCollector();
 
-      const deltaReader = new TestMetricReader(() => AggregationTemporality.DELTA);
+      const deltaReader = new TestDeltaMetricReader();
       meterProvider.addMetricReader(deltaReader);
       const deltaCollector = deltaReader.getMetricCollector();
 

--- a/experimental/packages/opentelemetry-sdk-metrics/test/state/MetricCollector.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/test/state/MetricCollector.test.ts
@@ -18,7 +18,6 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { MeterProvider, TimeoutError } from '../../src';
 import { DataPointType } from '../../src/export/MetricData';
-import { PushMetricExporter } from '../../src/export/MetricExporter';
 import { MeterProviderSharedState } from '../../src/state/MeterProviderSharedState';
 import { MetricCollector } from '../../src/state/MetricCollector';
 import {
@@ -29,8 +28,7 @@ import {
   ObservableCallbackDelegate,
   BatchObservableCallbackDelegate,
 } from '../util';
-import { TestMetricReader } from '../export/TestMetricReader';
-import { TestDeltaMetricExporter, TestMetricExporter } from '../export/TestMetricExporter';
+import { TestDeltaMetricReader, TestMetricReader } from '../export/TestMetricReader';
 
 describe('MetricCollector', () => {
   afterEach(() => {
@@ -40,20 +38,18 @@ describe('MetricCollector', () => {
   describe('constructor', () => {
     it('should construct MetricCollector without exceptions', () => {
       const meterProviderSharedState = new MeterProviderSharedState(defaultResource);
-      const exporters = [ new TestMetricExporter(), new TestDeltaMetricExporter() ];
-      for (const exporter of exporters) {
-        const reader = new TestMetricReader(exporter.selectAggregationTemporality);
+      const readers = [ new TestMetricReader(), new TestDeltaMetricReader() ];
+      for (const reader of readers) {
         assert.doesNotThrow(() => new MetricCollector(meterProviderSharedState, reader));
       }
     });
   });
 
   describe('collect', () => {
-
-    function setupInstruments(exporter: PushMetricExporter) {
+    function setupInstruments() {
       const meterProvider = new MeterProvider({ resource: defaultResource });
 
-      const reader = new TestMetricReader(exporter.selectAggregationTemporality);
+      const reader = new TestMetricReader();
       meterProvider.addMetricReader(reader);
       const metricCollector = reader.getMetricCollector();
 
@@ -66,8 +62,7 @@ describe('MetricCollector', () => {
 
     it('should collect sync metrics', async () => {
       /** preparing test instrumentations */
-      const exporter = new TestMetricExporter();
-      const { metricCollector, meter } = setupInstruments(exporter);
+      const { metricCollector, meter } = setupInstruments();
 
       /** creating metric events */
       const counter = meter.createCounter('counter1');
@@ -104,8 +99,7 @@ describe('MetricCollector', () => {
 
     it('should collect async metrics', async () => {
       /** preparing test instrumentations */
-      const exporter = new TestMetricExporter();
-      const { metricCollector, meter } = setupInstruments(exporter);
+      const { metricCollector, meter } = setupInstruments();
 
       /** creating metric events */
       /** observable */
@@ -163,8 +157,7 @@ describe('MetricCollector', () => {
     it('should collect observer metrics with timeout', async () => {
       sinon.useFakeTimers();
       /** preparing test instrumentations */
-      const exporter = new TestMetricExporter();
-      const { metricCollector, meter } = setupInstruments(exporter);
+      const { metricCollector, meter } = setupInstruments();
 
       /** creating metric events */
 
@@ -246,8 +239,7 @@ describe('MetricCollector', () => {
 
     it('should collect with throwing observable callbacks', async () => {
       /** preparing test instrumentations */
-      const exporter = new TestMetricExporter();
-      const { metricCollector, meter } = setupInstruments(exporter);
+      const { metricCollector, meter } = setupInstruments();
 
       /** creating metric events */
       const counter = meter.createCounter('counter1');
@@ -283,8 +275,7 @@ describe('MetricCollector', () => {
     it('should collect batch observer metrics with timeout', async () => {
       sinon.useFakeTimers();
       /** preparing test instrumentations */
-      const exporter = new TestMetricExporter();
-      const { metricCollector, meter } = setupInstruments(exporter);
+      const { metricCollector, meter } = setupInstruments();
 
       /** creating metric events */
 
@@ -366,8 +357,7 @@ describe('MetricCollector', () => {
 
     it('should collect with throwing batch observable callbacks', async () => {
       /** preparing test instrumentations */
-      const exporter = new TestMetricExporter();
-      const { metricCollector, meter } = setupInstruments(exporter);
+      const { metricCollector, meter } = setupInstruments();
 
       /** creating metric events */
       const counter = meter.createCounter('counter1');

--- a/experimental/packages/opentelemetry-sdk-metrics/test/view/ViewRegistry.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/test/view/ViewRegistry.test.ts
@@ -23,13 +23,6 @@ import { View } from '../../src';
 
 describe('ViewRegistry', () => {
   describe('findViews', () => {
-    it('should return default view if no view registered', () => {
-      const registry = new ViewRegistry();
-      const views = registry.findViews(defaultInstrumentDescriptor, defaultInstrumentationScope);
-      assert.strictEqual(views.length, 1);
-      assert.strictEqual(views[0], ViewRegistry['DEFAULT_VIEW']);
-    });
-
     describe('InstrumentSelector', () => {
       it('should match view with instrument name', () => {
         const registry = new ViewRegistry();


### PR DESCRIPTION
## Which problem is this PR solving?

Add support for per-metric-reader aggregation support

## Short description of the changes

**sdk-metrics-base**
https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#metricreader

The spec requires the SDK to allow constructing a MetricReader with an optional aggregation selector and an optional aggregation temporality selector. These selectors are only applicable to the specific metric reader, and should not cause side effects on other metric readers.

- [ ] Pending spec clarifications: https://github.com/open-telemetry/opentelemetry-specification/issues/2643
- [ ] Move the metric reader registrations to the option of construction of MeterProvider, same as views.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Create instruments with per-metric-reader aggregations.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
