### PR TITLE
Update typescript and downlevel types for 3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ build/Release
 node_modules/
 jspm_packages/
 build/
+ts3.4/
 
 # TypeScript v1 declaration files
 typings/

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -12,7 +12,8 @@
     "jaeger:client": "cross-env EXPORTER=jaeger node ./client.js",
     "docker:start": "cd ./docker && docker-compose down && docker-compose up",
     "docker:startd": "cd ./docker && docker-compose down && docker-compose up -d",
-    "docker:stop": "cd ./docker && docker-compose down"
+    "docker:stop": "cd ./docker && docker-compose down",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "repository": {
     "type": "git",
@@ -44,6 +45,14 @@
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {
-    "cross-env": "^6.0.0"
+    "cross-env": "^6.0.0",
+    "downlevel-dts": "0.10.0"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
   }
 }

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -12,8 +12,7 @@
     "jaeger:client": "cross-env EXPORTER=jaeger node ./client.js",
     "docker:start": "cd ./docker && docker-compose down && docker-compose up",
     "docker:startd": "cd ./docker && docker-compose down && docker-compose up -d",
-    "docker:stop": "cd ./docker && docker-compose down",
-    "downlevel": "downlevel-dts . ts3.4"
+    "docker:stop": "cd ./docker && docker-compose down"
   },
   "repository": {
     "type": "git",
@@ -45,14 +44,6 @@
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {
-    "cross-env": "^6.0.0",
-    "downlevel-dts": "0.10.0"
-  },
-  "typesVersions": {
-    "<4.0": {
-      "*": [
-        "ts3.4/*"
-      ]
-    }
+    "cross-env": "^6.0.0"
   }
 }

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -35,7 +35,7 @@
     "@babel/core": "^7.6.0",
     "babel-loader": "^8.0.6",
     "ts-loader": "^9.2.6",
-    "typescript": "4.7.4",
+    "typescript": "^4.7.4",
     "webpack": "^5.65.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.6.0",

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -35,7 +35,7 @@
     "@babel/core": "^7.6.0",
     "babel-loader": "^8.0.6",
     "ts-loader": "^9.2.6",
-    "typescript": "^4.5.2",
+    "typescript": "4.7.4",
     "webpack": "^5.65.0",
     "webpack-cli": "^4.9.1",
     "webpack-dev-server": "^4.6.0",

--- a/experimental/backwards-compatability/node14/package.json
+++ b/experimental/backwards-compatability/node14/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/node": "^14.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/experimental/backwards-compatability/node16/package.json
+++ b/experimental/backwards-compatability/node16/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/node": "^16.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -61,7 +61,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -18,7 +18,8 @@
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -55,6 +56,7 @@
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
     "cpx": "1.5.0",
+    "downlevel-dts": "0.10.0",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
@@ -75,5 +77,12 @@
     "@opentelemetry/resources": "1.5.0",
     "@opentelemetry/sdk-trace-base": "1.5.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-grpc"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-grpc",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -85,7 +85,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -29,7 +29,8 @@
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -72,6 +73,7 @@
     "babel-loader": "8.2.3",
     "codecov": "3.8.3",
     "cpx": "1.5.0",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
@@ -100,5 +102,12 @@
     "@opentelemetry/resources": "1.5.0",
     "@opentelemetry/sdk-trace-base": "1.5.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -60,7 +60,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -18,7 +18,8 @@
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -54,6 +55,7 @@
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
     "cpx": "1.5.0",
+    "downlevel-dts": "0.10.0",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
@@ -75,5 +77,12 @@
     "@opentelemetry/sdk-trace-base": "1.5.0",
     "protobufjs": "^6.9.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/opentelemetry-api-metrics/package.json
+++ b/experimental/packages/opentelemetry-api-metrics/package.json
@@ -27,7 +27,8 @@
     "version": "node ../../../scripts/version-update.js",
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
-    "prewatch": "node ../../../scripts/version-update.js"
+    "prewatch": "node ../../../scripts/version-update.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -68,6 +69,7 @@
     "@types/node": "18.6.5",
     "@types/webpack-env": "1.16.3",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
@@ -82,5 +84,12 @@
     "typescript": "4.7.4",
     "webpack": "4.46.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-api-metrics"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-api-metrics",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/opentelemetry-api-metrics/package.json
