### PR TITLE
feat(sdk-node): override IdGenerator when using NodeSDK

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to experimental packages in this project will be documented 
 * feat: use HTTP_ROUTE in span name [#3603](https://github.com/open-telemetry/opentelemetry-js/pull/3603) @Flarna
 * feat: add HTTP_ROUTE attribute to http incoming metrics if present [#3581](https://github.com/open-telemetry/opentelemetry-js/pull/3581) @hermogenes
 * feat(sdk-node): install diag logger with OTEL_LOG_LEVEL [#3627](https://github.com/open-telemetry/opentelemetry-js/pull/3627) @legendecas
+* feat(sdk-node): override IdGenerator when using NodeSDK [#3645](https://github.com/open-telemetry/opentelemetry-js/pull/3645) @haddasbronfman
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -117,6 +117,9 @@ export class NodeSDK {
       if (configuration.spanLimits) {
         tracerProviderConfig.spanLimits = configuration.spanLimits;
       }
+      if (configuration.idGenerator) {
+        tracerProviderConfig.idGenerator = configuration.idGenerator;
+      }
 
       const spanProcessor =
         configuration.spanProcessor ??

--- a/experimental/packages/opentelemetry-sdk-node/src/types.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/types.ts
@@ -24,6 +24,7 @@ import {
   SpanExporter,
   SpanLimits,
   SpanProcessor,
+  IdGenerator
 } from '@opentelemetry/sdk-trace-base';
 
 export interface NodeSDKConfiguration {
@@ -41,4 +42,5 @@ export interface NodeSDKConfiguration {
   spanProcessor: SpanProcessor;
   traceExporter: SpanExporter;
   spanLimits: SpanLimits;
+  idGenerator: IdGenerator
 }

--- a/experimental/packages/opentelemetry-sdk-node/src/types.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/types.ts
@@ -24,7 +24,7 @@ import {
   SpanExporter,
   SpanLimits,
   SpanProcessor,
-  IdGenerator
+  IdGenerator,
 } from '@opentelemetry/sdk-trace-base';
 
 export interface NodeSDKConfiguration {
@@ -42,5 +42,5 @@ export interface NodeSDKConfiguration {
   spanProcessor: SpanProcessor;
   traceExporter: SpanExporter;
   spanLimits: SpanLimits;
-  idGenerator: IdGenerator
+  idGenerator: IdGenerator;
 }

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -23,7 +23,6 @@ import {
   DiagLogLevel,
   metrics,
   DiagConsoleLogger,
-  SpanKind,
 } from '@opentelemetry/api';
 import {
   AsyncHooksContextManager,

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -695,7 +695,6 @@ describe('Node SDK', () => {
   });
 
   describe('configure IdGenerator', async () => {
-
     class CustomIdGenerator implements IdGenerator {
       generateTraceId(): string {
         return 'constant-test-trace-id';
@@ -710,7 +709,7 @@ describe('Node SDK', () => {
       const spanProcessor = new SimpleSpanProcessor(new ConsoleSpanExporter());
       const sdk = new NodeSDK({
         idGenerator,
-        spanProcessor
+        spanProcessor,
       });
       sdk.start();
 
@@ -719,8 +718,8 @@ describe('Node SDK', () => {
       });
       span.end();
 
-      assert.strictEqual(span.spanContext().spanId, 'constant-test-span-id')
-      assert.strictEqual(span.spanContext().traceId, 'constant-test-trace-id')
+      assert.strictEqual(span.spanContext().spanId, 'constant-test-span-id');
+      assert.strictEqual(span.spanContext().traceId, 'constant-test-trace-id');
     });
   });
 });

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -713,9 +713,7 @@ describe('Node SDK', () => {
       });
       sdk.start();
 
-      const span = trace.getTracer('test').startSpan('testName', {
-        kind: SpanKind.INTERNAL,
-      });
+      const span = trace.getTracer('test').startSpan('testName');
       span.end();
 
       assert.strictEqual(span.spanContext().spanId, 'constant-test-span-id');


### PR DESCRIPTION
## Which problem is this PR solving?
Add ability to override `idGenerator` when using NodeSDK
Fixes #3435 

## Short description of the changes
Add 'idGenerator' to the configuration of NodeSDK

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
I added a test that creates NodeSDK with a custom idGenerator object, then I created span and verified it has the id that my custom generator generates. (a constant id just for testing)
