### PR TITLE
Prometheus exporter server config

### DIFF
--- a/experimental/packages/opentelemetry-exporter-prometheus/README.md
+++ b/experimental/packages/opentelemetry-exporter-prometheus/README.md
@@ -25,8 +25,7 @@ const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
 const { MeterProvider }  = require('@opentelemetry/sdk-metrics');
 
 // Add your port and startServer to the Prometheus options
-const options = {port: 9464, startServer: true};
-const exporter = new PrometheusExporter(options);
+const exporter = new PrometheusExporter({port: 9464});
 
 // Creates MeterProvider and installs the exporter as a MetricReader
 const meterProvider = new MeterProvider();
@@ -38,6 +37,28 @@ const counter = meter.createCounter('metric_name', {
   description: 'Example of a counter'
 });
 counter.add(10, { pid: process.pid });
+
+// .. some other work
+```
+
+Create & register the exporter on your application on a http existing server.
+
+```js
+const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
+const { MeterProvider }  = require('@opentelemetry/sdk-metrics');
+const { http }  = require('http');
+
+const httpServer = http.createServer();
+const httpOptions = {path: '/monitoring', port: 9464 };
+const exporter = new PrometheusExporter({
+  preventServerStart: true,
+  server: httpServer
+});
+
+// Start http server
+exporter.startServer(httpOptions).then(() => {
+  console.log(`Prometheus exporter server started`);
+});
 
 // .. some other work
 ```

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/export/types.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/export/types.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { Server } from 'http';
+
 /**
  * Configuration interface for prometheus exporter
  */
@@ -56,4 +58,11 @@ export interface ExporterConfig {
    * @default false
    */
   preventServerStart?: boolean;
+
+  /**
+   * HTTP Server where the Prometheus exporter request listener is will be attached.
+   *
+   * @default undefined (create a new server)
+   */
+  server?: Server;
 }


### PR DESCRIPTION
## Which problem is this PR solving?
This allows the `PrometheusExporter` server to be further configured.

## Short description of the changes

The constructor now receives a server as a argument and only creates a new one if none is provided..
`PrometheusExporter#startServer` can also receive `ListenOptions` for to allow for more configuration option..

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

New tests have been added to `PrometheusExporter.test.ts` to make sure that the new options are being used and the existing one continue to work..

- [X] PrometheusExporter.test.ts

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been added
- [X] Documentation has been updated
