### PR TITLE
Release proposal 1.8.0 / 0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file.
 
 ### :boom: Breaking Change
 
+### :rocket: (Enhancement)
+
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 1.8.0
+
+### :boom: Breaking Change
+
 * feat(api): merge api-metrics into api [#3374](https://github.com/open-telemetry/opentelemetry-js/pull/3374) @legendecas
 
 ### :rocket: (Enhancement)
@@ -23,8 +35,6 @@ All notable changes to this project will be documented in this file.
   [#3359](https://github.com/open-telemetry/opentelemetry-js/pull/3359) @dyladan
 * fix(resources): strict OTEL_RESOURCE_ATTRIBUTES baggage octet decoding
   [#3341](https://github.com/open-telemetry/opentelemetry-js/pull/3341) @legendecas
-
-### :books: (Refine Doc)
 
 ### :house: (Internal)
 

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,7 +1,7 @@
 {
   "name": "https-example",
   "private": true,
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Example of HTTPs integration with OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -33,14 +33,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/exporter-jaeger": "1.7.0",
-    "@opentelemetry/exporter-zipkin": "1.7.0",
-    "@opentelemetry/instrumentation": "0.33.0",
-    "@opentelemetry/instrumentation-http": "0.33.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
-    "@opentelemetry/sdk-trace-node": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0"
+    "@opentelemetry/exporter-jaeger": "1.8.0",
+    "@opentelemetry/exporter-zipkin": "1.8.0",
+    "@opentelemetry/instrumentation": "0.34.0",
+    "@opentelemetry/instrumentation-http": "0.34.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
+    "@opentelemetry/sdk-trace-node": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-opentelemetry-example",
   "private": true,
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Example of using @opentelemetry/sdk-trace-web and @opentelemetry/sdk-metrics in browser",
   "main": "index.js",
   "scripts": {
@@ -43,19 +43,19 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.2.0",
-    "@opentelemetry/context-zone": "1.7.0",
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.33.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.33.0",
-    "@opentelemetry/exporter-zipkin": "1.7.0",
-    "@opentelemetry/instrumentation": "0.33.0",
-    "@opentelemetry/instrumentation-fetch": "0.33.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.33.0",
-    "@opentelemetry/propagator-b3": "1.7.0",
-    "@opentelemetry/sdk-metrics": "0.33.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
-    "@opentelemetry/sdk-trace-web": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0"
+    "@opentelemetry/context-zone": "1.8.0",
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.34.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.34.0",
+    "@opentelemetry/exporter-zipkin": "1.8.0",
+    "@opentelemetry/instrumentation": "0.34.0",
+    "@opentelemetry/instrumentation-fetch": "0.34.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.34.0",
+    "@opentelemetry/propagator-b3": "1.8.0",
+    "@opentelemetry/sdk-metrics": "0.34.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
+    "@opentelemetry/sdk-trace-web": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web"
 }

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-otlp-exporter-node",
   "private": true,
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
@@ -29,17 +29,17 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.2.0",
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.33.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.33.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "0.33.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.33.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.33.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.33.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/sdk-metrics": "0.33.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.34.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.34.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "0.34.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.34.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.34.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.34.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-metrics": "0.34.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/otlp-exporter-node"
 }

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+### :rocket: (Enhancement)
+
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 0.34.0
+
+### :boom: Breaking Change
+
 * Add semver check to metrics API [#3357](https://github.com/open-telemetry/opentelemetry-js/pull/3357) @dyladan
   * Previously API versions were only considered compatible if the API was exactly the same
 

--- a/experimental/backwards-compatability/node14/package.json
+++ b/experimental/backwards-compatability/node14/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node14",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "private": true,
   "description": "Backwards compatability app for node 14 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.33.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0"
+    "@opentelemetry/sdk-node": "0.34.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0"
   },
   "devDependencies": {
     "@types/node": "14.18.25",

--- a/experimental/backwards-compatability/node16/package.json
+++ b/experimental/backwards-compatability/node16/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node16",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "private": true,
   "description": "Backwards compatability app for node 16 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.33.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0"
+    "@opentelemetry/sdk-node": "0.34.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0"
   },
   "devDependencies": {
     "@types/node": "16.11.52",

--- a/experimental/examples/prometheus/package.json
+++ b/experimental/examples/prometheus/package.json
@@ -1,6 +1,7 @@
 {
   "name": "prometheus-example",
-  "version": "0.33.0",
+  "version": "0.34.0",
+  "private": true,
   "description": "Example of using @opentelemetry/sdk-metrics and @opentelemetry/exporter-prometheus",
   "main": "index.js",
   "scripts": {
@@ -10,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/api": "^1.2.0",
-    "@opentelemetry/exporter-prometheus": "0.33.0",
-    "@opentelemetry/sdk-metrics": "0.33.0"
+    "@opentelemetry/exporter-prometheus": "0.34.0",
+    "@opentelemetry/sdk-metrics": "0.34.0"
   }
 }

--- a/experimental/packages/api-logs/package.json
+++ b/experimental/packages/api-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-logs",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Public logs API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-grpc",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,7 +50,7 @@
     "@babel/core": "7.16.0",
     "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/otlp-exporter-base": "0.33.0",
+    "@opentelemetry/otlp-exporter-base": "0.34.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -69,11 +69,11 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.33.0",
-    "@opentelemetry/otlp-transformer": "0.33.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.34.0",
+    "@opentelemetry/otlp-transformer": "0.34.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-http",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry Collector Trace Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,11 +94,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/otlp-exporter-base": "0.33.0",
-    "@opentelemetry/otlp-transformer": "0.33.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/otlp-exporter-base": "0.34.0",
+    "@opentelemetry/otlp-transformer": "0.34.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-proto",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -66,12 +66,12 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/otlp-exporter-base": "0.33.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.33.0",
-    "@opentelemetry/otlp-transformer": "0.33.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/otlp-exporter-base": "0.34.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.34.0",
+    "@opentelemetry/otlp-transformer": "0.34.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/opentelemetry-browser-detector",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry Resource Detector for Browser",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -70,8 +70,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0"
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/browser-detector"
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -68,12 +68,12 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.33.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.33.0",
-    "@opentelemetry/otlp-transformer": "0.33.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/sdk-metrics": "0.33.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.34.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.34.0",
+    "@opentelemetry/otlp-transformer": "0.34.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-metrics": "0.34.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-http",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,11 +94,11 @@
     "@opentelemetry/api": "^1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/otlp-exporter-base": "0.33.0",
-    "@opentelemetry/otlp-transformer": "0.33.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/sdk-metrics": "0.33.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/otlp-exporter-base": "0.34.0",
+    "@opentelemetry/otlp-transformer": "0.34.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-metrics": "0.34.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-proto",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -66,13 +66,13 @@
     "@opentelemetry/api": "^1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.33.0",
-    "@opentelemetry/otlp-exporter-base": "0.33.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.33.0",
-    "@opentelemetry/otlp-transformer": "0.33.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/sdk-metrics": "0.33.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.34.0",
+    "@opentelemetry/otlp-exporter-base": "0.34.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.34.0",
+    "@opentelemetry/otlp-transformer": "0.34.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-metrics": "0.34.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -59,9 +59,9 @@
     "@opentelemetry/api": "^1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/sdk-metrics": "0.33.0",
-    "@opentelemetry/resources": "1.7.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-metrics": "0.34.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-prometheus",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-fetch",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry fetch automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-zone": "1.7.0",
-    "@opentelemetry/propagator-b3": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
+    "@opentelemetry/context-zone": "1.8.0",
+    "@opentelemetry/propagator-b3": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -87,10 +87,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/instrumentation": "0.33.0",
-    "@opentelemetry/sdk-trace-web": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/instrumentation": "0.34.0",
+    "@opentelemetry/sdk-trace-web": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-grpc",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry grpc automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -48,10 +48,10 @@
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/api": "^1.2.0",
-    "@opentelemetry/context-async-hooks": "1.7.0",
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
-    "@opentelemetry/sdk-trace-node": "1.7.0",
+    "@opentelemetry/context-async-hooks": "1.8.0",
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
+    "@opentelemetry/sdk-trace-node": "1.8.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/semver": "7.3.9",
@@ -71,8 +71,8 @@
     "@opentelemetry/api": "^1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "0.33.0",
-    "@opentelemetry/semantic-conventions": "1.7.0"
+    "@opentelemetry/instrumentation": "0.34.0",
+    "@opentelemetry/semantic-conventions": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-http",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry http/https automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,10 +46,10 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.2.0",
-    "@opentelemetry/context-async-hooks": "1.7.0",
-    "@opentelemetry/sdk-metrics": "0.33.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
-    "@opentelemetry/sdk-trace-node": "1.7.0",
+    "@opentelemetry/context-async-hooks": "1.8.0",
+    "@opentelemetry/sdk-metrics": "0.34.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
+    "@opentelemetry/sdk-trace-node": "1.8.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/request-promise-native": "1.0.18",
@@ -73,9 +73,9 @@
     "@opentelemetry/api": "^1.2.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/instrumentation": "0.33.0",
-    "@opentelemetry/semantic-conventions": "1.7.0",
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/instrumentation": "0.34.0",
+    "@opentelemetry/semantic-conventions": "1.8.0",
     "semver": "^7.3.5"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http",

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-xml-http-request",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry XMLHttpRequest automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-zone": "1.7.0",
-    "@opentelemetry/propagator-b3": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
+    "@opentelemetry/context-zone": "1.8.0",
+    "@opentelemetry/propagator-b3": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -87,10 +87,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/instrumentation": "0.33.0",
-    "@opentelemetry/sdk-trace-web": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/instrumentation": "0.34.0",
+    "@opentelemetry/sdk-trace-web": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Base class for node which OpenTelemetry instrumentation modules extend",
   "author": "OpenTelemetry Authors",
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation",

--- a/experimental/packages/opentelemetry-sdk-metrics/package.json
+++ b/experimental/packages/opentelemetry-sdk-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Work in progress OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -77,8 +77,8 @@
     "@opentelemetry/api": ">=1.2.0 <1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/resources": "1.7.0",
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/resources": "1.8.0",
     "lodash.merge": "4.6.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-sdk-metrics",

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-node",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry SDK for Node.js",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,25 +44,25 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/exporter-jaeger": "1.7.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.33.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.33.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.33.0",
-    "@opentelemetry/exporter-zipkin": "1.7.0",
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/instrumentation": "0.33.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/sdk-metrics": "0.33.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
-    "@opentelemetry/sdk-trace-node": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/exporter-jaeger": "1.8.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.34.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.34.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.34.0",
+    "@opentelemetry/exporter-zipkin": "1.8.0",
+    "@opentelemetry/instrumentation": "0.34.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-metrics": "0.34.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
+    "@opentelemetry/sdk-trace-node": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.2.0 <1.3.0"
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.2.0 <1.3.0",
-    "@opentelemetry/context-async-hooks": "1.7.0",
+    "@opentelemetry/context-async-hooks": "1.8.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/semver": "7.3.9",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-exporter-base",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry OTLP Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0"
+    "@opentelemetry/core": "1.8.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-grpc-exporter-base",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry OTLP-gRPC Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -51,9 +51,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/otlp-transformer": "0.33.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
+    "@opentelemetry/otlp-transformer": "0.34.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -73,8 +73,8 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.3",
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/otlp-exporter-base": "0.33.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/otlp-exporter-base": "0.34.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-grpc-exporter-base",
   "sideEffects": false

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-proto-exporter-base",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "OpenTelemetry OTLP-HTTP-protobuf Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -63,8 +63,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/otlp-exporter-base": "0.33.0",
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/otlp-exporter-base": "0.34.0",
     "protobufjs": "7.1.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-proto-exporter-base",

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Transform OpenTelemetry SDK data into OTLP",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
@@ -76,10 +76,10 @@
     "webpack": "4.46.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/sdk-metrics": "0.33.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-metrics": "0.34.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-transformer",
   "sideEffects": false

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.7.0",
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
+    "@opentelemetry/context-async-hooks": "1.8.0",
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
     "axios": "0.24.0",
     "body-parser": "1.19.0",
     "express": "4.17.1"

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -74,7 +74,7 @@
     "webpack-merge": "5.8.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.7.0",
+    "@opentelemetry/context-zone-peer-dep": "1.8.0",
     "zone.js": "^0.11.0"
   },
   "sideEffects": true,

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,7 +91,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.7.0"
+    "@opentelemetry/semantic-conventions": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core",
   "sideEffects": false

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/resources": "1.7.0",
+    "@opentelemetry/resources": "1.8.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -62,9 +62,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0",
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0",
     "jaeger-client": "^3.15.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,10 +91,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin",
   "sideEffects": false

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0"
+    "@opentelemetry/core": "1.8.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.3.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -80,7 +80,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0"
+    "@opentelemetry/core": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger",
   "sideEffects": false

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -89,8 +89,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,9 +91,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.3.0",
-    "@opentelemetry/resources": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0",
+    "@opentelemetry/resources": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/semver": "7.3.9",
@@ -64,11 +64,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.7.0",
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/propagator-b3": "1.7.0",
-    "@opentelemetry/propagator-jaeger": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
+    "@opentelemetry/context-async-hooks": "1.8.0",
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/propagator-b3": "1.8.0",
+    "@opentelemetry/propagator-jaeger": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
     "semver": "^7.3.5"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,9 +57,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": ">=1.0.0 <1.3.0",
-    "@opentelemetry/context-zone": "1.7.0",
-    "@opentelemetry/propagator-b3": "1.7.0",
-    "@opentelemetry/resources": "1.7.0",
+    "@opentelemetry/context-zone": "1.8.0",
+    "@opentelemetry/propagator-b3": "1.8.0",
+    "@opentelemetry/resources": "1.8.0",
     "@types/jquery": "3.5.8",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
@@ -91,9 +91,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0"
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web",
   "sideEffects": false

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -43,9 +43,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.3.0",
-    "@opentelemetry/propagator-b3": "1.7.0",
-    "@opentelemetry/propagator-jaeger": "1.7.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
+    "@opentelemetry/propagator-b3": "1.8.0",
+    "@opentelemetry/propagator-jaeger": "1.8.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
@@ -59,8 +59,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.7.0",
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/semantic-conventions": "1.8.0",
     "opentracing": "^0.14.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
@@ -56,16 +56,16 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.7.0",
-    "@opentelemetry/core": "1.7.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.33.0",
-    "@opentelemetry/exporter-zipkin": "1.7.0",
-    "@opentelemetry/instrumentation": "0.33.0",
-    "@opentelemetry/instrumentation-fetch": "0.33.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.33.0",
-    "@opentelemetry/sdk-metrics": "0.33.0",
-    "@opentelemetry/sdk-trace-base": "1.7.0",
-    "@opentelemetry/sdk-trace-web": "1.7.0",
+    "@opentelemetry/context-zone-peer-dep": "1.8.0",
+    "@opentelemetry/core": "1.8.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.34.0",
+    "@opentelemetry/exporter-zipkin": "1.8.0",
+    "@opentelemetry/instrumentation": "0.34.0",
+    "@opentelemetry/instrumentation-fetch": "0.34.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.34.0",
+    "@opentelemetry/sdk-metrics": "0.34.0",
+    "@opentelemetry/sdk-trace-base": "1.8.0",
+    "@opentelemetry/sdk-trace-web": "1.8.0",
     "zone.js": "0.11.4"
   }
 }


### PR DESCRIPTION
## 1.8.0

### :boom: Breaking Change

* feat(api): merge api-metrics into api [#3374](https://github.com/open-telemetry/opentelemetry-js/pull/3374) @legendecas

### :rocket: (Enhancement)

* feat(sdk-trace): re-export sdk-trace-base in sdk-trace-node and web [#3319](https://github.com/open-telemetry/opentelemetry-js/pull/3319) @legendecas
* feat: enable tree shaking [#3329](https://github.com/open-telemetry/opentelemetry-js/pull/3329) @pkanal

### :bug: (Bug Fix)

* fix(sdk-trace): enforce consistent span durations
  [#3327](https://github.com/open-telemetry/opentelemetry-js/pull/3327) @dyladan
* fix(resources): fix EnvDetector throwing errors when attribute values contain spaces
  [#3295](https://github.com/open-telemetry/opentelemetry-js/issues/3295)
* fix(trace): fix an issue which caused negative span durations in web based spans
  [#3359](https://github.com/open-telemetry/opentelemetry-js/pull/3359) @dyladan
* fix(resources): strict OTEL_RESOURCE_ATTRIBUTES baggage octet decoding
  [#3341](https://github.com/open-telemetry/opentelemetry-js/pull/3341) @legendecas

## Experimental 0.34.0

### :boom: Breaking Change

* Add semver check to metrics API [#3357](https://github.com/open-telemetry/opentelemetry-js/pull/3357) @dyladan
  * Previously API versions were only considered compatible if the API was exactly the same

### :rocket: (Enhancement)

* feat(metrics-sdk): Add tracing suppresing for Metrics Export [#3332](https://github.com/open-telemetry/opentelemetry-js/pull/3332) @hectorhdzg
* feat(instrumentation): implement `require-in-the-middle` singleton [#3161](https://github.com/open-telemetry/opentelemetry-js/pull/3161) @mhassan1
* feat(sdk-node): configure trace exporter with environment variables [#3143](https://github.com/open-telemetry/opentelemetry-js/pull/3143) @svetlanabrennan
* feat: enable tree shaking [#3329](https://github.com/open-telemetry/opentelemetry-js/pull/3329) @pkanal
* feat(prometheus): serialize resource as target_info gauge [#3300](https://github.com/open-telemetry/opentelemetry-js/pull/3300) @pichlermarc
* feat(detectors): add browser detector module [#3292](https://github.com/open-telemetry/opentelemetry-js/pull/3292) @abinet18
* deps: remove unused proto-loader dependencies and update grpc-js and proto-loader versions [#3337](https://github.com/open-telemetry/opentelemetry-js/pull/3337) @seemk
* feat(metrics-exporters): configure temporality via environment variable [#3305](https://github.com/open-telemetry/opentelemetry-js/pull/3305) @pichlermarc

### :bug: (Bug Fix)

* fix(node-sdk): move `@opentelemetry/semantic-conventions` to `dependencies` [#3283](https://github.com/open-telemetry/opentelemetry-js/pull/3283) @mhassan1
* fix(exporters): do not append trailing '/' when URL contains path [#3274](https://github.com/open-telemetry/opentelemetry-js/pull/3274) @pichlermarc
* fix(instrumentation): debug log on no modules defined for instrumentation [#3308](https://github.com/open-telemetry/opentelemetry-js/pull/3308) @legendecas

### :books: (Refine Doc)

* docs(metrics-exporters): fix wrong exporter const name in example [#3270](https://github.com/open-telemetry/opentelemetry-js/issues/3270) @pichlermarc

### :house: (Internal)

* ci(instrumentation-http): remove got devDependency
  [#3347](https://github.com/open-telemetry/opentelemetry-js/issues/3347) @dyladan
* deps(instrumentation-http): move sdk-metrics to dev dependencies [#3380](https://github.com/open-telemetry/opentelemetry-js/issues/3380) @pichlermarc