### PR TITLE
chore(sdk-metrics): clean up exports

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to experimental packages in this project will be documented 
 ### :boom: Breaking Change
 
 * Rename @opentelemetry/sdk-metrics-base package to @opentelemetry/sdk-metrics  [#3162](https://github.com/open-telemetry/opentelemetry-js/pull/3162) @hectorhdzg
+* chore(metrics-sdk): clean up exports [#3197](https://github.com/open-telemetry/opentelemetry-js/pull/3197) @pichlermarc
+  * removes export for:
+    * `AccumulationRecord`
+    * `Aggregator`
+    * `AggregatorKind`
+    * `Accumulation`
+    * `CollectionResult`
+    * `createInstrumentDescriptor`
+    * `createInstrumentDescriptorWithView`
+    * `isDescriptorCompatibleWith`
+    * `TimeoutError`
 
 ### :rocket: (Enhancement)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,11 +12,9 @@ All notable changes to experimental packages in this project will be documented 
     * `Aggregator`
     * `AggregatorKind`
     * `Accumulation`
-    * `CollectionResult`
     * `createInstrumentDescriptor`
     * `createInstrumentDescriptorWithView`
     * `isDescriptorCompatibleWith`
-    * `TimeoutError`
 
 ### :rocket: (Enhancement)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+* chore(metrics-sdk): clean up exports [#3197](https://github.com/open-telemetry/opentelemetry-js/pull/3197) @pichlermarc
+  * removes export for:
+    * `AccumulationRecord`
+    * `Aggregator`
+    * `AggregatorKind`
+    * `Accumulation`
+    * `CollectionResult`
+    * `createInstrumentDescriptor`
+    * `createInstrumentDescriptorWithView`
+    * `isDescriptorCompatibleWith`
+    * `TimeoutError`
+
 ### :rocket: (Enhancement)
 
 ### :bug: (Bug Fix)
@@ -19,17 +31,6 @@ All notable changes to experimental packages in this project will be documented 
 ### :boom: Breaking Change
 
 * Rename @opentelemetry/sdk-metrics-base package to @opentelemetry/sdk-metrics  [#3162](https://github.com/open-telemetry/opentelemetry-js/pull/3162) @hectorhdzg
-* chore(metrics-sdk): clean up exports [#3197](https://github.com/open-telemetry/opentelemetry-js/pull/3197) @pichlermarc
-  * removes export for:
-    * `AccumulationRecord`
-    * `Aggregator`
-    * `AggregatorKind`
-    * `Accumulation`
-    * `CollectionResult`
-    * `createInstrumentDescriptor`
-    * `createInstrumentDescriptorWithView`
-    * `isDescriptorCompatibleWith`
-    * `TimeoutError`
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/opentelemetry-sdk-metrics/src/export/MetricData.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/export/MetricData.ts
@@ -25,7 +25,7 @@ import { Histogram } from '../aggregator/types';
 /**
  * Basic metric data fields.
  */
-export interface BaseMetricData {
+interface BaseMetricData {
   readonly descriptor: InstrumentDescriptor;
   readonly aggregationTemporality: AggregationTemporality;
   /**

--- a/experimental/packages/opentelemetry-sdk-metrics/src/index.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/index.ts
@@ -34,6 +34,7 @@ export {
   ResourceMetrics,
   ScopeMetrics,
   MetricData,
+  CollectionResult,
 } from './export/MetricData';
 
 export {

--- a/experimental/packages/opentelemetry-sdk-metrics/src/index.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/index.ts
@@ -85,3 +85,7 @@ export {
   View,
   ViewOptions,
 } from './view/View';
+
+export {
+  TimeoutError
+} from './utils';

--- a/experimental/packages/opentelemetry-sdk-metrics/src/index.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/index.ts
@@ -14,19 +14,74 @@
  * limitations under the License.
  */
 
-export { Sum, LastValue, Histogram } from './aggregator/types';
-export * from './export/AggregationTemporality';
-export * from './export/MetricData';
-export * from './export/MetricExporter';
-export * from './export/MetricProducer';
-export * from './export/MetricReader';
-export * from './export/PeriodicExportingMetricReader';
-export * from './export/InMemoryMetricExporter';
-export * from './export/ConsoleMetricExporter';
-export { InstrumentDescriptor, InstrumentType } from './InstrumentDescriptor';
-export * from './Meter';
-export * from './MeterProvider';
-export * from './ObservableResult';
-export { TimeoutError } from './utils';
-export * from './view/Aggregation';
-export * from './view/View';
+export {
+  Sum,
+  LastValue,
+  Histogram,
+} from './aggregator/types';
+
+export {
+  AggregationTemporality,
+  AggregationTemporalitySelector,
+} from './export/AggregationTemporality';
+
+export {
+  DataPoint,
+  DataPointType,
+  SumMetricData,
+  GaugeMetricData,
+  HistogramMetricData,
+  ResourceMetrics,
+  ScopeMetrics,
+  MetricData,
+} from './export/MetricData';
+
+export {
+  PushMetricExporter,
+} from './export/MetricExporter';
+
+export {
+  MetricReader,
+} from './export/MetricReader';
+
+export {
+  PeriodicExportingMetricReader,
+  PeriodicExportingMetricReaderOptions,
+} from './export/PeriodicExportingMetricReader';
+
+export {
+  InMemoryMetricExporter,
+} from './export/InMemoryMetricExporter';
+
+export {
+  ConsoleMetricExporter,
+} from './export/ConsoleMetricExporter';
+
+export {
+  InstrumentDescriptor,
+  InstrumentType,
+} from './InstrumentDescriptor';
+
+export {
+  Meter,
+} from './Meter';
+
+export {
+  MeterProvider,
+  MeterProviderOptions,
+} from './MeterProvider';
+
+export {
+  DefaultAggregation,
+  ExplicitBucketHistogramAggregation,
+  DropAggregation,
+  HistogramAggregation,
+  LastValueAggregation,
+  SumAggregation,
+  Aggregation
+} from './view/Aggregation';
+
+export {
+  View,
+  ViewOptions,
+} from './view/View';

--- a/experimental/packages/opentelemetry-sdk-metrics/test/ObservableResult.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/test/ObservableResult.test.ts
@@ -16,9 +16,12 @@
 
 import { ValueType } from '@opentelemetry/api-metrics';
 import * as assert from 'assert';
-import { BatchObservableResultImpl, InstrumentType } from '../src';
+import { InstrumentType } from '../src';
 import { ObservableInstrument } from '../src/Instruments';
-import { ObservableResultImpl } from '../src/ObservableResult';
+import {
+  BatchObservableResultImpl,
+  ObservableResultImpl
+} from '../src/ObservableResult';
 import { ObservableRegistry } from '../src/state/ObservableRegistry';
 import { commonAttributes, commonValues, defaultInstrumentDescriptor } from './util';
 

--- a/experimental/packages/opentelemetry-sdk-metrics/test/state/MeterSharedState.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/test/state/MeterSharedState.test.ts
@@ -21,12 +21,12 @@ import {
   Meter,
   MeterProvider,
   DataPointType,
-  CollectionResult,
   View
 } from '../../src';
 import { assertMetricData, defaultInstrumentationScope, defaultResource, sleep } from '../util';
 import { TestMetricReader } from '../export/TestMetricReader';
 import { MeterSharedState } from '../../src/state/MeterSharedState';
+import { CollectionResult } from '../../src/export/MetricData';
 
 describe('MeterSharedState', () => {
   afterEach(() => {

--- a/experimental/packages/opentelemetry-sdk-metrics/test/state/MetricCollector.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/test/state/MetricCollector.test.ts
@@ -16,7 +16,8 @@
 
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { MeterProvider, TimeoutError } from '../../src';
+import { MeterProvider } from '../../src';
+import { TimeoutError } from '../../src/utils';
 import { DataPointType } from '../../src/export/MetricData';
 import { PushMetricExporter } from '../../src/export/MetricExporter';
 import { MeterProviderSharedState } from '../../src/state/MeterProviderSharedState';


### PR DESCRIPTION
## Which problem is this PR solving?

`@opentelemetry/sdk-metrics` exports some classes and functions that are intended for internal use. In an effort to reduce the API surface before declaring metrics GA, this PR replaces the existing wildcard exports with explicit exports.

Related: #3158 

## Short description of the changes

Replaces the existing wildcard exports with explicit exports and removes export for:
- AccumulationRecord
- Aggregator
- AggregatorKind 
- Accumulation
- ~~CollectionResult~~
- createInstrumentDescriptor
- createInstrumentDescriptorWithView
- isDescriptorCompatibleWith
- ~~TimeoutError~~

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] existing tests

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
