### PR TITLE
fix(test): fix failing tests by preventing source-map generation

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,4 +1,5 @@
 {
+  "produceSourceMap": false,
   "extension": [
     ".ts"
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :house: (Internal)
 
-* fix(sdk-metrics): ix flaky LastValueAggregator test by using fake timer [#3587](https://github.com/open-telemetry/opentelemetry-js/pull/3587) @pichlermarc
+* fix(sdk-metrics): fix flaky LastValueAggregator test by using fake timer [#3587](https://github.com/open-telemetry/opentelemetry-js/pull/3587) @pichlermarc
+* fix(test): fix failing tests by preventing source-map generation [#3642](https://github.com/open-telemetry/opentelemetry-js/pull/3642) @pichlermarc
 
 ## 1.9.1
 


### PR DESCRIPTION
## Which problem is this PR solving?

Windows tests are currently running out of heap space, which seems to be related to source map merging. As far as I can tell, we're already generating source maps for the browser/webworker tests, and using ts-mocha already provides us with source-maps. While investigating #3628, I found that the merging of source maps (persumably merging the existing ones and the ones generated by nyc/istanbul) is what allocates a lot of memory. This PR disables the generation of source maps and reduces the amount of memory used significantly from >3.9GB to 174MB
  
Fixes #3628 

## Short description of the changes

Prevent source map generation by `nyc` 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Local testing (memory profiling, sanity check by looking at `Maximum resident set size` produced by `time -v`)
