### PR TITLE
fix(ci): use npx to run tsc 4.4.4 in api-eol-node-test

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -197,7 +197,7 @@ jobs:
           npm install --ignore-scripts
           npm install @types/mocha@^7 mocha@^7 ts-loader@^8 ts-mocha@^8
           node ../scripts/version-update.js
-          tsc --build tsconfig.json tsconfig.esm.json
+          npx tsc --build tsconfig.json tsconfig.esm.json
 
       - name: Test
         working-directory: ./api


### PR DESCRIPTION
## Which problem is this PR solving?

`api-eol-node-test` is failing as it uses typescript 5.0.2 to compile tests.
This PR changes the job to use the typescript version from package.json to compile the API & tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] internal

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
