### PR TITLE
fix: include TraceState in trace exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * fix: avoid grpc types dependency [#3551](https://github.com/open-telemetry/opentelemetry-js/pull/3551) @flarna
 * fix(otlp-proto-exporter-base): Match Accept header with Content-Type in the proto exporter
  [#3562](https://github.com/open-telemetry/opentelemetry-js/pull/3562) @scheler
+* fix: include tracestate in export [#FixMe](https://github.com/open-telemetry/opentelemetry-js/pull/FixMe) @flarna
 
 ### :books: (Refine Doc)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * fix: avoid grpc types dependency [#3551](https://github.com/open-telemetry/opentelemetry-js/pull/3551) @flarna
 * fix(otlp-proto-exporter-base): Match Accept header with Content-Type in the proto exporter
  [#3562](https://github.com/open-telemetry/opentelemetry-js/pull/3562) @scheler
-* fix: include tracestate in export [#FixMe](https://github.com/open-telemetry/opentelemetry-js/pull/FixMe) @flarna
+* fix: include tracestate in export [#3569](https://github.com/open-telemetry/opentelemetry-js/pull/3569) @flarna
 
 ### :books: (Refine Doc)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix: include tracestate in export [#FixMe](https://github.com/open-telemetry/opentelemetry-js/pull/FixMe) @flarna
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
-* fix: include tracestate in export [#FixMe](https://github.com/open-telemetry/opentelemetry-js/pull/FixMe) @flarna
+* fix: include tracestate in export [#3569](https://github.com/open-telemetry/opentelemetry-js/pull/3569) @flarna
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/otlp-transformer/src/trace/internal.ts
+++ b/experimental/packages/otlp-transformer/src/trace/internal.ts
@@ -32,6 +32,7 @@ export function sdkSpanToOtlpSpan(span: ReadableSpan, useHex?: boolean): ISpan {
     traceId: useHex ? ctx.traceId : core.hexToBase64(ctx.traceId),
     spanId: useHex ? ctx.spanId : core.hexToBase64(ctx.spanId),
     parentSpanId: parentSpanId,
+    traceState: ctx.traceState?.serialize(),
     name: span.name,
     // Span kind is offset by 1 because the API does not define a value for unset
     kind: span.kind == null ? 0 : span.kind + 1,
@@ -60,6 +61,7 @@ export function toOtlpLink(link: Link, useHex?: boolean): ILink {
     traceId: useHex
       ? link.context.traceId
       : core.hexToBase64(link.context.traceId),
+    traceState: link.context.traceState?.serialize(),
     droppedAttributesCount: 0,
   };
 }

--- a/experimental/packages/otlp-transformer/test/trace.test.ts
+++ b/experimental/packages/otlp-transformer/test/trace.test.ts
@@ -60,6 +60,7 @@ function createExpectedSpanJson(useHex: boolean) {
                 traceId: traceId,
                 spanId: spanId,
                 parentSpanId: parentSpanId,
+                traceState: 'span=bar',
                 name: 'span-name',
                 kind: ESpanKind.SPAN_KIND_CLIENT,
                 links: [
@@ -67,6 +68,7 @@ function createExpectedSpanJson(useHex: boolean) {
                     droppedAttributesCount: 0,
                     spanId: linkSpanId,
                     traceId: linkTraceId,
+                    traceState: 'link=foo',
                     attributes: [
                       {
                         key: 'link-attribute',
@@ -134,7 +136,7 @@ describe('Trace', () => {
           traceFlags: 1,
           traceId: '00000000000000000000000000000001',
           isRemote: false,
-          traceState: new TraceState(''),
+          traceState: new TraceState('span=bar'),
         }),
         parentSpanId: '0000000000000001',
         attributes: { 'string-attribute': 'some attribute value' },
@@ -163,7 +165,7 @@ describe('Trace', () => {
               traceId: '00000000000000000000000000000002',
               traceFlags: 1,
               isRemote: false,
-              traceState: new TraceState(''),
+              traceState: new TraceState('link=foo'),
             },
             attributes: {
               'link-attribute': 'string value',

--- a/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
@@ -57,6 +57,7 @@ export class ConsoleSpanExporter implements SpanExporter {
     return {
       traceId: span.spanContext().traceId,
       parentId: span.parentSpanId,
+      traceState: span.spanContext().traceState?.serialize(),
       name: span.name,
       id: span.spanContext().spanId,
       kind: span.kind,

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/ConsoleSpanExporter.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/ConsoleSpanExporter.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { SpanContext, TraceFlags } from '@opentelemetry/api';
+import { TraceState } from '@opentelemetry/core';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import {
@@ -63,6 +64,7 @@ describe('ConsoleSpanExporter', () => {
         const span = tracer.startSpan('foo', {
           links: [{ context, attributes: { anAttr: 'aValue' } }],
         });
+        span.spanContext().traceState = new TraceState('trace=state');
         span.addEvent('foobar');
         span.end();
 
@@ -85,6 +87,7 @@ describe('ConsoleSpanExporter', () => {
           'status',
           'timestamp',
           'traceId',
+          'traceState',
         ].join(',');
 
         assert.ok(firstSpan.name === 'foo');


### PR DESCRIPTION
fix: include TraceState in trace exports

## Short description of the changes

Include TraceState in OTEL spans and links.
Print span.traceState in ConsoleSpanExporter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] adapted tests `createExportTraceServiceRequest`, `should export information about span`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added/updated
 
