### PR TITLE
chore(api-metrics): clean up exports

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,19 +6,6 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
-### :rocket: (Enhancement)
-
-### :bug: (Bug Fix)
-
-### :books: (Refine Doc)
-
-### :house: (Internal)
-
-## 0.32.0
-
-### :boom: Breaking Change
-
-* Rename @opentelemetry/sdk-metrics-base package to @opentelemetry/sdk-metrics  [#3162](https://github.com/open-telemetry/opentelemetry-js/pull/3162) @hectorhdzg
 * chore(api-metrics): clean up exports [#3198](https://github.com/open-telemetry/opentelemetry-js/pull/3198) @pichlermarc
   * removes export for:
     * `NoopMeter`
@@ -37,6 +24,20 @@ All notable changes to experimental packages in this project will be documented 
     * `NOOP_OBSERVABLE_GAUGE_METRIC`
     * `NOOP_OBSERVABLE_UP_DOWN_COUNTER_METRIC`
     * `NoopMeterProvider`
+
+### :rocket: (Enhancement)
+
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 0.32.0
+
+### :boom: Breaking Change
+
+* Rename @opentelemetry/sdk-metrics-base package to @opentelemetry/sdk-metrics  [#3162](https://github.com/open-telemetry/opentelemetry-js/pull/3162) @hectorhdzg
 
 ### :rocket: (Enhancement)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -17,23 +17,23 @@ All notable changes to experimental packages in this project will be documented 
     * `isDescriptorCompatibleWith`
 * chore(api-metrics): clean up exports [#3198](https://github.com/open-telemetry/opentelemetry-js/pull/3198) @pichlermarc
   * removes export for:
-    * `NoopMeter`
-    * `NoopMetric`
-    * `NoopCounterMetric`
-    * `NoopUpDownCounterMetric`
-    * `NoopHistogramMetric`
-    * `NoopObservableMetric`
-    * `NoopObservableCounterMetric`
-    * `NoopObservableGaugeMetric`
-    * `NoopObservableUpDownCounterMetric`
     * `NOOP_COUNTER_METRIC`
     * `NOOP_HISTOGRAM_METRIC`
-    * `NOOP_UP_DOWN_COUNTER_METRIC`
+    * `NOOP_METER_PROVIDER`
     * `NOOP_OBSERVABLE_COUNTER_METRIC`
     * `NOOP_OBSERVABLE_GAUGE_METRIC`
     * `NOOP_OBSERVABLE_UP_DOWN_COUNTER_METRIC`
+    * `NOOP_UP_DOWN_COUNTER_METRIC`
+    * `NoopCounterMetric`
+    * `NoopHistogramMetric`
+    * `NoopMeter`
     * `NoopMeterProvider`
-    * `NOOP_METER_PROVIDER`
+    * `NoopMetric`
+    * `NoopObservableCounterMetric`
+    * `NoopObservableGaugeMetric`
+    * `NoopObservableMetric`
+    * `NoopObservableUpDownCounterMetric`
+    * `NoopUpDownCounterMetric`
 
 ### :rocket: (Enhancement)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :boom: Breaking Change
 
 * Rename @opentelemetry/sdk-metrics-base package to @opentelemetry/sdk-metrics  [#3162](https://github.com/open-telemetry/opentelemetry-js/pull/3162) @hectorhdzg
+* chore(api-metrics): clean up exports [#3198](https://github.com/open-telemetry/opentelemetry-js/pull/3198) @pichlermarc
 
 ### :rocket: (Enhancement)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to experimental packages in this project will be documented 
     * `NOOP_OBSERVABLE_GAUGE_METRIC`
     * `NOOP_OBSERVABLE_UP_DOWN_COUNTER_METRIC`
     * `NoopMeterProvider`
+    * `NOOP_METER_PROVIDER`
 
 ### :rocket: (Enhancement)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -8,6 +8,23 @@ All notable changes to experimental packages in this project will be documented 
 
 * Rename @opentelemetry/sdk-metrics-base package to @opentelemetry/sdk-metrics  [#3162](https://github.com/open-telemetry/opentelemetry-js/pull/3162) @hectorhdzg
 * chore(api-metrics): clean up exports [#3198](https://github.com/open-telemetry/opentelemetry-js/pull/3198) @pichlermarc
+  * removes export for:
+    * `NoopMeter`
+    * `NoopMetric`
+    * `NoopCounterMetric`
+    * `NoopUpDownCounterMetric`
+    * `NoopHistogramMetric`
+    * `NoopObservableMetric`
+    * `NoopObservableCounterMetric`
+    * `NoopObservableGaugeMetric`
+    * `NoopObservableUpDownCounterMetric`
+    * `NOOP_COUNTER_METRIC`
+    * `NOOP_HISTOGRAM_METRIC`
+    * `NOOP_UP_DOWN_COUNTER_METRIC`
+    * `NOOP_OBSERVABLE_COUNTER_METRIC`
+    * `NOOP_OBSERVABLE_GAUGE_METRIC`
+    * `NOOP_OBSERVABLE_UP_DOWN_COUNTER_METRIC`
+    * `NoopMeterProvider`
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/opentelemetry-api-metrics/src/NoopMeter.ts
+++ b/experimental/packages/opentelemetry-api-metrics/src/NoopMeter.ts
@@ -132,3 +132,8 @@ export const NOOP_UP_DOWN_COUNTER_METRIC = new NoopUpDownCounterMetric();
 export const NOOP_OBSERVABLE_COUNTER_METRIC = new NoopObservableCounterMetric();
 export const NOOP_OBSERVABLE_GAUGE_METRIC = new NoopObservableGaugeMetric();
 export const NOOP_OBSERVABLE_UP_DOWN_COUNTER_METRIC = new NoopObservableUpDownCounterMetric();
+
+// Utility functions
+export function createNoopMeter(): Meter{
+  return NOOP_METER;
+}

--- a/experimental/packages/opentelemetry-api-metrics/src/NoopMeter.ts
+++ b/experimental/packages/opentelemetry-api-metrics/src/NoopMeter.ts
@@ -114,11 +114,14 @@ export class NoopHistogramMetric extends NoopMetric implements Histogram {
 
 export class NoopObservableMetric {
   addCallback(_callback: ObservableCallback) {}
+
   removeCallback(_callback: ObservableCallback) {}
 }
 
 export class NoopObservableCounterMetric extends NoopObservableMetric implements ObservableCounter {}
+
 export class NoopObservableGaugeMetric extends NoopObservableMetric implements ObservableGauge {}
+
 export class NoopObservableUpDownCounterMetric extends NoopObservableMetric implements ObservableUpDownCounter {}
 
 export const NOOP_METER = new NoopMeter();
@@ -136,6 +139,6 @@ export const NOOP_OBSERVABLE_UP_DOWN_COUNTER_METRIC = new NoopObservableUpDownCo
 /**
  * Create a no-op Meter
  */
-export function createNoopMeter(): Meter{
+export function createNoopMeter(): Meter {
   return NOOP_METER;
 }

--- a/experimental/packages/opentelemetry-api-metrics/src/NoopMeter.ts
+++ b/experimental/packages/opentelemetry-api-metrics/src/NoopMeter.ts
@@ -133,7 +133,9 @@ export const NOOP_OBSERVABLE_COUNTER_METRIC = new NoopObservableCounterMetric();
 export const NOOP_OBSERVABLE_GAUGE_METRIC = new NoopObservableGaugeMetric();
 export const NOOP_OBSERVABLE_UP_DOWN_COUNTER_METRIC = new NoopObservableUpDownCounterMetric();
 
-// Utility functions
+/**
+ * Create a no-op Meter
+ */
 export function createNoopMeter(): Meter{
   return NOOP_METER;
 }

--- a/experimental/packages/opentelemetry-api-metrics/src/index.ts
+++ b/experimental/packages/opentelemetry-api-metrics/src/index.ts
@@ -19,10 +19,6 @@ export {
 } from './NoopMeter';
 
 export {
-  NOOP_METER_PROVIDER,
-} from './NoopMeterProvider';
-
-export {
   MeterOptions,
   Meter,
 } from './types/Meter';

--- a/experimental/packages/opentelemetry-api-metrics/src/index.ts
+++ b/experimental/packages/opentelemetry-api-metrics/src/index.ts
@@ -14,13 +14,45 @@
  * limitations under the License.
  */
 
-export * from './NoopMeter';
-export * from './NoopMeterProvider';
-export * from './types/Meter';
-export * from './types/MeterProvider';
-export * from './types/Metric';
-export * from './types/ObservableResult';
+export {
+  NOOP_METER
+} from './NoopMeter';
+
+export {
+  NOOP_METER_PROVIDER
+} from './NoopMeterProvider';
+
+export {
+  MeterOptions,
+  Meter,
+} from './types/Meter';
+
+export {
+  MeterProvider
+} from './types/MeterProvider';
+
+export {
+  ValueType,
+  Counter,
+  Histogram,
+  MetricOptions,
+  Observable,
+  ObservableCounter,
+  ObservableGauge,
+  ObservableUpDownCounter,
+  UpDownCounter,
+  BatchObservableCallback,
+  MetricAttributes,
+  MetricAttributeValue,
+  ObservableCallback
+} from './types/Metric';
+
+export {
+  BatchObservableResult,
+  ObservableResult
+} from './types/ObservableResult';
 
 import { MetricsAPI } from './api/metrics';
+
 /** Entrypoint for metrics API */
 export const metrics = MetricsAPI.getInstance();

--- a/experimental/packages/opentelemetry-api-metrics/src/index.ts
+++ b/experimental/packages/opentelemetry-api-metrics/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 export {
-  NOOP_METER,
+  createNoopMeter,
 } from './NoopMeter';
 
 export {

--- a/experimental/packages/opentelemetry-api-metrics/src/index.ts
+++ b/experimental/packages/opentelemetry-api-metrics/src/index.ts
@@ -15,11 +15,11 @@
  */
 
 export {
-  NOOP_METER
+  NOOP_METER,
 } from './NoopMeter';
 
 export {
-  NOOP_METER_PROVIDER
+  NOOP_METER_PROVIDER,
 } from './NoopMeterProvider';
 
 export {
@@ -28,7 +28,7 @@ export {
 } from './types/Meter';
 
 export {
-  MeterProvider
+  MeterProvider,
 } from './types/MeterProvider';
 
 export {
@@ -44,12 +44,12 @@ export {
   BatchObservableCallback,
   MetricAttributes,
   MetricAttributeValue,
-  ObservableCallback
+  ObservableCallback,
 } from './types/Metric';
 
 export {
   BatchObservableResult,
-  ObservableResult
+  ObservableResult,
 } from './types/ObservableResult';
 
 import { MetricsAPI } from './api/metrics';

--- a/experimental/packages/opentelemetry-api-metrics/test/api/api.test.ts
+++ b/experimental/packages/opentelemetry-api-metrics/test/api/api.test.ts
@@ -15,7 +15,10 @@
  */
 
 import * as assert from 'assert';
-import { metrics, NoopMeter, NoopMeterProvider } from '../../src';
+import { metrics } from '../../src';
+import { NoopMeter } from '../../src/NoopMeter';
+import { NoopMeterProvider } from '../../src/NoopMeterProvider';
+
 
 describe('API', () => {
   it('should expose a meter provider via getMeterProvider', () => {

--- a/experimental/packages/opentelemetry-api-metrics/test/api/global.test.ts
+++ b/experimental/packages/opentelemetry-api-metrics/test/api/global.test.ts
@@ -16,7 +16,7 @@
 
 import * as assert from 'assert';
 import { _global, GLOBAL_METRICS_API_KEY } from '../../src/api/global-utils';
-import { NoopMeterProvider } from '../../src';
+import { NoopMeterProvider } from '../../src/NoopMeterProvider';
 
 const api1 = require('../../src') as typeof import('../../src');
 

--- a/experimental/packages/opentelemetry-api-metrics/test/noop-implementations/noop-meter.test.ts
+++ b/experimental/packages/opentelemetry-api-metrics/test/noop-implementations/noop-meter.test.ts
@@ -23,9 +23,9 @@ import {
   NOOP_OBSERVABLE_GAUGE_METRIC,
   NOOP_OBSERVABLE_UP_DOWN_COUNTER_METRIC,
   NOOP_UP_DOWN_COUNTER_METRIC,
+  createNoopMeter,
 } from '../../src/NoopMeter';
 import { NoopMeterProvider } from '../../src/NoopMeterProvider';
-
 
 const attributes = {};
 const options = {
@@ -132,5 +132,11 @@ describe('NoopMeter', () => {
     const meter = new NoopMeterProvider().getMeter('test-noop');
     meter.addBatchObservableCallback(() => {}, []);
     meter.removeBatchObservableCallback(() => {}, []);
+  });
+});
+
+describe('createNoopMeter', () => {
+  it('should return NoopMeter', () => {
+    assert.ok(createNoopMeter() instanceof NoopMeter);
   });
 });

--- a/experimental/packages/opentelemetry-api-metrics/test/noop-implementations/noop-meter.test.ts
+++ b/experimental/packages/opentelemetry-api-metrics/test/noop-implementations/noop-meter.test.ts
@@ -17,14 +17,15 @@
 import * as assert from 'assert';
 import {
   NoopMeter,
-  NoopMeterProvider,
   NOOP_COUNTER_METRIC,
   NOOP_HISTOGRAM_METRIC,
   NOOP_OBSERVABLE_COUNTER_METRIC,
   NOOP_OBSERVABLE_GAUGE_METRIC,
   NOOP_OBSERVABLE_UP_DOWN_COUNTER_METRIC,
   NOOP_UP_DOWN_COUNTER_METRIC,
-} from '../../src';
+} from '../../src/NoopMeter';
+import { NoopMeterProvider } from '../../src/NoopMeterProvider';
+
 
 const attributes = {};
 const options = {

--- a/experimental/packages/opentelemetry-instrumentation/test/common/autoLoader.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation/test/common/autoLoader.test.ts
@@ -15,16 +15,28 @@
  */
 
 import { Tracer, TracerProvider } from '@opentelemetry/api';
-import { NOOP_METER_PROVIDER } from '@opentelemetry/api-metrics';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { InstrumentationBase, registerInstrumentations } from '../../src';
+import {
+  Meter,
+  MeterOptions,
+  MeterProvider,
+  NOOP_METER
+} from '@opentelemetry/api-metrics';
 
 class DummyTracerProvider implements TracerProvider {
   getTracer(name: string, version?: string): Tracer {
     throw new Error('not implemented');
   }
 }
+
+class DummyMeterProvider implements MeterProvider {
+  getMeter(name: string, version?: string, options?: MeterOptions): Meter {
+    return NOOP_METER;
+  }
+}
+
 class FooInstrumentation extends InstrumentationBase {
   init() {
     return [];
@@ -50,14 +62,14 @@ describe('autoLoader', () => {
       let instrumentation: InstrumentationBase;
       let enableSpy: sinon.SinonSpy;
       let setTracerProviderSpy: sinon.SinonSpy;
-      let setsetMeterProvider: sinon.SinonSpy;
+      let setMeterProvider: sinon.SinonSpy;
       const tracerProvider = new DummyTracerProvider();
-      const meterProvider = NOOP_METER_PROVIDER;
+      const meterProvider = new DummyMeterProvider();
       beforeEach(() => {
         instrumentation = new FooInstrumentation('foo', '1', {});
         enableSpy = sinon.spy(instrumentation, 'enable');
         setTracerProviderSpy = sinon.stub(instrumentation, 'setTracerProvider');
-        setsetMeterProvider = sinon.stub(instrumentation, 'setMeterProvider');
+        setMeterProvider = sinon.stub(instrumentation, 'setMeterProvider');
         unload = registerInstrumentations({
           instrumentations: [instrumentation],
           tracerProvider,
@@ -104,9 +116,9 @@ describe('autoLoader', () => {
       });
 
       it('should set MeterProvider', () => {
-        assert.strictEqual(setsetMeterProvider.callCount, 1);
-        assert.ok(setsetMeterProvider.lastCall.args[0] === meterProvider);
-        assert.strictEqual(setsetMeterProvider.lastCall.args.length, 1);
+        assert.strictEqual(setMeterProvider.callCount, 1);
+        assert.ok(setMeterProvider.lastCall.args[0] === meterProvider);
+        assert.strictEqual(setMeterProvider.lastCall.args.length, 1);
       });
     });
   });

--- a/experimental/packages/opentelemetry-instrumentation/test/common/autoLoader.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation/test/common/autoLoader.test.ts
@@ -22,7 +22,6 @@ import {
   Meter,
   MeterOptions,
   MeterProvider,
-  NOOP_METER
 } from '@opentelemetry/api-metrics';
 
 class DummyTracerProvider implements TracerProvider {
@@ -33,7 +32,7 @@ class DummyTracerProvider implements TracerProvider {
 
 class DummyMeterProvider implements MeterProvider {
   getMeter(name: string, version?: string, options?: MeterOptions): Meter {
-    return NOOP_METER;
+    throw new Error('not implemented');
   }
 }
 
@@ -62,14 +61,14 @@ describe('autoLoader', () => {
       let instrumentation: InstrumentationBase;
       let enableSpy: sinon.SinonSpy;
       let setTracerProviderSpy: sinon.SinonSpy;
-      let setMeterProvider: sinon.SinonSpy;
+      let setMeterProviderSpy: sinon.SinonSpy;
       const tracerProvider = new DummyTracerProvider();
       const meterProvider = new DummyMeterProvider();
       beforeEach(() => {
         instrumentation = new FooInstrumentation('foo', '1', {});
         enableSpy = sinon.spy(instrumentation, 'enable');
         setTracerProviderSpy = sinon.stub(instrumentation, 'setTracerProvider');
-        setMeterProvider = sinon.stub(instrumentation, 'setMeterProvider');
+        setMeterProviderSpy = sinon.stub(instrumentation, 'setMeterProvider');
         unload = registerInstrumentations({
           instrumentations: [instrumentation],
           tracerProvider,
@@ -97,6 +96,7 @@ describe('autoLoader', () => {
         );
         enableSpy = sinon.spy(instrumentation, 'enable');
         setTracerProviderSpy = sinon.stub(instrumentation, 'setTracerProvider');
+        setMeterProviderSpy = sinon.stub(instrumentation, 'setMeterProvider');
         unload = registerInstrumentations({
           instrumentations: [instrumentation],
           tracerProvider,
@@ -116,9 +116,9 @@ describe('autoLoader', () => {
       });
 
       it('should set MeterProvider', () => {
-        assert.strictEqual(setMeterProvider.callCount, 1);
-        assert.ok(setMeterProvider.lastCall.args[0] === meterProvider);
-        assert.strictEqual(setMeterProvider.lastCall.args.length, 1);
+        assert.strictEqual(setMeterProviderSpy.callCount, 1);
+        assert.ok(setMeterProviderSpy.lastCall.args[0] === meterProvider);
+        assert.strictEqual(setMeterProviderSpy.lastCall.args.length, 1);
       });
     });
   });

--- a/experimental/packages/opentelemetry-sdk-metrics/src/MeterProvider.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/MeterProvider.ts
@@ -55,7 +55,7 @@ export class MeterProvider implements metrics.MeterProvider {
     // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#meter-creation
     if (this._shutdown) {
       api.diag.warn('A shutdown MeterProvider cannot provide a Meter');
-      return metrics.NOOP_METER;
+      return metrics.createNoopMeter();
     }
 
     return this._sharedState

--- a/experimental/packages/opentelemetry-sdk-metrics/test/MeterProvider.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/test/MeterProvider.test.ts
@@ -15,7 +15,6 @@
  */
 
 import * as assert from 'assert';
-import { NOOP_METER } from '@opentelemetry/api-metrics';
 import { Meter, MeterProvider, InstrumentType, DataPointType } from '../src';
 import {
   assertScopeMetrics,
@@ -62,7 +61,8 @@ describe('MeterProvider', () => {
       const meterProvider = new MeterProvider();
       meterProvider.shutdown();
       const meter = meterProvider.getMeter('meter1', '1.0.0');
-      assert.strictEqual(meter, NOOP_METER);
+      // returned tracer should be no-op, not instance of Meter (from SDK)
+      assert.ok(!(meter instanceof Meter));
     });
 
     it('get meter with same identity', async () => {

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -22,13 +22,21 @@ import {
   diag,
   DiagLogLevel,
 } from '@opentelemetry/api';
-import { metrics, NoopMeterProvider } from '@opentelemetry/api-metrics';
+import { metrics } from '@opentelemetry/api-metrics';
 import {
   AsyncHooksContextManager,
   AsyncLocalStorageContextManager,
 } from '@opentelemetry/context-async-hooks';
 import { CompositePropagator } from '@opentelemetry/core';
-import { AggregationTemporality, ConsoleMetricExporter, InMemoryMetricExporter, InstrumentType, MeterProvider, PeriodicExportingMetricReader, View } from '@opentelemetry/sdk-metrics';
+import {
+  AggregationTemporality,
+  ConsoleMetricExporter,
+  InMemoryMetricExporter,
+  InstrumentType,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+  View,
+} from '@opentelemetry/sdk-metrics';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import {
   assertServiceResource,
@@ -41,7 +49,10 @@ import * as assert from 'assert';
 import * as semver from 'semver';
 import * as Sinon from 'sinon';
 import { NodeSDK } from '../src';
-import { envDetector, processDetector } from '@opentelemetry/resources';
+import {
+  envDetector,
+  processDetector
+} from '@opentelemetry/resources';
 
 
 const DefaultContextManager = semver.gte(process.version, '14.8.0')
@@ -76,7 +87,7 @@ describe('Node SDK', () => {
       assert.strictEqual(propagation['_getGlobalPropagator'](), propagator, 'propagator should not change');
       assert.strictEqual((trace.getTracerProvider() as ProxyTracerProvider).getDelegate(), delegate, 'tracer provider should not have changed');
 
-      assert.ok(metrics.getMeterProvider() instanceof NoopMeterProvider);
+      assert.ok(!(metrics.getMeterProvider() instanceof MeterProvider));
     });
 
     it('should register a tracer provider if an exporter is provided', async () => {
@@ -87,7 +98,7 @@ describe('Node SDK', () => {
 
       await sdk.start();
 
-      assert.ok(metrics.getMeterProvider() instanceof NoopMeterProvider);
+      assert.ok(!(metrics.getMeterProvider() instanceof MeterProvider));
 
       assert.ok(
         context['_getContextManager']().constructor.name === DefaultContextManager.name
@@ -110,7 +121,7 @@ describe('Node SDK', () => {
 
       await sdk.start();
 
-      assert.ok(metrics.getMeterProvider() instanceof NoopMeterProvider);
+      assert.ok(!(metrics.getMeterProvider() instanceof MeterProvider));
 
       assert.ok(
         context['_getContextManager']().constructor.name === DefaultContextManager.name
@@ -295,7 +306,7 @@ describe('Node SDK', () => {
               throw new Error('Buggy detector');
             }
           },
-          envDetector]
+            envDetector]
         });
         const resource = sdk['_resource'];
 

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -306,7 +306,7 @@ describe('Node SDK', () => {
               throw new Error('Buggy detector');
             }
           },
-            envDetector]
+          envDetector]
         });
         const resource = sdk['_resource'];
 


### PR DESCRIPTION
## Which problem is this PR solving?

`@opentelemetry/api-metrics` exports some classes and constants that are intended for internal use. In an effort to reduce the API surface before declaring metrics GA, this PR replaces the existing wildcard exports with explicit exports.

Related: https://github.com/open-telemetry/opentelemetry-js/issues/3158

## Short description of the changes
Replaces the existing wildcard exports with explicit exports and removes export for:
  - `NoopMeter`
  - `NoopMetric`
  - `NoopCounterMetric`
  - `NoopUpDownCounterMetric`
  - `NoopHistogramMetric`
  - `NoopObservableMetric`
  - `NoopObservableCounterMetric`
  - `NoopObservableGaugeMetric`
  - `NoopObservableUpDownCounterMetric`
  - `NOOP_COUNTER_METRIC`
  - `NOOP_HISTOGRAM_METRIC`
  - `NOOP_UP_DOWN_COUNTER_METRIC`
  - `NOOP_OBSERVABLE_COUNTER_METRIC`
  - `NOOP_OBSERVABLE_GAUGE_METRIC`
  - `NOOP_OBSERVABLE_UP_DOWN_COUNTER_METRIC`
  - `NoopMeterProvider`
  - `NOOP_METER_PROVIDER`

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Existing tests

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
