### PR TITLE
feat(sdk-node): install diag logger with OTEL_LOG_LEVEL

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :rocket: (Enhancement)
 
 * feat: add HTTP_ROUTE attribute to http incoming metrics if present [#3581](https://github.com/open-telemetry/opentelemetry-js/pull/3581) @hermogenes
+* feat(sdk-node): install diag logger with OTEL_LOG_LEVEL [#3627](https://github.com/open-telemetry/opentelemetry-js/pull/3627) @legendecas
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -143,7 +143,21 @@ Configure the [service name](https://github.com/open-telemetry/opentelemetry-spe
 
 Disable the SDK by setting the `OTEL_SDK_DISABLED` environment variable to `true`.
 
-## Configure Trace Exporter from  Environment
+## Configure log level from the environment
+
+Set the log level by setting the `OTEL_LOG_LEVEL` environment variable to enums:
+
+- `NONE`,
+- `ERROR`,
+- `WARN`,
+- `INFO`,
+- `DEBUG`,
+- `VERBOSE`,
+- `ALL`.
+
+The default level is `INFO`.
+
+## Configure Trace Exporter from environment
 
 This is an alternative to programmatically configuring an exporter or span processor. This package will auto setup the default `otlp` exporter with `http/protobuf` protocol if `traceExporter` or `spanProcessor` hasn't been passed into the `NodeSDK` constructor.
 

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { ContextManager, TextMapPropagator, metrics } from '@opentelemetry/api';
+import {
+  ContextManager,
+  TextMapPropagator,
+  metrics,
+  diag,
+  DiagConsoleLogger,
+} from '@opentelemetry/api';
 import {
   InstrumentationOption,
   registerInstrumentations,
@@ -80,10 +86,16 @@ export class NodeSDK {
    * Create a new NodeJS SDK instance
    */
   public constructor(configuration: Partial<NodeSDKConfiguration> = {}) {
-    if (getEnv().OTEL_SDK_DISABLED) {
+    const env = getEnv();
+    if (env.OTEL_SDK_DISABLED) {
       this._disabled = true;
       // Functions with possible side-effects are set
       // to no-op via the _disabled flag
+    }
+    if (env.OTEL_LOG_LEVEL) {
+      diag.setLogger(new DiagConsoleLogger(), {
+        logLevel: env.OTEL_LOG_LEVEL,
+      });
     }
 
     this._resource = configuration.resource ?? new Resource({});


### PR DESCRIPTION

## Which problem is this PR solving?

Register diag logger with environ `OTEL_LOG_LEVEL`.

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/3312

## Short description of the changes

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] `diag.setLogger` invoked with the expected log level and `DiagConsoleLogger`.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
