### PR TITLE
Feat support otel sdk disabled env

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -8,159 +8,158 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :rocket: (Enhancement)
 
-- feat(instrumentation-http): monitor error events with events.errorMonitor [#3402](https://github.com/open-telemetry/opentelemetry-js/pull/3402) @legendecas
-- feat(instrumentation-grpc): added grpc metadata client side attributes in instrumentation [#3386](https://github.com/open-telemetry/opentelemetry-js/pull/3386)
-- feat(instrumentation): add new `_setMeterInstruments` protected method that update the meter instruments every meter provider update.
-- feat(sdk-node): configure no-op sdk with `OTEL_SDK_DISABLED` environment variable @RazGvili
-- feat(api-logs): add the `SeverityNumber` enumeration. [#3443](https://github.com/open-telemetry/opentelemetry-js/pull/3443/) @fuaiyi
+* feat(instrumentation-http): monitor error events with events.errorMonitor [#3402](https://github.com/open-telemetry/opentelemetry-js/pull/3402) @legendecas
+* feat(instrumentation-grpc): added grpc metadata client side attributes in instrumentation [#3386](https://github.com/open-telemetry/opentelemetry-js/pull/3386)
+* feat(instrumentation): add new `_setMeterInstruments` protected method that update the meter instruments every meter provider update.
+* feat(api-logs): add the `SeverityNumber` enumeration. [#3443](https://github.com/open-telemetry/opentelemetry-js/pull/3443/) @fuaiyi
+* feat(sdk-node): configure no-op sdk with `OTEL_SDK_DISABLED` environment variable [#3485](https://github.com/open-telemetry/opentelemetry-js/pull/3485/files/2211c78aec39aeb6b4b3dae71844edf8ce234d20)  @RazGvili
 
 ### :bug: (Bug Fix)
 
-- fix(instrumentation-xhr): http.url attribute should be absolute [#3200](https://github.com/open-telemetry/opentelemetry-js/pull/3200) @t2t2
-- fix(instrumentation-grpc): always set grpc semcov status code attribute with numeric value [#3076](https://github.com/open-telemetry/opentelemetry-js/pull/3076) @blumamir
-- fix(instrumentation): only call `onRequire` for full matches on core modules with sub-paths [#3451](https://github.com/open-telemetry/opentelemetry-js/pull/3451) @mhassan1
-- fix(instrumentation): add back support for absolute paths via `require-in-the-middle` [#3457](https://github.com/open-telemetry/opentelemetry-js/pull/3457) @mhassan1
-- fix(prometheus-sanitization): replace repeated `_` with a single `_` [3470](https://github.com/open-telemetry/opentelemetry-js/pull/3470) @samimusallam
-- fix(prometheus-serializer): correct string used for NaN [#3477](https://github.com/open-telemetry/opentelemetry-js/pull/3477) @JacksonWeber
-- fix(instrumentation-http): close server span when response finishes [#3407](https://github.com/open-telemetry/opentelemetry-js/pull/3407) @legendecas
+* fix(instrumentation-xhr): http.url attribute should be absolute [#3200](https://github.com/open-telemetry/opentelemetry-js/pull/3200) @t2t2
+* fix(instrumentation-grpc): always set grpc semcov status code attribute with numeric value [#3076](https://github.com/open-telemetry/opentelemetry-js/pull/3076) @blumamir
+* fix(instrumentation): only call `onRequire` for full matches on core modules with sub-paths [#3451](https://github.com/open-telemetry/opentelemetry-js/pull/3451) @mhassan1
+* fix(instrumentation): add back support for absolute paths via `require-in-the-middle` [#3457](https://github.com/open-telemetry/opentelemetry-js/pull/3457) @mhassan1
+* fix(prometheus-sanitization): replace repeated `_` with a single `_` [3470](https://github.com/open-telemetry/opentelemetry-js/pull/3470) @samimusallam
+* fix(prometheus-serializer): correct string used for NaN [#3477](https://github.com/open-telemetry/opentelemetry-js/pull/3477) @JacksonWeber
+* fix(instrumentation-http): close server span when response finishes [#3407](https://github.com/open-telemetry/opentelemetry-js/pull/3407) @legendecas
 
 ### :books: (Refine Doc)
 
 ### :house: (Internal)
 
-- chore(otlp-proto-exporter-base): upgrade protobufjs to 7.1.2 and relax versioning [#3433](https://github.com/open-telemetry/opentelemetry-js/pull/3433) @seemk
+* chore(otlp-proto-exporter-base): upgrade protobufjs to 7.1.2 and relax versioning [#3433](https://github.com/open-telemetry/opentelemetry-js/pull/3433) @seemk
 
 ## 0.34.0
 
-- `@opentelemetry/sdk-metrics` moved to [packages/sdk-metrics](../packages/sdk-metrics)
-- `@opentelemetry/api-metrics` deprecated and merged into [api](../api)
+* `@opentelemetry/sdk-metrics` moved to [packages/sdk-metrics](../packages/sdk-metrics)
+* `@opentelemetry/api-metrics` deprecated and merged into [api](../api)
 
 ### :rocket: (Enhancement)
 
-- feat(metrics-sdk): Add tracing suppresing for Metrics Export [#3332](https://github.com/open-telemetry/opentelemetry-js/pull/3332) @hectorhdzg
-- feat(instrumentation): implement `require-in-the-middle` singleton [#3161](https://github.com/open-telemetry/opentelemetry-js/pull/3161) @mhassan1
-- feat(sdk-node): configure trace exporter with environment variables [#3143](https://github.com/open-telemetry/opentelemetry-js/pull/3143) @svetlanabrennan
-- feat: enable tree shaking [#3329](https://github.com/open-telemetry/opentelemetry-js/pull/3329) @pkanal
-- feat(prometheus): serialize resource as target_info gauge [#3300](https://github.com/open-telemetry/opentelemetry-js/pull/3300) @pichlermarc
-- feat(detectors): add browser detector module [#3292](https://github.com/open-telemetry/opentelemetry-js/pull/3292) @abinet18
-- deps: remove unused proto-loader dependencies and update grpc-js and proto-loader versions [#3337](https://github.com/open-telemetry/opentelemetry-js/pull/3337) @seemk
-- feat(metrics-exporters): configure temporality via environment variable [#3305](https://github.com/open-telemetry/opentelemetry-js/pull/3305) @pichlermarc
-- feat(console-metric-exporter): add temporality configuration [#3387](https://github.com/open-telemetry/opentelemetry-js/pull/3387) @pichlermarc
+* feat(metrics-sdk): Add tracing suppresing for Metrics Export [#3332](https://github.com/open-telemetry/opentelemetry-js/pull/3332) @hectorhdzg
+* feat(instrumentation): implement `require-in-the-middle` singleton [#3161](https://github.com/open-telemetry/opentelemetry-js/pull/3161) @mhassan1
+* feat(sdk-node): configure trace exporter with environment variables [#3143](https://github.com/open-telemetry/opentelemetry-js/pull/3143) @svetlanabrennan
+* feat: enable tree shaking [#3329](https://github.com/open-telemetry/opentelemetry-js/pull/3329) @pkanal
+* feat(prometheus): serialize resource as target_info gauge [#3300](https://github.com/open-telemetry/opentelemetry-js/pull/3300) @pichlermarc
+* feat(detectors): add browser detector module [#3292](https://github.com/open-telemetry/opentelemetry-js/pull/3292) @abinet18
+* deps: remove unused proto-loader dependencies and update grpc-js and proto-loader versions [#3337](https://github.com/open-telemetry/opentelemetry-js/pull/3337) @seemk
+* feat(metrics-exporters): configure temporality via environment variable [#3305](https://github.com/open-telemetry/opentelemetry-js/pull/3305) @pichlermarc
+* feat(console-metric-exporter): add temporality configuration [#3387](https://github.com/open-telemetry/opentelemetry-js/pull/3387) @pichlermarc
 
 ### :bug: (Bug Fix)
 
-- fix(node-sdk): move `@opentelemetry/semantic-conventions` to `dependencies` [#3283](https://github.com/open-telemetry/opentelemetry-js/pull/3283) @mhassan1
-- fix(exporters): do not append trailing '/' when URL contains path [#3274](https://github.com/open-telemetry/opentelemetry-js/pull/3274) @pichlermarc
-- fix(instrumentation): debug log on no modules defined for instrumentation [#3308](https://github.com/open-telemetry/opentelemetry-js/pull/3308) @legendecas
+* fix(node-sdk): move `@opentelemetry/semantic-conventions` to `dependencies` [#3283](https://github.com/open-telemetry/opentelemetry-js/pull/3283) @mhassan1
+* fix(exporters): do not append trailing '/' when URL contains path [#3274](https://github.com/open-telemetry/opentelemetry-js/pull/3274) @pichlermarc
+* fix(instrumentation): debug log on no modules defined for instrumentation [#3308](https://github.com/open-telemetry/opentelemetry-js/pull/3308) @legendecas
 
 ### :books: (Refine Doc)
 
-- docs(metrics-exporters): fix wrong exporter const name in example [#3270](https://github.com/open-telemetry/opentelemetry-js/issues/3270) @pichlermarc
+* docs(metrics-exporters): fix wrong exporter const name in example [#3270](https://github.com/open-telemetry/opentelemetry-js/issues/3270) @pichlermarc
 
 ### :house: (Internal)
 
-- ci(instrumentation-http): remove got devDependency
+* ci(instrumentation-http): remove got devDependency
   [#3347](https://github.com/open-telemetry/opentelemetry-js/issues/3347) @dyladan
-- deps(instrumentation-http): move sdk-metrics to dev dependencies [#3380](https://github.com/open-telemetry/opentelemetry-js/issues/3380) @pichlermarc
+* deps(instrumentation-http): move sdk-metrics to dev dependencies [#3380](https://github.com/open-telemetry/opentelemetry-js/issues/3380) @pichlermarc
 
 ## 0.33.0
 
 ### :boom: Breaking Change
 
-- Add `resourceDetectors` option to `NodeSDK` [#3210](https://github.com/open-telemetry/opentelemetry-js/issues/3210)
-
-  - `NodeSDK.detectResources()` function is no longer able to receive config as a parameter.
+* Add `resourceDetectors` option to `NodeSDK` [#3210](https://github.com/open-telemetry/opentelemetry-js/issues/3210)
+  * `NodeSDK.detectResources()` function is no longer able to receive config as a parameter.
     Instead, the detectors are passed to the constructor.
 
-- chore(metrics-sdk): clean up exports [#3197](https://github.com/open-telemetry/opentelemetry-js/pull/3197) @pichlermarc
-  - removes export for:
-    - `AccumulationRecord`
-    - `Aggregator`
-    - `AggregatorKind`
-    - `Accumulation`
-    - `createInstrumentDescriptor`
-    - `createInstrumentDescriptorWithView`
-    - `isDescriptorCompatibleWith`
-- chore(api-metrics): clean up exports [#3198](https://github.com/open-telemetry/opentelemetry-js/pull/3198) @pichlermarc
-  - removes export for:
-    - `NOOP_COUNTER_METRIC`
-    - `NOOP_HISTOGRAM_METRIC`
-    - `NOOP_METER_PROVIDER`
-    - `NOOP_OBSERVABLE_COUNTER_METRIC`
-    - `NOOP_OBSERVABLE_GAUGE_METRIC`
-    - `NOOP_OBSERVABLE_UP_DOWN_COUNTER_METRIC`
-    - `NOOP_UP_DOWN_COUNTER_METRIC`
-    - `NoopCounterMetric`
-    - `NoopHistogramMetric`
-    - `NoopMeter`
-    - `NoopMeterProvider`
-    - `NoopMetric`
-    - `NoopObservableCounterMetric`
-    - `NoopObservableGaugeMetric`
-    - `NoopObservableMetric`
-    - `NoopObservableUpDownCounterMetric`
-    - `NoopUpDownCounterMetric`
-- feat(sdk-metrics): align MetricReader with specification and other language implementations [#3225](https://github.com/open-telemetry/opentelemetry-js/pull/3225) @pichlermarc
-- chore(sdk-metrics): remove accidental export of the SDK `Meter` class [#3243](https://github.com/open-telemetry/opentelemetry-js/pull/3243) @pichlermarc
+* chore(metrics-sdk): clean up exports [#3197](https://github.com/open-telemetry/opentelemetry-js/pull/3197) @pichlermarc
+  * removes export for:
+    * `AccumulationRecord`
+    * `Aggregator`
+    * `AggregatorKind`
+    * `Accumulation`
+    * `createInstrumentDescriptor`
+    * `createInstrumentDescriptorWithView`
+    * `isDescriptorCompatibleWith`
+* chore(api-metrics): clean up exports [#3198](https://github.com/open-telemetry/opentelemetry-js/pull/3198) @pichlermarc
+  * removes export for:
+    * `NOOP_COUNTER_METRIC`
+    * `NOOP_HISTOGRAM_METRIC`
+    * `NOOP_METER_PROVIDER`
+    * `NOOP_OBSERVABLE_COUNTER_METRIC`
+    * `NOOP_OBSERVABLE_GAUGE_METRIC`
+    * `NOOP_OBSERVABLE_UP_DOWN_COUNTER_METRIC`
+    * `NOOP_UP_DOWN_COUNTER_METRIC`
+    * `NoopCounterMetric`
+    * `NoopHistogramMetric`
+    * `NoopMeter`
+    * `NoopMeterProvider`
+    * `NoopMetric`
+    * `NoopObservableCounterMetric`
+    * `NoopObservableGaugeMetric`
+    * `NoopObservableMetric`
+    * `NoopObservableUpDownCounterMetric`
+    * `NoopUpDownCounterMetric`
+* feat(sdk-metrics): align MetricReader with specification and other language implementations [#3225](https://github.com/open-telemetry/opentelemetry-js/pull/3225) @pichlermarc
+* chore(sdk-metrics): remove accidental export of the SDK `Meter` class [#3243](https://github.com/open-telemetry/opentelemetry-js/pull/3243) @pichlermarc
 
 ### :rocket: (Enhancement)
 
-- Add `resourceDetectors` option to `NodeSDK` [#3210](https://github.com/open-telemetry/opentelemetry-js/issues/3210)
-- feat: add Logs API @mkuba [#3117](https://github.com/open-telemetry/opentelemetry-js/pull/3117)
+* Add `resourceDetectors` option to `NodeSDK` [#3210](https://github.com/open-telemetry/opentelemetry-js/issues/3210)
+* feat: add Logs API @mkuba [#3117](https://github.com/open-telemetry/opentelemetry-js/pull/3117)
 
 ### :books: (Refine Doc)
 
-- docs(sdk-metrics): fix typos and add missing parameter docs. [#3244](https://github.com/open-telemetry/opentelemetry-js/pull/3244) @pichlermarc
+* docs(sdk-metrics): fix typos and add missing parameter docs. [#3244](https://github.com/open-telemetry/opentelemetry-js/pull/3244) @pichlermarc
 
 ### :house: (Internal)
 
-- ci(instrumentation-http): improve metrics test stability [#3242](https://github.com/open-telemetry/opentelemetry-js/pull/3242) @pichlermarc
-- deps: remove unused protobufjs and update used ones to 7.1.1 #3251 [#3251](https://github.com/open-telemetry/opentelemetry-js/pull/3251) @pichlermarc
+* ci(instrumentation-http): improve metrics test stability [#3242](https://github.com/open-telemetry/opentelemetry-js/pull/3242) @pichlermarc
+* deps: remove unused protobufjs and update used ones to 7.1.1 #3251 [#3251](https://github.com/open-telemetry/opentelemetry-js/pull/3251) @pichlermarc
 
 ## 0.32.0
 
 ### :boom: Breaking Change
 
-- Rename @opentelemetry/sdk-metrics-base package to @opentelemetry/sdk-metrics [#3162](https://github.com/open-telemetry/opentelemetry-js/pull/3162) @hectorhdzg
+* Rename @opentelemetry/sdk-metrics-base package to @opentelemetry/sdk-metrics  [#3162](https://github.com/open-telemetry/opentelemetry-js/pull/3162) @hectorhdzg
 
 ### :rocket: (Enhancement)
 
-- feature(instrumentation-http): Add HTTP Server and Client duration Metrics in HTTP Node.js Instrumentation [#3149](https://github.com/open-telemetry/opentelemetry-js/pull/3149) @hectorhdzg
-- fix(add-views-to-node-sdk): added the ability to define meter views in `NodeSDK` [#3066](https://github.com/open-telemetry/opentelemetry-js/pull/3124) @weyert
-- feature(add-console-metrics-exporter): add ConsoleMetricExporter [#3120](https://github.com/open-telemetry/opentelemetry-js/pull/3120) @weyert
-- feature(prometheus-serialiser): export the unit block when unit is set in metric descriptor [#3066](https://github.com/open-telemetry/opentelemetry-js/pull/3041) @weyert
-- feat: support latest `@opentelemetry/api` [#3177](https://github.com/open-telemetry/opentelemetry-js/pull/3177) @dyladan
-- feat(sdk-metrics-base): add per metric-reader aggregation support [#3153](https://github.com/open-telemetry/opentelemetry-js/pull/3153) @legendecas
-- chore(deps): update prometheus example dependencies to 0.32 [#3126](https://github.com/open-telemetry/opentelemetry-js/pull/3216) @avzis
-- feature(opentelemetry-api-metrics): Adding generics to `create{metricType}` [#3151](https://github.com/open-telemetry/opentelemetry-js/issues/3151) @tomerghelber-tm
+* feature(instrumentation-http): Add HTTP Server and Client duration Metrics in HTTP Node.js Instrumentation [#3149](https://github.com/open-telemetry/opentelemetry-js/pull/3149) @hectorhdzg
+* fix(add-views-to-node-sdk): added the ability to define meter views in `NodeSDK` [#3066](https://github.com/open-telemetry/opentelemetry-js/pull/3124) @weyert
+* feature(add-console-metrics-exporter): add ConsoleMetricExporter [#3120](https://github.com/open-telemetry/opentelemetry-js/pull/3120) @weyert
+* feature(prometheus-serialiser): export the unit block when unit is set in metric descriptor [#3066](https://github.com/open-telemetry/opentelemetry-js/pull/3041) @weyert
+* feat: support latest `@opentelemetry/api` [#3177](https://github.com/open-telemetry/opentelemetry-js/pull/3177) @dyladan
+* feat(sdk-metrics-base): add per metric-reader aggregation support [#3153](https://github.com/open-telemetry/opentelemetry-js/pull/3153) @legendecas
+* chore(deps): update prometheus example dependencies to 0.32 [#3126](https://github.com/open-telemetry/opentelemetry-js/pull/3216) @avzis
+* feature(opentelemetry-api-metrics): Adding generics to `create{metricType}` [#3151](https://github.com/open-telemetry/opentelemetry-js/issues/3151) @tomerghelber-tm
 
 ### :bug: (Bug Fix)
 
-- fix(instrumentation-http): add `http.host` attribute before sending the request #3054 @cuichenli
+* fix(instrumentation-http): add `http.host` attribute before sending the request #3054 @cuichenli
 
 ## 0.31.0
 
 ### :boom: Breaking Change
 
-- feature(views): move views registration to MeterProvider constructor [#3066](https://github.com/open-telemetry/opentelemetry-js/pull/3066) @pichlermarc
-- feat(sdk-metrics-base): split up Singular into Sum and Gauge in MetricData [#3079](https://github.com/open-telemetry/opentelemetry-js/pull/3079) @pichlermarc
-  - removes `DataPointType.SINGULAR`, and replaces it with `DataPointType.SUM` and `DataPointType.GAUGE`
-  - removes `SingularMetricData` and replaces it with `SumMetricData` (including an additional `isMonotonic` flag) and `GaugeMetricData`
-- feat(histogram): align collection of optional Histogram properties with spec [#3102](https://github.com/open-telemetry/opentelemetry-js/pull/3079) @pichlermarc
-  - changes type of `sum` property on `Histogram` to `number | undefined`
-  - changes type of `min` and `max` properties on `Histogram` to `number | undefined`
-  - removes `hasMinMax` flag on the exported `Histogram` - this is now indicated by `min` and `max` being `undefined`
+* feature(views): move views registration to MeterProvider constructor [#3066](https://github.com/open-telemetry/opentelemetry-js/pull/3066) @pichlermarc
+* feat(sdk-metrics-base): split up Singular into Sum and Gauge in MetricData [#3079](https://github.com/open-telemetry/opentelemetry-js/pull/3079) @pichlermarc
+  * removes `DataPointType.SINGULAR`, and replaces it with `DataPointType.SUM` and `DataPointType.GAUGE`
+  * removes `SingularMetricData` and replaces it with `SumMetricData` (including an additional `isMonotonic` flag) and `GaugeMetricData`
+* feat(histogram): align collection of optional Histogram properties with spec [#3102](https://github.com/open-telemetry/opentelemetry-js/pull/3079) @pichlermarc
+  * changes type of `sum` property on `Histogram` to `number | undefined`
+  * changes type of `min` and `max` properties on `Histogram` to `number | undefined`
+  * removes `hasMinMax` flag on the exported `Histogram` - this is now indicated by `min` and `max` being `undefined`
 
 ### :rocket: (Enhancement)
 
-- feat(metrics-api): use common attributes definitions #3038 @legendecas
-- feat(otlp-proto): pre-compile proto files [#3098](https://github.com/open-telemetry/opentelemetry-js/pull/3098) @legendecas
-- feat(opentelemetry-sdk-metrics-base): added InMemoryMetricExporter [#3039](https://github.com/open-telemetry/opentelemetry-js/pull/3039) @weyert
+* feat(metrics-api): use common attributes definitions #3038 @legendecas
+* feat(otlp-proto): pre-compile proto files [#3098](https://github.com/open-telemetry/opentelemetry-js/pull/3098) @legendecas
+* feat(opentelemetry-sdk-metrics-base): added InMemoryMetricExporter [#3039](https://github.com/open-telemetry/opentelemetry-js/pull/3039) @weyert
 
 ### :bug: (Bug Fix)
 
-- fix(histogram): fix maximum when only values < -1 are provided [#3086](https://github.com/open-telemetry/opentelemetry-js/pull/3086) @pichlermarc
-- fix(instrumentation-grpc): always set grpc semcov status code attribute with numeric value [#3076](https://github.com/open-telemetry/opentelemetry-js/pull/3076) @blumamir
+* fix(histogram): fix maximum when only values < -1 are provided [#3086](https://github.com/open-telemetry/opentelemetry-js/pull/3086) @pichlermarc
+* fix(instrumentation-grpc): always set grpc semcov status code attribute with numeric value [#3076](https://github.com/open-telemetry/opentelemetry-js/pull/3076) @blumamir
 
 ### :books: (Refine Doc)
 
@@ -170,75 +169,75 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
-- fix: remove aws and gcp detector from SDK [#3024](https://github.com/open-telemetry/opentelemetry-js/pull/3024) @flarna
-- feat(sdk-metrics-base): implement min/max recording for Histograms [#3032](https://github.com/open-telemetry/opentelemetry-js/pull/3032) @pichlermarc
-  - adds `min`/`max` recording to Histograms
-  - updates [opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto) to `0.18` so that `min` and
+* fix: remove aws and gcp detector from SDK [#3024](https://github.com/open-telemetry/opentelemetry-js/pull/3024) @flarna
+* feat(sdk-metrics-base): implement min/max recording for Histograms [#3032](https://github.com/open-telemetry/opentelemetry-js/pull/3032) @pichlermarc
+  * adds `min`/`max` recording to Histograms
+  * updates [opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto) to `0.18` so that `min` and
     `max` can be exported. This change breaks the OTLP/JSON Metric Exporter for all collector versions `<0.52` due to
     [open-telemetry/opentelemetry-collector#5312](https://github.com/open-telemetry/opentelemetry-collector/issues/5312).
 
 ### :rocket: (Enhancement)
 
-- feat(opentelemetry-instrumentation-fetch): optionally ignore network events [#3028](https://github.com/open-telemetry/opentelemetry-js/pull/3028) @gregolsen
-- feat(http-instrumentation): record exceptions in http instrumentation [#3008](https://github.com/open-telemetry/opentelemetry-js/pull/3008) @luismiramirez
-- feat(node-sdk): add serviceName config option [#2867](https://github.com/open-telemetry/opentelemetry-js/pull/2867) @naseemkullah
-- feat(opentelemetry-exporter-prometheus): export PrometheusSerializer [#3034](https://github.com/open-telemetry/opentelemetry-js/pull/3034) @matschaffer
-- feat(sdk-metrics-base): detect resets on async metrics [#2990](https://github.com/open-telemetry/opentelemetry-js/pull/2990) @legendecas
-  - Added monotonicity support in SumAggregator.
-  - Added reset and gaps detection for async metric instruments.
-  - Fixed the start time and end time of an exported metric with regarding to resets and gaps.
+* feat(opentelemetry-instrumentation-fetch): optionally ignore network events [#3028](https://github.com/open-telemetry/opentelemetry-js/pull/3028) @gregolsen
+* feat(http-instrumentation): record exceptions in http instrumentation [#3008](https://github.com/open-telemetry/opentelemetry-js/pull/3008) @luismiramirez
+* feat(node-sdk): add serviceName config option [#2867](https://github.com/open-telemetry/opentelemetry-js/pull/2867) @naseemkullah
+* feat(opentelemetry-exporter-prometheus): export PrometheusSerializer [#3034](https://github.com/open-telemetry/opentelemetry-js/pull/3034) @matschaffer
+* feat(sdk-metrics-base): detect resets on async metrics [#2990](https://github.com/open-telemetry/opentelemetry-js/pull/2990) @legendecas
+  * Added monotonicity support in SumAggregator.
+  * Added reset and gaps detection for async metric instruments.
+  * Fixed the start time and end time of an exported metric with regarding to resets and gaps.
 
 ### :bug: (Bug Fix)
 
-- fix(otlp-transformer): remove type dependency on Long [#3022](https://github.com/open-telemetry/opentelemetry-js/pull/3022) @legendecas
-- fix(grpc-exporter): use non-normalized URL to determine channel security [#3019](https://github.com/open-telemetry/opentelemetry-js/pull/3019) @pichlermarc
-- fix(otlp-exporter-base): fix gzip output stream in http otlp export [#3046](https://github.com/open-telemetry/opentelemetry-js/pull/3046) @mattolson
-- docs(grpc-exporters): remove 'web' as supported from README.md [#3070](https://github.com/open-telemetry/opentelemetry-js/pull/3070) @pichlermarc
+* fix(otlp-transformer): remove type dependency on Long [#3022](https://github.com/open-telemetry/opentelemetry-js/pull/3022) @legendecas
+* fix(grpc-exporter): use non-normalized URL to determine channel security [#3019](https://github.com/open-telemetry/opentelemetry-js/pull/3019) @pichlermarc
+* fix(otlp-exporter-base): fix gzip output stream in http otlp export [#3046](https://github.com/open-telemetry/opentelemetry-js/pull/3046) @mattolson
+* docs(grpc-exporters): remove 'web' as supported from README.md [#3070](https://github.com/open-telemetry/opentelemetry-js/pull/3070) @pichlermarc
 
 ### :house: (Internal)
 
-- test: add node 18 and remove EoL node versions [#3048](https://github.com/open-telemetry/opentelemetry-js/pull/3048) @dyladan
+* test: add node 18 and remove EoL node versions [#3048](https://github.com/open-telemetry/opentelemetry-js/pull/3048) @dyladan
 
 ## 0.29.2
 
-- Support for 1.3.1 of stable packages
+* Support for 1.3.1 of stable packages
 
 ## 0.29.1
 
 ### :bug: (Bug Fix)
 
-- fix(sdk-metrics-base): only record non-negative histogram values [#3002](https://github.com/open-telemetry/opentelemetry-js/pull/3002) @pichlermarc
-- fix(otlp-transformer): include missing prepublishOnly script which ensures esm and esnext build files are created and packaged @dyladan
+* fix(sdk-metrics-base): only record non-negative histogram values [#3002](https://github.com/open-telemetry/opentelemetry-js/pull/3002) @pichlermarc
+* fix(otlp-transformer): include missing prepublishOnly script which ensures esm and esnext build files are created and packaged @dyladan
 
 ## 0.29.0
 
 ### :boom: Breaking Change
 
-- feat(metrics): metric readers and exporters now select aggregation temporality based on instrument type [#2902](https://github.com/open-telemetry/opentelemetry-js/pull/2902) @seemk
-- refactor(metrics-sdk): rename InstrumentationLibrary -> InstrumentationScope [#2959](https://github.com/open-telemetry/opentelemetry-js/pull/2959) @pichlermarc
-- feat(metrics): multi-instrument async callback support [#2966](https://github.com/open-telemetry/opentelemetry-js/pull/2966) @legendecas
-  - changes on `meter.createObservableCounter`, `meter.createObservableGauge`, `meter.createObservableUpDownCounter`
-    - removed the second parameter `callback`
-    - returns an `Observable` object on which callbacks can be registered or unregistered.
-  - added `meter.addBatchObservableCallback` and `meter.removeBatchObservableCallback`.
-- fix: remove attributes from OTLPExporterConfigBase [#2991](https://github.com/open-telemetry/opentelemetry-js/pull/2991) @flarna
+* feat(metrics): metric readers and exporters now select aggregation temporality based on instrument type [#2902](https://github.com/open-telemetry/opentelemetry-js/pull/2902) @seemk
+* refactor(metrics-sdk): rename InstrumentationLibrary -> InstrumentationScope [#2959](https://github.com/open-telemetry/opentelemetry-js/pull/2959) @pichlermarc
+* feat(metrics): multi-instrument async callback support [#2966](https://github.com/open-telemetry/opentelemetry-js/pull/2966) @legendecas
+  * changes on `meter.createObservableCounter`, `meter.createObservableGauge`, `meter.createObservableUpDownCounter`
+    * removed the second parameter `callback`
+    * returns an `Observable` object on which callbacks can be registered or unregistered.
+  * added `meter.addBatchObservableCallback` and `meter.removeBatchObservableCallback`.
+* fix: remove attributes from OTLPExporterConfigBase [#2991](https://github.com/open-telemetry/opentelemetry-js/pull/2991) @flarna
 
 ### :rocket: (Enhancement)
 
-- feat(exporters): update proto version and use otlp-transformer [#2929](https://github.com/open-telemetry/opentelemetry-js/pull/2929) @pichlermarc
-- fix(sdk-metrics-base): misbehaving aggregation temporality selector tolerance [#2958](https://github.com/open-telemetry/opentelemetry-js/pull/2958) @legendecas
-- feat(trace-otlp-grpc): configure security with env vars [#2827](https://github.com/open-telemetry/opentelemetry-js/pull/2827) @svetlanabrennan
-- feat(sdk-metrics-base): async instruments callback timeout [#2742](https://github.com/open-telemetry/opentelemetry-js/pull/2742) @legendecas
+* feat(exporters): update proto version and use otlp-transformer [#2929](https://github.com/open-telemetry/opentelemetry-js/pull/2929) @pichlermarc
+* fix(sdk-metrics-base): misbehaving aggregation temporality selector tolerance [#2958](https://github.com/open-telemetry/opentelemetry-js/pull/2958) @legendecas
+* feat(trace-otlp-grpc): configure security with env vars [#2827](https://github.com/open-telemetry/opentelemetry-js/pull/2827) @svetlanabrennan
+* feat(sdk-metrics-base): async instruments callback timeout [#2742](https://github.com/open-telemetry/opentelemetry-js/pull/2742) @legendecas
 
 ### :bug: (Bug Fix)
 
-- fix(opentelemetry-instrumentation-http): use correct origin when port is `null` [#2948](https://github.com/open-telemetry/opentelemetry-js/pull/2948) @danielgblanco
-- fix(otlp-exporter-base): include esm and esnext in package files [#2952](https://github.com/open-telemetry/opentelemetry-js/pull/2952) @dyladan
-- fix(otlp-http-exporter): update endpoint to match spec [#2895](https://github.com/open-telemetry/opentelemetry-js/pull/2895) @svetlanabrennan
-- fix(instrumentation): only patch core modules if enabled [#2993](https://github.com/open-telemetry/opentelemetry-js/pull/2993) @santigimeno
-- fix(otlp-transformer): include esm and esnext in package files and update README [#2992](https://github.com/open-telemetry/opentelemetry-js/pull/2992) @pichlermarc
-- fix(metrics): specification compliant default metric unit [#2983](https://github.com/open-telemetry/opentelemetry-js/pull/2983) @andyfleming
-- fix(opentelemetry-instrumentation): use all provided patches for the same file [#2963](https://github.com/open-telemetry/opentelemetry-js/pull/2963) @Ugzuzg
+* fix(opentelemetry-instrumentation-http): use correct origin when port is `null` [#2948](https://github.com/open-telemetry/opentelemetry-js/pull/2948) @danielgblanco
+* fix(otlp-exporter-base): include esm and esnext in package files [#2952](https://github.com/open-telemetry/opentelemetry-js/pull/2952) @dyladan
+* fix(otlp-http-exporter): update endpoint to match spec [#2895](https://github.com/open-telemetry/opentelemetry-js/pull/2895) @svetlanabrennan
+* fix(instrumentation): only patch core modules if enabled [#2993](https://github.com/open-telemetry/opentelemetry-js/pull/2993) @santigimeno
+* fix(otlp-transformer): include esm and esnext in package files and update README [#2992](https://github.com/open-telemetry/opentelemetry-js/pull/2992) @pichlermarc
+* fix(metrics): specification compliant default metric unit [#2983](https://github.com/open-telemetry/opentelemetry-js/pull/2983) @andyfleming
+* fix(opentelemetry-instrumentation): use all provided patches for the same file [#2963](https://github.com/open-telemetry/opentelemetry-js/pull/2963) @Ugzuzg
 
 ### :books: (Refine Doc)
 
@@ -248,107 +247,107 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
-- feat(sdk-metrics-base): update metric exporter interfaces [#2707](https://github.com/open-telemetry/opentelemetry-js/pull/2707) @srikanthccv
-- feat(api-metrics): remove observable types [#2687](https://github.com/open-telemetry/opentelemetry-js/pull/2687) @legendecas
-- fix(otlp-http-exporter): remove content length header [#2879](https://github.com/open-telemetry/opentelemetry-js/pull/2879) @svetlanabrennan
-- feat(experimental-packages): Update packages to latest SDK Version. [#2871](https://github.com/open-telemetry/opentelemetry-js/pull/2871) @pichlermarc
-  - removed the -wip suffix from api-metrics and metrics-sdk-base.
-  - updated dependencies to stable packages to `1.1.1` for all "experimental" packages.
-  - updated Metrics Exporters to the latest Metrics SDK (`exporter-metrics-otlp-grpc`, `exporter-metrics-otlp-http`, `exporter-metrics-otlp-proto`)
-  - updated `opentelemetry-sdk-node` to the latest Metrics SDK.
-  - updated `otlp-transformer` to the latest Metrics SDK.
-  - updated all `instrumentation-*` packages to use local implementations of `parseUrl()` due to #2884
-- refactor(otlp-exporters) move base classes and associated types into their own packages [#2893](https://github.com/open-telemetry/opentelemetry-js/pull/2893) @pichlermarc
-  - `otlp-exporter-base` => `OTLPExporterBase`, `OTLPExporterBrowserBase`, `OTLPExporterNodeBase`
-  - `otlp-grpc-exporter-base` => `OTLPGRPCExporterNodeBase`
-  - `otlp-proto-exporter-base` => `OTLPProtoExporterNodeBase`
+* feat(sdk-metrics-base): update metric exporter interfaces [#2707](https://github.com/open-telemetry/opentelemetry-js/pull/2707) @srikanthccv
+* feat(api-metrics): remove observable types [#2687](https://github.com/open-telemetry/opentelemetry-js/pull/2687) @legendecas
+* fix(otlp-http-exporter): remove content length header [#2879](https://github.com/open-telemetry/opentelemetry-js/pull/2879) @svetlanabrennan
+* feat(experimental-packages): Update packages to latest SDK Version. [#2871](https://github.com/open-telemetry/opentelemetry-js/pull/2871) @pichlermarc
+  * removed the -wip suffix from api-metrics and metrics-sdk-base.
+  * updated dependencies to stable packages to `1.1.1` for all "experimental" packages.
+  * updated Metrics Exporters to the latest Metrics SDK (`exporter-metrics-otlp-grpc`, `exporter-metrics-otlp-http`, `exporter-metrics-otlp-proto`)
+  * updated `opentelemetry-sdk-node` to the latest Metrics SDK.
+  * updated `otlp-transformer` to the latest Metrics SDK.
+  * updated all `instrumentation-*` packages to use local implementations of `parseUrl()` due to #2884
+* refactor(otlp-exporters) move base classes and associated types into their own packages [#2893](https://github.com/open-telemetry/opentelemetry-js/pull/2893) @pichlermarc
+  * `otlp-exporter-base` => `OTLPExporterBase`, `OTLPExporterBrowserBase`, `OTLPExporterNodeBase`
+  * `otlp-grpc-exporter-base` => `OTLPGRPCExporterNodeBase`
+  * `otlp-proto-exporter-base` => `OTLPProtoExporterNodeBase`
 
 ### :rocket: (Enhancement)
 
-- feat: spec compliant metric creation and sync instruments [#2588](https://github.com/open-telemetry/opentelemetry-js/pull/2588) @dyladan
-- feat(api-metrics): async instruments spec compliance [#2569](https://github.com/open-telemetry/opentelemetry-js/pull/2569) @legendecas
-- feat(sdk-metrics-base): add ValueType support for sync instruments [#2776](https://github.com/open-telemetry/opentelemetry-js/pull/2776) @legendecas
-- feat(sdk-metrics-base): implement async instruments support [#2686](https://github.com/open-telemetry/opentelemetry-js/pull/2686) @legendecas
-- feat(sdk-metrics-base): meter registration [#2666](https://github.com/open-telemetry/opentelemetry-js/pull/2666) @legendecas
-- feat(sdk-metrics-base): bootstrap metrics exemplars [#2641](https://github.com/open-telemetry/opentelemetry-js/pull/2641) @srikanthccv
-- feat(metrics-sdk): bootstrap aggregation support [#2634](https://github.com/open-telemetry/opentelemetry-js/pull/2634) @legendecas
-- feat(metrics-sdk): bootstrap views api [#2625](https://github.com/open-telemetry/opentelemetry-js/pull/2625) @legendecas
-- feat(sdk-metrics): bootstrap metric streams [#2636](https://github.com/open-telemetry/opentelemetry-js/pull/2636) @legendecas
-- feat(views): add FilteringAttributesProcessor [#2733](https://github.com/open-telemetry/opentelemetry-js/pull/2733) @pichlermarc
-- feat(metric-reader): add metric-reader [#2681](https://github.com/open-telemetry/opentelemetry-js/pull/2681) @pichlermarc
-- feat(sdk-metrics-base): document and export basic APIs [#2725](https://github.com/open-telemetry/opentelemetry-js/pull/2725) @legendecas
-- feat(views): Update addView() to disallow named views that select more than one instrument. [#2820](https://github.com/open-telemetry/opentelemetry-js/pull/2820) @pichlermarc
-- feat(sdk-metrics-base): update exporting names [#2829](https://github.com/open-telemetry/opentelemetry-js/pull/2829) @legendecas
-- Add grpc compression to trace-otlp-grpc exporter [#2813](https://github.com/open-telemetry/opentelemetry-js/pull/2813) @svetlanabrennan
-- refactor: unifying shutdown once with BindOnceFuture [#2695](https://github.com/open-telemetry/opentelemetry-js/pull/2695) @legendecas
-- feat(prometheus): update prometheus exporter with wip metrics sdk [#2824](https://github.com/open-telemetry/opentelemetry-js/pull/2824) @legendecas
-- feat(instrumentation-xhr): add applyCustomAttributesOnSpan hook [#2134](https://github.com/open-telemetry/opentelemetry-js/pull/2134) @mhennoch
-- feat(proto): add @opentelemetry/otlp-transformer package with hand-rolled transformation [#2746](https://github.com/open-telemetry/opentelemetry-js/pull/2746) @dyladan
-- feat(sdk-metrics-base): shutdown and forceflush on MeterProvider [#2890](https://github.com/open-telemetry/opentelemetry-js/pull/2890) @legendecas
-- feat(sdk-metrics-base): return the same meter for identical input to getMeter [#2901](https://github.com/open-telemetry/opentelemetry-js/pull/2901) @legendecas
-- feat(otlp-exporter): add [OTEL_EXPORTER_OTLP_TIMEOUT](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options) env var to otlp exporters [#2738](https://github.com/open-telemetry/opentelemetry-js/pull/2738) @svetlanabrennan
-- feat(sdk-metrics-base): hoist async instrument callback invocations [#2822](https://github.com/open-telemetry/opentelemetry-js/pull/2822) @legendecas
+* feat: spec compliant metric creation and sync instruments [#2588](https://github.com/open-telemetry/opentelemetry-js/pull/2588) @dyladan
+* feat(api-metrics): async instruments spec compliance [#2569](https://github.com/open-telemetry/opentelemetry-js/pull/2569) @legendecas
+* feat(sdk-metrics-base): add ValueType support for sync instruments [#2776](https://github.com/open-telemetry/opentelemetry-js/pull/2776) @legendecas
+* feat(sdk-metrics-base): implement async instruments support [#2686](https://github.com/open-telemetry/opentelemetry-js/pull/2686) @legendecas
+* feat(sdk-metrics-base): meter registration [#2666](https://github.com/open-telemetry/opentelemetry-js/pull/2666) @legendecas
+* feat(sdk-metrics-base): bootstrap metrics exemplars [#2641](https://github.com/open-telemetry/opentelemetry-js/pull/2641) @srikanthccv
+* feat(metrics-sdk): bootstrap aggregation support [#2634](https://github.com/open-telemetry/opentelemetry-js/pull/2634) @legendecas
+* feat(metrics-sdk): bootstrap views api [#2625](https://github.com/open-telemetry/opentelemetry-js/pull/2625) @legendecas
+* feat(sdk-metrics): bootstrap metric streams [#2636](https://github.com/open-telemetry/opentelemetry-js/pull/2636) @legendecas
+* feat(views): add FilteringAttributesProcessor [#2733](https://github.com/open-telemetry/opentelemetry-js/pull/2733) @pichlermarc
+* feat(metric-reader): add metric-reader [#2681](https://github.com/open-telemetry/opentelemetry-js/pull/2681) @pichlermarc
+* feat(sdk-metrics-base): document and export basic APIs [#2725](https://github.com/open-telemetry/opentelemetry-js/pull/2725) @legendecas
+* feat(views): Update addView() to disallow named views that select more than one instrument. [#2820](https://github.com/open-telemetry/opentelemetry-js/pull/2820) @pichlermarc
+* feat(sdk-metrics-base): update exporting names [#2829](https://github.com/open-telemetry/opentelemetry-js/pull/2829) @legendecas
+* Add grpc compression to trace-otlp-grpc exporter [#2813](https://github.com/open-telemetry/opentelemetry-js/pull/2813) @svetlanabrennan
+* refactor: unifying shutdown once with BindOnceFuture [#2695](https://github.com/open-telemetry/opentelemetry-js/pull/2695) @legendecas
+* feat(prometheus): update prometheus exporter with wip metrics sdk [#2824](https://github.com/open-telemetry/opentelemetry-js/pull/2824) @legendecas
+* feat(instrumentation-xhr): add applyCustomAttributesOnSpan hook [#2134](https://github.com/open-telemetry/opentelemetry-js/pull/2134) @mhennoch
+* feat(proto): add @opentelemetry/otlp-transformer package with hand-rolled transformation [#2746](https://github.com/open-telemetry/opentelemetry-js/pull/2746) @dyladan
+* feat(sdk-metrics-base): shutdown and forceflush on MeterProvider [#2890](https://github.com/open-telemetry/opentelemetry-js/pull/2890) @legendecas
+* feat(sdk-metrics-base): return the same meter for identical input to getMeter [#2901](https://github.com/open-telemetry/opentelemetry-js/pull/2901) @legendecas
+* feat(otlp-exporter): add [OTEL_EXPORTER_OTLP_TIMEOUT](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options) env var to otlp exporters [#2738](https://github.com/open-telemetry/opentelemetry-js/pull/2738) @svetlanabrennan
+* feat(sdk-metrics-base): hoist async instrument callback invocations [#2822](https://github.com/open-telemetry/opentelemetry-js/pull/2822) @legendecas
 
 ### :bug: (Bug Fix)
 
-- fix(sdk-metrics-base): remove aggregator.toMetricData dependency on AggregationTemporality [#2676](https://github.com/open-telemetry/opentelemetry-js/pull/2676) @legendecas
-- fix(sdk-metrics-base): coerce histogram boundaries to be implicit Infinity [#2859](https://github.com/open-telemetry/opentelemetry-js/pull/2859) @legendecas
-- fix(instrumentation-http): HTTP 400 status code should not set span status to error on servers [#2789](https://github.com/open-telemetry/opentelemetry-js/pull/2789) @nordfjord
+* fix(sdk-metrics-base): remove aggregator.toMetricData dependency on AggregationTemporality [#2676](https://github.com/open-telemetry/opentelemetry-js/pull/2676) @legendecas
+* fix(sdk-metrics-base): coerce histogram boundaries to be implicit Infinity [#2859](https://github.com/open-telemetry/opentelemetry-js/pull/2859) @legendecas
+* fix(instrumentation-http): HTTP 400 status code should not set span status to error on servers [#2789](https://github.com/open-telemetry/opentelemetry-js/pull/2789) @nordfjord
 
 ### :books: (Refine Doc)
 
-- Update metrics example [#2658](https://github.com/open-telemetry/opentelemetry-js/pull/2658) @svetlanabrennan
-- docs(api-metrics): add notes on ObservableResult.observe [#2712](https://github.com/open-telemetry/opentelemetry-js/pull/2712) @legendecas
+* Update metrics example [#2658](https://github.com/open-telemetry/opentelemetry-js/pull/2658) @svetlanabrennan
+* docs(api-metrics): add notes on ObservableResult.observe [#2712](https://github.com/open-telemetry/opentelemetry-js/pull/2712) @legendecas
 
 ### :house: (Internal)
 
-- chore: move trace exporters back to experimental [#2835](https://github.com/open-telemetry/opentelemetry-js/pull/2835) @dyladan
-- refactor(sdk-metrics-base): meter shared states [#2821](https://github.com/open-telemetry/opentelemetry-js/pull/2821) @legendecas
+* chore: move trace exporters back to experimental [#2835](https://github.com/open-telemetry/opentelemetry-js/pull/2835) @dyladan
+* refactor(sdk-metrics-base): meter shared states [#2821](https://github.com/open-telemetry/opentelemetry-js/pull/2821) @legendecas
 
 ## v0.27.0
 
 ### :boom: Breaking Change
 
-- [#2566](https://github.com/open-telemetry/opentelemetry-js/pull/2566) feat!(metrics): remove batch observer ([@dyladan](https://github.com/dyladan))
-- [#2485](https://github.com/open-telemetry/opentelemetry-js/pull/2485) feat!: Split metric and trace exporters into new experimental packages ([@willarmiros](https://github.com/willarmiros))
-- [#2540](https://github.com/open-telemetry/opentelemetry-js/pull/2540) fix(sdk-metrics-base): remove metric kind BATCH_OBSERVER ([@legendecas](https://github.com/legendecas))
-- [#2496](https://github.com/open-telemetry/opentelemetry-js/pull/2496) feat(api-metrics): rename metric instruments to match feature-freeze API specification ([@legendecas](https://github.com/legendecas))
+* [#2566](https://github.com/open-telemetry/opentelemetry-js/pull/2566) feat!(metrics): remove batch observer ([@dyladan](https://github.com/dyladan))
+* [#2485](https://github.com/open-telemetry/opentelemetry-js/pull/2485) feat!: Split metric and trace exporters into new experimental packages ([@willarmiros](https://github.com/willarmiros))
+* [#2540](https://github.com/open-telemetry/opentelemetry-js/pull/2540) fix(sdk-metrics-base): remove metric kind BATCH_OBSERVER ([@legendecas](https://github.com/legendecas))
+* [#2496](https://github.com/open-telemetry/opentelemetry-js/pull/2496) feat(api-metrics): rename metric instruments to match feature-freeze API specification ([@legendecas](https://github.com/legendecas))
 
 ### :rocket: (Enhancement)
 
-- [#2523](https://github.com/open-telemetry/opentelemetry-js/pull/2523) feat: Rename Labels to Attributes ([@pirgeo](https://github.com/pirgeo))
-- [#2559](https://github.com/open-telemetry/opentelemetry-js/pull/2559) feat(api-metrics): remove bind/unbind and bound instruments ([@legendecas](https://github.com/legendecas))
-- [#2563](https://github.com/open-telemetry/opentelemetry-js/pull/2563) feat(sdk-metrics-base): remove per-meter config on MeterProvider.getMeter ([@legendecas](https://github.com/legendecas))
+* [#2523](https://github.com/open-telemetry/opentelemetry-js/pull/2523) feat: Rename Labels to Attributes ([@pirgeo](https://github.com/pirgeo))
+* [#2559](https://github.com/open-telemetry/opentelemetry-js/pull/2559) feat(api-metrics): remove bind/unbind and bound instruments ([@legendecas](https://github.com/legendecas))
+* [#2563](https://github.com/open-telemetry/opentelemetry-js/pull/2563) feat(sdk-metrics-base): remove per-meter config on MeterProvider.getMeter ([@legendecas](https://github.com/legendecas))
 
 ### :bug: (Bug Fix)
 
-- [#2610](https://github.com/open-telemetry/opentelemetry-js/pull/2610) fix: preventing double enable for instrumentation that has been already enabled ([@obecny](https://github.com/obecny))
-- [#2581](https://github.com/open-telemetry/opentelemetry-js/pull/2581) feat: lazy initialization of the gzip stream ([@fungiboletus](https://github.com/fungiboletus))
-- [#2584](https://github.com/open-telemetry/opentelemetry-js/pull/2584) fix: fixing compatibility versions for detectors ([@obecny](https://github.com/obecny))
-- [#2558](https://github.com/open-telemetry/opentelemetry-js/pull/2558) fix(@opentelemetry/exporter-prometheus): unref prometheus server to prevent process running indefinitely ([@mothershipper](https://github.com/mothershipper))
-- [#2495](https://github.com/open-telemetry/opentelemetry-js/pull/2495) fix(sdk-metrics-base): metrics name should be in the max length of 63 ([@legendecas](https://github.com/legendecas))
-- [#2497](https://github.com/open-telemetry/opentelemetry-js/pull/2497) feat(@opentelemetry-instrumentation-fetch): support reading response body from the hook applyCustomAttributesOnSpan ([@echoontheway](https://github.com/echoontheway))
+* [#2610](https://github.com/open-telemetry/opentelemetry-js/pull/2610) fix: preventing double enable for instrumentation that has been already enabled ([@obecny](https://github.com/obecny))
+* [#2581](https://github.com/open-telemetry/opentelemetry-js/pull/2581) feat: lazy initialization of the gzip stream ([@fungiboletus](https://github.com/fungiboletus))
+* [#2584](https://github.com/open-telemetry/opentelemetry-js/pull/2584) fix: fixing compatibility versions for detectors ([@obecny](https://github.com/obecny))
+* [#2558](https://github.com/open-telemetry/opentelemetry-js/pull/2558) fix(@opentelemetry/exporter-prometheus): unref prometheus server to prevent process running indefinitely ([@mothershipper](https://github.com/mothershipper))
+* [#2495](https://github.com/open-telemetry/opentelemetry-js/pull/2495) fix(sdk-metrics-base): metrics name should be in the max length of 63 ([@legendecas](https://github.com/legendecas))
+* [#2497](https://github.com/open-telemetry/opentelemetry-js/pull/2497) feat(@opentelemetry-instrumentation-fetch): support reading response body from the hook applyCustomAttributesOnSpan ([@echoontheway](https://github.com/echoontheway))
 
 ### :books: (Refine Doc)
 
-- [#2561](https://github.com/open-telemetry/opentelemetry-js/pull/2561) Use new canonical path to Getting Started ([@chalin](https://github.com/chalin))
-- [#2576](https://github.com/open-telemetry/opentelemetry-js/pull/2576) docs(instrumentation): update links in the Readme ([@OlivierAlbertini](https://github.com/OlivierAlbertini))
-- [#2600](https://github.com/open-telemetry/opentelemetry-js/pull/2600) docs: fix URLs in README post-experimental move ([@arbourd](https://github.com/arbourd))
-- [#2579](https://github.com/open-telemetry/opentelemetry-js/pull/2579) doc: Move upgrade propagator notes to correct section ([@NathanielRN](https://github.com/NathanielRN))
-- [#2568](https://github.com/open-telemetry/opentelemetry-js/pull/2568) chore(doc): update matrix with contrib version for 1.0 core ([@vmarchaud](https://github.com/vmarchaud))
-- [#2555](https://github.com/open-telemetry/opentelemetry-js/pull/2555) docs: expose existing comments ([@moander](https://github.com/moander))
-- [#2493](https://github.com/open-telemetry/opentelemetry-js/pull/2493) chore: remove getting started and link to documentation. ([@svrnm](https://github.com/svrnm))
+* [#2561](https://github.com/open-telemetry/opentelemetry-js/pull/2561) Use new canonical path to Getting Started ([@chalin](https://github.com/chalin))
+* [#2576](https://github.com/open-telemetry/opentelemetry-js/pull/2576) docs(instrumentation): update links in the Readme ([@OlivierAlbertini](https://github.com/OlivierAlbertini))
+* [#2600](https://github.com/open-telemetry/opentelemetry-js/pull/2600) docs: fix URLs in README post-experimental move ([@arbourd](https://github.com/arbourd))
+* [#2579](https://github.com/open-telemetry/opentelemetry-js/pull/2579) doc: Move upgrade propagator notes to correct section ([@NathanielRN](https://github.com/NathanielRN))
+* [#2568](https://github.com/open-telemetry/opentelemetry-js/pull/2568) chore(doc): update matrix with contrib version for 1.0 core ([@vmarchaud](https://github.com/vmarchaud))
+* [#2555](https://github.com/open-telemetry/opentelemetry-js/pull/2555) docs: expose existing comments ([@moander](https://github.com/moander))
+* [#2493](https://github.com/open-telemetry/opentelemetry-js/pull/2493) chore: remove getting started and link to documentation. ([@svrnm](https://github.com/svrnm))
 
 ### :house: (Internal)
 
-- [#2404](https://github.com/open-telemetry/opentelemetry-js/pull/2404) chore: Fix lint warnings in instrumentation package ([@alisabzevari](https://github.com/alisabzevari))
-- [#2533](https://github.com/open-telemetry/opentelemetry-js/pull/2533) chore: regularly close stale issues ([@Rauno56](https://github.com/Rauno56))
-- [#2570](https://github.com/open-telemetry/opentelemetry-js/pull/2570) chore: adding selenium tests with browserstack ([@obecny](https://github.com/obecny))
-- [#2522](https://github.com/open-telemetry/opentelemetry-js/pull/2522) chore: cleanup setting config in instrumentations ([@Flarna](https://github.com/Flarna))
-- [#2541](https://github.com/open-telemetry/opentelemetry-js/pull/2541) chore: slim font size for section title in PR template ([@legendecas](https://github.com/legendecas))
-- [#2509](https://github.com/open-telemetry/opentelemetry-js/pull/2509) chore: expand pull request template with action items ([@pragmaticivan](https://github.com/pragmaticivan))
-- [#2488](https://github.com/open-telemetry/opentelemetry-js/pull/2488) chore: inline sources in source maps ([@dyladan](https://github.com/dyladan))
-- [#2514](https://github.com/open-telemetry/opentelemetry-js/pull/2514) chore: update stable dependencies to 1.0 ([@dyladan](https://github.com/dyladan))
+* [#2404](https://github.com/open-telemetry/opentelemetry-js/pull/2404) chore: Fix lint warnings in instrumentation package ([@alisabzevari](https://github.com/alisabzevari))
+* [#2533](https://github.com/open-telemetry/opentelemetry-js/pull/2533) chore: regularly close stale issues ([@Rauno56](https://github.com/Rauno56))
+* [#2570](https://github.com/open-telemetry/opentelemetry-js/pull/2570) chore: adding selenium tests with browserstack ([@obecny](https://github.com/obecny))
+* [#2522](https://github.com/open-telemetry/opentelemetry-js/pull/2522) chore: cleanup setting config in instrumentations ([@Flarna](https://github.com/Flarna))
+* [#2541](https://github.com/open-telemetry/opentelemetry-js/pull/2541) chore: slim font size for section title in PR template ([@legendecas](https://github.com/legendecas))
+* [#2509](https://github.com/open-telemetry/opentelemetry-js/pull/2509) chore: expand pull request template with action items ([@pragmaticivan](https://github.com/pragmaticivan))
+* [#2488](https://github.com/open-telemetry/opentelemetry-js/pull/2488) chore: inline sources in source maps ([@dyladan](https://github.com/dyladan))
+* [#2514](https://github.com/open-telemetry/opentelemetry-js/pull/2514) chore: update stable dependencies to 1.0 ([@dyladan](https://github.com/dyladan))
 
 ## Previous releases
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to experimental packages in this project will be documented 
 * feat(instrumentation-http): monitor error events with events.errorMonitor [#3402](https://github.com/open-telemetry/opentelemetry-js/pull/3402) @legendecas
 * feat(instrumentation-grpc): added grpc metadata client side attributes in instrumentation [#3386](https://github.com/open-telemetry/opentelemetry-js/pull/3386)
 * feat(instrumentation): add new `_setMeterInstruments` protected method that update the meter instruments every meter provider update.
+* feat(sdk-node): configure no-op sdk with `OTEL_SDK_DISABLED` environment variable @RazGvili
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -157,6 +157,11 @@ This is an alternative to programmatically configuring an exporter or span proce
 | OTEL_EXPORTER_OTLP_TRACES_PROTOCOL | The transport protocol to use on OTLP trace requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`. |
 | OTEL_EXPORTER_OTLP_METRICS_PROTOCOL | The transport protocol to use on OTLP metric requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`. |
 
+### Disable the SDK from the environment
+
+Disable the SDK by setting the `OTEL_SDK_DISABLED` environment variable to `true`.  
+
+
 Additionally, you can specify other applicable environment variables that apply to each exporter such as the following:
 
 - [OTLP exporter environment configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options)

--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -141,7 +141,7 @@ Configure the [service name](https://github.com/open-telemetry/opentelemetry-spe
 
 ## Disable the SDK from the environment
 
-Disable the SDK by setting the `OTEL_SDK_DISABLED` environment variable to `true`.  
+Disable the SDK by setting the `OTEL_SDK_DISABLED` environment variable to `true`.
 
 ## Configure Trace Exporter from  Environment
 
@@ -160,7 +160,6 @@ This is an alternative to programmatically configuring an exporter or span proce
 | OTEL_EXPORTER_OTLP_PROTOCOL | The transport protocol to use on OTLP trace, metric, and log requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`. |
 | OTEL_EXPORTER_OTLP_TRACES_PROTOCOL | The transport protocol to use on OTLP trace requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`. |
 | OTEL_EXPORTER_OTLP_METRICS_PROTOCOL | The transport protocol to use on OTLP metric requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`. |
-
 
 Additionally, you can specify other applicable environment variables that apply to each exporter such as the following:
 

--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -139,6 +139,10 @@ Configure tracing parameters. These are the same trace parameters used to [confi
 
 Configure the [service name](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service).
 
+## Disable the SDK from the environment
+
+Disable the SDK by setting the `OTEL_SDK_DISABLED` environment variable to `true`.  
+
 ## Configure Trace Exporter from  Environment
 
 This is an alternative to programmatically configuring an exporter or span processor. This package will auto setup the default `otlp` exporter with `http/protobuf` protocol if `traceExporter` or `spanProcessor` hasn't been passed into the `NodeSDK` constructor.
@@ -156,10 +160,6 @@ This is an alternative to programmatically configuring an exporter or span proce
 | OTEL_EXPORTER_OTLP_PROTOCOL | The transport protocol to use on OTLP trace, metric, and log requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`. |
 | OTEL_EXPORTER_OTLP_TRACES_PROTOCOL | The transport protocol to use on OTLP trace requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`. |
 | OTEL_EXPORTER_OTLP_METRICS_PROTOCOL | The transport protocol to use on OTLP metric requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`. |
-
-### Disable the SDK from the environment
-
-Disable the SDK by setting the `OTEL_SDK_DISABLED` environment variable to `true`.  
 
 
 Additionally, you can specify other applicable environment variables that apply to each exporter such as the following:

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -39,6 +39,7 @@ import {
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { NodeSDKConfiguration } from './types';
 import { TracerProviderWithEnvExporters } from './TracerProviderWithEnvExporter';
+import { getEnv } from '@opentelemetry/core';
 
 /** This class represents everything needed to register a fully configured OpenTelemetry Node.js SDK */
 
@@ -71,10 +72,18 @@ export class NodeSDK {
   private _meterProvider?: MeterProvider;
   private _serviceName?: string;
 
+  private _disabled?: boolean;
+
   /**
    * Create a new NodeJS SDK instance
    */
   public constructor(configuration: Partial<NodeSDKConfiguration> = {}) {
+    if (getEnv().OTEL_SDK_DISABLED) {
+      this._disabled = true;
+      // Finish the instantiation of SDK class
+      // Functions with possible side-effects are set to no-op
+    }
+
     this._resource = configuration.resource ?? new Resource({});
     this._resourceDetectors = configuration.resourceDetectors ?? [
       envDetector,
@@ -175,6 +184,10 @@ export class NodeSDK {
 
   /** Detect resource attributes */
   public async detectResources(): Promise<void> {
+    if (this._disabled) {
+      return;
+    }
+
     const internalConfig: ResourceDetectionConfig = {
       detectors: this._resourceDetectors,
     };
@@ -191,6 +204,10 @@ export class NodeSDK {
    * Once the SDK has been configured, call this method to construct SDK components and register them with the OpenTelemetry API.
    */
   public async start(): Promise<void> {
+    if (this._disabled) {
+      return;
+    }
+
     if (this._autoDetectResources) {
       await this.detectResources();
     }

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -80,8 +80,8 @@ export class NodeSDK {
   public constructor(configuration: Partial<NodeSDKConfiguration> = {}) {
     if (getEnv().OTEL_SDK_DISABLED) {
       this._disabled = true;
-      // Finish the instantiation of SDK object
-      // Functions with possible side-effects are set to no-op
+      // Functions with possible side-effects are set
+      // to no-op via the _disabled flag
     }
 
     this._resource = configuration.resource ?? new Resource({});

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -80,7 +80,7 @@ export class NodeSDK {
   public constructor(configuration: Partial<NodeSDKConfiguration> = {}) {
     if (getEnv().OTEL_SDK_DISABLED) {
       this._disabled = true;
-      // Finish the instantiation of SDK class
+      // Finish the instantiation of SDK object
       // Functions with possible side-effects are set to no-op
     }
 

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -626,6 +626,36 @@ describe('Node SDK', () => {
 
       await sdk.shutdown();
     });
+
+    describe('detectResources should be no-op', async () => {
+      beforeEach(() => {
+        process.env.OTEL_RESOURCE_ATTRIBUTES =
+          'service.instance.id=627cc493,service.name=my-service,service.namespace=default,service.version=0.0.1';
+      });
+
+      afterEach(() => {
+        delete process.env.OTEL_RESOURCE_ATTRIBUTES;
+      });
+
+      it('detectResources will not read resources from env or manually', async () => {
+        const sdk = new NodeSDK({
+          autoDetectResources: true,
+          resourceDetectors: [
+            processDetector,
+            {
+              async detect(): Promise<Resource> {
+                return new Resource({ customAttr: 'someValue' });
+              },
+            },
+            envDetector,
+          ],
+        });
+        await sdk.detectResources();
+        const resource = sdk['_resource'];
+
+        assert.deepStrictEqual(resource, Resource.empty());
+      });
+    });
   });
 });
 

--- a/packages/opentelemetry-core/src/utils/environment.ts
+++ b/packages/opentelemetry-core/src/utils/environment.ts
@@ -24,6 +24,18 @@ const DEFAULT_LIST_SEPARATOR = ',';
  * Environment interface to define all names
  */
 
+const ENVIRONMENT_BOOLEAN_KEYS = ['OTEL_SDK_DISABLED'] as const;
+
+type ENVIRONMENT_BOOLEANS = {
+  [K in typeof ENVIRONMENT_BOOLEAN_KEYS[number]]?: boolean;
+};
+
+function isEnvVarABoolean(key: unknown): key is keyof ENVIRONMENT_BOOLEANS {
+  return (
+    ENVIRONMENT_BOOLEAN_KEYS.indexOf(key as keyof ENVIRONMENT_BOOLEANS) > -1
+  );
+}
+
 const ENVIRONMENT_NUMBERS_KEYS = [
   'OTEL_BSP_EXPORT_TIMEOUT',
   'OTEL_BSP_MAX_EXPORT_BATCH_SIZE',
@@ -107,7 +119,8 @@ export type ENVIRONMENT = {
   OTEL_EXPORTER_OTLP_TRACES_PROTOCOL?: string;
   OTEL_EXPORTER_OTLP_METRICS_PROTOCOL?: string;
   OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE?: string;
-} & ENVIRONMENT_NUMBERS &
+} & ENVIRONMENT_BOOLEANS &
+  ENVIRONMENT_NUMBERS &
   ENVIRONMENT_LISTS;
 
 export type RAW_ENVIRONMENT = {
@@ -122,6 +135,7 @@ export const DEFAULT_ATTRIBUTE_COUNT_LIMIT = 128;
  * Default environment variables
  */
 export const DEFAULT_ENVIRONMENT: Required<ENVIRONMENT> = {
+  OTEL_SDK_DISABLED: false,
   CONTAINER_NAME: '',
   ECS_CONTAINER_METADATA_URI_V4: '',
   ECS_CONTAINER_METADATA_URI: '',
@@ -181,6 +195,25 @@ export const DEFAULT_ENVIRONMENT: Required<ENVIRONMENT> = {
   OTEL_EXPORTER_OTLP_METRICS_PROTOCOL: 'http/protobuf',
   OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: 'cumulative',
 };
+
+/**
+ * @param key
+ * @param environment
+ * @param values
+ */
+function parseBoolean(
+  key: keyof ENVIRONMENT_BOOLEANS,
+  environment: ENVIRONMENT,
+  values: RAW_ENVIRONMENT
+) {
+  if (typeof values[key] === 'undefined') {
+    return;
+  }
+
+  const value = String(values[key]);
+  // support case-insensitive "true"
+  environment[key] = value.toLowerCase() === 'true';
+}
 
 /**
  * Parses a variable as number with number validation
@@ -277,7 +310,9 @@ export function parseEnvironment(values: RAW_ENVIRONMENT): ENVIRONMENT {
         break;
 
       default:
-        if (isEnvVarANumber(key)) {
+        if (isEnvVarABoolean(key)) {
+          parseBoolean(key, environment, values);
+        } else if (isEnvVarANumber(key)) {
           parseNumber(key, environment, values);
         } else if (isEnvVarAList(key)) {
           parseStringList(key, environment, values);

--- a/packages/opentelemetry-core/test/utils/environment.test.ts
+++ b/packages/opentelemetry-core/test/utils/environment.test.ts
@@ -75,6 +75,7 @@ describe('environment', () => {
         HOSTNAME: 'hostname',
         KUBERNETES_SERVICE_HOST: 'https://k8s.host/',
         NAMESPACE: 'namespace',
+        OTEL_SDK_DISABLED: 'true',
         OTEL_BSP_MAX_EXPORT_BATCH_SIZE: 40,
         OTEL_BSP_SCHEDULE_DELAY: 50,
         OTEL_EXPORTER_JAEGER_AGENT_HOST: 'host.domain.com',
@@ -98,6 +99,7 @@ describe('environment', () => {
       });
       const env = getEnv();
       assert.deepStrictEqual(env.OTEL_NO_PATCH_MODULES, ['a', 'b', 'c']);
+      assert.strictEqual(env.OTEL_SDK_DISABLED, true);
       assert.strictEqual(env.OTEL_LOG_LEVEL, DiagLogLevel.ERROR);
       assert.strictEqual(env.OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT, 40);
       assert.strictEqual(env.OTEL_ATTRIBUTE_COUNT_LIMIT, 50);
@@ -132,6 +134,14 @@ describe('environment', () => {
       assert.strictEqual(env.OTEL_TRACES_SAMPLER_ARG, '0.5');
       assert.strictEqual(env.OTEL_EXPORTER_OTLP_TIMEOUT, 15000);
       assert.strictEqual(env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT, 12000);
+    });
+
+    it('should parse OTEL_SDK_DISABLED despite casing', () => {
+      mockEnvironment({
+        OTEL_SDK_DISABLED: 'TrUe',
+      });
+      const env = getEnv();
+      assert.strictEqual(env.OTEL_SDK_DISABLED, true);
     });
 
     it('should parse OTEL_LOG_LEVEL despite casing', () => {

--- a/packages/opentelemetry-core/test/utils/environment.test.ts
+++ b/packages/opentelemetry-core/test/utils/environment.test.ts
@@ -145,21 +145,16 @@ describe('environment', () => {
     });
 
     describe('OTEL_SDK_DISABLED falsy values', () => {
-      it('should parse OTEL_SDK_DISABLED falsy value despite casing', () => {
-        mockEnvironment({
-          OTEL_SDK_DISABLED: 'FaLse',
+      const falsyValues = ['False', ''];
+      for (const falsyValue of falsyValues) {
+        it(`should parse falsy value: ${falsyValue}`, () => {
+          mockEnvironment({
+            OTEL_SDK_DISABLED: falsyValue,
+          });
+          const env = getEnv();
+          assert.strictEqual(env.OTEL_SDK_DISABLED, false);
         });
-        const env = getEnv();
-        assert.strictEqual(env.OTEL_SDK_DISABLED, false);
-      });
-
-      it('should parse OTEL_SDK_DISABLED empty string as false', () => {
-        mockEnvironment({
-          OTEL_SDK_DISABLED: '',
-        });
-        const env = getEnv();
-        assert.strictEqual(env.OTEL_SDK_DISABLED, false);
-      });
+      }
     });
 
     it('should parse OTEL_LOG_LEVEL despite casing', () => {

--- a/packages/opentelemetry-core/test/utils/environment.test.ts
+++ b/packages/opentelemetry-core/test/utils/environment.test.ts
@@ -136,12 +136,30 @@ describe('environment', () => {
       assert.strictEqual(env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT, 12000);
     });
 
-    it('should parse OTEL_SDK_DISABLED despite casing', () => {
+    it('should parse OTEL_SDK_DISABLED truthy value despite casing', () => {
       mockEnvironment({
         OTEL_SDK_DISABLED: 'TrUe',
       });
       const env = getEnv();
       assert.strictEqual(env.OTEL_SDK_DISABLED, true);
+    });
+
+    describe('OTEL_SDK_DISABLED falsy values', () => {
+      it('should parse OTEL_SDK_DISABLED falsy value despite casing', () => {
+        mockEnvironment({
+          OTEL_SDK_DISABLED: 'FaLse',
+        });
+        const env = getEnv();
+        assert.strictEqual(env.OTEL_SDK_DISABLED, false);
+      });
+
+      it('should parse OTEL_SDK_DISABLED empty string as false', () => {
+        mockEnvironment({
+          OTEL_SDK_DISABLED: '',
+        });
+        const env = getEnv();
+        assert.strictEqual(env.OTEL_SDK_DISABLED, false);
+      });
     });
 
     it('should parse OTEL_LOG_LEVEL despite casing', () => {


### PR DESCRIPTION
## Which problem is this PR solving?
Support for the `OTEL_SDK_DISABLED` env variable. 
 
## Short description of the changes
In the case of a truthy value, the SDK functions(`start`, `detectResources`) that might create side effects are set to be no-op.
Parsing of boolean env variables. 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] if SDK is disabled -> `sdk.start`  should be a no-op. Should not register a trace/meter provider. 
- [ ] if SDK is disabled -> `sdk.detectResources` should be a no-op. Should not detect resources. 

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
