### PR TITLE
fix(resources): change fs/promises import to be node 12 compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 ### :bug: (Bug Fix)
 
 * fix(resource): make properties for async resource resolution optional [#3677](https://github.com/open-telemetry/opentelemetry-js/pull/3677) @pichlermarc
+* fix(resources): change fs/promises import to be node 12 compatible [#3681](https://github.com/open-telemetry/opentelemetry-js/pull/3681) @pichlermarc
 
 ### :books: (Refine Doc)
 

--- a/packages/opentelemetry-resources/src/platform/node/machine-id/getMachineId-bsd.ts
+++ b/packages/opentelemetry-resources/src/platform/node/machine-id/getMachineId-bsd.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs/promises';
+import { promises as fs } from 'fs';
 import { execAsync } from './execAsync';
 import { diag } from '@opentelemetry/api';
 

--- a/packages/opentelemetry-resources/src/platform/node/machine-id/getMachineId-linux.ts
+++ b/packages/opentelemetry-resources/src/platform/node/machine-id/getMachineId-linux.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as fs from 'fs/promises';
+import { promises as fs } from 'fs';
 import { diag } from '@opentelemetry/api';
 
 export async function getMachineId(): Promise<string> {

--- a/packages/opentelemetry-resources/test/detectors/node/machine-id/getMachineId-bsd.test.ts
+++ b/packages/opentelemetry-resources/test/detectors/node/machine-id/getMachineId-bsd.test.ts
@@ -16,7 +16,7 @@
 
 import * as sinon from 'sinon';
 import * as assert from 'assert';
-import * as fs from 'fs/promises';
+import { promises as fs } from 'fs';
 import { PromiseWithChild } from 'child_process';
 import * as util from '../../../../src/platform/node/machine-id/execAsync';
 import { getMachineId } from '../../../../src/platform/node/machine-id/getMachineId-bsd';

--- a/packages/opentelemetry-resources/test/detectors/node/machine-id/getMachineId-linux.test.ts
+++ b/packages/opentelemetry-resources/test/detectors/node/machine-id/getMachineId-linux.test.ts
@@ -16,7 +16,7 @@
 
 import * as sinon from 'sinon';
 import * as assert from 'assert';
-import * as fs from 'fs/promises';
+import { promises as fs } from 'fs';
 
 import { getMachineId } from '../../../../src/platform/node/machine-id/getMachineId-linux';
 


### PR DESCRIPTION
## Which problem is this PR solving?

This PR changes the import according to https://github.com/nodejs/node/issues/35740#issuecomment-713778857 to make the default detectors work again with Node.js v12. 

**Note: Node.js <14 remains unsupported by this project.**

Fixes #3673 

## Short description of the changes

## Type of change

- [x] Bug fix

## How Has This Been Tested?

- [x] Local testing

**Note: CI does not run for Node 12**

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
