### PR TITLE
chore(deps): update prometheus example dependencies to 0.32

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to experimental packages in this project will be documented 
 * feature(add-console-metrics-exporter): add ConsoleMetricExporter [#3120](https://github.com/open-telemetry/opentelemetry-js/pull/3120) @weyert
 * feature(prometheus-serialiser): export the unit block when unit is set in metric descriptor [#3066](https://github.com/open-telemetry/opentelemetry-js/pull/3041) @weyert
 * feat: support latest `@opentelemetry/api` [#3177](https://github.com/open-telemetry/opentelemetry-js/pull/3177) @dyladan
+* chore(deps): update prometheus example dependencies to 0.32 [#3126](https://github.com/open-telemetry/opentelemetry-js/pull/3216) @avzis
 
 ### :bug: (Bug Fix)
 

--- a/experimental/examples/prometheus/package.json
+++ b/experimental/examples/prometheus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prometheus-example",
-  "version": "0.28.0",
-  "description": "Example of using @opentelemetry/sdk-metrics-base and  @opentelemetry/exporter-prometheus",
+  "version": "0.32.0",
+  "description": "Example of using @opentelemetry/sdk-metrics and @opentelemetry/exporter-prometheus",
   "main": "index.js",
   "scripts": {
     "start": "node index.js"
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/api": "^1.0.2",
-    "@opentelemetry/exporter-prometheus": "0.28.0",
-    "@opentelemetry/sdk-metrics-base": "0.28.0"
+    "@opentelemetry/exporter-prometheus": "0.32.0",
+    "@opentelemetry/sdk-metrics": "0.32.0"
   }
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Update outdated prometheus example

Fixes #3165 

## Short description of the changes

Updated dependencies from 0.28.0 to the latest (0.32.0)

## How Has This Been Tested?

Using the demo app that is included, which demonstrates basic metrics collection and exports those metrics to a Prometheus endpoint
