### PR TITLE
fix(sdk-trace-web): make parseUrl respect document.baseURI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+* fix(sdk-trace-web): make `parseUrl()` respect document.baseURI [#3670](https://github.com/open-telemetry/opentelemetry-js/pull/3670) @domasx2
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -305,7 +305,10 @@ export interface URLLike {
  */
 export function parseUrl(url: string): URLLike {
   if (typeof URL === 'function') {
-    return new URL(url, (typeof document !== 'undefined' ? document.baseURI : location.href));
+    return new URL(
+      url,
+      typeof document !== 'undefined' ? document.baseURI : location.href
+    );
   }
   const element = getUrlNormalizingAnchor();
   element.href = url;

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -305,7 +305,7 @@ export interface URLLike {
  */
 export function parseUrl(url: string): URLLike {
   if (typeof URL === 'function') {
-    return new URL(url, document.baseURI);
+    return new URL(url, (typeof document !== 'undefined' ? document.baseURI : location.href));
   }
   const element = getUrlNormalizingAnchor();
   element.href = url;

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -305,7 +305,7 @@ export interface URLLike {
  */
 export function parseUrl(url: string): URLLike {
   if (typeof URL === 'function') {
-    return new URL(url, location.href);
+    return new URL(url, document.baseURI);
   }
   const element = getUrlNormalizingAnchor();
   element.href = url;

--- a/packages/opentelemetry-sdk-trace-web/test/window/utils.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/window/utils.test.ts
@@ -171,6 +171,12 @@ describe('utils', () => {
         assert.strictEqual(typeof url[field], 'string');
       });
     });
+
+    it('should correctly parse relative url in presence of base tag', () => {
+      sinon.stub(globalThis.document, 'baseURI').value('http://foobar.com');
+      const url = parseUrl('foo/bar');
+      assert.strictEqual(url.href, 'http://foobar.com/foo/bar');
+    });
   });
 
   describe('normalizeUrl', () => {
@@ -180,6 +186,8 @@ describe('utils', () => {
       assert.strictEqual(url, 'https://opentelemetry.io/%E4%BD%A0%E5%A5%BD');
     });
   });
+
+  
 });
 
 function getElementByXpath(path: string) {

--- a/packages/opentelemetry-sdk-trace-web/test/window/utils.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/window/utils.test.ts
@@ -186,8 +186,6 @@ describe('utils', () => {
       assert.strictEqual(url, 'https://opentelemetry.io/%E4%BD%A0%E5%A5%BD');
     });
   });
-
-  
 });
 
 function getElementByXpath(path: string) {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Noticed that [fetch instrumentation](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch) breaks web apps that provide relative urls to `window.fetch` and have URL base explicitly set via a [base element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base). The root cause seems to be `parseUrl`, which resolves absolute URL using `location.href` as URL base when it should use [document.baseURI](https://www.w3schools.com/jsref/prop_doc_baseuri.asp). 

## Short description of the changes

Makes `parseUrl` use `document.baseURI` when available and fall back to `location.href` when not (web workers). 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I'm attempting to instrument [Grafana](https://github.com/grafana/grafana) frontend with tracing. If fetch instrumentation is enabled, dashboards do not load due to mangled API request URLs. Applying this fix resolves the issue.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
