### PR TITLE
deps: remove unused protobufjs and update used ones to 7.1.1

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :house: (Internal)
 
 * ci(instrumentation-http): improve metrics test stability [#3242](https://github.com/open-telemetry/opentelemetry-js/pull/3242) @pichlermarc
+* deps: remove unused protobufjs and update used ones to 7.1.1 #3251 [#3251](https://github.com/open-telemetry/opentelemetry-js/pull/3251) @pichlermarc
 
 ## 0.32.0
 

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -72,8 +72,7 @@
     "@opentelemetry/otlp-proto-exporter-base": "0.32.0",
     "@opentelemetry/otlp-transformer": "0.32.0",
     "@opentelemetry/resources": "1.6.0",
-    "@opentelemetry/sdk-trace-base": "1.6.0",
-    "protobufjs": "^6.9.0"
+    "@opentelemetry/sdk-trace-base": "1.6.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto"
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -74,8 +74,7 @@
     "@opentelemetry/otlp-proto-exporter-base": "0.32.0",
     "@opentelemetry/otlp-transformer": "0.32.0",
     "@opentelemetry/resources": "1.6.0",
-    "@opentelemetry/sdk-metrics": "0.32.0",
-    "protobufjs": "^6.9.0"
+    "@opentelemetry/sdk-metrics": "0.32.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto"
 }

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -52,7 +52,7 @@
     "codecov": "3.8.3",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
-    "protobufjs": "6.11.3",
+    "protobufjs-cli": "^1.0.2",
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
@@ -65,7 +65,8 @@
   "dependencies": {
     "@grpc/proto-loader": "^0.6.9",
     "@opentelemetry/core": "1.6.0",
-    "@opentelemetry/otlp-exporter-base": "0.32.0"
+    "@opentelemetry/otlp-exporter-base": "0.32.0",
+    "protobufjs": "7.1.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-proto-exporter-base"
 }

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -69,7 +69,6 @@
     "mkdirp": "1.0.4",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
-    "protobufjs": "6.11.3",
     "rimraf": "3.0.2",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",


### PR DESCRIPTION
## Which problem is this PR solving?

`protobufjs` was oudated and unused in some packages. This PR: 

- Moves the dependency on `protobufjs` from `@opentelemetry/exporter-trace-otlp-proto` and `@opentelemetry/exporter-metrics-otlp-proto` to `@opentelemetry/otlp-proto-exporter-base`.
- Removes the dependency on `protobufjs` from `@opentelemetry/otlp-transformer` as it is not used there.
- Adds a dev dependency on `protobufjs-cli` to `@opentelemetry/otlp-proto-exporter-base`, as the CLI has been moved to its own package in https://github.com/protobufjs/protobuf.js/releases/tag/protobufjs-v7.0.0
- Updates all dependencies to `protobufjs` to `7.1.1`

Supersedes #3164

## How Has This Been Tested?

- [x] Existing tests

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
