### PR TITLE
Rename Diag/LoggerOptions to DiagLoggerOptions

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### :bug: (Bug Fix)
 
 * fix(metrics): export `MetricsAPI` type [#3535](https://github.com/open-telemetry/opentelemetry-js/pull/3535)
+* fix(api): rename `LoggerOptions` to `DiagLoggerOptions` [#3641](https://github.com/open-telemetry/opentelemetry-js/pull/3641)
 
 ## 1.4.0
 

--- a/api/src/diag/types.ts
+++ b/api/src/diag/types.ts
@@ -97,7 +97,7 @@ export interface ComponentLoggerOptions {
   namespace: string;
 }
 
-export interface LoggerOptions {
+export interface DiagLoggerOptions {
   /**
    * The {@link DiagLogLevel} used to filter logs sent to the logger.
    *
@@ -117,10 +117,10 @@ export interface DiagLoggerApi {
    * If a global diag logger is already set, this will override it.
    *
    * @param logger - The {@link DiagLogger} instance to set as the default logger.
-   * @param options - A {@link LoggerOptions} object. If not provided, default values will be set.
+   * @param options - A {@link DiagLoggerOptions} object. If not provided, default values will be set.
    * @returns `true` if the logger was successfully registered, else `false`
    */
-  setLogger(logger: DiagLogger, options?: LoggerOptions): boolean;
+  setLogger(logger: DiagLogger, options?: DiagLoggerOptions): boolean;
 
   /**
    *


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
Conflicting type name `LoggerOptions` in API and experimental logs API

Fixes #3640 

## Short description of the changes
Renaming `LoggerOptions` to `DiagLoggerOptions`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
N/A

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
