### PR TITLE
Add svetlanabrennan as an approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Approvers ([@open-telemetry/js-approvers](https://github.com/orgs/open-telemetry
 - [Naseem K. Ullah](https://github.com/naseemkullah), Transit
 - [Neville Wylie](https://github.com/MSNev), Microsoft
 - [Olivier Albertini](https://github.com/OlivierAlbertini), Ville de Montréal
-- [Rauno Viskus](https://github.com/Rauno56), Splunk
+- [Svetlana Brennan](https://github.com/svetlanabrennan), New Relic
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).*
 


### PR DESCRIPTION
Svetlana Brennan (@svetlanabrennan) has been contributing to the OpenTelemetry JavaScript projects actively in a variety of areas, especially OTLP exporters. I believe it would be valuable to have her on the team, and I would like to nominate Svetlana as an approver for the OpenTelemetry JavaScript project.

(@Rauno56 is an incumbent maintainer, delisting the duplicated entry)
