### PR TITLE
fix(sdk-metrics): fix duplicated registration of metrics for collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
     * `telemetry.sdk.language`
     * `telemetry.sdk.version`
 * fix(selenium-tests): updated webpack version for selenium test issue [#3456](https://github.com/open-telemetry/opentelemetry-js/issues/3456) @SaumyaBhushan
+* fix(sdk-metrics): fix duplicated registration of metrics for collectors [#3488](https://github.com/open-telemetry/opentelemetry-js/pull/3488) @legendecas
 
 ### :books: (Refine Doc)
 

--- a/packages/sdk-metrics/src/state/MetricStorageRegistry.ts
+++ b/packages/sdk-metrics/src/state/MetricStorageRegistry.ts
@@ -96,7 +96,7 @@ export class MetricStorageRegistry {
       return null;
     }
 
-    const storages = this._sharedRegistry.get(expectedDescriptor.name);
+    const storages = storageMap.get(expectedDescriptor.name);
     if (storages === undefined) {
       return null;
     }

--- a/packages/sdk-metrics/test/state/MetricStorageRegistry.test.ts
+++ b/packages/sdk-metrics/test/state/MetricStorageRegistry.test.ts
@@ -401,7 +401,22 @@ describe('MetricStorageRegistry', () => {
 
       // registered the storage for each collector
       assert.deepStrictEqual(registry.getStorages(collectorHandle), [storage]);
+      assert.strictEqual(
+        registry.findOrUpdateCompatibleCollectorStorage(
+          collectorHandle,
+          descriptor
+        ),
+        storage
+      );
+
       assert.deepStrictEqual(registry.getStorages(collectorHandle2), [storage]);
+      assert.strictEqual(
+        registry.findOrUpdateCompatibleCollectorStorage(
+          collectorHandle2,
+          descriptor
+        ),
+        storage
+      );
     });
   });
 });


### PR DESCRIPTION


## Which problem is this PR solving?

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/3472

## Short description of the changes

- Fixes that `MetricStorageRegistry.findOrUpdateCompatibleCollectorStorage` always returns `undefined`, which leads to duplicated registration of metric storage for a collector.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Verified that `MetricStorageRegistry.findOrUpdateCompatibleCollectorStorage` returns the expected value.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
