### PR TITLE
fix(sdk-metrics): fix flaky LastValueAggregator test by using fake timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :house: (Internal)
 
+* fix(sdk-metrics): ix flaky LastValueAggregator test by using fake timer [#3587](https://github.com/open-telemetry/opentelemetry-js/pull/3587) @pichlermarc
+
 ## 1.9.1
 
 ### :bug: (Bug Fix)

--- a/packages/sdk-metrics/test/aggregator/LastValue.test.ts
+++ b/packages/sdk-metrics/test/aggregator/LastValue.test.ts
@@ -64,10 +64,10 @@ describe('LastValueAggregator', () => {
       const accumulation2 = aggregator.createAccumulation([1, 1]);
 
       accumulation1.record(2);
-      clock.tick(1);
+      clock.tick(100);
       accumulation2.record(3);
       // refresh the accumulation1
-      clock.tick(1);
+      clock.tick(100);
       accumulation1.record(4);
 
       assert.deepStrictEqual(
@@ -111,7 +111,7 @@ describe('LastValueAggregator', () => {
       accumulation1.record(2);
       accumulation2.record(3);
       // refresh the accumulation1
-      clock.tick(1);
+      clock.tick(100);
       accumulation1.record(4);
 
       assert.deepStrictEqual(

--- a/packages/sdk-metrics/test/aggregator/LastValue.test.ts
+++ b/packages/sdk-metrics/test/aggregator/LastValue.test.ts
@@ -16,15 +16,26 @@
 
 import { HrTime } from '@opentelemetry/api';
 import * as assert from 'assert';
+import * as sinon from 'sinon';
 import { AggregationTemporality } from '../../src';
 import {
   LastValueAccumulation,
   LastValueAggregator,
 } from '../../src/aggregator';
 import { MetricData, DataPointType } from '../../src/export/MetricData';
-import { commonValues, defaultInstrumentDescriptor, sleep } from '../util';
+import { commonValues, defaultInstrumentDescriptor } from '../util';
 
 describe('LastValueAggregator', () => {
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
   describe('createAccumulation', () => {
     it('no exceptions on createAccumulation', () => {
       const aggregator = new LastValueAggregator();
@@ -47,16 +58,16 @@ describe('LastValueAggregator', () => {
       assert.deepStrictEqual(aggregator.merge(prev, delta), expected);
     });
 
-    it('return the newly sampled accumulation', async () => {
+    it('return the newly sampled accumulation', () => {
       const aggregator = new LastValueAggregator();
       const accumulation1 = aggregator.createAccumulation([0, 0]);
       const accumulation2 = aggregator.createAccumulation([1, 1]);
 
       accumulation1.record(2);
-      await sleep(1);
+      clock.tick(1);
       accumulation2.record(3);
       // refresh the accumulation1
-      await sleep(1);
+      clock.tick(1);
       accumulation1.record(4);
 
       assert.deepStrictEqual(
@@ -92,7 +103,7 @@ describe('LastValueAggregator', () => {
       assert.deepStrictEqual(aggregator.diff(prev, curr), expected);
     });
 
-    it('return the newly sampled accumulation', async () => {
+    it('return the newly sampled accumulation', () => {
       const aggregator = new LastValueAggregator();
       const accumulation1 = aggregator.createAccumulation([0, 0]);
       const accumulation2 = aggregator.createAccumulation([1, 1]);
@@ -100,7 +111,7 @@ describe('LastValueAggregator', () => {
       accumulation1.record(2);
       accumulation2.record(3);
       // refresh the accumulation1
-      await sleep(1);
+      clock.tick(1);
       accumulation1.record(4);
 
       assert.deepStrictEqual(


### PR DESCRIPTION
## Which problem is this PR solving?

This PR fixes the flaky test described in #3572 by using fake timers instead of setting and awaiting timeouts.

Fixes #3572 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally tests in a loop

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
