### PR TITLE
feat: added ability to hook into specific libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 ## Unreleased
 
 * feat: collect host id for non-cloud environments [#3575](https://github.com/open-telemetry/opentelemetry-js/pull/3575) @mwear
+* feat: added env variable to require only specific libraries [#3666](https://github.com/open-telemetry/opentelemetry-js/pull/3666) @kirrg001
 
 ### :boom: Breaking Change
 


### PR DESCRIPTION
refs #3655

This PR adds the ability to only listen on specific require calls.
Helpful when you want to use Otel programmatically.

This PR references #3655 but it does not solve the underlying bug. The bug needs to be solved in the target npm module (already reported)

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
