### PR TITLE
ci: run browser tests without circle

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,118 +6,120 @@ on:
   pull_request:
 
 jobs:
-  node-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        node_version:
-          - "14"
-          - "16"
-          - "18"
+  # node-tests:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       node_version:
+  #         - "14"
+  #         - "16"
+  #         - "18"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     NPM_CONFIG_UNSAFE_PERM: true
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: ${{ matrix.node_version }}
+
+  #     - run: npm install -g npm@latest
+
+  #     - name: restore lerna
+  #       id: cache
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           node_modules
+  #           package-lock.json
+  #           packages/*/node_modules
+  #           packages/*/package-lock.json
+  #           experimental/packages/*/node_modules
+  #           experimental/packages/*/package-lock.json
+  #         key: node-tests-${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}-04292022
+
+  #     - name: Bootstrap
+  #       run: |
+  #         npm install --ignore-scripts
+  #         npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --ignore @opentelemetry/selenium-tests
+
+  #     - name: Build 🔧
+  #       run: |
+  #         npm run compile
+
+  #     - name: Unit tests
+  #       run: npm run test
+  #     - name: Report Coverage
+  #       run: npm run codecov
+  #       if: ${{ matrix.node_version == '14' }}
+  # node-windows-tests:
+  #   strategy:
+  #     fail-fast: false
+  #   runs-on: windows-latest
+  #   env:
+  #     NPM_CONFIG_UNSAFE_PERM: true
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: '16'
+
+  #     - run: npm install -g npm@latest
+
+  #     - name: restore lerna
+  #       id: cache
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           node_modules
+  #           package-lock.json
+  #           packages/*/node_modules
+  #           packages/*/package-lock.json
+  #           experimental/packages/*/node_modules
+  #           experimental/packages/*/package-lock.json
+  #         key: node-windows-tests-${{ runner.os }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}
+
+  #     - name: Bootstrap
+  #       run: |
+  #         npm install --ignore-scripts
+  #         npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --ignore @opentelemetry/selenium-tests
+
+  #     - name: Build 🔧
+  #       run: |
+  #         npm run compile
+
+  #     - name: Unit tests
+  #       run: npm run test
+  browser-tests:
     runs-on: ubuntu-latest
+
     env:
       NPM_CONFIG_UNSAFE_PERM: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
 
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
 
-      - run: npm install -g npm@latest
-
-      - name: restore lerna
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules
-            package-lock.json
-            packages/*/node_modules
-            packages/*/package-lock.json
-            experimental/packages/*/node_modules
-            experimental/packages/*/package-lock.json
-          key: node-tests-${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}-04292022
-
-      - name: Bootstrap
-        run: |
-          npm install --ignore-scripts
-          npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --ignore @opentelemetry/selenium-tests
-
-      - name: Build 🔧
-        run: |
-          npm run compile
-
-      - name: Unit tests
-        run: npm run test
-      - name: Report Coverage
-        run: npm run codecov
-        if: ${{ matrix.node_version == '14' }}
-  node-windows-tests:
-    strategy:
-      fail-fast: false
-    runs-on: windows-latest
-    env:
-      NPM_CONFIG_UNSAFE_PERM: true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-
-      - run: npm install -g npm@latest
-
-      - name: restore lerna
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules
-            package-lock.json
-            packages/*/node_modules
-            packages/*/package-lock.json
-            experimental/packages/*/node_modules
-            experimental/packages/*/package-lock.json
-          key: node-windows-tests-${{ runner.os }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}
-
-      - name: Bootstrap
-        run: |
-          npm install --ignore-scripts
-          npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --ignore @opentelemetry/selenium-tests
-
-      - name: Build 🔧
-        run: |
-          npm run compile
-
-      - name: Unit tests
-        run: npm run test
-  browser-tests:
-    runs-on: ubuntu-latest
-    container:
-      image: circleci/node:16-browsers
-    env:
-      NPM_CONFIG_UNSAFE_PERM: true
-    steps:
-      - name: Permission Setup
-        run: sudo chmod -R 777 /github /__w
-      - name: Checkout
-        uses: actions/checkout@v3.0.2
-
-      - name: restore lerna
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules
-            package-lock.json
-            packages/*/node_modules
-            packages/*/package-lock.json
-            experimental/packages/*/node_modules
-            experimental/packages/*/package-lock.json
-          key: browser-tests-${{ runner.os }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}-04292022
+      # - name: restore lerna
+      #   id: cache
+      #   uses: actions/cache@v3
+      #   with:
+      #     path: |
+      #       node_modules
+      #       package-lock.json
+      #       packages/*/node_modules
+      #       packages/*/package-lock.json
+      #       experimental/packages/*/node_modules
+      #       experimental/packages/*/package-lock.json
+      #     key: browser-tests-${{ runner.os }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}-04292022
 
       - name: Bootstrap
         run: |
