### PR TITLE
fix(instrumentation): fix web instrumentation span clock drifts

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to experimental packages in this project will be documented 
 * fix(prometheus-sanitization): replace repeated `_` with a single `_` [3470](https://github.com/open-telemetry/opentelemetry-js/pull/3470) @samimusallam
 * fix(prometheus-serializer): correct string used for NaN [#3477](https://github.com/open-telemetry/opentelemetry-js/pull/3477) @JacksonWeber
 * fix(instrumentation-http): close server span when response finishes [#3407](https://github.com/open-telemetry/opentelemetry-js/pull/3407) @legendecas
+* fix(instrumentation): fix web instrumentation span clock drifts [3518](https://github.com/open-telemetry/opentelemetry-js/pull/3518) @legendecas
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/types.ts
@@ -41,5 +41,8 @@ export interface SpanData {
   entries: PerformanceResourceTiming[];
   observer?: PerformanceObserver;
   spanUrl: string;
+  // startTime of the span from the epoch.
   startTime: api.HrTime;
+  // startTime of the span used to calculate durations.
+  startHrTime: api.HrTime;
 }

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/types.ts
@@ -55,8 +55,12 @@ export interface XhrMem {
   span: api.Span;
   // span url - not available on types.Span
   spanUrl?: string;
-  // startTime of send function - used to filter cors preflight requests
-  sendStartTime?: api.HrTime;
+  // startTime of the span from the epoch.
+  startTime: api.HrTime;
+  // startTime of the span used to calculate durations.
+  startHrTime: api.HrTime;
+  // startTime of send function - used to filter cors preflight requests.
+  sendStartHrTime?: api.HrTime;
   // resources created between send and end plus some additional timeout
   createdResources?: {
     observer: PerformanceObserver;

--- a/packages/opentelemetry-core/src/common/time.ts
+++ b/packages/opentelemetry-core/src/common/time.ts
@@ -33,7 +33,7 @@ const SECOND_TO_NANOSECONDS = Math.pow(10, NANOSECOND_DIGITS);
  * This is represented in HrTime format as [1609504210, 150000000].
  * @param epochMillis
  */
-function numberToHrtime(epochMillis: number): api.HrTime {
+export function numberToHrtime(epochMillis: number): api.HrTime {
   const epochSeconds = epochMillis / 1000;
   // Decimals only.
   const seconds = Math.trunc(epochSeconds);
@@ -63,20 +63,10 @@ export function hrTime(performanceNow?: number): api.HrTime {
     typeof performanceNow === 'number' ? performanceNow : performance.now()
   );
 
-  let seconds = timeOrigin[0] + now[0];
-  let nanos = timeOrigin[1] + now[1];
-
-  // Nanoseconds
-  if (nanos > SECOND_TO_NANOSECONDS) {
-    nanos -= SECOND_TO_NANOSECONDS;
-    seconds += 1;
-  }
-
-  return [seconds, nanos];
+  return hrTimeAdd(timeOrigin, now);
 }
 
 /**
- *
  * Converts a TimeInput to an HrTime, defaults to _hrtime().
  * @param time
  */
@@ -119,6 +109,25 @@ export function hrTimeDuration(
   }
 
   return [seconds, nanos];
+}
+
+/**
+ * Calculate the arithmetic sum of two provided HrTime and return the sum
+ * in a new HrTime.
+ */
+export function hrTimeAdd(time1: api.HrTime, time2: api.HrTime): api.HrTime {
+  const out: api.HrTime = [time1[0] + time2[0], time1[1] + time2[1]];
+
+  if (out[1] > SECOND_TO_NANOSECONDS) {
+    out[0] = out[0] + Math.floor(out[1] / SECOND_TO_NANOSECONDS);
+    out[1] = out[1] % SECOND_TO_NANOSECONDS;
+  } else if (out[1] < 0) {
+    out[0] -= 1;
+    // negate
+    out[1] += SECOND_TO_NANOSECONDS;
+  }
+
+  return out;
 }
 
 /**

--- a/packages/opentelemetry-core/test/common/time.test.ts
+++ b/packages/opentelemetry-core/test/common/time.test.ts
@@ -27,6 +27,7 @@ import {
   hrTimeToMicroseconds,
   hrTimeToTimeStamp,
   isTimeInput,
+  hrTimeAdd,
 } from '../../src/common/time';
 
 describe('time', () => {
@@ -148,6 +149,48 @@ describe('time', () => {
 
       const output = hrTimeDuration(startTime, endTime);
       assert.deepStrictEqual(output, [9, 800000000]);
+    });
+
+    it('should handle negative duration', () => {
+      const startTime: api.HrTime = [22, 400000000];
+      const endTime: api.HrTime = [12, 200000000];
+
+      const output = hrTimeDuration(startTime, endTime);
+      assert.deepStrictEqual(output, [-11, 800000000]);
+    });
+  });
+
+  describe('#hrTimeAdd', () => {
+    it('should return duration', () => {
+      const startTime: api.HrTime = [22, 100000000];
+      const endTime: api.HrTime = [32, 800000000];
+
+      const output = hrTimeAdd(startTime, endTime);
+      assert.deepStrictEqual(output, [54, 900000000]);
+    });
+
+    it('should handle nanosecond overflow', () => {
+      const startTime: api.HrTime = [22, 400000000];
+      const endTime: api.HrTime = [32, 800000000];
+
+      const output = hrTimeAdd(startTime, endTime);
+      assert.deepStrictEqual(output, [55, 200000000]);
+    });
+
+    it('should handle negative seconds', () => {
+      const startTime: api.HrTime = [22, 400000000];
+      const endTime: api.HrTime = [-12, 200000000];
+
+      const output = hrTimeAdd(startTime, endTime);
+      assert.deepStrictEqual(output, [10, 600000000]);
+    });
+
+    it('should handle negative nanoseconds', () => {
+      const startTime: api.HrTime = [22, 400000000];
+      const endTime: api.HrTime = [0, -600000000];
+
+      const output = hrTimeAdd(startTime, endTime);
+      assert.deepStrictEqual(output, [21, 800000000]);
     });
   });
 

--- a/packages/opentelemetry-sdk-trace-web/test/utils.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/utils.test.ts
@@ -15,7 +15,9 @@
  */
 
 import {
+  hrTimeAdd,
   hrTimeToNanoseconds,
+  numberToHrtime,
   otperformance as performance,
 } from '@opentelemetry/core';
 import * as core from '@opentelemetry/core';
@@ -37,6 +39,9 @@ import {
 import { PerformanceTimingNames as PTN } from '../src/enums/PerformanceTimingNames';
 
 const SECOND_TO_NANOSECONDS = 1e9;
+// Stub startTime and startHrTime that are identical to indicate that there is no time shifts.
+const startTime: HrTime = [0, 0];
+const startHrTime: HrTime = [0, 0];
 
 function createHrTime(startTime: HrTime, addToStart: number): HrTime {
   let seconds = startTime[0];
@@ -115,7 +120,7 @@ describe('utils', () => {
 
       assert.strictEqual(addEventSpy.callCount, 0);
 
-      addSpanNetworkEvents(span, entries);
+      addSpanNetworkEvents(span, entries, startTime, startHrTime);
 
       assert.strictEqual(addEventSpy.callCount, 9);
       assert.strictEqual(setAttributeSpy.callCount, 2);
@@ -134,7 +139,7 @@ describe('utils', () => {
 
       assert.strictEqual(setAttributeSpy.callCount, 0);
 
-      addSpanNetworkEvents(span, entries);
+      addSpanNetworkEvents(span, entries, startTime, startHrTime);
 
       assert.strictEqual(addEventSpy.callCount, 0);
       assert.strictEqual(setAttributeSpy.callCount, 1);
@@ -154,13 +159,22 @@ describe('utils', () => {
 
           assert.strictEqual(addEventSpy.callCount, 0);
 
-          addSpanNetworkEvent(span, PTN.FETCH_START, entries);
+          addSpanNetworkEvent(
+            span,
+            PTN.FETCH_START,
+            entries,
+            startTime,
+            startHrTime
+          );
 
           assert.strictEqual(addEventSpy.callCount, 1);
           const args = addEventSpy.args[0];
 
           assert.strictEqual(args[0], 'fetchStart');
-          assert.strictEqual(args[1], value);
+          assert.deepStrictEqual(
+            args[1],
+            hrTimeAdd([0, 0], numberToHrtime(value))
+          );
         });
       });
     });
@@ -179,7 +193,9 @@ describe('utils', () => {
         addSpanNetworkEvent(
           span,
           PTN.FETCH_START,
-          entries as PerformanceEntries
+          entries as PerformanceEntries,
+          startTime,
+          startHrTime
         );
 
         assert.strictEqual(addEventSpy.callCount, 0);
@@ -197,7 +213,7 @@ describe('utils', () => {
 
         assert.strictEqual(addEventSpy.callCount, 0);
 
-        addSpanNetworkEvent(span, 'foo', entries);
+        addSpanNetworkEvent(span, 'foo', entries, startTime, startHrTime);
 
         assert.strictEqual(
           addEventSpy.callCount,


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes parts of https://github.com/open-telemetry/opentelemetry-js/issues/3355

## Short description of the changes

- This PR addresses the call sites in the fetch/xhr instrumentations that spans are created and end with hard-coded performance clocks.
- This PR should be complementary to https://github.com/open-telemetry/opentelemetry-js/pull/3384 / https://github.com/open-telemetry/opentelemetry-js/pull/3434, which provide a solution in the trace-sdk.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] TODO

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
