### PR TITLE
test(api): disable module concatenation in tree-shaking test

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+* test(api): disable module concatenation in tree-shaking test [#3409](https://github.com/open-telemetry/opentelemetry-js/pull/3409) @legendecas
+
 ## [1.3.0](https://www.github.com/open-telemetry/opentelemetry-js-api/compare/v1.2.0...v1.3.0)
 
 * feat(api): merge api-metrics into api [#3374](https://github.com/open-telemetry/opentelemetry-js/pull/3374) @legendecas

--- a/api/test/tree-shaking/tree-shaking.test.ts
+++ b/api/test/tree-shaking/tree-shaking.test.ts
@@ -74,6 +74,8 @@ describe('tree-shaking', () => {
         optimization: {
           // disable minimization so that we can inspect the output easily.
           minimize: false,
+          // disable module concatenation so that variable names will not be mangled.
+          concatenateModules: false,
         }
       });
 


### PR DESCRIPTION

## Which problem is this PR solving?

Fixes CI failures in https://github.com/open-telemetry/opentelemetry-js/pull/3208#issuecomment-1312384503.

## Short description of the changes

When small modules are concatenated, variable names are mangled, which fails the matching in the tree-shaking test.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
