### PR TITLE
feat(api-logs): add the SeverityNumber enumeration

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to experimental packages in this project will be documented 
 * feat(instrumentation-grpc): added grpc metadata client side attributes in instrumentation [#3386](https://github.com/open-telemetry/opentelemetry-js/pull/3386)
 * feat(instrumentation): add new `_setMeterInstruments` protected method that update the meter instruments every meter provider update.
 * feat(api-logs): add the `SeverityNumber` enumeration. [#3443](https://github.com/open-telemetry/opentelemetry-js/pull/3443/) @fuaiyi
+
 ### :bug: (Bug Fix)
 
 * fix(instrumentation-xhr): http.url attribute should be absolute [#3200](https://github.com/open-telemetry/opentelemetry-js/pull/3200) @t2t2

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to experimental packages in this project will be documented 
 * feat(instrumentation-http): monitor error events with events.errorMonitor [#3402](https://github.com/open-telemetry/opentelemetry-js/pull/3402) @legendecas
 * feat(instrumentation-grpc): added grpc metadata client side attributes in instrumentation [#3386](https://github.com/open-telemetry/opentelemetry-js/pull/3386)
 * feat(instrumentation): add new `_setMeterInstruments` protected method that update the meter instruments every meter provider update.
-
+* feat(api-logs): add the `SeverityNumber` enumeration. [#3443](https://github.com/open-telemetry/opentelemetry-js/pull/3443/) @fuaiyi
 ### :bug: (Bug Fix)
 
 * fix(instrumentation-xhr): http.url attribute should be absolute [#3200](https://github.com/open-telemetry/opentelemetry-js/pull/3200) @t2t2

--- a/experimental/packages/api-logs/README.md
+++ b/experimental/packages/api-logs/README.md
@@ -42,7 +42,7 @@ const logger = api.logs.getLogger(name, version);
 logger.emitEvent({ name: 'event-name', domain: 'event-domain' });
 
 // logging an event in a log appender
-logger.emitLogRecord({ severityNumber: 1, body: 'log data' });
+logger.emitLogRecord({ severityNumber: SeverityNumber.TRACE, body: 'log data' });
 ```
 
 ## Useful links

--- a/experimental/packages/api-logs/src/types/LogRecord.ts
+++ b/experimental/packages/api-logs/src/types/LogRecord.ts
@@ -16,6 +16,34 @@
 
 import { Attributes } from '@opentelemetry/api';
 
+export enum SeverityNumber {
+  UNSPECIFIED = 0,
+  TRACE = 1,
+  TRACE2 = 2,
+  TRACE3 = 3,
+  TRACE4 = 4,
+  DEBUG = 5,
+  DEBUG2 = 6,
+  DEBUG3 = 7,
+  DEBUG4 = 8,
+  INFO = 9,
+  INFO2 = 10,
+  INFO3 = 11,
+  INFO4 = 12,
+  WARN = 13,
+  WARN2 = 14,
+  WARN3 = 15,
+  WARN4 = 16,
+  ERROR = 17,
+  ERROR2 = 18,
+  ERROR3 = 19,
+  ERROR4 = 20,
+  FATAL = 21,
+  FATAL2 = 22,
+  FATAL3 = 23,
+  FATAL4 = 24,
+}
+
 export interface LogRecord {
   /**
    * The time when the log record occurred as UNIX Epoch time in nanoseconds.
@@ -25,7 +53,7 @@ export interface LogRecord {
   /**
    * Numerical value of the severity.
    */
-  severityNumber?: number;
+  severityNumber?: SeverityNumber;
 
   /**
    * The severity text.

--- a/experimental/packages/api-logs/test/noop-implementations/noop-logger.test.ts
+++ b/experimental/packages/api-logs/test/noop-implementations/noop-logger.test.ts
@@ -32,6 +32,9 @@ describe('NoopLogger', () => {
 
   it('calling emitLogRecord should not crash', () => {
     const logger = new NoopLoggerProvider().getLogger('test-noop');
-    logger.emitLogRecord({ severityNumber: SeverityNumber.TRACE, body: 'log body' });
+    logger.emitLogRecord({
+      severityNumber: SeverityNumber.TRACE,
+      body: 'log body',
+    });
   });
 });

--- a/experimental/packages/api-logs/test/noop-implementations/noop-logger.test.ts
+++ b/experimental/packages/api-logs/test/noop-implementations/noop-logger.test.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from 'assert';
+import { SeverityNumber } from '../../src';
 import { NoopLogger } from '../../src/NoopLogger';
 import { NoopLoggerProvider } from '../../src/NoopLoggerProvider';
 
@@ -31,6 +32,6 @@ describe('NoopLogger', () => {
 
   it('calling emitLogRecord should not crash', () => {
     const logger = new NoopLoggerProvider().getLogger('test-noop');
-    logger.emitLogRecord({ severityNumber: 1, body: 'log body' });
+    logger.emitLogRecord({ severityNumber: SeverityNumber.TRACE, body: 'log body' });
   });
 });


### PR DESCRIPTION
### Background
Our company is also using OpenTelemetry standard for observability. I have been paying attention to the construction of OpenTelemetry, but I found that the Logs capability is not provided. so we developed the implementation of Logs by referring to the design standard. Recently, the community started developing Logs after the Metric stable release was completed. so I want to contribute the code that has been done with reference to the community's latest specifications and style, as well as the recent implementation of Logs in java, to build on and improve the capability of Logs. Accelerate the building of Logs capability so that developers like me can use the stable version of OpenTelemetry capability sooner rather than later. Welcome to participate in the CR and discussion.

We've done some capability development
- api-logs
- sdk-logs
- exporter-logs-otlp-http


### PR
> Note:  Because the amount of code submitted at one time is too large, I conducted PR several times. The PR content of this time is as follows (My colleague also submitted a full amount of code for your convenience: https://github.com/open-telemetry/opentelemetry-js/pull/3442)

#### api-logs
**Module directory**: experimental/packages/API - logs
**Detail**: in the process of development, it is found that the existing api-logs (v0.34.0) is inconsistent with the design standard and fails to meet part of the sdk capabilities, so a part of the code is reconstructed after referring to the design standard and java implementation. The main details are as follows:

1. delete LogEvent
2. Logger implements:  emitLogRecord -> modification; getLogRecord; emitEvent -> getLogEvent
3. LogRecord modification (I think the LogRecord in api should provide the corresponding method and configuration, rather than the specific data model, can refer to the implementation in Trace)
4. implementation of NoopLogger
5. add NoopLogRecord
6. modify the unit test
7. modify README