### PR TITLE
fix(instrumentation-http): use semantic convention metric descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 ### :rocket: (Enhancement)
 
 ### :bug: (Bug Fix)
+
 * fix(instrumentation-http): fixed description for http.server.duration metric [#3710](https://github.com/open-telemetry/opentelemetry-js/pull/3710)
 
 ### :books: (Refine Doc)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 ### :rocket: (Enhancement)
 
 ### :bug: (Bug Fix)
+* fix(instrumentation-http): fixed description for http.server.duration metric [#3710](https://github.com/open-telemetry/opentelemetry-js/pull/3710)
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -88,7 +88,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
     this._httpClientDurationHistogram = this.meter.createHistogram(
       'http.client.duration',
       {
-        description: 'Measures the duration of inbound HTTP requests.',
+        description: 'Measures the duration of outbound HTTP requests.',
         unit: 'ms',
         valueType: ValueType.DOUBLE,
       }

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -80,7 +80,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
     this._httpServerDurationHistogram = this.meter.createHistogram(
       'http.server.duration',
       {
-        description: 'measures the duration of the inbound HTTP requests',
+        description: 'Measures the duration of inbound HTTP requests.',
         unit: 'ms',
         valueType: ValueType.DOUBLE,
       }
@@ -88,7 +88,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
     this._httpClientDurationHistogram = this.meter.createHistogram(
       'http.client.duration',
       {
-        description: 'measures the duration of the outbound HTTP requests',
+        description: 'Measures the duration of inbound HTTP requests.',
         unit: 'ms',
         valueType: ValueType.DOUBLE,
       }

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
@@ -82,7 +82,7 @@ describe('metrics', () => {
     assert.strictEqual(metrics[0].dataPointType, DataPointType.HISTOGRAM);
     assert.strictEqual(
       metrics[0].descriptor.description,
-      'measures the duration of the inbound HTTP requests'
+      'Measures the duration of inbound HTTP requests.'
     );
     assert.strictEqual(metrics[0].descriptor.name, 'http.server.duration');
     assert.strictEqual(metrics[0].descriptor.unit, 'ms');
@@ -119,7 +119,7 @@ describe('metrics', () => {
     assert.strictEqual(metrics[1].dataPointType, DataPointType.HISTOGRAM);
     assert.strictEqual(
       metrics[1].descriptor.description,
-      'measures the duration of the outbound HTTP requests'
+      'Measures the duration of outbound HTTP requests.'
     );
     assert.strictEqual(metrics[1].descriptor.name, 'http.client.duration');
     assert.strictEqual(metrics[1].descriptor.unit, 'ms');


### PR DESCRIPTION
## Which problem is this PR solving?

Updates description for HTTP auto instrumentation metrics to match [semantic conventions.](https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/metrics/http.yaml#LL5C10-L5C10)

If the proper description is not provided the Prometheus exporter from the OpenTelemetry Collector will report an error on the `http.server.duration` metric.

Fixes [this issue](https://github.com/open-telemetry/opentelemetry-demo/issues/737) in the Demo repo.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
