### PR TITLE
Document repo settings

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -2,7 +2,7 @@
 
 This document describes any changes that have been made to the
 settings for this repository beyond the [OpenTelemetry default repository
-settings]([../docs/how-to-configure-new-repository.md#repository-settings](https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md#repository-settings)).
+settings](https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md#repository-settings).
 
 ## General
 

--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -1,0 +1,35 @@
+# Repository settings
+
+This document describes any changes that have been made to the
+settings for this repository beyond the [OpenTelemetry default repository
+settings]([../docs/how-to-configure-new-repository.md#repository-settings](https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md#repository-settings)).
+
+## General
+
+No changes
+
+## Collaborators and Teams
+
+* There is currently no `javascript-triagers` role
+* `javascript-maintainers` has `Admin` permission
+
+## Branches
+
+## Branch protection rules
+
+### `dependabot/**/**`
+
+There is currently not an explicit rule for this branch pattern.
+Our dependencies are managed by a bot which creates PRs from a fork.
+
+### `gh-pages`
+
+This is a special branch which we use to publish the automatically generated docs.
+It is exempt from most protections.
+ 
+* Allow force pushes from everyone
+
+## Pages
+
+* Source: Deploy from a branch
+* Branch: `gh-pages` `/ (root)`

--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -17,6 +17,10 @@ No changes
 
 ## Branch protection rules
 
+### `main`
+
+* Uncheck "Restrict who can push to matching branches"
+
 ### `dependabot/**/**`
 
 There is currently not an explicit rule for this branch pattern.
@@ -27,7 +31,7 @@ Our dependencies are managed by a bot which creates PRs from a fork.
 This is a special branch which we use to publish the automatically generated docs.
 It is exempt from most protections.
  
-* Allow force pushes from everyone
+* "Allow force pushes from everyone" (requires write permission)
 
 ## Pages
 


### PR DESCRIPTION
Following the new guidance at https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md#collaborators-and-teams:

> If requested, `foo-maintainers` will be granted `Admin` permissions, and in return they must document any changes they make to the repository settings in a file named `.github/repository-settings.md` in their repository (other than temporarily disabling "Do not allow bypassing the above settings", see branch protection rules below).
