### PR TITLE
chore: remove handling of node versions 8, 9 and 10 in tests

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
@@ -35,7 +35,6 @@ import {
 } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import * as fs from 'fs';
-import * as semver from 'semver';
 import * as nock from 'nock';
 import * as path from 'path';
 import { HttpInstrumentation } from '../../src/http';
@@ -548,15 +547,7 @@ describe('HttpsInstrumentation', () => {
           assert.fail();
         } catch (error) {
           const spans = memoryExporter.getFinishedSpans();
-          /**
-           * There is an edge case with node 8 because the https module
-           * just call the http one, resulting in 2 span. The fix only works
-           * if the protocol is 'https:' resulting in 2 span only for this test.
-           */
-          assert.strictEqual(
-            spans.length,
-            semver.gt(process.version, '9.0.0') ? 1 : 2
-          );
+          assert.strictEqual(spans.length, 1);
         }
       });
 

--- a/packages/opentelemetry-context-async-hooks/test/AsyncHooksContextManager.test.ts
+++ b/packages/opentelemetry-context-async-hooks/test/AsyncHooksContextManager.test.ts
@@ -35,16 +35,6 @@ for (const contextManagerClass of [
       | AsyncHooksContextManager
       | AsyncLocalStorageContextManager;
 
-    before(function () {
-      if (
-        contextManagerClass.name === 'AsyncLocalStorageContextManager' &&
-        (process.version.startsWith('v8.') ||
-          process.version.startsWith('v10.'))
-      ) {
-        this.skip();
-      }
-    });
-
     beforeEach(() => {
       contextManager = new contextManagerClass();
       contextManager.enable();


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Extracted from #3689.

Fixes # N/A

## Short description of the changes

CI only runs on Node 14+, so this is dead code

## Type of change

Housekeeping

## How Has This Been Tested?

CI

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
