### PR TITLE
fix: batchspanprocessor.test for TS > 4.6.0

### DIFF
--- a/packages/opentelemetry-sdk-trace-base/test/browser/export/BatchSpanProcessor.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/browser/export/BatchSpanProcessor.test.ts
@@ -20,11 +20,17 @@ import { SpanExporter } from '../../../src';
 import { BatchSpanProcessor } from '../../../src/platform/browser/export/BatchSpanProcessor';
 import { TestTracingSpanExporter } from '../../common/export/TestTracingSpanExporter';
 
+/**
+ * VisibilityState has been removed from TypeScript 4.6.0+
+ * So just defining a simple replacement
+ */
+type WebVisibilityState = 'visible' | 'hidden';
+
 const describeDocument =
   typeof document === 'object' ? describe : describe.skip;
 
 describeDocument('BatchSpanProcessor - web main context', () => {
-  let visibilityState: VisibilityState = 'visible';
+  let visibilityState: WebVisibilityState = 'visible';
   let exporter: SpanExporter;
   let processor: BatchSpanProcessor;
   let forceFlushSpy: sinon.SinonStub;


### PR DESCRIPTION
## Which problem is this PR solving?

The BatchSpanProcessor.test.ts is using the type `VisibilityState`, this was removed from TypeScript v4.6.0+

As part of merging the JS and Contrib repo's to the web js sandbox, which is using a later version of TypeScript this test fails to build. The sandbox also attempts to run all tests in node, browser and web worker automatically as part of merging.

This change is required so that the code can be successfully merged to the sandbox.