### PR TITLE
fix(sdk-node): only set DiagConsoleLogger when OTEL_LOG_LEVEL is set

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(sdk-node): only set DiagConsoleLogger when OTEL_LOG_LEVEL is set [#3693](https://github.com/open-telemetry/opentelemetry-js/pull/3672) @pichlermarc
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -47,7 +47,7 @@ import {
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { NodeSDKConfiguration } from './types';
 import { TracerProviderWithEnvExporters } from './TracerProviderWithEnvExporter';
-import { getEnv } from '@opentelemetry/core';
+import { getEnv, getEnvWithoutDefaults } from '@opentelemetry/core';
 import { parseInstrumentationOptions } from './utils';
 
 /** This class represents everything needed to register a fully configured OpenTelemetry Node.js SDK */
@@ -89,14 +89,19 @@ export class NodeSDK {
    */
   public constructor(configuration: Partial<NodeSDKConfiguration> = {}) {
     const env = getEnv();
+    const envWithoutDefaults = getEnvWithoutDefaults();
+
     if (env.OTEL_SDK_DISABLED) {
       this._disabled = true;
       // Functions with possible side-effects are set
       // to no-op via the _disabled flag
     }
-    if (env.OTEL_LOG_LEVEL) {
+
+    // Default is INFO, use environment without defaults to check
+    // if the user originally set the environment variable.
+    if (envWithoutDefaults.OTEL_LOG_LEVEL) {
       diag.setLogger(new DiagConsoleLogger(), {
-        logLevel: env.OTEL_LOG_LEVEL,
+        logLevel: envWithoutDefaults.OTEL_LOG_LEVEL,
       });
     }
 

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -134,6 +134,19 @@ describe('Node SDK', () => {
       delete env.OTEL_LOG_LEVEL;
     });
 
+    it('should not register a diag logger with OTEL_LOG_LEVEL unset', () => {
+      delete env.OTEL_LOG_LEVEL;
+
+      const spy = Sinon.spy(diag, 'setLogger');
+      const sdk = new NodeSDK({
+        autoDetectResources: false,
+      });
+
+      sdk.start();
+
+      assert.strictEqual(spy.callCount, 0);
+    });
+
     it('should register a tracer provider if an exporter is provided', async () => {
       const sdk = new NodeSDK({
         traceExporter: new ConsoleSpanExporter(),


### PR DESCRIPTION
## Which problem is this PR solving?

Since #3627 `DiagConsoleLogger` is instantiated and set even when `OTEL_LOG_LEVEL` is unset, which can cause unintended logs to appear on the console.

This PR changes it, so the environment is used before it is merged with the default values.  

Related #3683 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added unit test
