### PR TITLE
Fix Fetch and XHR instrumentation to use anchored clock

### DIFF
--- a/api/src/trace/NonRecordingSpan.ts
+++ b/api/src/trace/NonRecordingSpan.ts
@@ -15,7 +15,7 @@
  */
 
 import { Exception } from '../common/Exception';
-import { TimeInput } from '../common/Time';
+import { HrTime, TimeInput } from '../common/Time';
 import { SpanAttributes } from './attributes';
 import { INVALID_SPAN_CONTEXT } from './invalid-span-constants';
 import { Span } from './span';
@@ -72,4 +72,8 @@ export class NonRecordingSpan implements Span {
 
   // By default does nothing
   recordException(_exception: Exception, _time?: TimeInput): void {}
+
+  currentTime(): HrTime {
+    return [0, 0];
+  }
 }

--- a/api/src/trace/span.ts
+++ b/api/src/trace/span.ts
@@ -15,7 +15,7 @@
  */
 
 import { Exception } from '../common/Exception';
-import { TimeInput } from '../common/Time';
+import { HrTime, TimeInput } from '../common/Time';
 import { SpanAttributes, SpanAttributeValue } from './attributes';
 import { SpanContext } from './span_context';
 import { SpanStatus } from './status';
@@ -126,4 +126,10 @@ export interface Span {
    *     use the current time.
    */
   recordException(exception: Exception, time?: TimeInput): void;
+
+  /**
+   * Returns current time based on the anchored clock.
+   * Used to snapshot time when the span has to be ended later.
+   */
+  currentTime(): HrTime;
 }

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -278,7 +278,7 @@ export class FetchInstrumentation extends InstrumentationBase<Promise<Response>>
     spanData: SpanData,
     response: FetchResponse
   ) {
-    const endTime = core.hrTime();
+    const endTime = span.currentTime();
     this._addFinalSpanAttributes(span, response);
 
     setTimeout(() => {
@@ -308,7 +308,8 @@ export class FetchInstrumentation extends InstrumentationBase<Promise<Response>>
         if (!createdSpan) {
           return original.apply(this, args);
         }
-        const spanData = plugin._prepareSpanData(url);
+        const startTime = createdSpan.currentTime();
+        const spanData = plugin._prepareSpanData(url, startTime);
 
         function endSpanOnError(span: api.Span, error: FetchError) {
           plugin._applyAttributesAfterFetch(span, options, error);
@@ -427,8 +428,7 @@ export class FetchInstrumentation extends InstrumentationBase<Promise<Response>>
    *     resources
    * @param spanUrl
    */
-  private _prepareSpanData(spanUrl: string): SpanData {
-    const startTime = core.hrTime();
+  private _prepareSpanData(spanUrl: string, startTime: api.HrTime): SpanData {
     const entries: PerformanceResourceTiming[] = [];
     if (typeof PerformanceObserver !== 'function') {
       return { entries, startTime, spanUrl };

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -21,7 +21,7 @@ import {
   InstrumentationConfig,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
-import { hrTime, isUrlIgnored, otperformance } from '@opentelemetry/core';
+import { isUrlIgnored, otperformance } from '@opentelemetry/core';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import {
   addSpanNetworkEvents,
@@ -431,7 +431,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
       if (xhrMem.span) {
         plugin._applyAttributesAfterXHR(xhrMem.span, xhr);
       }
-      const endTime = hrTime();
+      const endTime = xhrMem.span?.currentTime();
 
       // the timeout is needed as observer doesn't have yet information
       // when event "load" is called. Also the time may differ depends on
@@ -486,7 +486,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
             api.trace.setSpan(api.context.active(), currentSpan),
             () => {
               plugin._tasksCount++;
-              xhrMem.sendStartTime = hrTime();
+              xhrMem.sendStartTime = currentSpan.currentTime();
               currentSpan.addEvent(EventNames.METHOD_SEND);
 
               this.addEventListener('abort', onAbort);

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -243,6 +243,10 @@ export class Span implements api.Span, ReadableSpan {
     return this._ended;
   }
 
+  currentTime(): api.HrTime {
+    return timeInputToHrTime(this._clock.now());
+  }
+
   private _isSpanEnded(): boolean {
     if (this._ended) {
       api.diag.warn(`Can not execute the operation on ended Span {traceId: ${this._spanContext.traceId}, spanId: ${this._spanContext.spanId}}`);


### PR DESCRIPTION
## Which problem is this PR solving?

Originally reported [here](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1210#issuecomment-1260949415)

After introducing anchored clock in [this PR](https://github.com/open-telemetry/opentelemetry-js/pull/3134) XHR and Fetch instrumentation started producing spans with negative duration. `hrTime()` is used to set end time of the spans but it is not aligned with an instance of an anchored clock inside the spans. 

## Short description of the changes

Instead of using `hrTime()` a new method `currentTime()` introduced to a Span. It returns the time from the anchored clock ensuring consistency with the start time of the span. This new method is used in both Fetch and XHR instrumentations to set end time of the span.
The fix is inspired by this fix for a similar problem in express instrumentation https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1210/files

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I've been testing this by producing spans with negative duration after putting computer to sleep for a few minutes.
In Honeycomb spans with negative duration are overflow and have long duration:
<img width="1390" alt="image" src="https://user-images.githubusercontent.com/287994/195293451-a856403c-0ad8-42a4-ba45-2e15dc8cb882.png">

With the issue fixed, I couldn't produce spans with negative duration anymore. Notice how spans have `clock_drift` over 500 seconds. `clock_drift` was set on the client with `Date.now - (performance.timeOrigin + performance.now())`:
<img width="1362" alt="image" src="https://user-images.githubusercontent.com/287994/195293764-5564c779-b169-444d-9589-c77275f13999.png">

### Steps to reproduce:
* Open a browser tab with an app using OTEL XHR/Fetch instrumentation (1.7.0+)
* Put computer into sleep for a few minutes
* "Wake" computer up and reload the page in the same tab to produce new traces
**Expected**: span duration for XHR/Fetch spans should be positive
**Actual**: span duration for XHR/Fetch spans is negative

## Checklist:

I'm not sure how to write a unit test for it.

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated

cc @dyladan as the one with context on the clock drift
