### PR TITLE
fix(test): windows tests are failing

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -64,6 +64,7 @@ jobs:
     runs-on: windows-latest
     env:
       NPM_CONFIG_UNSAFE_PERM: true
+      NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -9,7 +9,7 @@
     "prepublishOnly": "npm run compile",
     "compile": "tsc --build",
     "clean": "tsc --build --clean",
-    "test": "nyc ts-mocha -p tsconfig.json test/**/*.test.ts",
+    "test": "cross-env NODE_OPTIONS='--max-old-space-size=8192' nyc ts-mocha -p tsconfig.json test/**/*.test.ts",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",


### PR DESCRIPTION
## Which problem is this PR solving?

This issue is occurring because the underlying v8 engine used by node is consuming more memory on windows, while #3628 is about the `tests` failing on WIndows build, it also fails on a windows machine.

Fixes #3628 

## Short description of the changes

This is a targeted fix for the current project that is failing to build, this could also be applied in the unit-test.yml, but that would not address (fix) for anyone cloning and running tests in the repo on a Windows machine.

For reference the `--max-old-space-size=` is actually a v8 configuration option (not specifically node)
https://github.com/nodejs/node/issues/7937

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested locally on a Windows development machine with the following repo steps (the only way locally I found to repo), the clean is required because lerna was caching the result once a successful build occurred.

```
git clean -xdf
npm install
npm run compile
npm run test
```

And also in the GitHub pipeline

