### PR TITLE
chore: fix cross project links and missing implicitly exported types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :house: (Internal)
 
+* chore: fix cross project links and missing implicitly exported types [#3533](https://github.com/open-telemetry/opentelemetry-js/pull/3533) @legendecas
+
 ## 1.9.0
 
 ### :rocket: (Enhancement)

--- a/package.json
+++ b/package.json
@@ -62,7 +62,9 @@
     "markdownlint-cli": "0.32.2",
     "prettier": "2.8.0",
     "semver": "7.3.5",
-    "typedoc": "0.22.10",
+    "typedoc": "0.22.18",
+    "typedoc-plugin-missing-exports": "1.0.0",
+    "typedoc-plugin-resolve-crossmodule-references": "0.2.2",
     "typescript": "4.4.4"
   },
   "changelog": {


### PR DESCRIPTION

## Which problem is this PR solving?

Fixes `docs:test` failure in PRs like https://github.com/open-telemetry/opentelemetry-js/pull/3514 and https://github.com/open-telemetry/opentelemetry-js/pull/3517.

## Short description of the changes

- Add plugin `typedoc-plugin-missing-exports` to generate docs for implicitly exported types.
- Add plugin `typedoc-plugin-resolve-crossmodule-references` to generate links between projects in the monorepo.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

Tested locally with `NODE_OPTIONS=--max-old-space-size=6144 npm run docs` and verified that the docs are generated as expected.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Documentation has been updated
