### PR TITLE
feat(sdk-trace): re-export sdk-trace-base in sdk-trace-node and web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### :rocket: (Enhancement)
 
+* feat(sdk-trace): re-export sdk-trace-base in sdk-trace-node and web [#3319](https://github.com/open-telemetry/opentelemetry-js/pull/3319) @legendecas
+
 ### :bug: (Bug Fix)
 
 ### :books: (Refine Doc)

--- a/experimental/packages/exporter-trace-otlp-http/README.md
+++ b/experimental/packages/exporter-trace-otlp-http/README.md
@@ -25,8 +25,10 @@ To see documentation and sample code for the metric exporter, see the [exporter-
 The OTLPTraceExporter in Web expects the endpoint to end in `/v1/traces`.
 
 ```js
-import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import {
+  BatchSpanProcessor,
+  WebTracerProvider,
+} from '@opentelemetry/sdk-trace-web';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
 const collectorOptions = {

--- a/experimental/packages/opentelemetry-instrumentation-fetch/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/README.md
@@ -16,9 +16,11 @@ npm install --save @opentelemetry/instrumentation-fetch
 ## Usage
 
 ```js
-'use strict';
-import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import {
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+  WebTracerProvider,
+} from '@opentelemetry/sdk-trace-web';
 import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';

--- a/experimental/packages/opentelemetry-instrumentation-http/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-http/README.md
@@ -24,8 +24,11 @@ To load a specific instrumentation (HTTP in this case), specify it in the Node T
 
 ```js
 const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http');
-const { ConsoleSpanExporter, SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
-const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
+const {
+  ConsoleSpanExporter,
+  NodeTracerProvider,
+  SimpleSpanProcessor,
+} = require('@opentelemetry/sdk-trace-node');
 const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 
 const provider = new NodeTracerProvider();

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/README.md
@@ -16,8 +16,11 @@ npm install --save @opentelemetry/instrumentation-xml-http-request
 ## Usage
 
 ```js
-import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import {
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+  WebTracerProvider,
+} from '@opentelemetry/sdk-trace-web';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';

--- a/packages/opentelemetry-context-zone-peer-dep/README.md
+++ b/packages/opentelemetry-context-zone-peer-dep/README.md
@@ -20,8 +20,11 @@ npm install --save @opentelemetry/context-zone-peer-dep
 
 ```js
 import { context, trace } from '@opentelemetry/api';
-import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import {
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+  WebTracerProvider,
+} from '@opentelemetry/sdk-trace-web';
 import { ZoneContextManager } from '@opentelemetry/context-zone-peer-dep';
 
 const providerWithZone = new WebTracerProvider();

--- a/packages/opentelemetry-context-zone/README.md
+++ b/packages/opentelemetry-context-zone/README.md
@@ -17,8 +17,11 @@ npm install --save @opentelemetry/context-zone
 
 ```js
 import { context, trace } from '@opentelemetry/api';
-import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import {
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+  WebTracerProvider,
+} from '@opentelemetry/sdk-trace-web';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 
 const providerWithZone = new WebTracerProvider();

--- a/packages/opentelemetry-sdk-trace-base/README.md
+++ b/packages/opentelemetry-sdk-trace-base/README.md
@@ -57,10 +57,12 @@ Samples every trace regardless of upstream sampling decisions.
 > This is used as a default Sampler
 
 ```js
-const { NodeTracerProvider } = require("@opentelemetry/sdk-trace-node");
-const { AlwaysOnSampler } = require("@opentelemetry/core");
+const {
+  AlwaysOnSampler,
+  BasicTracerProvider,
+} = require("@opentelemetry/sdk-trace-base");
 
-const tracerProvider = new NodeTracerProvider({
+const tracerProvider = new BasicTracerProvider({
   sampler: new AlwaysOnSampler()
 });
 ```
@@ -70,10 +72,12 @@ const tracerProvider = new NodeTracerProvider({
 Doesn't sample any trace, regardless of upstream sampling decisions.
 
 ```js
-const { NodeTracerProvider } = require("@opentelemetry/sdk-trace-node");
-const { AlwaysOffSampler } = require("@opentelemetry/core");
+const {
+  AlwaysOffSampler,
+  BasicTracerProvider,
+} = require("@opentelemetry/sdk-trace-base");
 
-const tracerProvider = new NodeTracerProvider({
+const tracerProvider = new BasicTracerProvider({
   sampler: new AlwaysOffSampler()
 });
 ```
@@ -86,10 +90,12 @@ Any trace that would be sampled at a given percentage will also be sampled at an
 The `TraceIDRatioSampler` may be used with the `ParentBasedSampler` to respect the sampled flag of an incoming trace.
 
 ```js
-const { NodeTracerProvider } = require("@opentelemetry/sdk-trace-node");
-const { TraceIdRatioBasedSampler } = require("@opentelemetry/core");
+const {
+  BasicTracerProvider,
+  TraceIdRatioBasedSampler,
+} = require("@opentelemetry/sdk-trace-base");
 
-const tracerProvider = new NodeTracerProvider({
+const tracerProvider = new BasicTracerProvider({
   // See details of ParentBasedSampler below
   sampler: new ParentBasedSampler({
     // Trace ID Ratio Sampler accepts a positional argument
@@ -130,10 +136,14 @@ Optional parameters:
 |present|false|false|`localParentNotSampled()`|
 
 ```js
-const { NodeTracerProvider } = require("@opentelemetry/sdk-trace-node");
-const { ParentBasedSampler, AlwaysOffSampler, TraceIdRatioBasedSampler } = require("@opentelemetry/core");
+const {
+  AlwaysOffSampler,
+  BasicTracerProvider,
+  ParentBasedSampler,
+  TraceIdRatioBasedSampler,
+} = require("@opentelemetry/sdk-trace-base");
 
-const tracerProvider = new NodeTracerProvider({
+const tracerProvider = new BasicTracerProvider({
   sampler: new ParentBasedSampler({
     // By default, the ParentBasedSampler will respect the parent span's sampling
     // decision. This is configurable by providing a different sampler to use

--- a/packages/opentelemetry-sdk-trace-node/src/index.ts
+++ b/packages/opentelemetry-sdk-trace-node/src/index.ts
@@ -16,3 +16,4 @@
 
 export { NodeTracerConfig } from './config';
 export * from './NodeTracerProvider';
+export * from '@opentelemetry/sdk-trace-base';

--- a/packages/opentelemetry-sdk-trace-web/README.md
+++ b/packages/opentelemetry-sdk-trace-web/README.md
@@ -31,8 +31,11 @@ npm install --save @opentelemetry/sdk-trace-web
 ## Usage
 
 ```js
-import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import {
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+  WebTracerProvider,
+} from '@opentelemetry/sdk-trace-web';
 import { DocumentLoad } from '@opentelemetry/plugin-document-load';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';

--- a/packages/opentelemetry-sdk-trace-web/src/index.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/index.ts
@@ -19,3 +19,4 @@ export * from './StackContextManager';
 export * from './enums/PerformanceTimingNames';
 export * from './types';
 export * from './utils';
+export * from '@opentelemetry/sdk-trace-base';


### PR DESCRIPTION
## Which problem is this PR solving?

Re-export sdk-trace-base members from sdk-trace-node and sdk-trace-web so that people using the platform SDK don't need to depends on the `sdk-trace-base` again.

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/3318

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated
