### PR TITLE
Export DiagLoggerOptions Type

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 * fix(metrics): export `MetricsAPI` type [#3535](https://github.com/open-telemetry/opentelemetry-js/pull/3535)
 * fix(api): rename `LoggerOptions` to `DiagLoggerOptions` [#3641](https://github.com/open-telemetry/opentelemetry-js/pull/3641)
+* fix(api): export `DiagLoggerOptions` type [#3639](https://github.com/open-telemetry/opentelemetry-js/pull/3639)
 
 ## 1.4.0
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -32,7 +32,7 @@ export {
   DiagLogger,
   DiagLogLevel,
   ComponentLoggerOptions,
-  LoggerOptions
+  LoggerOptions,
 } from './diag/types';
 export type { DiagAPI } from './api/diag';
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -32,7 +32,7 @@ export {
   DiagLogger,
   DiagLogLevel,
   ComponentLoggerOptions,
-  LoggerOptions,
+  DiagLoggerOptions,
 } from './diag/types';
 export type { DiagAPI } from './api/diag';
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -32,6 +32,7 @@ export {
   DiagLogger,
   DiagLogLevel,
   ComponentLoggerOptions,
+  LoggerOptions
 } from './diag/types';
 export type { DiagAPI } from './api/diag';
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- `DiagLoggerApi.setLogger` has two overrides. One of them has `options: DiagLoggerOptions` parameter. However, `DiagLoggerOptions` is not exported through `index.ts`. 
Fixes #3638 

## Short description of the changes

Exporting `DiagLoggerOptions` interface in index.ts

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

N/A 

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