@@ -134,43 +136,43 @@ jobs:
         run: npm run test:browser
       - name: Report Coverage
         run: npm run codecov:browser
-  webworker-tests:
-    runs-on: ubuntu-latest
-    container:
-      image: circleci/node:16-browsers
-    env:
-      NPM_CONFIG_UNSAFE_PERM: true
-    steps:
-      - name: Permission Setup
-        run: sudo chmod -R 777 /github /__w
-      - name: Checkout
-        uses: actions/checkout@v3.0.2
+  # webworker-tests:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: circleci/node:16-browsers
+  #   env:
+  #     NPM_CONFIG_UNSAFE_PERM: true
+  #   steps:
+  #     - name: Permission Setup
+  #       run: sudo chmod -R 777 /github /__w
+  #     - name: Checkout
+  #       uses: actions/checkout@v3.0.2
 
-      - name: restore lerna
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules
-            package-lock.json
-            packages/*/node_modules
-            packages/*/package-lock.json
-            experimental/packages/*/node_modules
-            experimental/packages/*/package-lock.json
-          key: webworker-tests-${{ runner.os }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}-04292022
+  #     - name: restore lerna
+  #       id: cache
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           node_modules
+  #           package-lock.json
+  #           packages/*/node_modules
+  #           packages/*/package-lock.json
+  #           experimental/packages/*/node_modules
+  #           experimental/packages/*/package-lock.json
+  #         key: webworker-tests-${{ runner.os }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}-04292022
 
-      - name: Bootstrap
-        run: |
-          npm install --ignore-scripts
-          npx lerna bootstrap --no-ci --hoist --nohoist='zone.js'
+  #     - name: Bootstrap
+  #       run: |
+  #         npm install --ignore-scripts
+  #         npx lerna bootstrap --no-ci --hoist --nohoist='zone.js'
 
-      - name: Build 🔧
-        run: |
-          npm run compile
-          # run additional compilation variants
-          npx lerna run compile
+  #     - name: Build 🔧
+  #       run: |
+  #         npm run compile
+  #         # run additional compilation variants
+  #         npx lerna run compile
 
-      - name: Unit tests
-        run: npm run test:webworker
-      - name: Report Coverage
-        run: npm run codecov:webworker
+  #     - name: Unit tests
+  #       run: npm run test:webworker
+  #     - name: Report Coverage
+  #       run: npm run codecov:webworker

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -124,7 +124,6 @@ jobs:
 
       - name: Build 🔧
         run: |
-          npx lerna run protos
           npx lerna run compile
 
       - name: Unit tests
@@ -140,7 +139,7 @@ jobs:
         uses: actions/checkout@v3.0.2
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
 
       - name: restore lerna
         id: cache
@@ -162,7 +161,6 @@ jobs:
 
       - name: Build 🔧
         run: |
-          npx lerna run protos
           npx lerna run compile
 
       - name: Unit tests

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -102,7 +102,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 16
 
       - name: restore lerna
         id: cache

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,94 +6,94 @@ on:
   pull_request:
 
 jobs:
