### PR TITLE
Add baggage hook

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -462,7 +462,7 @@ export class FetchInstrumentation extends InstrumentationBase<
   ) {
     const addBaggage = this._getConfig().addBaggage;
     if (addBaggage) {
-      safeExecuteInTheMiddle(
+      return safeExecuteInTheMiddle(
         () => addBaggage(url, request),
         error => {
           if (!error) {

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -759,7 +759,7 @@ describe('fetch', () => {
   describe('when request is NOT successful (wrong url)', () => {
     beforeEach(async () => {
       const propagateTraceHeaderCorsUrls = badUrl;
-      await prepareData(badUrl, {propagateTraceHeaderCorsUrls});
+      await prepareData(badUrl, { propagateTraceHeaderCorsUrls });
     });
     afterEach(() => {
       clearData();
@@ -777,7 +777,7 @@ describe('fetch', () => {
   describe('when request is NOT successful (405)', () => {
     beforeEach(async () => {
       const propagateTraceHeaderCorsUrls = url;
-      await prepareData(url, {propagateTraceHeaderCorsUrls}, 'DELETE');
+      await prepareData(url, { propagateTraceHeaderCorsUrls }, 'DELETE');
     });
     afterEach(() => {
       clearData();


### PR DESCRIPTION

## Which problem is this PR solving?

This PR solves the problem of not being able to add a baggage when using `FetchInstrumentation` (opentelemetry-instrumentation-fetch).

Fixes #3352 

## Short description of the changes

Adds a `addBaggage` hook to opentelemetry-instrumentation-fetch that can be used to add data to baggage 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

unit tests
manual tests

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been added
- [ ] Documentation has been updated
