### PR TITLE
chore: cleanup eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,7 +45,6 @@ module.exports = {
             "leadingUnderscore": "require"
           }
         ],
-        "@typescript-eslint/no-shadow": ["warn"],
         "@typescript-eslint/no-unused-vars": ["error", {"argsIgnorePattern": "^_", "args": "after-used"}],
         "@typescript-eslint/no-inferrable-types": ["error", { ignoreProperties: true }],
         "@typescript-eslint/no-empty-function": ["off"],
@@ -65,7 +64,6 @@ module.exports = {
         "@typescript-eslint/ban-ts-ignore": "off",
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-floating-promises": 1,
         "@typescript-eslint/no-unused-vars": "off",
         "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/no-shadow": ["off"],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,7 @@ module.exports = {
     "indent": ["error", 2, { "SwitchCase": 1 }],
     "no-trailing-spaces": "error",
     "eol-last": "error",
-    "quotes": [2, "single", { "avoidEscape": true }],
+    "quotes": ["error", "single", { "avoidEscape": true }],
     "brace-style": ["error", "1tbs"],
     "eqeqeq": [
       "error",
@@ -24,7 +24,7 @@ module.exports = {
     "no-shadow": "off",
     "arrow-parens": ["error", "as-needed"],
     "node/no-deprecated-api": ["warn"],
-    "header/header": [2, "block", [{
+    "header/header": ["error", "block", [{
       pattern: / \* Copyright The OpenTelemetry Authors[\r\n]+ \*[\r\n]+ \* Licensed under the Apache License, Version 2\.0 \(the \"License\"\);[\r\n]+ \* you may not use this file except in compliance with the License\.[\r\n]+ \* You may obtain a copy of the License at[\r\n]+ \*[\r\n]+ \*      https:\/\/www\.apache\.org\/licenses\/LICENSE-2\.0[\r\n]+ \*[\r\n]+ \* Unless required by applicable law or agreed to in writing, software[\r\n]+ \* distributed under the License is distributed on an \"AS IS\" BASIS,[\r\n]+ \* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.[\r\n]+ \* See the License for the specific language governing permissions and[\r\n]+ \* limitations under the License\./gm,
       template:
         `\n * Copyright The OpenTelemetry Authors\n *\n * Licensed under the Apache License, Version 2.0 (the "License");\n * you may not use this file except in compliance with the License.\n * You may obtain a copy of the License at\n *\n *      https://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required by applicable law or agreed to in writing, software\n * distributed under the License is distributed on an "AS IS" BASIS,\n * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n * See the License for the specific language governing permissions and\n * limitations under the License.\n `
@@ -34,7 +34,7 @@ module.exports = {
     {
       files: ['*.ts'],
       rules: {
-        "@typescript-eslint/no-floating-promises": 2,
+        "@typescript-eslint/no-floating-promises": "error",
         "@typescript-eslint/no-this-alias": "off",
         "@typescript-eslint/naming-convention": [
           "error",


### PR DESCRIPTION
## Which problem is this PR solving?

`eslint` rules `@typescript-eslint/no-shadow` (for `*.ts`) and `@typescript-eslint/no-floating-promises` (for `test/**/*.ts`)  were duplicated. 

This PR removes the duplicated `@typescript-eslint/no-shadow` rule and uses the newer entry for `@typescript-eslint/no-floating-promises`.
