### PR TITLE
chore: fix proto generation

### DIFF
--- a/experimental/packages/otlp-proto-exporter-base/scripts/protos.js
+++ b/experimental/packages/otlp-proto-exporter-base/scripts/protos.js
@@ -45,6 +45,7 @@ async function pbjs(files) {
   const outFile = path.join(generatedPath, 'root.js');
   const pbjsOptions = [
     '-t', 'static-module',
+    '-p', protosPath,
     '-w', 'commonjs',
     '--null-defaults',
     '-o', outFile,


### PR DESCRIPTION
## Short description of the changes

Seems protobufjs 7.2.0 requires to include a search path.


