### PR TITLE
chore(sdk-trace): replace instrumentation library with instrumentation scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ All notable changes to this project will be documented in this file.
 
 ### :rocket: (Enhancement)
 
+* Add `instrumentationScope` property to the `ReadableSpan` interface and deprecate `instrumentationLibrary` [#3202](https://github.com/open-telemetry/opentelemetry-js/pull/3202) @mwear
+
 ### :bug: (Bug Fix)
 
 ### :books: (Refine Doc)
 
 ### :house: (Internal)
-
-* Replace internal references to InstrumentationLibrary with InstrumentationScope [#3202](https://github.com/open-telemetry/opentelemetry-js/pull/3202) @mwear
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 
 ### :house: (Internal)
 
+* Replace internal references to InstrumentationLibrary with InstrumentationScope [#3202](https://github.com/open-telemetry/opentelemetry-js/pull/3202) @mwear
+
 ## 1.6.0
 
 ### :rocket: (Enhancement)

--- a/experimental/packages/exporter-trace-otlp-grpc/test/traceHelper.ts
+++ b/experimental/packages/exporter-trace-otlp-grpc/test/traceHelper.ts
@@ -42,7 +42,7 @@ const traceIdArr = [
 ];
 const spanIdArr = [94, 16, 114, 97, 246, 79, 165, 62];
 const parentIdArr = [120, 168, 145, 80, 152, 134, 67, 136];
-const scope = { name: 'default', version: '0.0.1' }
+const scope = { name: 'default', version: '0.0.1' };
 
 export const mockedReadableSpan: ReadableSpan = {
   name: 'documentFetch',

--- a/experimental/packages/exporter-trace-otlp-grpc/test/traceHelper.ts
+++ b/experimental/packages/exporter-trace-otlp-grpc/test/traceHelper.ts
@@ -42,6 +42,7 @@ const traceIdArr = [
 ];
 const spanIdArr = [94, 16, 114, 97, 246, 79, 165, 62];
 const parentIdArr = [120, 168, 145, 80, 152, 134, 67, 136];
+const scope = { name: 'default', version: '0.0.1' }
 
 export const mockedReadableSpan: ReadableSpan = {
   name: 'documentFetch',
@@ -97,7 +98,8 @@ export const mockedReadableSpan: ReadableSpan = {
     version: 1,
     cost: 112.12,
   })),
-  instrumentationLibrary: { name: 'default', version: '0.0.1' },
+  instrumentationLibrary: scope,
+  instrumentationScope: scope,
 };
 
 export function ensureExportedEventsAreCorrect(

--- a/experimental/packages/exporter-trace-otlp-http/test/traceHelper.ts
+++ b/experimental/packages/exporter-trace-otlp-http/test/traceHelper.ts
@@ -40,7 +40,7 @@ if (typeof Buffer === 'undefined') {
 const traceIdHex = '1f1008dc8e270e85c40a0d7c3939b278';
 const spanIdHex = '5e107261f64fa53e';
 const parentIdHex = '78a8915098864388';
-const scope = { name: 'default', version: '0.0.1' }
+const scope = { name: 'default', version: '0.0.1' };
 export const mockedReadableSpan: ReadableSpan = {
   name: 'documentFetch',
   kind: 0,

--- a/experimental/packages/exporter-trace-otlp-http/test/traceHelper.ts
+++ b/experimental/packages/exporter-trace-otlp-http/test/traceHelper.ts
@@ -15,7 +15,7 @@
  */
 
 import { SpanStatusCode, TraceFlags } from '@opentelemetry/api';
-import { hexToBase64, InstrumentationLibrary, VERSION } from '@opentelemetry/core';
+import { hexToBase64, InstrumentationScope, VERSION } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
@@ -40,7 +40,7 @@ if (typeof Buffer === 'undefined') {
 const traceIdHex = '1f1008dc8e270e85c40a0d7c3939b278';
 const spanIdHex = '5e107261f64fa53e';
 const parentIdHex = '78a8915098864388';
-
+const scope = { name: 'default', version: '0.0.1' }
 export const mockedReadableSpan: ReadableSpan = {
   name: 'documentFetch',
   kind: 0,
@@ -96,7 +96,8 @@ export const mockedReadableSpan: ReadableSpan = {
       version: 1,
       cost: 112.12,
     })),
-  instrumentationLibrary: { name: 'default', version: '0.0.1' },
+  instrumentationLibrary: scope,
+  instrumentationScope: scope,
 };
 
 export const mockedResources: Resource[] = [
@@ -104,7 +105,7 @@ export const mockedResources: Resource[] = [
   new Resource({ name: 'resource 2' }),
 ];
 
-export const mockedInstrumentationLibraries: InstrumentationLibrary[] = [
+export const mockedInstrumentationScopes: InstrumentationScope[] = [
   {
     name: 'lib1',
     version: '0.0.1',
@@ -136,7 +137,8 @@ export const basicTrace: ReadableSpan[] = [
     events: [],
     duration: [0, 8885000],
     resource: mockedResources[0],
-    instrumentationLibrary: mockedInstrumentationLibraries[0],
+    instrumentationLibrary: mockedInstrumentationScopes[0],
+    instrumentationScope: mockedInstrumentationScopes[0],
   },
   {
     name: 'span2',
@@ -158,7 +160,8 @@ export const basicTrace: ReadableSpan[] = [
     events: [],
     duration: [0, 8775000],
     resource: mockedResources[0],
-    instrumentationLibrary: mockedInstrumentationLibraries[0],
+    instrumentationLibrary: mockedInstrumentationScopes[0],
+    instrumentationScope: mockedInstrumentationScopes[0],
   },
   {
     name: 'span3',
@@ -180,7 +183,8 @@ export const basicTrace: ReadableSpan[] = [
     events: [],
     duration: [0, 8775000],
     resource: mockedResources[0],
-    instrumentationLibrary: mockedInstrumentationLibraries[0],
+    instrumentationLibrary: mockedInstrumentationScopes[0],
+    instrumentationScope: mockedInstrumentationScopes[0],
   },
 ];
 
@@ -202,15 +206,18 @@ export const multiResourceTrace: ReadableSpan[] = [
 export const multiInstrumentationLibraryTrace: ReadableSpan[] = [
   {
     ...basicTrace[0],
-    instrumentationLibrary: mockedInstrumentationLibraries[0],
+    instrumentationLibrary: mockedInstrumentationScopes[0],
+    instrumentationScope: mockedInstrumentationScopes[0],
   },
   {
     ...basicTrace[1],
-    instrumentationLibrary: mockedInstrumentationLibraries[0],
+    instrumentationLibrary: mockedInstrumentationScopes[0],
+    instrumentationScope: mockedInstrumentationScopes[0],
   },
   {
     ...basicTrace[2],
-    instrumentationLibrary: mockedInstrumentationLibraries[1],
+    instrumentationLibrary: mockedInstrumentationScopes[1],
+    instrumentationScope: mockedInstrumentationScopes[1],
   },
 ];
 

--- a/experimental/packages/exporter-trace-otlp-proto/test/traceHelper.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/test/traceHelper.ts
@@ -25,6 +25,7 @@ import { IEvent, IExportTraceServiceRequest, IKeyValue, ILink, ISpan } from '@op
 const traceIdHex = '1f1008dc8e270e85c40a0d7c3939b278';
 const spanIdHex = '5e107261f64fa53e';
 const parentIdHex = '78a8915098864388';
+const scope = { name: 'default', version: '0.0.1' };
 
 export const mockedReadableSpan: ReadableSpan = {
   name: 'documentFetch',
@@ -80,7 +81,8 @@ export const mockedReadableSpan: ReadableSpan = {
     version: 1,
     cost: 112.12,
   }),
-  instrumentationLibrary: { name: 'default', version: '0.0.1' },
+  instrumentationLibrary: scope,
+  instrumentationScope: scope,
 };
 
 export function ensureProtoEventsAreCorrect(

--- a/experimental/packages/otlp-grpc-exporter-base/test/traceHelper.ts
+++ b/experimental/packages/otlp-grpc-exporter-base/test/traceHelper.ts
@@ -42,7 +42,7 @@ const traceIdArr = [
 ];
 const spanIdArr = [94, 16, 114, 97, 246, 79, 165, 62];
 const parentIdArr = [120, 168, 145, 80, 152, 134, 67, 136];
-const scope = { name: 'default', version: '0.0.1' }
+const scope = { name: 'default', version: '0.0.1' };
 
 export const mockedReadableSpan: ReadableSpan = {
   name: 'documentFetch',

--- a/experimental/packages/otlp-grpc-exporter-base/test/traceHelper.ts
+++ b/experimental/packages/otlp-grpc-exporter-base/test/traceHelper.ts
@@ -42,6 +42,7 @@ const traceIdArr = [
 ];
 const spanIdArr = [94, 16, 114, 97, 246, 79, 165, 62];
 const parentIdArr = [120, 168, 145, 80, 152, 134, 67, 136];
+const scope = { name: 'default', version: '0.0.1' }
 
 export const mockedReadableSpan: ReadableSpan = {
   name: 'documentFetch',
@@ -97,7 +98,8 @@ export const mockedReadableSpan: ReadableSpan = {
     version: 1,
     cost: 112.12,
   })),
-  instrumentationLibrary: { name: 'default', version: '0.0.1' },
+  instrumentationLibrary: scope,
+  instrumentationScope: scope,
 };
 
 export function ensureExportedEventsAreCorrect(events: IEvent[]) {

--- a/experimental/packages/otlp-transformer/src/trace/index.ts
+++ b/experimental/packages/otlp-transformer/src/trace/index.ts
@@ -36,12 +36,12 @@ function createResourceMap(readableSpans: ReadableSpan[]) {
     }
 
     // TODO this is duplicated in basic tracer. Consolidate on a common helper in core
-    const instrumentationLibraryKey = `${record.instrumentationLibrary.name}@${record.instrumentationLibrary.version || ''}:${record.instrumentationLibrary.schemaUrl || ''}`;
-    let records = ilmMap.get(instrumentationLibraryKey);
+    const instrumentationScopeKey = `${record.instrumentationScope.name}@${record.instrumentationScope.version || ''}:${record.instrumentationScope.schemaUrl || ''}`;
+    let records = ilmMap.get(instrumentationScopeKey);
 
     if (!records) {
       records = [];
-      ilmMap.set(instrumentationLibraryKey, records);
+      ilmMap.set(instrumentationScopeKey, records);
     }
 
     records.push(record);
@@ -64,7 +64,7 @@ function spanRecordsToResourceSpans(readableSpans: ReadableSpan[], useHex?: bool
     while (!ilmEntry.done) {
       const scopeSpans = ilmEntry.value;
       if (scopeSpans.length > 0) {
-        const { name, version, schemaUrl } = scopeSpans[0].instrumentationLibrary;
+        const { name, version, schemaUrl } = scopeSpans[0].instrumentationScope;
         const spans = scopeSpans.map(readableSpan => sdkSpanToOtlpSpan(readableSpan, useHex));
 
         scopeResourceSpans.push({

--- a/experimental/packages/otlp-transformer/test/trace.test.ts
+++ b/experimental/packages/otlp-transformer/test/trace.test.ts
@@ -111,6 +111,11 @@ describe('Trace', () => {
   describe('createExportTraceServiceRequest', () => {
     let resource: Resource;
     let span: ReadableSpan;
+    const scope = {
+      name: 'myLib',
+      version: '0.1.0',
+      schemaUrl: 'http://url.to.schema',
+    }
 
     beforeEach(() => {
       resource = new Resource({
@@ -138,11 +143,8 @@ describe('Trace', () => {
             }
           }
         ],
-        instrumentationLibrary: {
-          name: 'myLib',
-          version: '0.1.0',
-          schemaUrl: 'http://url.to.schema',
-        },
+        instrumentationLibrary: scope,
+        instrumentationScope: scope,
         kind: SpanKind.CLIENT,
         links: [
           {

--- a/experimental/packages/otlp-transformer/test/trace.test.ts
+++ b/experimental/packages/otlp-transformer/test/trace.test.ts
@@ -115,7 +115,7 @@ describe('Trace', () => {
       name: 'myLib',
       version: '0.1.0',
       schemaUrl: 'http://url.to.schema',
-    }
+    };
 
     beforeEach(() => {
       resource = new Resource({

--- a/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
@@ -26,6 +26,10 @@ import * as nock from 'nock';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 
 describe('JaegerExporter', () => {
+  const scope = {
+    name: 'default',
+    version: '0.0.1',
+  }
   const readableSpan: ReadableSpan = {
     name: 'my-span1',
     kind: api.SpanKind.CLIENT,
@@ -49,10 +53,8 @@ describe('JaegerExporter', () => {
     resource: new Resource({
       [SemanticResourceAttributes.SERVICE_NAME]: 'opentelemetry'
     }),
-    instrumentationLibrary: {
-      name: 'default',
-      version: '0.0.1',
-    },
+    instrumentationLibrary: scope,
+    instrumentationScope: scope,
   };
   describe('constructor', () => {
     afterEach(() => {

--- a/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
@@ -29,7 +29,7 @@ describe('JaegerExporter', () => {
   const scope = {
     name: 'default',
     version: '0.0.1',
-  }
+  };
   const readableSpan: ReadableSpan = {
     name: 'my-span1',
     kind: api.SpanKind.CLIENT,

--- a/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
@@ -31,6 +31,10 @@ describe('transform', () => {
       traceFlags: TraceFlags.NONE,
     };
   };
+  const scope = {
+    name: 'default',
+    version: '0.0.1',
+  };
 
   describe('spanToThrift', () => {
     it('should convert an OpenTelemetry span to a Thrift', () => {
@@ -78,10 +82,8 @@ describe('transform', () => {
           version: 1,
           cost: 112.12,
         }),
-        instrumentationLibrary: {
-          name: 'default',
-          version: '0.0.1',
-        },
+        instrumentationLibrary: scope,
+        instrumentationScope: scope,
       };
 
       const thriftSpan = spanToThrift(readableSpan);
@@ -166,10 +168,8 @@ describe('transform', () => {
         events: [],
         duration: [32, 800000000],
         resource: Resource.empty(),
-        instrumentationLibrary: {
-          name: 'default',
-          version: '0.0.1',
-        },
+        instrumentationLibrary: scope,
+        instrumentationScope: scope,
       };
 
       const thriftSpan = spanToThrift(readableSpan);
@@ -233,10 +233,8 @@ describe('transform', () => {
         events: [],
         duration: [32, 800000000],
         resource: Resource.empty(),
-        instrumentationLibrary: {
-          name: 'default',
-          version: '0.0.1',
-        },
+        instrumentationLibrary: scope,
+        instrumentationScope: scope,
       };
 
       const thriftSpan = spanToThrift(readableSpan);
@@ -278,10 +276,8 @@ describe('transform', () => {
         events: [],
         duration: [32, 800000000],
         resource: Resource.empty(),
-        instrumentationLibrary: {
-          name: 'default',
-          version: '0.0.1',
-        },
+        instrumentationLibrary: scope,
+        instrumentationScope: scope,
       };
 
       const thriftSpan = spanToThrift(readableSpan);
@@ -340,10 +336,8 @@ describe('transform', () => {
           version: 1,
           cost: 112.12,
         }),
-        instrumentationLibrary: {
-          name: 'default',
-          version: '0.0.1',
-        },
+        instrumentationLibrary: scope,
+        instrumentationScope: scope,
       };
       let thriftSpan = spanToThrift(readableSpan);
       assert.strictEqual(

--- a/packages/opentelemetry-exporter-zipkin/test/helper.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/helper.ts
@@ -20,6 +20,7 @@ import { Resource } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import { Span } from '../src/types';
 
+const scope = { name: 'default', version: '0.0.1' }
 export const mockedReadableSpan: ReadableSpan = {
   name: 'documentFetch',
   kind: 0,
@@ -44,7 +45,8 @@ export const mockedReadableSpan: ReadableSpan = {
     version: 1,
     cost: 112.12,
   }),
-  instrumentationLibrary: { name: 'default', version: '0.0.1' },
+  instrumentationLibrary: scope,
+  instrumentationScope: scope,
 };
 
 export function ensureHeadersContain(

--- a/packages/opentelemetry-exporter-zipkin/test/helper.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/helper.ts
@@ -20,7 +20,7 @@ import { Resource } from '@opentelemetry/resources';
 import * as assert from 'assert';
 import { Span } from '../src/types';
 
-const scope = { name: 'default', version: '0.0.1' }
+const scope = { name: 'default', version: '0.0.1' };
 export const mockedReadableSpan: ReadableSpan = {
   name: 'documentFetch',
   kind: 0,

--- a/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
@@ -34,6 +34,7 @@ const MICROS_PER_SECS = 1e6;
 function getReadableSpan() {
   const startTime = 1566156729709;
   const duration = 2000;
+  const instrumentationScope = { name: 'default', version: '0.0.1' };
   const readableSpan: ReadableSpan = {
     name: 'my-span',
     kind: api.SpanKind.INTERNAL,
@@ -55,7 +56,8 @@ function getReadableSpan() {
     links: [],
     events: [],
     resource: Resource.empty(),
-    instrumentationLibrary: { name: 'default', version: '0.0.1' },
+    instrumentationLibrary: instrumentationScope,
+    instrumentationScope: instrumentationScope,
   };
   return readableSpan;
 }
@@ -131,7 +133,7 @@ describe('Zipkin Exporter - node', () => {
       const parentSpanId = '5c1c63257de34c67';
       const startTime = 1566156729709;
       const duration = 2000;
-
+      const instrumentationScope = { name: 'default', version: '0.0.1' };
       const span1: ReadableSpan = {
         name: 'my-span',
         kind: api.SpanKind.INTERNAL,
@@ -163,7 +165,8 @@ describe('Zipkin Exporter - node', () => {
           },
         ],
         resource: Resource.empty(),
-        instrumentationLibrary: { name: 'default', version: '0.0.1' },
+        instrumentationLibrary: instrumentationScope,
+        instrumentationScope: instrumentationScope,
       };
       const span2: ReadableSpan = {
         name: 'my-span',
@@ -186,7 +189,8 @@ describe('Zipkin Exporter - node', () => {
         links: [],
         events: [],
         resource: Resource.empty(),
-        instrumentationLibrary: { name: 'default', version: '0.0.1' },
+        instrumentationLibrary: instrumentationScope,
+        instrumentationScope: instrumentationScope,
       };
 
       const exporter = new ZipkinExporter({
@@ -347,7 +351,7 @@ describe('Zipkin Exporter - node', () => {
     const parentSpanId = '5c1c63257de34c67';
     const startTime = 1566156729709;
     const duration = 2000;
-
+    const instrumentationScope = { name: 'default', version: '0.0.1' };
     const span1: ReadableSpan = {
       name: 'my-span',
       kind: api.SpanKind.INTERNAL,
@@ -379,7 +383,8 @@ describe('Zipkin Exporter - node', () => {
       resource: new Resource({
         [SemanticResourceAttributes.SERVICE_NAME]: resource_service_name,
       }),
-      instrumentationLibrary: { name: 'default', version: '0.0.1' },
+      instrumentationLibrary: instrumentationScope,
+      instrumentationScope: instrumentationScope,
     };
     const span2: ReadableSpan = {
       name: 'my-span',
@@ -402,7 +407,8 @@ describe('Zipkin Exporter - node', () => {
       resource: new Resource({
         [SemanticResourceAttributes.SERVICE_NAME]: resource_service_name_prime,
       }),
-      instrumentationLibrary: { name: 'default', version: '0.0.1' },
+      instrumentationLibrary: instrumentationScope,
+      instrumentationScope: instrumentationScope,
     };
 
     const exporter = new ZipkinExporter({});
@@ -436,6 +442,7 @@ describe('Zipkin Exporter - node', () => {
     const parentSpanId = '5c1c63257de34c67';
     const startTime = 1566156729709;
     const duration = 2000;
+    const instrumentationScope = { name: 'default', version: '0.0.1' };
 
     const span1: ReadableSpan = {
       name: 'my-span',
@@ -467,7 +474,8 @@ describe('Zipkin Exporter - node', () => {
         },
       ],
       resource: Resource.empty(),
-      instrumentationLibrary: { name: 'default', version: '0.0.1' },
+      instrumentationLibrary: instrumentationScope,
+      instrumentationScope: instrumentationScope,
     };
     const span2: ReadableSpan = {
       name: 'my-span',
@@ -490,7 +498,8 @@ describe('Zipkin Exporter - node', () => {
       links: [],
       events: [],
       resource: Resource.empty(),
-      instrumentationLibrary: { name: 'default', version: '0.0.1' },
+      instrumentationLibrary: instrumentationScope,
+      instrumentationScope: instrumentationScope,
     };
 
     const exporter = new ZipkinExporter({});

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -20,6 +20,7 @@ import {
   hrTime,
   hrTimeDuration,
   InstrumentationLibrary,
+  InstrumentationScope,
   isTimeInput,
   timeInputToHrTime,
   sanitizeAttributes,
@@ -48,6 +49,10 @@ export class Span implements api.Span, ReadableSpan {
   readonly events: TimedEvent[] = [];
   readonly startTime: api.HrTime;
   readonly resource: Resource;
+  readonly instrumentationScope: InstrumentationScope;
+  // instrumentationLibrary is an alias for instrumentationScope and
+  // is retained for backwards compatibility and to satisfy the
+  // ReadableSpan interface
   readonly instrumentationLibrary: InstrumentationLibrary;
   name: string;
   status: api.SpanStatus = {
@@ -78,7 +83,8 @@ export class Span implements api.Span, ReadableSpan {
     this.links = links;
     this.startTime = timeInputToHrTime(startTime);
     this.resource = parentTracer.resource;
-    this.instrumentationLibrary = parentTracer.instrumentationLibrary;
+    this.instrumentationLibrary = parentTracer.instrumentationScope as InstrumentationLibrary;
+    this.instrumentationScope = parentTracer.instrumentationScope;
     this._spanLimits = parentTracer.getSpanLimits();
     this._spanProcessor = parentTracer.getActiveSpanProcessor();
     this._spanProcessor.onStart(this, context);

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -83,7 +83,7 @@ export class Span implements api.Span, ReadableSpan {
     this.links = links;
     this.startTime = timeInputToHrTime(startTime);
     this.resource = parentTracer.resource;
-    this.instrumentationLibrary = parentTracer.instrumentationScope as InstrumentationLibrary;
+    this.instrumentationLibrary = parentTracer.instrumentationScope;
     this.instrumentationScope = parentTracer.instrumentationScope;
     this._spanLimits = parentTracer.getSpanLimits();
     this._spanProcessor = parentTracer.getActiveSpanProcessor();

--- a/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
@@ -16,7 +16,7 @@
 
 import * as api from '@opentelemetry/api';
 import {
-  InstrumentationLibrary,
+  InstrumentationScope,
   sanitizeAttributes,
   isTracingSuppressed,
 } from '@opentelemetry/core';
@@ -39,13 +39,13 @@ export class Tracer implements api.Tracer {
   private readonly _spanLimits: SpanLimits;
   private readonly _idGenerator: IdGenerator;
   readonly resource: Resource;
-  readonly instrumentationLibrary: InstrumentationLibrary;
+  readonly instrumentationScope: InstrumentationScope;
 
   /**
    * Constructs a new Tracer instance.
    */
   constructor(
-    instrumentationLibrary: InstrumentationLibrary,
+    instrumentationScope: InstrumentationScope,
     config: TracerConfig,
     private _tracerProvider: BasicTracerProvider
   ) {
@@ -55,7 +55,7 @@ export class Tracer implements api.Tracer {
     this._spanLimits = localConfig.spanLimits;
     this._idGenerator = config.idGenerator || new RandomIdGenerator();
     this.resource = _tracerProvider.resource;
-    this.instrumentationLibrary = instrumentationLibrary;
+    this.instrumentationScope = instrumentationScope;
   }
 
   /**

--- a/packages/opentelemetry-sdk-trace-base/src/export/ReadableSpan.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/ReadableSpan.ts
@@ -23,7 +23,7 @@ import {
   SpanContext,
 } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
-import { InstrumentationLibrary } from '@opentelemetry/core';
+import { InstrumentationLibrary, InstrumentationScope } from '@opentelemetry/core';
 import { TimedEvent } from '../TimedEvent';
 
 export interface ReadableSpan {
@@ -40,5 +40,9 @@ export interface ReadableSpan {
   readonly duration: HrTime;
   readonly ended: boolean;
   readonly resource: Resource;
+  readonly instrumentationScope: InstrumentationScope;
+  /**
+   * @deprecated use `instrumentationScope` instead
+   */
   readonly instrumentationLibrary: InstrumentationLibrary;
 }

--- a/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
@@ -25,7 +25,6 @@ import {
   SpanAttributes,
   SpanAttributeValue,
 } from '@opentelemetry/api';
-import { InstrumentationScope } from '@opentelemetry/core';
 import {
   DEFAULT_ATTRIBUTE_COUNT_LIMIT,
   DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT,
@@ -752,7 +751,7 @@ describe('Span', () => {
     assert.deepStrictEqual(span.events, []);
     assert.ok(span.instrumentationLibrary);
     assert.ok(span.instrumentationScope);
-    assert.strictEqual(span.instrumentationScope, span.instrumentationLibrary as InstrumentationScope);
+    assert.strictEqual(span.instrumentationScope, span.instrumentationLibrary);
     const { name, version } = span.instrumentationScope;
     assert.strictEqual(name, 'default');
     assert.strictEqual(version, undefined);

--- a/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
@@ -25,6 +25,7 @@ import {
   SpanAttributes,
   SpanAttributeValue,
 } from '@opentelemetry/api';
+import { InstrumentationScope } from '@opentelemetry/core';
 import {
   DEFAULT_ATTRIBUTE_COUNT_LIMIT,
   DEFAULT_ATTRIBUTE_VALUE_LENGTH_LIMIT,
@@ -749,9 +750,10 @@ describe('Span', () => {
     assert.deepStrictEqual(span.attributes, {});
     assert.deepStrictEqual(span.links, []);
     assert.deepStrictEqual(span.events, []);
-
     assert.ok(span.instrumentationLibrary);
-    const { name, version } = span.instrumentationLibrary;
+    assert.ok(span.instrumentationScope);
+    assert.strictEqual(span.instrumentationScope, span.instrumentationLibrary as InstrumentationScope);
+    const { name, version } = span.instrumentationScope;
     assert.strictEqual(name, 'default');
     assert.strictEqual(version, undefined);
   });

--- a/packages/opentelemetry-sdk-trace-base/test/common/Tracer.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Tracer.test.ts
@@ -28,7 +28,7 @@ import {
 } from '@opentelemetry/api';
 import { getSpan } from '@opentelemetry/api/build/src/trace/context-utils';
 import {
-  InstrumentationLibrary,
+  InstrumentationScope,
   sanitizeAttributes,
   suppressTracing
 } from '@opentelemetry/core';
@@ -150,14 +150,14 @@ describe('Tracer', () => {
     span.end();
   });
 
-  it('should have an instrumentationLibrary', () => {
+  it('should have an instrumentationScope', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       {},
       tracerProvider
     );
 
-    const lib: InstrumentationLibrary = tracer.instrumentationLibrary;
+    const lib: InstrumentationScope = tracer.instrumentationScope;
 
     assert.strictEqual(lib.name, 'default');
     assert.strictEqual(lib.version, '0.0.1');


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #2937

## Short description of the changes

This PR updates internal references of `InstrumentationLibrary` to `InstrumentationScope`. In order to do this in a backwards compatible manner, `instrumentationScope` was added to `ReadableSpan` and the `instrumentationLibrary` property was preserved, but marked as deprecated. Unfortunately, we need both properties in our test fixtures to satisfy the `ReadableSpan` interface for the time being.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests have been updated.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
