### PR TITLE
chore: fix grpc and proto-loader deps

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -15,7 +15,6 @@ All notable changes to experimental packages in this project will be documented 
 * feat(prometheus): serialize resource as target_info gauge [#3300](https://github.com/open-telemetry/opentelemetry-js/pull/3300) @pichlermarc
 * deps: remove unused proto-loader dependencies and update grpc-js and proto-loader versions [#3337](https://github.com/open-telemetry/opentelemetry-js/pull/3337) @seemk
 
-
 ### :bug: (Bug Fix)
 
 * fix(node-sdk): move `@opentelemetry/semantic-conventions` to `dependencies` [#3283](https://github.com/open-telemetry/opentelemetry-js/pull/3283) @mhassan1

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :rocket: (Enhancement)
 
 * feat(sdk-node): configure trace exporter with environment variables [#3143](https://github.com/open-telemetry/opentelemetry-js/pull/3143) @svetlanabrennan
+* deps: remove unused proto-loader dependencies and update grpc-js and proto-loader versions [#3337](https://github.com/open-telemetry/opentelemetry-js/pull/3337) @seemk
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.16.0",
+    "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/otlp-exporter-base": "0.33.0",
     "@types/mocha": "10.0.0",
@@ -67,8 +68,7 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.5.9",
-    "@grpc/proto-loader": "^0.6.9",
+    "@grpc/grpc-js": "^1.7.1",
     "@opentelemetry/core": "1.7.0",
     "@opentelemetry/otlp-grpc-exporter-base": "0.33.0",
     "@opentelemetry/otlp-transformer": "0.33.0",

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -66,7 +66,6 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@grpc/proto-loader": "^0.6.9",
     "@opentelemetry/core": "1.7.0",
     "@opentelemetry/otlp-exporter-base": "0.33.0",
     "@opentelemetry/otlp-proto-exporter-base": "0.33.0",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.16.0",
+    "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/api-metrics": "0.33.0",
     "@types/mocha": "10.0.0",
@@ -67,8 +68,7 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.5.9",
-    "@grpc/proto-loader": "^0.6.9",
+    "@grpc/grpc-js": "^1.7.1",
     "@opentelemetry/core": "1.7.0",
     "@opentelemetry/exporter-metrics-otlp-http": "0.33.0",
     "@opentelemetry/otlp-grpc-exporter-base": "0.33.0",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -67,7 +67,6 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@grpc/proto-loader": "0.6.9",
     "@opentelemetry/core": "1.7.0",
     "@opentelemetry/exporter-metrics-otlp-http": "0.33.0",
     "@opentelemetry/otlp-exporter-base": "0.33.0",

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -45,8 +45,8 @@
     "access": "public"
   },
   "devDependencies": {
-    "@grpc/grpc-js": "1.5.9",
-    "@grpc/proto-loader": "0.6.9",
+    "@grpc/grpc-js": "^1.7.1",
+    "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/context-async-hooks": "1.7.0",
     "@opentelemetry/core": "1.7.0",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -71,8 +71,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.5.9",
-    "@grpc/proto-loader": "^0.6.9",
+    "@grpc/grpc-js": "^1.7.1",
+    "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/core": "1.7.0",
     "@opentelemetry/otlp-exporter-base": "0.33.0"
   },

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -63,7 +63,6 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@grpc/proto-loader": "^0.6.9",
     "@opentelemetry/core": "1.7.0",
     "@opentelemetry/otlp-exporter-base": "0.33.0",
     "protobufjs": "7.1.1"


### PR DESCRIPTION
* Remove unused `@grpc/proto-loader` dependencies or move them to dev deps where possible.
* Update grpc-js and proto-loader versions: most of the packages contain `grpc-js` with `^1.5.9` versioning, which might install (currently) up to grpc-js 1.7, which depends on proto-loader 0.7.x. However proto-loader dependencies were pinned to patch versions, this would cause duplicate proto-loader package installs.
* Remove exact grpc-js and proto-loader versions from `opentelemetry-instrumentation-grpc`.