### PR TITLE
deps: update typescript to latest

### DIFF
--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -35,7 +35,7 @@
     "@babel/core": "^7.6.0",
     "babel-loader": "^8.0.6",
     "ts-loader": "^9.2.6",
-    "typescript": "4.7.4",
+    "typescript": "^4.7.4",
     "webpack": "^5.65.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.6.0",

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -35,7 +35,7 @@
     "@babel/core": "^7.6.0",
     "babel-loader": "^8.0.6",
     "ts-loader": "^9.2.6",
-    "typescript": "^4.5.2",
+    "typescript": "4.7.4",
     "webpack": "^5.65.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.6.0",

--- a/experimental/backwards-compatability/node14/package.json
+++ b/experimental/backwards-compatability/node14/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/node": "^14.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/experimental/backwards-compatability/node16/package.json
+++ b/experimental/backwards-compatability/node16/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/node": "^16.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -61,7 +61,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -85,7 +85,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -60,7 +60,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/opentelemetry-api-metrics/package.json
+++ b/experimental/packages/opentelemetry-api-metrics/package.json
@@ -79,7 +79,7 @@
     "nyc": "15.1.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-api-metrics"

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -61,7 +61,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -85,7 +85,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -61,7 +61,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -53,7 +53,7 @@
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -78,7 +78,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -301,7 +301,16 @@ export class FetchInstrumentation extends InstrumentationBase<Promise<Response>>
         ...args: Parameters<typeof fetch>
       ): Promise<Response> {
         const self = this;
-        const url = web.parseUrl(args[0] instanceof Request ? args[0].url : args[0]).href;
+        let url: string
+        if (typeof args[0] === 'string') {
+          url = web.parseUrl(args[0]).href;
+        } else if (args[0] instanceof Request) {
+          url = web.parseUrl(args[0].url).href;
+        } else if (args[0] instanceof URL) {
+          url = args[0].href;
+        } else {
+          return original.apply(this, args);
+        }
 
         const options = args[0] instanceof Request ? args[0] : args[1] || {};
         const createdSpan = plugin._createSpan(url, options);

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -301,7 +301,7 @@ export class FetchInstrumentation extends InstrumentationBase<Promise<Response>>
         ...args: Parameters<typeof fetch>
       ): Promise<Response> {
         const self = this;
-        let url: string
+        let url: string;
         if (typeof args[0] === 'string') {
           url = web.parseUrl(args[0]).href;
         } else if (args[0] instanceof Request) {

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -65,7 +65,7 @@
     "semver": "7.3.5",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -68,7 +68,7 @@
     "sinon": "14.0.0",
     "superagent": "6.1.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -78,7 +78,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -101,7 +101,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -71,7 +71,7 @@
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -71,7 +71,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-sdk-node"
 }

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -76,7 +76,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -65,7 +65,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -57,7 +57,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -73,7 +73,7 @@
     "rimraf": "3.0.2",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0"
   },
   "dependencies": {

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -20,7 +20,7 @@
     "express": "4.17.1"
   },
   "devDependencies": {
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "engines": {
     "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "markdownlint-cli": "0.29.0",
     "semver": "7.3.5",
     "typedoc": "0.22.10",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "update-ts-references": "2.4.1"
   },
   "changelog": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "linkinator": "3.0.3",
     "markdownlint-cli": "0.29.0",
     "semver": "7.3.5",
-    "typedoc": "0.22.10",
+    "typedoc": "0.23.10",
     "typescript": "4.7.4",
     "update-ts-references": "2.4.1"
   },

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -52,7 +52,7 @@
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0"

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -75,7 +75,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "zone.js": "0.11.4"

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -68,7 +68,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -84,7 +84,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0"
   },
   "peerDependencies": {

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -56,7 +56,7 @@
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -82,7 +82,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -67,7 +67,7 @@
     "rimraf": "3.0.2",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-b3"
 }

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -73,7 +73,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0"
   },
   "peerDependencies": {

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -80,7 +80,7 @@
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -84,7 +84,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0"
   },
   "peerDependencies": {

--- a/packages/opentelemetry-sdk-trace-base/test/browser/export/BatchSpanProcessor.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/browser/export/BatchSpanProcessor.test.ts
@@ -23,7 +23,7 @@ import { TestTracingSpanExporter } from '../../common/export/TestTracingSpanExpo
 const describeDocument = typeof document === 'object' ? describe : describe.skip;
 
 describeDocument('BatchSpanProcessor - web main context', () => {
-  let visibilityState: VisibilityState = 'visible';
+  let visibilityState: DocumentVisibilityState = 'visible';
   let exporter: SpanExporter;
   let processor: BatchSpanProcessor;
   let forceFlushSpy: sinon.SinonStub;

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -58,7 +58,7 @@
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0"

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -82,7 +82,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -59,7 +59,7 @@
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-semantic-conventions"
 }

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -53,7 +53,7 @@
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0"

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -78,7 +78,7 @@
   ],
   "devDependencies": {
     "@types/node": "18.6.5",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "Add these to devDependencies for testing": {
     "@types/mocha": "9.1.1",


### PR DESCRIPTION
Update typescript to latest. I'm going to try to use a tool like downlevel-dts to publish types compatible with older versions of typescript