### PR TITLE
fix!: span name on instrumentation-xml-http-request

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix: remove HTTP/HTTPS prefix from span name in instrumentation-xml-http-request
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,8 +12,6 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
-* fix: remove HTTP/HTTPS prefix from span name in instrumentation-xml-http-request [#3672](https://github.com/open-telemetry/opentelemetry-js/pull/3672) @jufab
-
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,11 +6,13 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+* fix: remove HTTP/HTTPS prefix from span name in instrumentation-xml-http-request [#3672](https://github.com/open-telemetry/opentelemetry-js/pull/3672) @jufab
+
 ### :rocket: (Enhancement)
 
 ### :bug: (Bug Fix)
 
-* fix: remove HTTP/HTTPS prefix from span name in instrumentation-xml-http-request
+* fix: remove HTTP/HTTPS prefix from span name in instrumentation-xml-http-request [#3672](https://github.com/open-telemetry/opentelemetry-js/pull/3672) @jufab
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -329,7 +329,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
       this._diag.debug('ignoring span as url matches ignored url');
       return;
     }
-    const spanName = `HTTP ${method.toUpperCase()}`;
+    const spanName = `${method.toUpperCase()}`;
 
     const currentSpan = this.tracer.startSpan(spanName, {
       kind: api.SpanKind.CLIENT,

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -329,7 +329,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
       this._diag.debug('ignoring span as url matches ignored url');
       return;
     }
-    const spanName = `${method.toUpperCase()}`;
+    const spanName = method.toUpperCase();
 
     const currentSpan = this.tracer.startSpan(spanName, {
       kind: api.SpanKind.CLIENT,

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -318,7 +318,7 @@ describe('xhr', () => {
 
         it('span should have correct name', () => {
           const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
-          assert.strictEqual(span.name, 'HTTP GET', 'span has wrong name');
+          assert.strictEqual(span.name, 'GET', 'span has wrong name');
         });
 
         it('span should have correct kind', () => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fix span name on package instrumentation-xml-http-request after pull #3603  

## Short description of the changes

Remove `HTTP` on span name

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Unit test

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been added
- [ ] Documentation has been updated
