### PR TITLE
chore: improve windows compatibility of update-ts-config

### DIFF
--- a/scripts/update-ts-configs-constants.js
+++ b/scripts/update-ts-configs-constants.js
@@ -18,7 +18,7 @@ const path = require('path');
 
 function getDefaultTsConfig(pkgRoot, projectRoot) {
   return {
-    extends: path.relative(pkgRoot, path.join(projectRoot, 'tsconfig.base.json')),
+    extends: toPosix(path.relative(pkgRoot, path.join(projectRoot, 'tsconfig.base.json'))),
     compilerOptions: {
       rootDir: '.',
       outDir: 'build',
@@ -33,7 +33,7 @@ function getDefaultTsConfig(pkgRoot, projectRoot) {
 
 function getEsmTsConfig(pkgRoot, projectRoot) {
   return {
-    extends: path.relative(pkgRoot, path.join(projectRoot, 'tsconfig.base.esm.json')),
+    extends: toPosix(path.relative(pkgRoot, path.join(projectRoot, 'tsconfig.base.esm.json'))),
     compilerOptions: {
       rootDir: 'src',
       outDir: 'build/esm',
@@ -48,7 +48,7 @@ function getEsmTsConfig(pkgRoot, projectRoot) {
 
 function getEsnextTsConfig(pkgRoot, projectRoot) {
   return {
-    extends: path.relative(pkgRoot, path.join(projectRoot, 'tsconfig.base.esnext.json')),
+    extends: toPosix(path.relative(pkgRoot, path.join(projectRoot, 'tsconfig.base.esnext.json'))),
     compilerOptions: {
       rootDir: 'src',
       outDir: 'build/esnext',
@@ -61,8 +61,13 @@ function getEsnextTsConfig(pkgRoot, projectRoot) {
   };
 }
 
+function toPosix(p) {
+  return p.split(path.sep).join(path.posix.sep);
+}
+
 module.exports = {
   getDefaultTsConfig,
   getEsmTsConfig,
   getEsnextTsConfig,
+  toPosix
 };

--- a/scripts/update-ts-configs-constants.js
+++ b/scripts/update-ts-configs-constants.js
@@ -61,6 +61,8 @@ function getEsnextTsConfig(pkgRoot, projectRoot) {
   };
 }
 
+// Helper to convert windows path style to posix to ensure platform independent
+// tsconfig generation.
 function toPosix(p) {
   return p.split(path.sep).join(path.posix.sep);
 }

--- a/scripts/update-ts-configs.js
+++ b/scripts/update-ts-configs.js
@@ -32,6 +32,7 @@ const {
   getDefaultTsConfig,
   getEsmTsConfig,
   getEsnextTsConfig,
+  toPosix
 } = require('./update-ts-configs-constants');
 
 const packageJsonDependencyFields = ['dependencies', 'peerDependencies', 'devDependencies'];
@@ -99,13 +100,13 @@ function writeRootTsConfigJson(pkgRoot, projectRoot, lernaProjects) {
   const tsconfig = readJSON(tsconfigPath);
   const references = Array.from(lernaProjects.values())
     .filter(it => it.isTsProject)
-    .map(it => path.relative(pkgRoot, path.join(projectRoot, it.dir))).sort();
+    .map(it => toPosix(path.relative(pkgRoot, path.join(projectRoot, it.dir)))).sort();
   tsconfig.references = references.map(path => {
-    return { path }
+    return { path: toPosix(path) }
   });
   tsconfig.typedocOptions.entryPoints = Array.from(lernaProjects.values())
     .filter(it => !it.private && it.isTsProject)
-    .map(it => path.relative(pkgRoot, path.join(projectRoot, it.dir))).sort();
+    .map(it => toPosix(path.relative(pkgRoot, path.join(projectRoot, it.dir)))).sort();
   writeJSON(tsconfigPath, tsconfig, dryRun);
 
   for (const tsconfigName of ['tsconfig.esm.json', 'tsconfig.esnext.json']) {
@@ -113,9 +114,9 @@ function writeRootTsConfigJson(pkgRoot, projectRoot, lernaProjects) {
     const tsconfig = readJSON(tsconfigPath);
     const references = Array.from(lernaProjects.values())
       .filter(it => it.isTsProject && it.hasMultiTarget)
-      .map(it => path.relative(pkgRoot, path.join(projectRoot, it.dir))).sort();
+      .map(it => toPosix(path.relative(pkgRoot, path.join(projectRoot, it.dir)))).sort();
     tsconfig.references = references.map(pkgPath => {
-      return { path: path.join(pkgPath, tsconfigName), }
+      return { path: toPosix(path.join(pkgPath, tsconfigName)), }
     });
     writeJSON(tsconfigPath, tsconfig, dryRun);
   }
@@ -131,7 +132,7 @@ function writeMultiTargetTsConfigs(pkgRoot, projectRoot, references) {
     const tsconfigPath = path.join(pkgRoot, tsconfigName);
     let tsconfig = getTsConfig(pkgRoot, projectRoot);
     tsconfig.references = references.map(path => {
-      return { path };
+      return { path: toPosix(path) };
     });
     tsconfig = readAndMaybeMergeTsConfig(tsconfigPath, tsconfig);
     writeJSON(tsconfigPath, tsconfig, dryRun);
@@ -142,7 +143,7 @@ function writeSingleTargetTsConfig(pkgRoot, projectRoot, references) {
   const tsconfigPath = path.join(pkgRoot, 'tsconfig.json');
   let tsconfig = getDefaultTsConfig(pkgRoot, projectRoot);
   tsconfig.references = references.map(path => {
-    return { path }
+    return { path: toPosix(path) }
   });
   tsconfig = readAndMaybeMergeTsConfig(tsconfigPath, tsconfig);
   writeJSON(tsconfigPath, tsconfig, dryRun);


### PR DESCRIPTION
Change update-ts-config script to generate posix path also on windows to avoid that tsconfig.json files are wrongly modified.

