### PR TITLE
fix(resource): make properties for async resource resolution optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+* fix(resource): make properties for async resource resolution optional [#3677](https://github.com/open-telemetry/opentelemetry-js/pull/3677) @pichlermarc
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -27,8 +27,9 @@ import { IResource } from './IResource';
  */
 export class Resource implements IResource {
   static readonly EMPTY = new Resource({});
-  private _syncAttributes: ResourceAttributes;
-  private _asyncAttributesPromise: Promise<ResourceAttributes> | undefined;
+  private _syncAttributes?: ResourceAttributes;
+  private _asyncAttributesPromise?: Promise<ResourceAttributes>;
+  private _attributes?: ResourceAttributes;
 
   /**
    * Check if async attributes have resolved. This is useful to avoid awaiting
@@ -36,7 +37,7 @@ export class Resource implements IResource {
    *
    * @returns true if the resource "attributes" property is not yet settled to its final value
    */
-  public asyncAttributesPending: boolean;
+  public asyncAttributesPending?: boolean;
 
   /**
    * Returns an empty Resource
@@ -66,11 +67,12 @@ export class Resource implements IResource {
      * information about the entity as numbers, strings or booleans
      * TODO: Consider to add check/validation on attributes.
      */
-    private _attributes: ResourceAttributes,
+    attributes: ResourceAttributes,
     asyncAttributesPromise?: Promise<ResourceAttributes>
   ) {
+    this._attributes = attributes;
     this.asyncAttributesPending = asyncAttributesPromise != null;
-    this._syncAttributes = _attributes;
+    this._syncAttributes = this._attributes ?? {};
     this._asyncAttributesPromise = asyncAttributesPromise?.then(
       asyncAttributes => {
         this._attributes = Object.assign({}, this._attributes, asyncAttributes);
@@ -92,7 +94,7 @@ export class Resource implements IResource {
       );
     }
 
-    return this._attributes;
+    return this._attributes ?? {};
   }
 
   /**
@@ -100,7 +102,7 @@ export class Resource implements IResource {
    * this Resource's attributes. This is useful in exporters to block until resource detection
    * has finished.
    */
-  async waitForAsyncAttributes(): Promise<void> {
+  async waitForAsyncAttributes?(): Promise<void> {
     if (this.asyncAttributesPending) {
       await this._asyncAttributesPromise;
     }

--- a/packages/opentelemetry-resources/test/Resource.test.ts
+++ b/packages/opentelemetry-resources/test/Resource.test.ts
@@ -155,7 +155,7 @@ describe('Resource', () => {
       for (const resource of [resourceResolve, resourceReject]) {
         assert.ok(resource.asyncAttributesPending);
         await clock.nextAsync();
-        await resource.waitForAsyncAttributes();
+        await resource.waitForAsyncAttributes?.();
         assert.ok(!resource.asyncAttributesPending);
       }
     });
@@ -174,7 +174,7 @@ describe('Resource', () => {
         asyncAttributes
       );
 
-      await resource.waitForAsyncAttributes();
+      await resource.waitForAsyncAttributes?.();
       assert.deepStrictEqual(resource.attributes, {
         sync: 'fromsync',
         // async takes precedence
@@ -266,7 +266,7 @@ describe('Resource', () => {
       const debugStub = sinon.spy(diag, 'debug');
 
       const resource = new Resource({}, Promise.reject(new Error('rejected')));
-      await resource.waitForAsyncAttributes();
+      await resource.waitForAsyncAttributes?.();
 
       assert.ok(
         debugStub.calledWithMatch(

--- a/packages/opentelemetry-resources/test/Resource.test.ts
+++ b/packages/opentelemetry-resources/test/Resource.test.ts
@@ -325,10 +325,6 @@ describe('Resource', () => {
       const resource = Resource.EMPTY;
       const oldResource = new Resource190({ fromold: 'fromold' });
 
-      //TODO: find a solution for ts-ignore
-
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       const mergedResource = resource.merge(oldResource);
 
       assert.strictEqual(mergedResource.attributes['fromold'], 'fromold');
@@ -339,19 +335,12 @@ describe('Resource', () => {
         {},
         Promise.resolve({ fromnew: 'fromnew' })
       );
-
       const oldResource = new Resource190({ fromold: 'fromold' });
 
-      //TODO: find a solution for ts-ignore
-
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       const mergedResource = resource.merge(oldResource);
-
       assert.strictEqual(mergedResource.attributes['fromold'], 'fromold');
 
       await mergedResource.waitForAsyncAttributes?.();
-
       assert.strictEqual(mergedResource.attributes['fromnew'], 'fromnew');
     });
   });

--- a/packages/opentelemetry-resources/test/regression/existing-detectors-1-9-1.test.ts
+++ b/packages/opentelemetry-resources/test/regression/existing-detectors-1-9-1.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Resource, Detector, ResourceDetectionConfig } from '../../src';
+import * as assert from 'assert';
+
+// DO NOT MODIFY THIS DETECTOR: Previous detectors used Resource as IResource did not yet exist.
+// If compilation fails at this point then the changes made are breaking.
+class RegressionTestResourceDetector_1_9_1 implements Detector {
+  async detect(_config?: ResourceDetectionConfig): Promise<Resource> {
+    return Resource.empty();
+  }
+}
+
+describe('Regression Test @opentelemetry/resources@1.9.1', () => {
+  it('constructor', () => {
+    assert.ok(new RegressionTestResourceDetector_1_9_1());
+  });
+});

--- a/packages/opentelemetry-sdk-trace-base/src/export/SimpleSpanProcessor.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/SimpleSpanProcessor.ts
@@ -79,17 +79,21 @@ export class SimpleSpanProcessor implements SpanProcessor {
     // Avoid scheduling a promise to make the behavior more predictable and easier to test
     if (span.resource.asyncAttributesPending) {
       const exportPromise = (span.resource as Resource)
-        .waitForAsyncAttributes()
+        .waitForAsyncAttributes?.()
         .then(
           () => {
-            this._unresolvedExports.delete(exportPromise);
+            if (exportPromise != null) {
+              this._unresolvedExports.delete(exportPromise);
+            }
             return doExport();
           },
           err => globalErrorHandler(err)
         );
 
       // store the unresolved exports
-      this._unresolvedExports.add(exportPromise);
+      if (exportPromise != null) {
+        this._unresolvedExports.add(exportPromise);
+      }
     } else {
       void doExport();
     }


### PR DESCRIPTION
## Which problem is this PR solving?

See #3676, existing detectors that previously worked with `1.9.1` do not compile anymore. This PR fixes this, but will break the use of `resource.waitForAsyncAttributes()` that was introduced in the most recent version. Looks like this is the only way to restore compatibility. I'm open to any suggestions to improve this. 

Fixes #3676
Fixes open-telemetry/opentelemetry-js-contrib#1429

## Short description of the changes

- make properties for async resource resolution optional

## Type of change

- [x] Bug fix, restoring backwards compatibility, see [semver](https://semver.org/#what-do-i-do-if-i-accidentally-release-a-backwards-incompatible-change-as-a-minor-version): 
     > **What do I do if I accidentally release a backwards incompatible change as a minor version?**
     > 
     > As soon as you realize that you’ve broken the Semantic Versioning spec, fix the problem and release a new minor version that corrects the problem and restores backwards compatibility. Even under this circumstance, it is unacceptable to modify versioned releases. If it’s appropriate, document the offending version and inform your users of the problem so that they are aware of the offending version.

## How Has This Been Tested?

- [x] Existing tests
- [x] Added an unmodified 1.9.1-style `Detector` as a regression test that should fail compilation when incompatible changes are made in the future.

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
