### PR TITLE
fix: add examples/http to ignoredLernaProjects

### DIFF
--- a/scripts/update-ts-configs.js
+++ b/scripts/update-ts-configs.js
@@ -51,6 +51,7 @@ const ignoredLernaProjects = [
   'examples/otlp-exporter-node',
   'examples/opentelemetry-web',
   'examples/https',
+  'examples/http',
 ];
 
 let dryRun = false;


### PR DESCRIPTION
## Which problem is this PR solving?

From a clean clone of the project, `npm install` is failing on the `postinstall` step, as the example under `examples/https` does not have a `tsconfig.json`. As `examples/http` is a plain JavaScript project, it does not need a `tsconfig.json`. This PR adds the example to the ignore list.

## Short description of the changes

Add newly linked `http` example to `ignoredLernaProjects` in `update-ts-configs.js` 

## Type of change

- [x] Internal

## How Has This Been Tested?

- [x] Manually running `git clean -ffdx && npm install`
