### PR TITLE
chore: upgrade linkinator to 4.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "gh-pages": "4.0.0",
     "lerna": "5.4.3",
     "lerna-changelog": "2.2.0",
-    "linkinator": "3.0.3",
+    "linkinator": "4.0.3",
     "markdownlint-cli": "0.29.0",
     "semver": "7.3.5",
     "typedoc": "0.22.10",


### PR DESCRIPTION
## Which problem is this PR solving?

We previously rolled back `linkinator` to `3.0.3` due to some typing issues (#3231) that were introduced by the newer version. `4.0.3` of linkinator fixes this issue by dropping the dependency to `update-notifier` which used `responselike` down the chain.

Additional info:
 - https://github.com/JustinBeckwith/linkinator/pull/519
 - https://github.com/JustinBeckwith/linkinator/releases/tag/4.0.3

## How Has This Been Tested?

- [x] Running in CI

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
