### PR TITLE
Updated Node SDK example in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :books: (Refine Doc)
 
+* doc(sdk): update NodeSDK example [#3684](https://github.com/open-telemetry/opentelemetry-js/pull/3684) @martinkuba
+
 ### :house: (Internal)
 
 ## 1.10.0

--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -58,11 +58,7 @@ const sdk = new opentelemetry.NodeSDK({
   // See the Configuration section below for additional  configuration options
 });
 
-// You can optionally detect resources asynchronously from the environment.
-// Detected resources are merged with the resources provided in the SDK configuration.
-sdk.start().then(() => {
-  // Resources have been detected and SDK is started
-});
+sdk.start();
 
 // You can also use the shutdown method to gracefully shut down the SDK before process shutdown
 // or on some operating system signal.


### PR DESCRIPTION
## Which problem is this PR solving?

The start() method in the NodeSDK class has been recently updated to be synchronous (in https://github.com/open-telemetry/opentelemetry-js/pull/3460) - it no longer returns a promise. This is a minor update to the example in the corresponding README.
