### PR TITLE
chore: enable merge queues

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -20,6 +20,12 @@ No changes
 ### `main`
 
 * Uncheck "Restrict who can push to matching branches"
+* Check "Require merge queue"
+  * Build concurrency: 5
+  * Minimum pull requests to merge: 1 or after 5 minutes
+  * Maximum pull requests to merge: 5
+  * Check "Only merge non-failing pull requests"
+  * Status check timeout: 60 minutes
 
 ### `dependabot/**/**`
 


### PR DESCRIPTION
On advice of @legendecas consider merge queues. This can help in the case that many PRs are ready to be merged but have to each be manually merged and updated.