### PR TITLE
chore(sdk-metrics): remove accidental export of the SDK Meter class

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to experimental packages in this project will be documented 
     * `NoopObservableMetric`
     * `NoopObservableUpDownCounterMetric`
     * `NoopUpDownCounterMetric`
+* chore(sdk-metrics): remove accidental export of the SDK `Meter` class [#3243](https://github.com/open-telemetry/opentelemetry-js/pull/3243) @pichlermarc
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/opentelemetry-sdk-metrics/src/index.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/src/index.ts
@@ -68,10 +68,6 @@ export {
 } from './InstrumentDescriptor';
 
 export {
-  Meter,
-} from './Meter';
-
-export {
   MeterProvider,
   MeterProviderOptions,
 } from './MeterProvider';

--- a/experimental/packages/opentelemetry-sdk-metrics/test/MeterProvider.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/test/MeterProvider.test.ts
@@ -15,7 +15,7 @@
  */
 
 import * as assert from 'assert';
-import { Meter, MeterProvider, InstrumentType, DataPointType } from '../src';
+import { MeterProvider, InstrumentType, DataPointType } from '../src';
 import {
   assertScopeMetrics,
   assertMetricData,
@@ -25,6 +25,7 @@ import {
 import { TestMetricReader } from './export/TestMetricReader';
 import * as sinon from 'sinon';
 import { View } from '../src/view/View';
+import { Meter } from '../src/Meter';
 
 describe('MeterProvider', () => {
   afterEach(() => {

--- a/experimental/packages/opentelemetry-sdk-metrics/test/state/MeterSharedState.test.ts
+++ b/experimental/packages/opentelemetry-sdk-metrics/test/state/MeterSharedState.test.ts
@@ -17,7 +17,6 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import {
-  Meter,
   MeterProvider,
   DataPointType,
   View,
@@ -29,6 +28,7 @@ import { assertMetricData, defaultInstrumentationScope, defaultResource, sleep }
 import { TestDeltaMetricReader, TestMetricReader } from '../export/TestMetricReader';
 import { MeterSharedState } from '../../src/state/MeterSharedState';
 import { CollectionResult } from '../../src/export/MetricData';
+import { Meter } from '../../src/Meter';
 
 describe('MeterSharedState', () => {
   afterEach(() => {


### PR DESCRIPTION
## Which problem is this PR solving?

Looks like I missed the export of the SDKs `Meter` during the SDK clean up in #3197. This PR removes the export for `Meter` as the API's `Meter` interface is supposed to be used instead.

Related #3158

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Existing tests

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
