### PR TITLE
chore: remove experimental note in sdk-metrics

### DIFF
--- a/packages/sdk-metrics/README.md
+++ b/packages/sdk-metrics/README.md
@@ -3,8 +3,6 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
-**Note: This is an experimental package under active development. New releases may include breaking changes.**
-
 OpenTelemetry metrics module contains the foundation for all metrics SDKs of [opentelemetry-js](https://github.com/open-telemetry/opentelemetry-js).
 
 Used standalone, this module provides methods for manual instrumentation of code, offering full control over recording metrics for client-side JavaScript (browser) and Node.js.

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opentelemetry/sdk-metrics",
   "version": "1.8.0",
-  "description": "Work in progress OpenTelemetry metrics SDK",
+  "description": "OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
@@ -81,6 +81,6 @@
     "@opentelemetry/resources": "1.8.0",
     "lodash.merge": "4.6.2"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-sdk-metrics",
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-metrics",
   "sideEffects": false
 }


### PR DESCRIPTION
## Short description of the changes

sdk-metrics is GA therefore readme should no longer tell it's experimental. Besides that the link to the repo is updated in package.json.

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated
