### PR TITLE
fix: remove JSON syntax error and regenerate tsconfig files

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix: remove JSON syntax error and regenerate tsconfig files [#3566](https://github.com/open-telemetry/opentelemetry-js/pull/3566) @Flarna
+  * Fixes an error where the generated JS files were not included in the esnext package due to a failure of the tsconfig generation
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/exporter-trace-otlp-proto/tsconfig.esm.json
+++ b/experimental/packages/exporter-trace-otlp-proto/tsconfig.esm.json
@@ -14,6 +14,21 @@
     },
     {
       "path": "../../../packages/opentelemetry-core"
+    },
+    {
+      "path": "../../../packages/opentelemetry-resources"
+    },
+    {
+      "path": "../../../packages/opentelemetry-sdk-trace-base"
+    },
+    {
+      "path": "../otlp-exporter-base"
+    },
+    {
+      "path": "../otlp-proto-exporter-base"
+    },
+    {
+      "path": "../otlp-transformer"
     }
   ]
 }

--- a/experimental/packages/exporter-trace-otlp-proto/tsconfig.esnext.json
+++ b/experimental/packages/exporter-trace-otlp-proto/tsconfig.esnext.json
@@ -14,6 +14,21 @@
     },
     {
       "path": "../../../packages/opentelemetry-core"
+    },
+    {
+      "path": "../../../packages/opentelemetry-resources"
+    },
+    {
+      "path": "../../../packages/opentelemetry-sdk-trace-base"
+    },
+    {
+      "path": "../otlp-exporter-base"
+    },
+    {
+      "path": "../otlp-proto-exporter-base"
+    },
+    {
+      "path": "../otlp-transformer"
     }
   ]
 }

--- a/experimental/packages/otlp-proto-exporter-base/tsconfig.esm.json
+++ b/experimental/packages/otlp-proto-exporter-base/tsconfig.esm.json
@@ -16,6 +16,9 @@
     },
     {
       "path": "../../../packages/opentelemetry-core"
+    },
+    {
+      "path": "../otlp-exporter-base"
     }
   ]
 }

--- a/experimental/packages/otlp-proto-exporter-base/tsconfig.esnext.json
+++ b/experimental/packages/otlp-proto-exporter-base/tsconfig.esnext.json
@@ -1,14 +1,12 @@
 {
   "extends": "../../../tsconfig.base.esnext.json",
   "compilerOptions": {
-    "allowJs": true,
-    "outDir": "build/esnext",
     "rootDir": "src",
+    "outDir": "build/esnext",
     "tsBuildInfoFile": "build/esnext/tsconfig.esnext.tsbuildinfo"
   },
   "include": [
-    "src/**/*.ts",
-    "src/generated/*.js",
+    "src/**/*.ts"
   ],
   "references": [
     {
@@ -16,6 +14,9 @@
     },
     {
       "path": "../../../packages/opentelemetry-core"
+    },
+    {
+      "path": "../otlp-exporter-base"
     }
   ]
 }

--- a/experimental/packages/otlp-proto-exporter-base/tsconfig.esnext.json
+++ b/experimental/packages/otlp-proto-exporter-base/tsconfig.esnext.json
@@ -1,12 +1,14 @@
 {
   "extends": "../../../tsconfig.base.esnext.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "allowJs": true,
     "outDir": "build/esnext",
+    "rootDir": "src",
     "tsBuildInfoFile": "build/esnext/tsconfig.esnext.tsbuildinfo"
   },
   "include": [
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "src/generated/*.js"
   ],
   "references": [
     {

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -12,6 +12,9 @@
       "path": "experimental/packages/exporter-trace-otlp-http/tsconfig.esm.json"
     },
     {
+      "path": "experimental/packages/exporter-trace-otlp-proto/tsconfig.esm.json"
+    },
+    {
       "path": "experimental/packages/opentelemetry-browser-detector/tsconfig.esm.json"
     },
     {
@@ -28,6 +31,9 @@
     },
     {
       "path": "experimental/packages/otlp-exporter-base/tsconfig.esm.json"
+    },
+    {
+      "path": "experimental/packages/otlp-proto-exporter-base/tsconfig.esm.json"
     },
     {
       "path": "experimental/packages/otlp-transformer/tsconfig.esm.json"

--- a/tsconfig.esnext.json
+++ b/tsconfig.esnext.json
@@ -12,6 +12,9 @@
       "path": "experimental/packages/exporter-trace-otlp-http/tsconfig.esnext.json"
     },
     {
+      "path": "experimental/packages/exporter-trace-otlp-proto/tsconfig.esnext.json"
+    },
+    {
       "path": "experimental/packages/opentelemetry-browser-detector/tsconfig.esnext.json"
     },
     {
@@ -28,6 +31,9 @@
     },
     {
       "path": "experimental/packages/otlp-exporter-base/tsconfig.esnext.json"
+    },
+    {
+      "path": "experimental/packages/otlp-proto-exporter-base/tsconfig.esnext.json"
     },
     {
       "path": "experimental/packages/otlp-transformer/tsconfig.esnext.json"


### PR DESCRIPTION
## Short description of the changes

Regenerated some tsconfig.json file because they are shown as modified by git after `npm install`.

Refs: https://github.com/open-telemetry/opentelemetry-js/pull/3208