-  # node-tests:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       node_version:
-  #         - "14"
-  #         - "16"
-  #         - "18"
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     NPM_CONFIG_UNSAFE_PERM: true
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
+  node-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version:
+          - "14"
+          - "16"
+          - "18"
+    runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_UNSAFE_PERM: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-  #     - uses: actions/setup-node@v3
-  #       with:
-  #         node-version: ${{ matrix.node_version }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version }}
 
-  #     - run: npm install -g npm@latest
+      - run: npm install -g npm@latest
 
-  #     - name: restore lerna
-  #       id: cache
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           node_modules
-  #           package-lock.json
-  #           packages/*/node_modules
-  #           packages/*/package-lock.json
-  #           experimental/packages/*/node_modules
-  #           experimental/packages/*/package-lock.json
-  #         key: node-tests-${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}-04292022
+      - name: restore lerna
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            package-lock.json
+            packages/*/node_modules
+            packages/*/package-lock.json
+            experimental/packages/*/node_modules
+            experimental/packages/*/package-lock.json
+          key: node-tests-${{ runner.os }}-${{ matrix.node_version }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}-04292022
 
-  #     - name: Bootstrap
-  #       run: |
-  #         npm install --ignore-scripts
-  #         npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --ignore @opentelemetry/selenium-tests
+      - name: Bootstrap
+        run: |
+          npm install --ignore-scripts
+          npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --ignore @opentelemetry/selenium-tests
 
-  #     - name: Build 🔧
-  #       run: |
-  #         npm run compile
+      - name: Build 🔧
+        run: |
+          npm run compile
 
-  #     - name: Unit tests
-  #       run: npm run test
-  #     - name: Report Coverage
-  #       run: npm run codecov
-  #       if: ${{ matrix.node_version == '14' }}
-  # node-windows-tests:
-  #   strategy:
-  #     fail-fast: false
-  #   runs-on: windows-latest
-  #   env:
-  #     NPM_CONFIG_UNSAFE_PERM: true
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
+      - name: Unit tests
+        run: npm run test
+      - name: Report Coverage
+        run: npm run codecov
+        if: ${{ matrix.node_version == '14' }}
+  node-windows-tests:
+    strategy:
+      fail-fast: false
+    runs-on: windows-latest
+    env:
+      NPM_CONFIG_UNSAFE_PERM: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-  #     - uses: actions/setup-node@v3
-  #       with:
-  #         node-version: '16'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
 
-  #     - run: npm install -g npm@latest
+      - run: npm install -g npm@latest
 
-  #     - name: restore lerna
-  #       id: cache
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           node_modules
-  #           package-lock.json
-  #           packages/*/node_modules
-  #           packages/*/package-lock.json
-  #           experimental/packages/*/node_modules
-  #           experimental/packages/*/package-lock.json
-  #         key: node-windows-tests-${{ runner.os }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}
+      - name: restore lerna
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            package-lock.json
+            packages/*/node_modules
+            packages/*/package-lock.json
+            experimental/packages/*/node_modules
+            experimental/packages/*/package-lock.json
+          key: node-windows-tests-${{ runner.os }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}
 
-  #     - name: Bootstrap
-  #       run: |
-  #         npm install --ignore-scripts
-  #         npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --ignore @opentelemetry/selenium-tests
+      - name: Bootstrap
+        run: |
+          npm install --ignore-scripts
+          npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --ignore @opentelemetry/selenium-tests
 
-  #     - name: Build 🔧
-  #       run: |
-  #         npm run compile
+      - name: Build 🔧
+        run: |
+          npm run compile
 
-  #     - name: Unit tests
-  #       run: npm run test
+      - name: Unit tests
+        run: npm run test
   browser-tests:
     runs-on: ubuntu-latest
 
@@ -108,71 +108,71 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
 
