### PR TITLE
fix(typo): Fix typo in Resource.default docstring

### DIFF
--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -34,7 +34,7 @@ export class Resource {
   }
 
   /**
-   * Returns a Resource that indentifies the SDK in use.
+   * Returns a Resource that identifies the SDK in use.
    */
   static default(): Resource {
     return new Resource({


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

A meaningless typo in `Resource.default` docstring that bothered me.

## Type of change

- [V] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Using my browser spellchecker.

## Checklist:

- [V] Followed the style guidelines of this project