### PR TITLE
chore: update http example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :books: (Refine Doc)
 
+* chore: update http example [#3651](https://github.com/open-telemetry/opentelemetry-js/pull/3651) @JamieDanielson
+
 ### :house: (Internal)
 
 * fix(sdk-metrics): fix flaky LastValueAggregator test by using fake timer [#3587](https://github.com/open-telemetry/opentelemetry-js/pull/3587) @pichlermarc

--- a/examples/http/client.js
+++ b/examples/http/client.js
@@ -9,8 +9,7 @@ function makeRequest() {
   // span corresponds to outgoing requests. Here, we have manually created
   // the span, which is created to track work that happens outside of the
   // request lifecycle entirely.
-  const span = tracer.startSpan('makeRequest');
-  api.context.with(api.trace.setSpan(api.context.active(), span), () => {
+  tracer.startActiveSpan('makeRequest', (span) => {
     http.get({
       host: 'localhost',
       port: 8080,

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-example",
   "private": true,
-  "version": "0.25.0",
+  "version": "0.35.1",
   "description": "Example of HTTP integration with OpenTelemetry",
   "main": "index.js",
   "scripts": {
@@ -28,15 +28,15 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.2",
-    "@opentelemetry/exporter-jaeger": "0.25.0",
-    "@opentelemetry/exporter-zipkin": "0.25.0",
-    "@opentelemetry/instrumentation": "0.25.0",
-    "@opentelemetry/instrumentation-http": "0.25.0",
-    "@opentelemetry/resources": "0.25.0",
-    "@opentelemetry/semantic-conventions": "0.25.0",
-    "@opentelemetry/sdk-trace-node": "0.25.0",
-    "@opentelemetry/sdk-trace-base": "0.25.0"
+    "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/exporter-jaeger": "1.9.1",
+    "@opentelemetry/exporter-zipkin": "1.9.1",
+    "@opentelemetry/instrumentation": "0.35.1",
+    "@opentelemetry/instrumentation-http": "0.35.1",
+    "@opentelemetry/resources": "1.9.1",
+    "@opentelemetry/semantic-conventions": "1.9.1",
+    "@opentelemetry/sdk-trace-node": "1.9.1",
+    "@opentelemetry/sdk-trace-base": "1.9.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/http",
   "devDependencies": {

--- a/examples/http/server.js
+++ b/examples/http/server.js
@@ -19,9 +19,10 @@ function startServer(port) {
 
 /** A function which handles requests and send response. */
 function handleRequest(request, response) {
-  const currentSpan = api.trace.getSpan(api.context.active());
+  const currentSpan = api.trace.getActiveSpan();
   // display traceid in the terminal
-  console.log(`traceid: ${currentSpan.spanContext().traceId}`);
+  const traceId = currentSpan.spanContext().traceId;
+  console.log(`traceId: ${traceId}`);
   const span = tracer.startSpan('handleRequest', {
     kind: 1, // server
     attributes: { key: 'value' },

--- a/lerna.json
+++ b/lerna.json
@@ -11,6 +11,7 @@
     "selenium-tests",
     "examples/otlp-exporter-node",
     "examples/opentelemetry-web",
+    "examples/http",
     "examples/https"
   ]
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The `http` example had outdated dependencies, and were still using older functions for getting active spans when newer convenience APIs are available now.

## Short description of the changes

- Updates dependencies in `package.json`
  - It seems like these are usually updated with each release now, but this was further behind than the others so it probably wasn't as obvious with a Find/Replace
- Uses newer `startActiveSpan()` and `getActiveSpan()`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual testing with new and old versions of packages to ensure the same results

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