-      # - name: restore lerna
-      #   id: cache
-      #   uses: actions/cache@v3
-      #   with:
-      #     path: |
-      #       node_modules
-      #       package-lock.json
-      #       packages/*/node_modules
-      #       packages/*/package-lock.json
-      #       experimental/packages/*/node_modules
-      #       experimental/packages/*/package-lock.json
-      #     key: browser-tests-${{ runner.os }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}-04292022
+      - name: restore lerna
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            package-lock.json
+            packages/*/node_modules
+            packages/*/package-lock.json
+            experimental/packages/*/node_modules
+            experimental/packages/*/package-lock.json
+          key: browser-tests-${{ runner.os }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}-04292022
 
       - name: Bootstrap
         run: |
           npm install --ignore-scripts
-          npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --ignore @opentelemetry/selenium-tests --scope @opentelemetry/core --include-dependencies
+          npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --ignore @opentelemetry/selenium-tests
 
       - name: Build 🔧
         run: |
           # npm run compile
           # run additional compilation variants
-          npx lerna run compile --scope @opentelemetry/core --include-dependencies
+          npx lerna run compile
 
       - name: Unit tests
-        run: npm run test:browser --scope @opentelemetry/core --include-dependencies
-      # - name: Report Coverage
-      #   run: npm run codecov:browser
-  # webworker-tests:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: circleci/node:16-browsers
-  #   env:
-  #     NPM_CONFIG_UNSAFE_PERM: true
-  #   steps:
-  #     - name: Permission Setup
-  #       run: sudo chmod -R 777 /github /__w
-  #     - name: Checkout
-  #       uses: actions/checkout@v3.0.2
+        run: npm run test:browser
+      - name: Report Coverage
+        run: npm run codecov:browser
+  webworker-tests:
+    runs-on: ubuntu-latest
+    container:
+      image: circleci/node:16-browsers
+    env:
+      NPM_CONFIG_UNSAFE_PERM: true
+    steps:
+      - name: Permission Setup
+        run: sudo chmod -R 777 /github /__w
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
 
-  #     - name: restore lerna
-  #       id: cache
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           node_modules
-  #           package-lock.json
-  #           packages/*/node_modules
-  #           packages/*/package-lock.json
-  #           experimental/packages/*/node_modules
-  #           experimental/packages/*/package-lock.json
-  #         key: webworker-tests-${{ runner.os }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}-04292022
+      - name: restore lerna
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+            package-lock.json
+            packages/*/node_modules
+            packages/*/package-lock.json
+            experimental/packages/*/node_modules
+            experimental/packages/*/package-lock.json
+          key: webworker-tests-${{ runner.os }}-${{ hashFiles('package.json', 'packages/*/package.json', 'experimental/packages/*/package.json') }}-04292022
 
-  #     - name: Bootstrap
-  #       run: |
-  #         npm install --ignore-scripts
-  #         npx lerna bootstrap --no-ci --hoist --nohoist='zone.js'
+      - name: Bootstrap
+        run: |
+          npm install --ignore-scripts
+          npx lerna bootstrap --no-ci --hoist --nohoist='zone.js'
 
-  #     - name: Build 🔧
-  #       run: |
-  #         npm run compile
-  #         # run additional compilation variants
-  #         npx lerna run compile
+      - name: Build 🔧
+        run: |
+          npm run compile
+          # run additional compilation variants
+          npx lerna run compile
 
-  #     - name: Unit tests
-  #       run: npm run test:webworker
-  #     - name: Report Coverage
-  #       run: npm run codecov:webworker
+      - name: Unit tests
+        run: npm run test:webworker
+      - name: Report Coverage
+        run: npm run codecov:webworker

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -96,13 +96,11 @@ jobs:
         run: npm run test
   browser-tests:
     runs-on: ubuntu-latest
-
     env:
       NPM_CONFIG_UNSAFE_PERM: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
 
       - uses: actions/setup-node@v3
         with:
