### PR TITLE
chore: enable merge queue checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/peer-api.yml
+++ b/.github/workflows/peer-api.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 jobs:
   peer-api-check:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 jobs:
   node-tests:

--- a/.github/workflows/w3c-integration-test.yml
+++ b/.github/workflows/w3c-integration-test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 jobs:
   build-and-test:


### PR DESCRIPTION
## Which problem is this PR solving?

Currently, all queued items are pending for check status to be reported: https://github.com/open-telemetry/opentelemetry-js/queue/main

Refs: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

## Type of change

- [x] Internal setup

## Checklist:

- [x] Followed the style guidelines of this project
