### PR TITLE
fix: span log with nested attribute value serialized

### DIFF
--- a/packages/opentelemetry-core/src/common/attributes.ts
+++ b/packages/opentelemetry-core/src/common/attributes.ts
@@ -16,6 +16,19 @@
 
 import { diag, SpanAttributeValue, SpanAttributes } from '@opentelemetry/api';
 
+function serializeNonPrimitiveAttributeValue(
+  key: string,
+  value: unknown
+): SpanAttributeValue | undefined {
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch (error) {
+      diag.warn(`Invalid attribute value set for key: ${key}`);
+    }
+  }
+}
+
 export function sanitizeAttributes(attributes: unknown): SpanAttributes {
   const out: SpanAttributes = {};
 
@@ -29,7 +42,7 @@ export function sanitizeAttributes(attributes: unknown): SpanAttributes {
       continue;
     }
     if (!isAttributeValue(val)) {
-      diag.warn(`Invalid attribute value set for key: ${key}`);
+      out[key] = serializeNonPrimitiveAttributeValue(key, val);
       continue;
     }
     if (Array.isArray(val)) {

--- a/packages/opentelemetry-core/src/common/attributes.ts
+++ b/packages/opentelemetry-core/src/common/attributes.ts
@@ -20,7 +20,7 @@ function serializeNonPrimitiveAttributeValue(
   key: string,
   value: unknown
 ): SpanAttributeValue | undefined {
-  if (typeof value === 'object') {
+  if (typeof value === 'object' && Array.isArray(value)) {
     try {
       return JSON.stringify(value);
     } catch (error) {

--- a/packages/opentelemetry-core/test/common/attributes.test.ts
+++ b/packages/opentelemetry-core/test/common/attributes.test.ts
@@ -14,93 +14,107 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
+import * as assert from "assert";
 import {
   isAttributeValue,
   sanitizeAttributes,
-} from '../../src/common/attributes';
+} from "../../src/common/attributes";
 
-describe('attributes', () => {
-  describe('#isAttributeValue', () => {
-    it('should allow primitive values', () => {
+describe("attributes", () => {
+  describe("#isAttributeValue", () => {
+    it("should allow primitive values", () => {
       assert.ok(isAttributeValue(0));
       assert.ok(isAttributeValue(true));
-      assert.ok(isAttributeValue('str'));
+      assert.ok(isAttributeValue("str"));
     });
 
-    it('should allow nullish values', () => {
+    it("should allow nullish values", () => {
       assert.ok(isAttributeValue(null));
       assert.ok(isAttributeValue(undefined));
       // @ts-expect-error verify that no arg works
       assert.ok(isAttributeValue());
     });
 
-    it('should not allow objects', () => {
+    it("should not allow objects", () => {
       assert.ok(!isAttributeValue({}));
     });
 
-    it('should allow homogeneous arrays', () => {
+    it("should allow homogeneous arrays", () => {
       assert.ok(isAttributeValue([]));
       assert.ok(isAttributeValue([0, 1, 2]));
       assert.ok(isAttributeValue([true, false, true]));
-      assert.ok(isAttributeValue(['str1', 'str2', 'str3']));
+      assert.ok(isAttributeValue(["str1", "str2", "str3"]));
     });
 
-    it('should allow homogeneous arrays with null values', () => {
+    it("should allow homogeneous arrays with null values", () => {
       assert.ok(isAttributeValue([null]));
       assert.ok(isAttributeValue([0, null, 2]));
       assert.ok(isAttributeValue([true, null, true]));
-      assert.ok(isAttributeValue(['str1', undefined, 'str3']));
+      assert.ok(isAttributeValue(["str1", undefined, "str3"]));
     });
 
-    it('should not allow heterogeneous arrays', () => {
+    it("should not allow heterogeneous arrays", () => {
       assert.ok(!isAttributeValue([0, false, 2]));
-      assert.ok(!isAttributeValue([true, 'false', true]));
-      assert.ok(!isAttributeValue(['str1', 2, 'str3']));
+      assert.ok(!isAttributeValue([true, "false", true]));
+      assert.ok(!isAttributeValue(["str1", 2, "str3"]));
     });
 
-    it('should not allow arrays of objects or nested arrays', () => {
+    it("should not allow arrays of objects or nested arrays", () => {
       assert.ok(!isAttributeValue([{}]));
       assert.ok(!isAttributeValue([[]]));
     });
   });
-  describe('#sanitize', () => {
-    it('should remove invalid fields', () => {
+  describe("#sanitize", () => {
+    it("should remove invalid fields", () => {
       const attributes = sanitizeAttributes({
-        str: 'string',
+        str: "string",
         num: 0,
         bool: false,
         object: {},
-        arrStr: ['str1', null, 'str2'],
+        arrStr: ["str1", null, "str2"],
         arrNum: [0, null, 1],
         arrBool: [false, undefined, true],
         mixedArr: [0, false],
       });
 
       assert.deepStrictEqual(attributes, {
-        str: 'string',
+        str: "string",
         num: 0,
         bool: false,
-        arrStr: ['str1', null, 'str2'],
+        object: "{}",
+        arrStr: ["str1", null, "str2"],
         arrNum: [0, null, 1],
         arrBool: [false, undefined, true],
       });
     });
 
-    it('should copy the input', () => {
+    it("should serialize nested fields", () => {
+      const nested = {
+        test: "shouldBePassed",
+      };
+      const attributes = sanitizeAttributes({
+        nested,
+      });
+
+      assert.deepStrictEqual(attributes, {
+        nested: JSON.stringify(nested),
+      });
+    });
+
+    it("should copy the input", () => {
       const inp = {
-        str: 'unmodified',
-        arr: ['unmodified'],
+        str: "unmodified",
+        arr: ["unmodified"],
       };
 
       const attributes = sanitizeAttributes(inp);
 
-      inp.str = 'modified';
-      inp.arr[0] = 'modified';
+      inp.str = "modified";
+      inp.arr[0] = "modified";
 
-      assert.strictEqual(attributes.str, 'unmodified');
+      assert.strictEqual(attributes.str, "unmodified");
       assert.ok(Array.isArray(attributes.arr));
-      assert.strictEqual(attributes.arr[0], 'unmodified');
+      assert.strictEqual(attributes.arr[0], "unmodified");
     });
   });
 });


### PR DESCRIPTION
This PR fixes Issue #3234 

## Short description of the changes
I added JSON.parse serializer for nested log properties

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Tested with Unit tests and Nodejs Debugging 


## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
