### PR TITLE
fix(instrumentation-http): include query params in http.target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 ### :bug: (Bug Fix)
 
 * fix(core): added falsy check to make otel core work with browser where webpack config had process as false or null [#3613](https://github.com/open-telemetry/opentelemetry-js/issues/3613) @ravindra-dyte
+* fix(instrumentation-http): include query params in http.target [#3646](https://github.com/open-telemetry/opentelemetry-js/pull/3646) @kobi-co
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -484,7 +484,7 @@ export const getIncomingRequestAttributes = (
   }
 
   if (requestUrl) {
-    attributes[SemanticAttributes.HTTP_TARGET] = requestUrl.pathname || '/';
+    attributes[SemanticAttributes.HTTP_TARGET] = requestUrl.path || '/';
   }
 
   if (userAgent !== undefined) {

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -504,7 +504,7 @@ describe('Utility', () => {
       assert.strictEqual(attributes[SemanticAttributes.HTTP_ROUTE], undefined);
     });
 
-    it('should set http.target as full path in http span attributes', () => {
+    it('should set http.target as path in http span attributes', () => {
       const request = {
         url: 'http://hostname/user/?q=val',
         method: 'GET',

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -503,6 +503,23 @@ describe('Utility', () => {
       });
       assert.strictEqual(attributes[SemanticAttributes.HTTP_ROUTE], undefined);
     });
+
+    it('should set http.target as full path in http span attributes', () => {
+      const request = {
+        url: 'http://hostname/user/?q=val',
+        method: 'GET',
+      } as IncomingMessage;
+      request.headers = {
+        'user-agent': 'chrome',
+      };
+      const attributes = utils.getIncomingRequestAttributes(request, {
+        component: 'http',
+      });
+      assert.strictEqual(
+        attributes[SemanticAttributes.HTTP_TARGET],
+        '/user/?q=val'
+      );
+    });
   });
 
   describe('headers to span attributes capture', () => {


### PR DESCRIPTION
## Which problem is this PR solving?
According [to the spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions), `http.target` attribute should include path + query params, current implementation sets the path without query params.



Attribute | Type | Description | Examples | Requirement Level
-- | -- | -- | -- | --
http.target | string | The full request target as passed in a HTTP request line or equivalent. | /path/12314/?q=ddds | Required

## Short description of the changes
Fix `http.target` to use [urlObject.path](https://nodejs.org/docs/latest-v19.x/api/url.html#urlobjectpath) and not [urlObject.pathname](https://nodejs.org/docs/latest-v19.x/api/url.html#urlobjectpathname) which is the value the includes the query params.

## Type of change
Bug fix

## How Has This Been Tested?
Created a new unit test to check http.target attribute value.

