### PR TITLE
fix(build): rollback linkinator to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "gh-pages": "4.0.0",
     "lerna": "5.4.3",
     "lerna-changelog": "2.2.0",
-    "linkinator": "4.0.2",
+    "linkinator": "3.0.3",
     "markdownlint-cli": "0.29.0",
     "semver": "7.3.5",
     "typedoc": "0.22.10",


### PR DESCRIPTION
## Which problem is this PR solving?

Hypothesis: For some reason it looks like the type definitions for `responselike` are missing and this is failing the build while compiling. `linkinator` depends on this package, and rolling it back to `3.0.3` seems to fix the issue. This issue also only seems to happen in CI and I could not reproduce it on my machine or in docker.

Re-running builds on commits that previously passed now also fail. So this might also be related to caching. 

See this week-old commit as an example: 
  - [first attempt from 7 days ago](https://github.com/open-telemetry/opentelemetry-js/actions/runs/2951643982/attempts/1)
  - [second attempt from today](https://github.com/open-telemetry/opentelemetry-js/actions/runs/2951643982/attempts/2)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
