### PR TITLE
1.10.1 backports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+* fix(resource): make properties for async resource resolution optional [#3677](https://github.com/open-telemetry/opentelemetry-js/pull/3677) @pichlermarc
+* fix(resource): change fs/promises import to be node 12 compatible [#3681](https://github.com/open-telemetry/opentelemetry-js/pull/3681) @pichlermarc
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+* fix(resource): make properties for async resource resolution optional [#3677](https://github.com/open-telemetry/opentelemetry-js/pull/3677) @pichlermarc
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
-* fix(resource): make properties for async resource resolution optional [#3677](https://github.com/open-telemetry/opentelemetry-js/pull/3677) @pichlermarc
-
 ### :books: (Refine Doc)
 
 ### :house: (Internal)
+
+## 1.10.1
+
+### :bug: (Bug Fix)
+
+* fix(resource): make properties for async resource resolution optional [#3677](https://github.com/open-telemetry/opentelemetry-js/pull/3677) @pichlermarc
 
 ## 1.10.0
 

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-example",
   "private": true,
-  "version": "0.35.1",
+  "version": "0.35.2",
   "description": "Example of HTTP integration with OpenTelemetry",
   "main": "index.js",
   "scripts": {
@@ -34,9 +34,9 @@
     "@opentelemetry/instrumentation": "0.35.1",
     "@opentelemetry/instrumentation-http": "0.35.1",
     "@opentelemetry/resources": "1.9.1",
-    "@opentelemetry/semantic-conventions": "1.9.1",
+    "@opentelemetry/sdk-trace-base": "1.9.1",
     "@opentelemetry/sdk-trace-node": "1.9.1",
-    "@opentelemetry/sdk-trace-base": "1.9.1"
+    "@opentelemetry/semantic-conventions": "1.9.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/http",
   "devDependencies": {

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,7 +1,7 @@
 {
   "name": "https-example",
   "private": true,
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Example of HTTPs integration with OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -33,14 +33,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/exporter-jaeger": "1.10.0",
-    "@opentelemetry/exporter-zipkin": "1.10.0",
-    "@opentelemetry/instrumentation": "0.36.0",
-    "@opentelemetry/instrumentation-http": "0.36.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
-    "@opentelemetry/sdk-trace-node": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0"
+    "@opentelemetry/exporter-jaeger": "1.10.1",
+    "@opentelemetry/exporter-zipkin": "1.10.1",
+    "@opentelemetry/instrumentation": "0.36.1",
+    "@opentelemetry/instrumentation-http": "0.36.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
+    "@opentelemetry/sdk-trace-node": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-opentelemetry-example",
   "private": true,
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Example of using @opentelemetry/sdk-trace-web and @opentelemetry/sdk-metrics in browser",
   "main": "index.js",
   "scripts": {
@@ -43,20 +43,20 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/context-zone": "1.10.0",
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.36.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.36.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.36.0",
-    "@opentelemetry/exporter-zipkin": "1.10.0",
-    "@opentelemetry/instrumentation": "0.36.0",
-    "@opentelemetry/instrumentation-fetch": "0.36.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.36.0",
-    "@opentelemetry/propagator-b3": "1.10.0",
-    "@opentelemetry/sdk-metrics": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
-    "@opentelemetry/sdk-trace-web": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0"
+    "@opentelemetry/context-zone": "1.10.1",
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.36.1",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.36.1",
+    "@opentelemetry/exporter-zipkin": "1.10.1",
+    "@opentelemetry/instrumentation": "0.36.1",
+    "@opentelemetry/instrumentation-fetch": "0.36.1",
+    "@opentelemetry/instrumentation-xml-http-request": "0.36.1",
+    "@opentelemetry/propagator-b3": "1.10.1",
+    "@opentelemetry/sdk-metrics": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
+    "@opentelemetry/sdk-trace-web": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web"
 }

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-otlp-exporter-node",
   "private": true,
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
@@ -29,17 +29,17 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.36.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.36.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "0.36.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.36.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.36.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.36.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/sdk-metrics": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.36.1",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
+    "@opentelemetry/exporter-metrics-otlp-proto": "0.36.1",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.36.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.36.1",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.36.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/sdk-metrics": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/otlp-exporter-node"
 }

--- a/experimental/backwards-compatability/node14/package.json
+++ b/experimental/backwards-compatability/node14/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node14",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "private": true,
   "description": "Backwards compatability app for node 14 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.36.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0"
+    "@opentelemetry/sdk-node": "0.36.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1"
   },
   "devDependencies": {
     "@types/node": "14.18.25",

--- a/experimental/backwards-compatability/node16/package.json
+++ b/experimental/backwards-compatability/node16/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node16",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "private": true,
   "description": "Backwards compatability app for node 16 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.36.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0"
+    "@opentelemetry/sdk-node": "0.36.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1"
   },
   "devDependencies": {
     "@types/node": "16.11.52",

--- a/experimental/examples/prometheus/package.json
+++ b/experimental/examples/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prometheus-example",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "private": true,
   "description": "Example of using @opentelemetry/sdk-metrics and @opentelemetry/exporter-prometheus",
   "main": "index.js",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-prometheus": "0.36.0",
-    "@opentelemetry/sdk-metrics": "1.10.0"
+    "@opentelemetry/exporter-prometheus": "0.36.1",
+    "@opentelemetry/sdk-metrics": "1.10.1"
   }
 }

--- a/experimental/packages/api-events/package.json
+++ b/experimental/packages/api-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-events",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Public events API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/api-logs/package.json
+++ b/experimental/packages/api-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-logs",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Public logs API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-grpc",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,7 +50,7 @@
     "@babel/core": "7.16.0",
     "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/otlp-exporter-base": "0.36.0",
+    "@opentelemetry/otlp-exporter-base": "0.36.1",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -69,11 +69,11 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.36.0",
-    "@opentelemetry/otlp-transformer": "0.36.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.36.1",
+    "@opentelemetry/otlp-transformer": "0.36.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-http",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry Collector Trace Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,11 +94,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/otlp-exporter-base": "0.36.0",
-    "@opentelemetry/otlp-transformer": "0.36.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/otlp-exporter-base": "0.36.1",
+    "@opentelemetry/otlp-transformer": "0.36.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-proto",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -81,12 +81,12 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/otlp-exporter-base": "0.36.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.36.0",
-    "@opentelemetry/otlp-transformer": "0.36.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/otlp-exporter-base": "0.36.1",
+    "@opentelemetry/otlp-proto-exporter-base": "0.36.1",
+    "@opentelemetry/otlp-transformer": "0.36.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/opentelemetry-browser-detector",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry Resource Detector for Browser",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -70,8 +70,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0"
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/browser-detector"
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -68,12 +68,12 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.36.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.36.0",
-    "@opentelemetry/otlp-transformer": "0.36.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/sdk-metrics": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.36.1",
+    "@opentelemetry/otlp-transformer": "0.36.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/sdk-metrics": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-http",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,11 +94,11 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/otlp-exporter-base": "0.36.0",
-    "@opentelemetry/otlp-transformer": "0.36.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/sdk-metrics": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/otlp-exporter-base": "0.36.1",
+    "@opentelemetry/otlp-transformer": "0.36.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/sdk-metrics": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-proto",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -66,13 +66,13 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.36.0",
-    "@opentelemetry/otlp-exporter-base": "0.36.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.36.0",
-    "@opentelemetry/otlp-transformer": "0.36.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/sdk-metrics": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
+    "@opentelemetry/otlp-exporter-base": "0.36.1",
+    "@opentelemetry/otlp-proto-exporter-base": "0.36.1",
+    "@opentelemetry/otlp-transformer": "0.36.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/sdk-metrics": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/semantic-conventions": "1.10.0",
+    "@opentelemetry/semantic-conventions": "1.10.1",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -60,9 +60,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/sdk-metrics": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/sdk-metrics": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-prometheus",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-fetch",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry fetch automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-zone": "1.10.0",
-    "@opentelemetry/propagator-b3": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
+    "@opentelemetry/context-zone": "1.10.1",
+    "@opentelemetry/propagator-b3": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -87,10 +87,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/instrumentation": "0.36.0",
-    "@opentelemetry/sdk-trace-web": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/instrumentation": "0.36.1",
+    "@opentelemetry/sdk-trace-web": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-grpc",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry grpc automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -48,10 +48,10 @@
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-async-hooks": "1.10.0",
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
-    "@opentelemetry/sdk-trace-node": "1.10.0",
+    "@opentelemetry/context-async-hooks": "1.10.1",
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
+    "@opentelemetry/sdk-trace-node": "1.10.1",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/semver": "7.3.9",
@@ -71,8 +71,8 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "0.36.0",
-    "@opentelemetry/semantic-conventions": "1.10.0"
+    "@opentelemetry/instrumentation": "0.36.1",
+    "@opentelemetry/semantic-conventions": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-http",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry http/https automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,10 +46,10 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-async-hooks": "1.10.0",
-    "@opentelemetry/sdk-metrics": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
-    "@opentelemetry/sdk-trace-node": "1.10.0",
+    "@opentelemetry/context-async-hooks": "1.10.1",
+    "@opentelemetry/sdk-metrics": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
+    "@opentelemetry/sdk-trace-node": "1.10.1",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/request-promise-native": "1.0.18",
@@ -73,9 +73,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/instrumentation": "0.36.0",
-    "@opentelemetry/semantic-conventions": "1.10.0",
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/instrumentation": "0.36.1",
+    "@opentelemetry/semantic-conventions": "1.10.1",
     "semver": "^7.3.5"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http",

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-xml-http-request",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry XMLHttpRequest automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-zone": "1.10.0",
-    "@opentelemetry/propagator-b3": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
+    "@opentelemetry/context-zone": "1.10.1",
+    "@opentelemetry/propagator-b3": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -87,10 +87,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/instrumentation": "0.36.0",
-    "@opentelemetry/sdk-trace-web": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/instrumentation": "0.36.1",
+    "@opentelemetry/sdk-trace-web": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Base class for node which OpenTelemetry instrumentation modules extend",
   "author": "OpenTelemetry Authors",
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation",
@@ -78,7 +78,7 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/sdk-metrics": "1.10.0",
+    "@opentelemetry/sdk-metrics": "1.10.1",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/semver": "7.3.9",

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-node",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry SDK for Node.js",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,25 +44,25 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/exporter-jaeger": "1.10.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.36.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.36.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.36.0",
-    "@opentelemetry/exporter-zipkin": "1.10.0",
-    "@opentelemetry/instrumentation": "0.36.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/sdk-metrics": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
-    "@opentelemetry/sdk-trace-node": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/exporter-jaeger": "1.10.1",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.36.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.36.1",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.36.1",
+    "@opentelemetry/exporter-zipkin": "1.10.1",
+    "@opentelemetry/instrumentation": "0.36.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/sdk-metrics": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
+    "@opentelemetry/sdk-trace-node": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.3.0 <1.5.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-async-hooks": "1.10.0",
+    "@opentelemetry/context-async-hooks": "1.10.1",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/semver": "7.3.9",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-exporter-base",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry OTLP Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0"
+    "@opentelemetry/core": "1.10.1"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-grpc-exporter-base",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry OTLP-gRPC Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -51,9 +51,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/otlp-transformer": "0.36.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
+    "@opentelemetry/otlp-transformer": "0.36.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -73,8 +73,8 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.3",
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/otlp-exporter-base": "0.36.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/otlp-exporter-base": "0.36.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-grpc-exporter-base",
   "sideEffects": false

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-proto-exporter-base",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "OpenTelemetry OTLP-HTTP-protobuf Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -77,8 +77,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/otlp-exporter-base": "0.36.0",
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/otlp-exporter-base": "0.36.1",
     "protobufjs": "^7.1.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-proto-exporter-base",

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Transform OpenTelemetry SDK data into OTLP",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
@@ -76,10 +76,10 @@
     "webpack": "4.46.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/sdk-metrics": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/sdk-metrics": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-transformer",
   "sideEffects": false

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.10.0",
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
+    "@opentelemetry/context-async-hooks": "1.10.1",
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
     "axios": "0.24.0",
     "body-parser": "1.19.0",
     "express": "4.17.3"

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -74,7 +74,7 @@
     "webpack-merge": "5.8.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.10.0",
+    "@opentelemetry/context-zone-peer-dep": "1.10.1",
     "zone.js": "^0.11.0"
   },
   "sideEffects": true,

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,7 +91,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.10.0"
+    "@opentelemetry/semantic-conventions": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core",
   "sideEffects": false

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/resources": "1.10.0",
+    "@opentelemetry/resources": "1.10.1",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -62,9 +62,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0",
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1",
     "jaeger-client": "^3.15.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,10 +91,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin",
   "sideEffects": false

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0"
+    "@opentelemetry/core": "1.10.1"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.5.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -80,7 +80,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0"
+    "@opentelemetry/core": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger",
   "sideEffects": false

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -90,8 +90,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources",
   "sideEffects": false

--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -27,8 +27,9 @@ import { IResource } from './IResource';
  */
 export class Resource implements IResource {
   static readonly EMPTY = new Resource({});
-  private _syncAttributes: ResourceAttributes;
-  private _asyncAttributesPromise: Promise<ResourceAttributes> | undefined;
+  private _syncAttributes?: ResourceAttributes;
+  private _asyncAttributesPromise?: Promise<ResourceAttributes>;
+  private _attributes?: ResourceAttributes;
 
   /**
    * Check if async attributes have resolved. This is useful to avoid awaiting
@@ -36,7 +37,7 @@ export class Resource implements IResource {
    *
    * @returns true if the resource "attributes" property is not yet settled to its final value
    */
-  public asyncAttributesPending: boolean;
+  public asyncAttributesPending?: boolean;
 
   /**
    * Returns an empty Resource
@@ -66,11 +67,12 @@ export class Resource implements IResource {
      * information about the entity as numbers, strings or booleans
      * TODO: Consider to add check/validation on attributes.
      */
-    private _attributes: ResourceAttributes,
+    attributes: ResourceAttributes,
     asyncAttributesPromise?: Promise<ResourceAttributes>
   ) {
+    this._attributes = attributes;
     this.asyncAttributesPending = asyncAttributesPromise != null;
-    this._syncAttributes = _attributes;
+    this._syncAttributes = this._attributes ?? {};
     this._asyncAttributesPromise = asyncAttributesPromise?.then(
       asyncAttributes => {
         this._attributes = Object.assign({}, this._attributes, asyncAttributes);
@@ -92,7 +94,7 @@ export class Resource implements IResource {
       );
     }
 
-    return this._attributes;
+    return this._attributes ?? {};
   }
 
   /**
@@ -100,7 +102,7 @@ export class Resource implements IResource {
    * this Resource's attributes. This is useful in exporters to block until resource detection
    * has finished.
    */
-  async waitForAsyncAttributes(): Promise<void> {
+  async waitForAsyncAttributes?(): Promise<void> {
     if (this.asyncAttributesPending) {
       await this._asyncAttributesPromise;
     }

--- a/packages/opentelemetry-resources/src/platform/node/machine-id/getMachineId-bsd.ts
+++ b/packages/opentelemetry-resources/src/platform/node/machine-id/getMachineId-bsd.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs/promises';
+import { promises as fs } from 'fs';
 import { execAsync } from './execAsync';
 import { diag } from '@opentelemetry/api';
 

--- a/packages/opentelemetry-resources/src/platform/node/machine-id/getMachineId-linux.ts
+++ b/packages/opentelemetry-resources/src/platform/node/machine-id/getMachineId-linux.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as fs from 'fs/promises';
+import { promises as fs } from 'fs';
 import { diag } from '@opentelemetry/api';
 
 export async function getMachineId(): Promise<string> {

--- a/packages/opentelemetry-resources/test/Resource.test.ts
+++ b/packages/opentelemetry-resources/test/Resource.test.ts
@@ -155,7 +155,7 @@ describe('Resource', () => {
       for (const resource of [resourceResolve, resourceReject]) {
         assert.ok(resource.asyncAttributesPending);
         await clock.nextAsync();
-        await resource.waitForAsyncAttributes();
+        await resource.waitForAsyncAttributes?.();
         assert.ok(!resource.asyncAttributesPending);
       }
     });
@@ -174,7 +174,7 @@ describe('Resource', () => {
         asyncAttributes
       );
 
-      await resource.waitForAsyncAttributes();
+      await resource.waitForAsyncAttributes?.();
       assert.deepStrictEqual(resource.attributes, {
         sync: 'fromsync',
         // async takes precedence
@@ -266,7 +266,7 @@ describe('Resource', () => {
       const debugStub = sinon.spy(diag, 'debug');
 
       const resource = new Resource({}, Promise.reject(new Error('rejected')));
-      await resource.waitForAsyncAttributes();
+      await resource.waitForAsyncAttributes?.();
 
       assert.ok(
         debugStub.calledWithMatch(
@@ -325,10 +325,6 @@ describe('Resource', () => {
       const resource = Resource.EMPTY;
       const oldResource = new Resource190({ fromold: 'fromold' });
 
-      //TODO: find a solution for ts-ignore
-
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       const mergedResource = resource.merge(oldResource);
 
       assert.strictEqual(mergedResource.attributes['fromold'], 'fromold');
@@ -339,19 +335,12 @@ describe('Resource', () => {
         {},
         Promise.resolve({ fromnew: 'fromnew' })
       );
-
       const oldResource = new Resource190({ fromold: 'fromold' });
 
-      //TODO: find a solution for ts-ignore
-
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       const mergedResource = resource.merge(oldResource);
-
       assert.strictEqual(mergedResource.attributes['fromold'], 'fromold');
 
       await mergedResource.waitForAsyncAttributes?.();
-
       assert.strictEqual(mergedResource.attributes['fromnew'], 'fromnew');
     });
   });

--- a/packages/opentelemetry-resources/test/detectors/node/machine-id/getMachineId-bsd.test.ts
+++ b/packages/opentelemetry-resources/test/detectors/node/machine-id/getMachineId-bsd.test.ts
@@ -16,7 +16,7 @@
 
 import * as sinon from 'sinon';
 import * as assert from 'assert';
-import * as fs from 'fs/promises';
+import { promises as fs } from 'fs';
 import { PromiseWithChild } from 'child_process';
 import * as util from '../../../../src/platform/node/machine-id/execAsync';
 import { getMachineId } from '../../../../src/platform/node/machine-id/getMachineId-bsd';

--- a/packages/opentelemetry-resources/test/detectors/node/machine-id/getMachineId-linux.test.ts
+++ b/packages/opentelemetry-resources/test/detectors/node/machine-id/getMachineId-linux.test.ts
@@ -16,7 +16,7 @@
 
 import * as sinon from 'sinon';
 import * as assert from 'assert';
-import * as fs from 'fs/promises';
+import { promises as fs } from 'fs';
 
 import { getMachineId } from '../../../../src/platform/node/machine-id/getMachineId-linux';
 

--- a/packages/opentelemetry-resources/test/regression/existing-detectors-1-9-1.test.ts
+++ b/packages/opentelemetry-resources/test/regression/existing-detectors-1-9-1.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Resource, Detector, ResourceDetectionConfig } from '../../src';
+import * as assert from 'assert';
+
+// DO NOT MODIFY THIS DETECTOR: Previous detectors used Resource as IResource did not yet exist.
+// If compilation fails at this point then the changes made are breaking.
+class RegressionTestResourceDetector_1_9_1 implements Detector {
+  async detect(_config?: ResourceDetectionConfig): Promise<Resource> {
+    return Resource.empty();
+  }
+}
+
+describe('Regression Test @opentelemetry/resources@1.9.1', () => {
+  it('constructor', () => {
+    assert.ok(new RegressionTestResourceDetector_1_9_1());
+  });
+});

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -92,9 +92,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-base/src/export/SimpleSpanProcessor.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/SimpleSpanProcessor.ts
@@ -79,17 +79,21 @@ export class SimpleSpanProcessor implements SpanProcessor {
     // Avoid scheduling a promise to make the behavior more predictable and easier to test
     if (span.resource.asyncAttributesPending) {
       const exportPromise = (span.resource as Resource)
-        .waitForAsyncAttributes()
+        .waitForAsyncAttributes?.()
         .then(
           () => {
-            this._unresolvedExports.delete(exportPromise);
+            if (exportPromise != null) {
+              this._unresolvedExports.delete(exportPromise);
+            }
             return doExport();
           },
           err => globalErrorHandler(err)
         );
 
       // store the unresolved exports
-      this._unresolvedExports.add(exportPromise);
+      if (exportPromise != null) {
+        this._unresolvedExports.add(exportPromise);
+      }
     } else {
       void doExport();
     }

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.5.0",
-    "@opentelemetry/resources": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0",
+    "@opentelemetry/resources": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/semver": "7.3.9",
@@ -64,11 +64,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.10.0",
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/propagator-b3": "1.10.0",
-    "@opentelemetry/propagator-jaeger": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
+    "@opentelemetry/context-async-hooks": "1.10.1",
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/propagator-b3": "1.10.1",
+    "@opentelemetry/propagator-jaeger": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
     "semver": "^7.3.5"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,9 +57,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": ">=1.0.0 <1.5.0",
-    "@opentelemetry/context-zone": "1.10.0",
-    "@opentelemetry/propagator-b3": "1.10.0",
-    "@opentelemetry/resources": "1.10.0",
+    "@opentelemetry/context-zone": "1.10.1",
+    "@opentelemetry/propagator-b3": "1.10.1",
+    "@opentelemetry/resources": "1.10.1",
     "@types/jquery": "3.5.8",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
@@ -91,9 +91,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0"
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web",
   "sideEffects": false

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -43,9 +43,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.5.0",
-    "@opentelemetry/propagator-b3": "1.10.0",
-    "@opentelemetry/propagator-jaeger": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
+    "@opentelemetry/propagator-b3": "1.10.1",
+    "@opentelemetry/propagator-jaeger": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
@@ -59,8 +59,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/semantic-conventions": "1.10.0",
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/semantic-conventions": "1.10.1",
     "opentracing": "^0.14.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing",

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -77,8 +77,8 @@
     "@opentelemetry/api": ">=1.3.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/resources": "1.10.0",
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/resources": "1.10.1",
     "lodash.merge": "4.6.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-metrics",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
@@ -56,16 +56,16 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.10.0",
-    "@opentelemetry/core": "1.10.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.36.0",
-    "@opentelemetry/exporter-zipkin": "1.10.0",
-    "@opentelemetry/instrumentation": "0.36.0",
-    "@opentelemetry/instrumentation-fetch": "0.36.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.36.0",
-    "@opentelemetry/sdk-metrics": "1.10.0",
-    "@opentelemetry/sdk-trace-base": "1.10.0",
-    "@opentelemetry/sdk-trace-web": "1.10.0",
+    "@opentelemetry/context-zone-peer-dep": "1.10.1",
+    "@opentelemetry/core": "1.10.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.36.1",
+    "@opentelemetry/exporter-zipkin": "1.10.1",
+    "@opentelemetry/instrumentation": "0.36.1",
+    "@opentelemetry/instrumentation-fetch": "0.36.1",
+    "@opentelemetry/instrumentation-xml-http-request": "0.36.1",
+    "@opentelemetry/sdk-metrics": "1.10.1",
+    "@opentelemetry/sdk-trace-base": "1.10.1",
+    "@opentelemetry/sdk-trace-web": "1.10.1",
     "zone.js": "0.11.4"
   }
 }


### PR DESCRIPTION
Bumps the patch version for SDK packages.
 
Backported PRs:
- #3677
- #3681

Note: this PR goes into a branch specifically for the v1.10 release line since there was already a `feat` committed to main