### PR TITLE
fix(api): use active context as default in NoopTracer

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * fix(api): deprecate MetricAttributes and MetricAttributeValue [#3406](https://github.com/open-telemetry/opentelemetry-js/pull/3406) @blumamir
 * test(api): disable module concatenation in tree-shaking test [#3409](https://github.com/open-telemetry/opentelemetry-js/pull/3409) @legendecas
+* fix(api): use active context as default in NoopTracer [ToDo] (https://github.com/open-telemetry/opentelemetry-js/pull/ToDo) @flarna
 
 ## [1.3.0](https://www.github.com/open-telemetry/opentelemetry-js-api/compare/v1.2.0...v1.3.0)
 

--- a/api/src/trace/NoopTracer.ts
+++ b/api/src/trace/NoopTracer.ts
@@ -31,7 +31,11 @@ const contextApi = ContextAPI.getInstance();
  */
 export class NoopTracer implements Tracer {
   // startSpan starts a noop span.
-  startSpan(name: string, options?: SpanOptions, context?: Context): Span {
+  startSpan(
+    name: string,
+    options?: SpanOptions,
+    context = contextApi.active()
+  ): Span {
     const root = Boolean(options?.root);
     if (root) {
       return new NonRecordingSpan();

--- a/api/test/common/proxy-implementations/proxy-tracer.test.ts
+++ b/api/test/common/proxy-implementations/proxy-tracer.test.ts
@@ -174,9 +174,9 @@ describe('ProxyTracer', () => {
       tracer.startSpan(name, options, ctx);
 
       // Assert the proxy tracer has the full API of the NoopTracer
-      assert.strictEqual(
-        NoopTracer.prototype.startSpan.length,
-        ProxyTracer.prototype.startSpan.length
+      assert.ok(
+        ProxyTracer.prototype.startSpan.length >=
+          NoopTracer.prototype.startSpan.length
       );
       assert.deepStrictEqual(Object.getOwnPropertyNames(NoopTracer.prototype), [
         'constructor',


### PR DESCRIPTION
## Which problem is this PR solving?

[API without SDK usecase](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.15.0/specification/trace/api.md#behavior-of-the-api-in-the-absence-of-an-installed-sdk) (only proagator and context manager and maybe some instrumentations used) doesn't work is one relies on context manager.

## Short description of the changes

To support the API without SDK use cast to forward a span context it's needed to fetch active context via ContextManager also in NoopTracer. Otherwise only direct passing of a context works but not if context.with() is used.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

added unittest

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
