### PR TITLE
fix(api): deprecate MetricAttributes and MetricAttributeValue

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* fix(api): deprecate MetricsAttributes and MetricAttributeValue [#3406](https://github.com/open-telemetry/opentelemetry-js/pull/3406) @blumamir
+
 ## [1.3.0](https://www.github.com/open-telemetry/opentelemetry-js-api/compare/v1.2.0...v1.3.0)
 
 * feat(api): merge api-metrics into api [#3374](https://github.com/open-telemetry/opentelemetry-js/pull/3374) @legendecas

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-* fix(api): deprecate MetricsAttributes and MetricAttributeValue [#3406](https://github.com/open-telemetry/opentelemetry-js/pull/3406) @blumamir
+* fix(api): deprecate MetricAttributes and MetricAttributeValue [#3406](https://github.com/open-telemetry/opentelemetry-js/pull/3406) @blumamir
 
 ## [1.3.0](https://www.github.com/open-telemetry/opentelemetry-js-api/compare/v1.2.0...v1.3.0)
 

--- a/api/src/metrics/Metric.ts
+++ b/api/src/metrics/Metric.ts
@@ -83,19 +83,13 @@ export interface Histogram<AttributesTypes extends MetricAttributes = MetricAttr
   record(value: number, attributes?: AttributesTypes, context?: Context): void;
 }
 
-// api.MetricAttributes instead of api.Attributes is used here for api package backward compatibility.
 /**
- * Attributes is a map from string to attribute values.
- *
- * Note: only the own enumerable keys are counted as valid attribute keys.
+ * @deprecated please use {@link Attributes}
  */
 export type MetricAttributes = Attributes;
 
-// api.MetricAttributeValue instead of api.AttributeValue is used here for api package backward compatibility.
 /**
- * Attribute values may be any non-nullish primitive value except an object.
- *
- * null or undefined attribute values are invalid and will result in undefined behavior.
+ * @deprecated please use {@link AttributeValue}
  */
 export type MetricAttributeValue = AttributeValue;
 

--- a/api/src/metrics/Metric.ts
+++ b/api/src/metrics/Metric.ts
@@ -83,7 +83,7 @@ export interface Histogram<AttributesTypes extends MetricAttributes = MetricAttr
   record(value: number, attributes?: AttributesTypes, context?: Context): void;
 }
 
-// api.SpanAttributes instead of api.Attributes is used here for api package backward compatibility.
+// api.MetricAttributes instead of api.Attributes is used here for api package backward compatibility.
 /**
  * Attributes is a map from string to attribute values.
  *
@@ -91,7 +91,7 @@ export interface Histogram<AttributesTypes extends MetricAttributes = MetricAttr
  */
 export type MetricAttributes = Attributes;
 
-// api.SpanAttributeValue instead of api.AttributeValue is used here for api package backward compatibility.
+// api.MetricAttributeValue instead of api.AttributeValue is used here for api package backward compatibility.
 /**
  * Attribute values may be any non-nullish primitive value except an object.
  *


### PR DESCRIPTION
~~Just a small fix to the metrics API comment I spotted when reviewing https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1281~~

~~Probably it's a missed copy-paste mistake~~

deprecate `MetricAttribute` and `MetricAttributeValue` to align with `SpanAttributes` and `SpanAttributeValue`.

I wonder if it should also be replaced in the api package where it is used (I think yes)