### PR TITLE
fix(build): pin checkout actions for web build to 3.0.2

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Permission Setup
         run: sudo chmod -R 777 /github /__w
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
       - name: restore lerna
         id: cache
@@ -144,7 +144,7 @@ jobs:
       - name: Permission Setup
         run: sudo chmod -R 777 /github /__w
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
 
       - name: restore lerna
         id: cache


### PR DESCRIPTION
## Which problem is this PR solving?

This PR pins [`actions/checkout`](https://github.com/actions/checkout/) to `v3.0.2` in the web builds, as `v3.1.0` broke our pipeline.  

Our pipeline uses the `circleci/node:16-browsers` image, which sets the default user to a non-root `circleci` user. This is an unsupported path according to [GitHub Actions documentation](https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user). It causes files to be not writable, as they are owned by another user (see https://github.com/actions/checkout/issues/956), thus failing the build on checkout. 

This PR is NOT a permanent solution as we won't be able to update `actions/checkout` without switching to another image, but it will unblock other PRs with failing builds for now.

## Type of change

- [x] internal

## How Has This Been Tested?

- [x] Running the pipeline in CI