+++ b/experimental/packages/opentelemetry-api-metrics/package.json
@@ -79,7 +79,7 @@
     "nyc": "15.1.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-api-metrics"

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -18,7 +18,8 @@
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -55,6 +56,7 @@
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
     "cpx": "1.5.0",
+    "downlevel-dts": "0.10.0",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
@@ -76,5 +78,12 @@
     "@opentelemetry/resources": "1.5.0",
     "@opentelemetry/sdk-metrics-base": "0.31.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -61,7 +61,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -29,7 +29,8 @@
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -72,6 +73,7 @@
     "babel-loader": "8.2.3",
     "codecov": "3.8.3",
     "cpx": "1.5.0",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
@@ -101,5 +103,12 @@
     "@opentelemetry/resources": "1.5.0",
     "@opentelemetry/sdk-metrics-base": "0.31.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -85,7 +85,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -18,7 +18,8 @@
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -55,6 +56,7 @@
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
     "cpx": "1.5.0",
+    "downlevel-dts": "0.10.0",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
@@ -77,5 +79,12 @@
     "@opentelemetry/sdk-metrics-base": "0.31.0",
     "protobufjs": "^6.9.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -61,7 +61,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -53,7 +53,7 @@
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -18,7 +18,8 @@
     "watch": "tsc --build --watch",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -48,6 +49,7 @@
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
@@ -63,5 +65,12 @@
     "@opentelemetry/core": "1.5.0",
     "@opentelemetry/sdk-metrics-base": "0.31.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-prometheus"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-prometheus",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -78,7 +78,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -20,7 +20,8 @@
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "node ../../../scripts/version-update.js",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "fetch",
@@ -65,6 +66,7 @@
     "@types/webpack-env": "1.16.3",
     "babel-loader": "8.2.3",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
