### PR TITLE
fix(core): added falsy check to make otel core work with browser where webpack config had process as false or null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * feat: support TraceState in SamplingResult [#3530](https://github.com/open-telemetry/opentelemetry-js/pull/3530) @raphael-theriault-swi
 
 ### :bug: (Bug Fix)
+* fix(process-usage): added falsy check to make otel core work with browser where webpack config had process as false or null [#3613](https://github.com/open-telemetry/opentelemetry-js/issues/3613) @ravindra-dyte
 
 ### :books: (Refine Doc)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
-* fix(process-usage): added falsy check to make otel core work with browser where webpack config had process as false or null [#3613](https://github.com/open-telemetry/opentelemetry-js/issues/3613) @ravindra-dyte
+* fix(core): added falsy check to make otel core work with browser where webpack config had process as false or null [#3613](https://github.com/open-telemetry/opentelemetry-js/issues/3613) @ravindra-dyte
 
 ### :books: (Refine Doc)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * feat: support TraceState in SamplingResult [#3530](https://github.com/open-telemetry/opentelemetry-js/pull/3530) @raphael-theriault-swi
 
 ### :bug: (Bug Fix)
+
 * fix(process-usage): added falsy check to make otel core work with browser where webpack config had process as false or null [#3613](https://github.com/open-telemetry/opentelemetry-js/issues/3613) @ravindra-dyte
 
 ### :books: (Refine Doc)

--- a/packages/opentelemetry-core/src/utils/environment.ts
+++ b/packages/opentelemetry-core/src/utils/environment.ts
@@ -333,7 +333,7 @@ export function parseEnvironment(values: RAW_ENVIRONMENT): ENVIRONMENT {
  * populating default values.
  */
 export function getEnvWithoutDefaults(): ENVIRONMENT {
-  return typeof process !== 'undefined'
+  return typeof process !== 'undefined' && process && process.env
     ? parseEnvironment(process.env as RAW_ENVIRONMENT)
     : parseEnvironment(_globalThis as typeof globalThis & RAW_ENVIRONMENT);
 }

--- a/packages/opentelemetry-sdk-trace-web/test/NodeGlobalsFoolProofing.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/NodeGlobalsFoolProofing.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    context,
+    propagation,
+    trace,
+    ProxyTracerProvider,
+  } from '@opentelemetry/api';
+  import { Resource } from '@opentelemetry/resources';
+  import { Tracer } from '@opentelemetry/sdk-trace-base';
+  import * as assert from 'assert';
+  import { StackContextManager, WebTracerProvider } from '../src';
+  
+  describe('Node Globals Foolproofing', () => {
+    const originalProcess =  globalThis?.process;
+    before(() => {
+        Object.assign(globalThis, { process: false });
+    })
+      
+    after(() => {
+        Object.assign(globalThis, { process: originalProcess });
+    })
+
+    beforeEach(() => {
+      context.disable();
+      trace.disable();
+      propagation.disable();
+    });
+  
+    it('Can get TraceProvider without node globals such as process', () => {
+      const propagator = propagation['_getGlobalPropagator']();
+      const tracerProvider = new WebTracerProvider();
+      tracerProvider.register({
+        propagator: null,
+      });
+  
+      assert.strictEqual(
+        propagation['_getGlobalPropagator'](),
+        propagator,
+        'propagator should not change'
+      );
+  
+      assert.ok(context['_getContextManager']() instanceof StackContextManager);
+      const apiTracerProvider = trace.getTracerProvider() as ProxyTracerProvider;
+      assert.ok(apiTracerProvider.getDelegate() === tracerProvider);
+    });
+
+    it('Can get TraceProvider with custom id generator and without node globals such as process', () => {
+
+        const getRandomString = (length: number) => {
+            const alphanumericsList =  'abcdefghijklmnopqrstuvwxyz0123456789'.split("");
+            alphanumericsList.sort( () => .5 - Math.random() );
+            
+            return alphanumericsList.slice(0, length).join("");
+        }
+        
+        const tracer = new WebTracerProvider({
+            resource: new Resource({
+                'service.name': 'web-core',
+            }),
+            idGenerator: {
+                generateTraceId: () => getRandomString(32),
+                generateSpanId: () => getRandomString(16),
+            },
+        }).getTracer('default');
+
+        assert.ok(tracer instanceof Tracer);
+      });
+  });
+  

--- a/packages/opentelemetry-sdk-trace-web/test/NodeGlobalsFoolProofing.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/NodeGlobalsFoolProofing.test.ts
@@ -15,70 +15,70 @@
  */
 
 import {
-    context,
-    propagation,
-    trace,
-    ProxyTracerProvider,
-  } from '@opentelemetry/api';
-  import { Resource } from '@opentelemetry/resources';
-  import { Tracer } from '@opentelemetry/sdk-trace-base';
-  import * as assert from 'assert';
-  import { StackContextManager, WebTracerProvider } from '../src';
-  
-  describe('Node Globals Foolproofing', () => {
-    const originalProcess =  globalThis?.process;
-    before(() => {
-        Object.assign(globalThis, { process: false });
-    })
-      
-    after(() => {
-        Object.assign(globalThis, { process: originalProcess });
-    })
+  context,
+  propagation,
+  trace,
+  ProxyTracerProvider,
+} from '@opentelemetry/api';
+import { Resource } from '@opentelemetry/resources';
+import { Tracer } from '@opentelemetry/sdk-trace-base';
+import * as assert from 'assert';
+import { StackContextManager, WebTracerProvider } from '../src';
 
-    beforeEach(() => {
-      context.disable();
-      trace.disable();
-      propagation.disable();
-    });
-  
-    it('Can get TraceProvider without node globals such as process', () => {
-      const propagator = propagation['_getGlobalPropagator']();
-      const tracerProvider = new WebTracerProvider();
-      tracerProvider.register({
-        propagator: null,
-      });
-  
-      assert.strictEqual(
-        propagation['_getGlobalPropagator'](),
-        propagator,
-        'propagator should not change'
-      );
-  
-      assert.ok(context['_getContextManager']() instanceof StackContextManager);
-      const apiTracerProvider = trace.getTracerProvider() as ProxyTracerProvider;
-      assert.ok(apiTracerProvider.getDelegate() === tracerProvider);
-    });
-
-    it('Can get TraceProvider with custom id generator and without node globals such as process', () => {
-
-        const getRandomString = (length: number) => {
-            const alphanumericsList =  'abcdefghijklmnopqrstuvwxyz0123456789'.split("");
-            alphanumericsList.sort( () => .5 - Math.random() );
-            
-            return alphanumericsList.slice(0, length).join("");
-        }
-        
-        const tracer = new WebTracerProvider({
-            resource: new Resource({
-                'service.name': 'web-core',
-            }),
-            idGenerator: {
-                generateTraceId: () => getRandomString(32),
-                generateSpanId: () => getRandomString(16),
-            },
-        }).getTracer('default');
-
-        assert.ok(tracer instanceof Tracer);
-      });
+describe('Node Globals Foolproofing', () => {
+  const originalProcess = globalThis?.process;
+  before(() => {
+    Object.assign(globalThis, { process: false });
   });
-  
+
+  after(() => {
+    Object.assign(globalThis, { process: originalProcess });
+  });
+
+  beforeEach(() => {
+    context.disable();
+    trace.disable();
+    propagation.disable();
+  });
+
+  it('Can get TraceProvider without node globals such as process', () => {
+    const propagator = propagation['_getGlobalPropagator']();
+    const tracerProvider = new WebTracerProvider();
+    tracerProvider.register({
+      propagator: null,
+    });
+
+    assert.strictEqual(
+      propagation['_getGlobalPropagator'](),
+      propagator,
+      'propagator should not change'
+    );
+
+    assert.ok(context['_getContextManager']() instanceof StackContextManager);
+    const apiTracerProvider = trace.getTracerProvider() as ProxyTracerProvider;
+    assert.ok(apiTracerProvider.getDelegate() === tracerProvider);
+  });
+
+  it('Can get TraceProvider with custom id generator and without node globals such as process', () => {
+    const getRandomString = (length: number) => {
+      const alphanumericsList = 'abcdefghijklmnopqrstuvwxyz0123456789'.split(
+        ''
+      );
+      alphanumericsList.sort(() => 0.5 - Math.random());
+
+      return alphanumericsList.slice(0, length).join('');
+    };
+
+    const tracer = new WebTracerProvider({
+      resource: new Resource({
+        'service.name': 'web-core',
+      }),
+      idGenerator: {
+        generateTraceId: () => getRandomString(32),
+        generateSpanId: () => getRandomString(16),
+      },
+    }).getTracer('default');
+
+    assert.ok(tracer instanceof Tracer);
+  });
+});


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes [#3613](https://github.com/open-telemetry/opentelemetry-js/issues/3613)

Some customers of ours are using webpack where they had set all node globals to false (https://webpack.js.org/migrate/5/), as suggested by Stack overflow responses such as https://stackoverflow.com/questions/64557638/how-to-polyfill-node-core-modules-in-webpack-5 where best voted answers suggest devs to set Node Globals as false as a fallback. Current check on `process` was doing a plain type check to see equality with undefined however typeof false is boolean & typeof null is object.

To ensure that OTEL works with any config having undefined/null/false, this PR was raised.

## Short description of the changes

Added falsy checks while using `process` in browser environment to ensure that the OTEL can work with projects where webpack config has process set to false/null. Refer https://stackoverflow.com/questions/64557638/how-to-polyfill-node-core-modules-in-webpack-5 to see why process is set to false/null.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Created a separate file to write tests. A separate file for impact testing globals would make it expandable in the future to test out other globals such as URL, and crypto. For this new Test file, replaced the globals.process in before to test the scenario.

1. Added test to see if WebTraceProvider would initialise normally when globals process is set as false.
2. Added if it would work with a custom trace/span id generator.

Before change:
<img width="771" alt="image" src="https://user-images.githubusercontent.com/99713383/219346280-acae6cad-ce08-49b5-bc03-e2552f5db72c.png">

(If I set globals.process to false with existing tests) 
<img width="771" alt="image" src="https://user-images.githubusercontent.com/99713383/219346372-552e4761-daa0-4a57-8e13-0622af1d0dc2.png">

After:
<img width="771" alt="image" src="https://user-images.githubusercontent.com/99713383/219346641-45d076e6-774c-494d-883c-a2dd03271cca.png">


## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
