### PR TITLE
chore: ignore @opentelemetry/api in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,16 +7,12 @@
       "matchUpdateTypes": ["patch", "minor"]
     },
     {
-      "matchPackageNames": ["@opentelemetry/api"],
-      "rangeStrategy": "bump"
-    },
-    {
       "matchPaths": ["backwards-compatibility"],
       "matchPackageNames": ["@types/node"],
       "enabled": false
     }
   ],
-  "ignoreDeps": ["gcp-metadata", "got", "mocha", "husky", "karma-webpack"],
+  "ignoreDeps": ["gcp-metadata", "got", "mocha", "husky", "karma-webpack", "@opentelemetry/api"],
   "assignees": ["@blumamir", "@dyladan", "@legendecas", "@Rauno56", "@vmarchaud"],
   "schedule": ["before 3am on Friday"],
   "labels": ["dependencies"]


### PR DESCRIPTION
## Which problem is this PR solving?

Renovate Bot often tries to bump `@opentelemetry/api` to new versions and lumps that in together with other package updates. This makes renovate bot's PRs hard to impossible to merge. For most packages in this repository, `@opentelemetry/api` is kept at an older version on purpose to ensure maximum compatibility. Any updates should most likely be a conscious decision. 

See #3156

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