@@ -92,5 +94,12 @@
     "@opentelemetry/sdk-trace-web": "1.5.0",
     "@opentelemetry/semantic-conventions": "1.5.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -301,7 +301,16 @@ export class FetchInstrumentation extends InstrumentationBase<Promise<Response>>
         ...args: Parameters<typeof fetch>
       ): Promise<Response> {
         const self = this;
-        const url = web.parseUrl(args[0] instanceof Request ? args[0].url : args[0]).href;
+        let url: string
+        if (typeof args[0] === 'string') {
+          url = web.parseUrl(args[0]).href;
+        } else if (args[0] instanceof Request) {
+          url = web.parseUrl(args[0].url).href;
+        } else if (args[0] instanceof URL) {
+          url = args[0].href;
+        } else {
+          return original.apply(this, args);
+        }
 
         const options = args[0] instanceof Request ? args[0] : args[1] || {};
         const createdSpan = plugin._createSpan(url, options);

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -301,7 +301,7 @@ export class FetchInstrumentation extends InstrumentationBase<Promise<Response>>
         ...args: Parameters<typeof fetch>
       ): Promise<Response> {
         const self = this;
-        let url: string
+        let url: string;
         if (typeof args[0] === 'string') {
           url = web.parseUrl(args[0]).href;
         } else if (args[0] instanceof Request) {

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -65,7 +65,7 @@
     "semver": "7.3.5",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -18,7 +18,8 @@
     "watch": "tsc --build --watch",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "node ../../../scripts/version-update.js",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -57,6 +58,7 @@
     "@types/semver": "7.3.9",
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "grpc": "1.24.11",
     "mocha": "10.0.0",
     "node-pre-gyp": "0.17.0",
@@ -75,5 +77,12 @@
     "@opentelemetry/instrumentation": "0.31.0",
     "@opentelemetry/semantic-conventions": "1.5.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -68,7 +68,7 @@
     "sinon": "14.0.0",
     "superagent": "6.1.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -18,7 +18,8 @@
     "watch": "tsc --build --watch",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "node ../../../scripts/version-update.js",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -58,6 +59,7 @@
     "@types/superagent": "4.1.13",
     "axios": "0.24.0",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "got": "9.6.0",
     "mocha": "10.0.0",
     "nock": "13.0.11",
@@ -79,5 +81,12 @@
     "@opentelemetry/semantic-conventions": "1.5.0",
     "semver": "^7.3.5"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -20,7 +20,8 @@
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "node ../../../scripts/version-update.js",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -65,6 +66,7 @@
     "@types/webpack-env": "1.16.3",
     "babel-loader": "8.2.3",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
@@ -92,5 +94,12 @@
     "@opentelemetry/sdk-trace-web": "1.5.0",
     "@opentelemetry/semantic-conventions": "1.5.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -78,7 +78,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -53,7 +53,8 @@
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "node ../../../scripts/version-update.js",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -88,6 +89,7 @@
     "babel-loader": "8.2.3",
     "codecov": "3.8.3",
     "cpx": "1.5.0",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
@@ -108,5 +110,12 @@
   },
   "engines": {
     "node": ">=14"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -101,7 +101,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -22,7 +22,8 @@
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "node ../../../scripts/version-update.js",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -60,6 +61,7 @@
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
     "karma-coverage-istanbul-reporter": "3.0.3",
@@ -82,5 +84,12 @@
     "@opentelemetry/resources": "1.5.0",
     "lodash.merge": "4.6.2"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-sdk-metrics-base"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-sdk-metrics-base",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/opentelemetry-sdk-metrics-base/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics-base/package.json
@@ -71,7 +71,7 @@
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -17,7 +17,8 @@
     "watch": "tsc --build --watch",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -64,6 +65,7 @@
     "@types/semver": "7.3.9",
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
@@ -73,5 +75,12 @@
     "ts-mocha": "10.0.0",
     "typescript": "4.7.4"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-sdk-node"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-sdk-node",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -71,7 +71,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-sdk-node"
 }

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -28,7 +28,8 @@
     "version": "node ../../../scripts/version-update.js",
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
-    "prewatch": "npm run precompile"
+    "prewatch": "npm run precompile",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -69,6 +70,7 @@
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "mocha": "10.0.0",
     "nock": "13.0.11",
@@ -81,5 +83,12 @@
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-exporter-base"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-exporter-base",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -76,7 +76,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -65,7 +65,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -12,7 +12,7 @@
     "clean": "tsc --build --clean",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "postcompile": "npm run submodule && npm run protos:copy",
+    "downlevel": "downlevel-dts . ts3.4",
     "protos:copy": "cpx protos/opentelemetry/**/*.* build/protos/opentelemetry",
     "submodule": "git submodule sync --recursive && git submodule update --init --recursive",
     "tdd": "npm run test -- --watch-extensions ts --watch",
@@ -59,6 +59,7 @@
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
     "cpx": "1.5.0",
+    "downlevel-dts": "0.10.0",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
@@ -76,5 +77,12 @@
     "@opentelemetry/core": "1.5.0",
     "@opentelemetry/otlp-exporter-base": "0.31.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-grpc-exporter-base"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-grpc-exporter-base",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -57,7 +57,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -16,7 +16,8 @@
     "version": "node ../../../scripts/version-update.js",
     "watch": "npm run protos && tsc -w",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
-    "prewatch": "npm run precompile"
+    "prewatch": "npm run precompile",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -50,6 +51,7 @@
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "protobufjs": "^6.9.0",
@@ -67,5 +69,12 @@
     "@opentelemetry/core": "1.5.0",
     "@opentelemetry/otlp-exporter-base": "0.31.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-proto-exporter-base"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-proto-exporter-base",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -73,7 +73,7 @@
     "rimraf": "3.0.2",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0"
   },
   "dependencies": {

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -22,7 +22,8 @@
     "test:browser": "nyc karma start --single-run",
     "watch": "tsc --build -w tsconfig.all.json",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -59,6 +60,7 @@
     "@types/mocha": "9.1.1",
     "@types/webpack-env": "1.16.3",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
@@ -83,5 +85,12 @@
     "@opentelemetry/sdk-metrics-base": "0.31.0",
     "@opentelemetry/sdk-trace-base": "1.5.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-transformer"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-transformer",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -20,7 +20,7 @@
     "express": "4.17.1"
   },
   "devDependencies": {
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "engines": {
     "node": ">=14"

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -8,7 +8,8 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "scripts": {
-    "compile": "tsc --build"
+    "compile": "tsc --build",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
@@ -20,9 +21,17 @@
     "express": "4.17.1"
   },
   "devDependencies": {
+    "downlevel-dts": "0.10.0",
     "typescript": "4.7.4"
   },
   "engines": {
     "node": ">=14"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "markdownlint-cli": "0.29.0",
     "semver": "7.3.5",
     "typedoc": "0.22.10",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "update-ts-references": "2.4.1"
   },
   "changelog": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "watch": "tsc --build --watch",
     "clean": "tsc --build --clean",
     "postinstall": "npm run update-ts-references && npm run bootstrap",
-    "postcompile": "npm run submodule && npm run protos:copy",
+    "postcompile": "npm run submodule && npm run protos:copy && npm run downlevel",
     "submodule": "git submodule sync --recursive && git submodule update --init --recursive",
     "protos:copy": "lerna run protos:copy",
     "version:update": "lerna run version:update",
@@ -35,7 +35,8 @@
     "lint:markdown": "./node_modules/.bin/markdownlint $(git ls-files '*.md') -i ./CHANGELOG.md",
     "lint:markdown:fix": "./node_modules/.bin/markdownlint $(git ls-files '*.md') -i ./CHANGELOG.md --fix",
     "reset": "lerna clean -y && rm -rf node_modules && npm i && npm run compile && npm run lint:fix",
-    "update-ts-references": "update-ts-references"
+    "update-ts-references": "update-ts-references",
+    "downlevel": "lerna run downlevel"
   },
   "repository": "open-telemetry/opentelemetry-js",
   "keywords": [
@@ -50,6 +51,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "5.3.1",
     "@typescript-eslint/parser": "5.3.1",
+    "downlevel-dts": "^0.10.0",
     "eslint": "7.32.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-node": "11.1.0",
@@ -75,5 +77,12 @@
       "internal": ":house: (Internal)"
     },
     "cacheDir": ".changelog"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "linkinator": "3.0.3",
     "markdownlint-cli": "0.29.0",
     "semver": "7.3.5",
-    "typedoc": "0.22.10",
+    "typedoc": "0.23.10",
     "typescript": "4.7.4",
     "update-ts-references": "2.4.1"
   },

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -52,7 +52,7 @@
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0"

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -17,7 +17,8 @@
     "version": "node ../../scripts/version-update.js",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -48,6 +49,7 @@
     "@types/mocha": "9.1.1",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
