### PR TITLE
chore: improve logging for api registration mismatches

### DIFF
--- a/api/src/internal/global-utils.ts
+++ b/api/src/internal/global-utils.ts
@@ -54,7 +54,7 @@ export function registerGlobal<Type extends keyof OTelGlobalAPI>(
   if (api.version !== VERSION) {
     // All registered APIs must be of the same version exactly
     const err = new Error(
-      '@opentelemetry/api: All API registration versions must match'
+      `@opentelemetry/api: Registration of version v${api.version} for ${type} does not match API v${VERSION}`
     );
     diag.error(err.stack || err.message);
     return false;

--- a/api/src/internal/global-utils.ts
+++ b/api/src/internal/global-utils.ts
@@ -54,7 +54,7 @@ export function registerGlobal<Type extends keyof OTelGlobalAPI>(
   if (api.version !== VERSION) {
     // All registered APIs must be of the same version exactly
     const err = new Error(
-      `@opentelemetry/api: Registration of version v${api.version} for ${type} does not match API v${VERSION}`
+      `@opentelemetry/api: Registration of version v${api.version} for ${type} does not match previously registered API v${VERSION}`
     );
     diag.error(err.stack || err.message);
     return false;

--- a/api/test/common/internal/global.test.ts
+++ b/api/test/common/internal/global.test.ts
@@ -84,23 +84,22 @@ describe('Global Utils', () => {
     assert.notStrictEqual(manager, api1.context['_getContextManager']());
   });
 
-  it('should return the module NoOp implementation if the version is a mismatch', () => {
-    const newContextManager = new NoopContextManager();
-    api1.context.setGlobalContextManager(newContextManager);
+  it('should not register if the version is a mismatch', () => {
+    const logger1 = getMockLogger();
+    const logger2 = getMockLogger();
 
-    // ensure new context manager is returned
-    assert.strictEqual(api1.context['_getContextManager'](), newContextManager);
-
-    const globalInstance = getGlobal('context');
+    api1.diag.setLogger(logger1);
+    const globalInstance = getGlobal('diag');
     assert.ok(globalInstance);
     // @ts-expect-error we are modifying internals for testing purposes here
     _globalThis[Symbol.for(GLOBAL_API_SYMBOL_KEY)].version = '0.0.1';
 
-    // ensure new context manager is not returned because version above is incompatible
-    assert.notStrictEqual(
-      api1.context['_getContextManager'](),
-      newContextManager
-    );
+    assert.equal(false, api1.diag.setLogger(logger2)); // won't happen
+
+    api1.diag.info('message');
+    sinon.assert.notCalled(logger2.error);
+    sinon.assert.notCalled(logger2.info);
+    sinon.assert.notCalled(logger2.warn);
   });
 
   it('should debug log registrations', () => {


### PR DESCRIPTION

## Which problem is this PR solving?

The logging when api versions don't match in `registerGlobal` is not very helpful.  This adds all the relevant information to debug problems with this scenario.

## Short description of the changes

Add the type and the two mismatched version numbers to the mismatched version log message.

## How Has This Been Tested?

The previous unit test attempting to cover this case was not actually covering it because context global registration is
`!allowOverride` (the default), so I switched the test to use `diag` instead.  Now the `if (api.version !== VERSION)` block is actually hit by the unit test.

## Checklist:

- [ x ] Followed the style guidelines of this project
- [ x ] Unit tests have been added
