### PR TITLE
fix(api): declare this parameter type in observable callbacks

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 * fix(api): deprecate MetricAttributes and MetricAttributeValue [#3406](https://github.com/open-telemetry/opentelemetry-js/pull/3406) @blumamir
 * test(api): disable module concatenation in tree-shaking test [#3409](https://github.com/open-telemetry/opentelemetry-js/pull/3409) @legendecas
 * fix(api): use active context as default in NoopTracer [#3476](https://github.com/open-telemetry/opentelemetry-js/pull/3476) @flarna
+* fix(api): declare this parameter type in observable callbacks [#3497](https://github.com/open-telemetry/opentelemetry-js/pull/3497) @legendecas
 
 ## [1.3.0](https://www.github.com/open-telemetry/opentelemetry-js-api/compare/v1.2.0...v1.3.0)
 

--- a/api/src/metrics/ObservableResult.ts
+++ b/api/src/metrics/ObservableResult.ts
@@ -30,7 +30,11 @@ export interface ObservableResult<
    * one values associated with the same attributes values, SDK may pick the
    * last one or simply drop the entire observable result.
    */
-  observe(value: number, attributes?: AttributesTypes): void;
+  observe(
+    this: ObservableResult<AttributesTypes>,
+    value: number,
+    attributes?: AttributesTypes
+  ): void;
 }
 
 /**
@@ -49,6 +53,7 @@ export interface BatchObservableResult<
    * last one or simply drop the entire observable result.
    */
   observe(
+    this: BatchObservableResult<AttributesTypes>,
     metric: Observable<AttributesTypes>,
     value: number,
     attributes?: AttributesTypes


### PR DESCRIPTION

## Which problem is this PR solving?

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/3293

Declare the this parameter types for the observable callbacks.

This should not be a breaking change as usages without `this` parameter to be the expected one are not working anyways.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Existing code should continue to be able to compile without any touch.

## Checklist:

- [x] Followed the style guidelines of this project
