### PR TITLE
deps: update markdownlint-cli to 0.32.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
 
 ### :house: (Internal)
 
+* deps: update markdownlint-cli to 0.32.2 [#3253](https://github.com/open-telemetry/opentelemetry-js/pull/3253) @pichlermarc
+
 ## 1.6.0
 
 ### :rocket: (Enhancement)

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "lerna": "5.4.3",
     "lerna-changelog": "2.2.0",
     "linkinator": "4.0.3",
-    "markdownlint-cli": "0.29.0",
+    "markdownlint-cli": "0.32.2",
     "semver": "7.3.5",
     "typedoc": "0.22.10",
     "typescript": "4.4.4",


### PR DESCRIPTION
## Which problem is this PR solving?

`markdownlint-cli` was outdated, and `npm audit` complained about it. This PR updates the package to `0.32.2`. :slightly_smiling_face:

## How Has This Been Tested?

- ran the new version of `markdownlint` with the `npm lint:markdown` script included in `package.json` which prompted the changes in #3252 

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
