### PR TITLE
Match Accept header with Content-Type in the proto exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+* fix(otlp-proto-exporter-base): Match Accept header with Content-Type in the proto exporter
+ [#3562](https://github.com/open-telemetry/opentelemetry-js/pull/3562) @scheler
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/otlp-proto-exporter-base/src/platform/browser/OTLPProtoExporterBrowserBase.ts
+++ b/experimental/packages/otlp-proto-exporter-base/src/platform/browser/OTLPProtoExporterBrowserBase.ts
@@ -75,7 +75,7 @@ export abstract class OTLPProtoExporterBrowserBase<
         sendWithXhr(
           new Blob([body], { type: 'application/x-protobuf' }),
           this.url,
-          { ...this._headers, 'Content-Type': 'application/x-protobuf' },
+          { ...this._headers, 'Content-Type': 'application/x-protobuf', 'Accept': 'application/x-protobuf' },
           this.timeoutMillis,
           onSuccess,
           onError

--- a/experimental/packages/otlp-proto-exporter-base/src/platform/browser/OTLPProtoExporterBrowserBase.ts
+++ b/experimental/packages/otlp-proto-exporter-base/src/platform/browser/OTLPProtoExporterBrowserBase.ts
@@ -75,7 +75,11 @@ export abstract class OTLPProtoExporterBrowserBase<
         sendWithXhr(
           new Blob([body], { type: 'application/x-protobuf' }),
           this.url,
-          { ...this._headers, 'Content-Type': 'application/x-protobuf', 'Accept': 'application/x-protobuf' },
+          {
+            ...this._headers,
+            'Content-Type': 'application/x-protobuf',
+            Accept: 'application/x-protobuf',
+          },
           this.timeoutMillis,
           onSuccess,
           onError


### PR DESCRIPTION
## Which problem is this PR solving?

The protobuf exporter currently sends 'content-type' header as protobuf but 'accept' header as json. Otel collector ignores the accept header and sends the response with protobuf. However, this is an issue with other backends.

Fixes # (issue)

## Short description of the changes

Match Accept header with Content-Type in the proto exporter

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Tested using the opentelemetry-web example.