@@ -128,8 +126,7 @@ jobs:
 
       - name: Build 🔧
         run: |
-          # npm run compile
-          # run additional compilation variants
+          npx lerna run protos
           npx lerna run compile
 
       - name: Unit tests
@@ -138,13 +135,9 @@ jobs:
         run: npm run codecov:browser
   webworker-tests:
     runs-on: ubuntu-latest
-    container:
-      image: circleci/node:16-browsers
     env:
       NPM_CONFIG_UNSAFE_PERM: true
     steps:
-      - name: Permission Setup
-        run: sudo chmod -R 777 /github /__w
       - name: Checkout
         uses: actions/checkout@v3.0.2
 
@@ -168,8 +161,7 @@ jobs:
 
       - name: Build 🔧
         run: |
-          npm run compile
-          # run additional compilation variants
+          npx lerna run protos
           npx lerna run compile
 
       - name: Unit tests

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -124,18 +124,18 @@ jobs:
       - name: Bootstrap
         run: |
           npm install --ignore-scripts
-          npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --ignore @opentelemetry/selenium-tests
+          npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --ignore @opentelemetry/selenium-tests --scope @opentelemetry/core --include-dependencies
 
       - name: Build 🔧
         run: |
-          npm run compile
+          # npm run compile
           # run additional compilation variants
-          npx lerna run compile
+          npx lerna run compile --scope @opentelemetry/core --include-dependencies
 
       - name: Unit tests
-        run: npm run test:browser
-      - name: Report Coverage
-        run: npm run codecov:browser
+        run: npm run test:browser --scope @opentelemetry/core --include-dependencies
+      # - name: Report Coverage
+      #   run: npm run codecov:browser
   # webworker-tests:
   #   runs-on: ubuntu-latest
   #   container:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -55,8 +55,6 @@ jobs:
         run: npm run codecov
         if: ${{ matrix.node_version == '14' }}
   node-windows-tests:
-    strategy:
-      fail-fast: false
     runs-on: windows-latest
     env:
       NPM_CONFIG_UNSAFE_PERM: true
@@ -104,7 +102,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: 18
 
       - name: restore lerna
         id: cache
@@ -140,6 +138,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3.0.2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
 
       - name: restore lerna
         id: cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be documented in this file.
 
 ### :house: (Internal)
 
+* ci: run browser tests without circle [#3328](https://github.com/open-telemetry/opentelemetry-js/pull/3328) @dyladan
+
 ## 1.7.0
 
 ### :bug: (Bug Fix)

--- a/karma.base.js
+++ b/karma.base.js
@@ -17,7 +17,13 @@
 module.exports = {
   listenAddress: 'localhost',
   hostname: 'localhost',
-  browsers: ['ChromeHeadless'],
+  browsers: ['Chrome', 'ChromeHeadless', 'ChromeHeadlessCI'],
+  customLaunchers: {
+    ChromeHeadlessCI: {
+      base: 'ChromeHeadless',
+      flags: ['--no-sandbox']
+    }
+  },
   frameworks: ['mocha'],
   coverageIstanbulReporter: {
     reports: ['html', 'json'],

--- a/karma.base.js
+++ b/karma.base.js
@@ -17,13 +17,7 @@
 module.exports = {
   listenAddress: 'localhost',
   hostname: 'localhost',
-  browsers: ['Chrome', 'ChromeHeadless', 'ChromeHeadlessCI'],
-  customLaunchers: {
-    ChromeHeadlessCI: {
-      base: 'ChromeHeadless',
-      flags: ['--no-sandbox']
-    }
-  },
+  browsers: ['ChromeHeadless'],
   frameworks: ['mocha'],
   coverageIstanbulReporter: {
     reports: ['html', 'json'],


### PR DESCRIPTION
The circle ci image we've been using for testing was causing permissions issues in github actions. This was the original reason for the permission setting in the action run. Chrome has since been added to the default runner so we actually don't need the image at all.