### PR TITLE
feat(instrumentation-http): monitor error events with events.errorMonitor

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :rocket: (Enhancement)
 
+* feat(instrumentation-http): monitor error events with events.errorMonitor [#3402](https://github.com/open-telemetry/opentelemetry-js/pull/3402) @legendecas
+
 ### :bug: (Bug Fix)
 
 ### :books: (Refine Doc)

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -54,6 +54,7 @@ import {
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
 import { RPCMetadata, RPCType, setRPCMetadata } from '@opentelemetry/core';
+import { errorMonitor } from 'events';
 
 /**
  * Http instrumentation instrumentation for Opentelemetry
@@ -361,7 +362,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
 
           this._closeHttpSpan(span, SpanKind.CLIENT, startTime, metricAttributes);
         });
-        response.on('error', (error: Err) => {
+        response.on(errorMonitor, (error: Err) => {
           this._diag.debug('outgoingRequest on error()', error);
           utils.setSpanWithError(span, error);
           const code = utils.parseResponseStatus(SpanKind.CLIENT, response.statusCode);
@@ -376,7 +377,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
         this._closeHttpSpan(span, SpanKind.CLIENT, startTime, metricAttributes);
       }
     });
-    request.on('error', (error: Err) => {
+    request.on(errorMonitor, (error: Err) => {
       this._diag.debug('outgoingRequest on request error()', error);
       utils.setSpanWithError(span, error);
       this._closeHttpSpan(span, SpanKind.CLIENT, startTime, metricAttributes);


### PR DESCRIPTION
## Which problem is this PR solving?

Related: https://github.com/open-telemetry/opentelemetry-js/issues/225

As support for Node.js versions lower than v12 are dropped, `error` events can be monitored without side-effects with `events.errorMonitor`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Verified Error event listeners counts.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] ~~Documentation has been updated~~