@@ -57,5 +59,12 @@
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-context-async-hooks"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-context-async-hooks",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -75,7 +75,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "zone.js": "0.11.4"

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -20,7 +20,8 @@
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -62,6 +63,7 @@
     "@types/zone.js": "0.5.12",
     "babel-loader": "8.2.3",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
@@ -85,5 +87,12 @@
     "zone.js": "^0.10.2 || ^0.11.0"
   },
   "sideEffects": false,
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-context-zone-peer-dep"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-context-zone-peer-dep",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -68,7 +68,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -17,7 +17,8 @@
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -57,6 +58,7 @@
     "@types/webpack-env": "1.16.3",
     "babel-loader": "8.2.3",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
     "karma-mocha": "2.0.1",
@@ -78,5 +80,12 @@
     "zone.js": "^0.11.0"
   },
   "sideEffects": true,
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-context-zone"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-context-zone",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -84,7 +84,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0"
   },
   "peerDependencies": {

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -30,7 +30,8 @@
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -70,6 +71,7 @@
     "@types/sinon": "10.0.13",
     "@types/webpack-env": "1.16.3",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
@@ -93,5 +95,12 @@
   "dependencies": {
     "@opentelemetry/semantic-conventions": "1.5.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -18,7 +18,8 @@
     "watch": "tsc --build --watch",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -50,6 +51,7 @@
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "mocha": "10.0.0",
     "nock": "13.0.11",
     "nyc": "15.1.0",
@@ -67,5 +69,12 @@
     "@opentelemetry/semantic-conventions": "1.5.0",
     "jaeger-client": "^3.15.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -56,7 +56,7 @@
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -82,7 +82,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -28,7 +28,8 @@
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -68,6 +69,7 @@
     "@types/webpack-env": "1.16.3",
     "babel-loader": "8.2.3",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
@@ -96,5 +98,12 @@
     "@opentelemetry/sdk-trace-base": "1.5.0",
     "@opentelemetry/semantic-conventions": "1.5.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -67,7 +67,7 @@
     "rimraf": "3.0.2",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-b3"
 }

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -19,7 +19,8 @@
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -61,6 +62,7 @@
     "@types/mocha": "9.1.1",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
@@ -69,5 +71,12 @@
     "ts-mocha": "10.0.0",
     "typescript": "4.7.4"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-b3"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-b3",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -73,7 +73,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0"
   },
   "peerDependencies": {

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -22,7 +22,8 @@
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -60,6 +61,7 @@
     "@types/sinon": "10.0.13",
     "@types/webpack-env": "1.16.3",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
@@ -82,5 +84,12 @@
   "dependencies": {
     "@opentelemetry/core": "1.5.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -80,7 +80,7 @@
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -29,7 +29,8 @@
     "version": "node ../../scripts/version-update.js",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -67,6 +68,7 @@
     "@types/sinon": "10.0.13",
     "@types/webpack-env": "1.16.3",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
     "karma-coverage-istanbul-reporter": "3.0.3",
@@ -92,5 +94,12 @@
     "@opentelemetry/core": "1.5.0",
     "@opentelemetry/semantic-conventions": "1.5.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -84,7 +84,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0"
   },
   "peerDependencies": {

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -31,7 +31,8 @@
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -70,6 +71,7 @@
     "@types/sinon": "10.0.13",
     "@types/webpack-env": "1.16.3",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
@@ -95,5 +97,12 @@
     "@opentelemetry/resources": "1.5.0",
     "@opentelemetry/semantic-conventions": "1.5.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/opentelemetry-sdk-trace-base/test/browser/export/BatchSpanProcessor.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/browser/export/BatchSpanProcessor.test.ts
@@ -23,7 +23,7 @@ import { TestTracingSpanExporter } from '../../common/export/TestTracingSpanExpo
 const describeDocument = typeof document === 'object' ? describe : describe.skip;
 
 describeDocument('BatchSpanProcessor - web main context', () => {
-  let visibilityState: VisibilityState = 'visible';
+  let visibilityState: DocumentVisibilityState = 'visible';
   let exporter: SpanExporter;
   let processor: BatchSpanProcessor;
   let forceFlushSpy: sinon.SinonStub;

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -58,7 +58,7 @@
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0"

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -18,7 +18,8 @@
     "watch": "tsc --build --watch",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -53,6 +54,7 @@
     "@types/semver": "7.3.9",
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
@@ -71,5 +73,12 @@
     "@opentelemetry/sdk-trace-base": "1.5.0",
     "semver": "^7.3.5"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -82,7 +82,7 @@
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.9.1",
     "webpack-merge": "5.8.0"

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -22,7 +22,8 @@
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -67,6 +68,7 @@
     "@types/webpack-env": "1.16.3",
     "babel-loader": "8.2.3",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "istanbul-instrumenter-loader": "3.0.1",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",
@@ -95,5 +97,12 @@
     "@opentelemetry/sdk-trace-base": "1.5.0",
     "@opentelemetry/semantic-conventions": "1.5.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -17,7 +17,8 @@
     "watch": "tsc --build --watch tsconfig.all.json",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -53,6 +54,7 @@
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "mocha": "10.0.0",
     "nock": "13.0.11",
     "nyc": "15.1.0",
@@ -61,5 +63,12 @@
     "ts-mocha": "10.0.0",
     "typescript": "4.7.4"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-semantic-conventions"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-semantic-conventions",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -59,7 +59,7 @@
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-semantic-conventions"
 }

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -53,7 +53,7 @@
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.2.0"

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -17,7 +17,8 @@
     "version": "node ../../scripts/version-update.js",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "keywords": [
     "opentelemetry",
@@ -49,6 +50,7 @@
     "@types/mocha": "9.1.1",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
+    "downlevel-dts": "0.10.0",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
@@ -63,5 +65,12 @@
     "@opentelemetry/semantic-conventions": "1.5.0",
     "opentracing": "^0.14.4"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing",
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  }
 }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -32,7 +32,8 @@
     "clean": "tsc --build --clean",
     "precompile": "lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "downlevel": "downlevel-dts . ts3.4"
   },
   "Add these to scripts": {
     "compile": "tsc --build",
@@ -78,6 +79,7 @@
   ],
   "devDependencies": {
     "@types/node": "18.6.5",
+    "downlevel-dts": "0.10.0",
     "typescript": "4.7.4"
   },
   "Add these to devDependencies for testing": {
@@ -100,5 +102,12 @@
     "karma-webpack": "4.0.2",
     "ts-loader": "8.4.0",
     "webpack": "4.46.0"
+  },
+  "typesVersions": {
+    "<4.0": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
   }
 }

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -78,7 +78,7 @@
   ],
   "devDependencies": {
     "@types/node": "18.6.5",
-    "typescript": "4.4.4"
+    "typescript": "4.7.4"
   },
   "Add these to devDependencies for testing": {
     "@types/mocha": "9.1.1",


### PR DESCRIPTION
This is an expansion of #3160 which updates typescript but also adds downleveled types so that OTel can be used with older typescript compilers