### PR TITLE
feat(sdk-node): tracer provider factory via config

### DIFF
--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -117,19 +117,40 @@ Configure a resource. Resources may also be detected by using the `autoDetectRes
 Configure resource detectors. By default, the resource detectors are [envDetector, processDetector].
 NOTE: In order to enable the detection, the parameter `autoDetectResources` has to be `true`.
 
-### sampler
+### Tracer configuration
+
+Tracers can be configured in a few ways:
+
+1. Explicitly pass `spanProcessor` or `traceExporter` and configure further with `sampler` and `spanLimits` options.
+2. Implicitly configure via the `OTEL_TRACES_EXPORTER` env var, which specifies a comma-separated list of exporters
+   that will be automatically configured. Exporter configuration can be influenced by their supported env vars.
+3. Explicitly provide factory method that creates a TracerProvider from the Resource detected on SDK start.
+
+#### sampler
 
 Configure a custom sampler. By default, all traces will be sampled.
 
-### spanProcessor
+#### spanProcessor
 
-### traceExporter
+#### traceExporter
 
 Configure a trace exporter. If an exporter is configured, it will be used with a [BatchSpanProcessor](../../../packages/opentelemetry-sdk-trace-base/src/platform/node/export/BatchSpanProcessor.ts). If an exporter OR span processor is not configured programatically, this package will auto setup the default `otlp` exporter  with `http/protobuf` protocol with a `BatchSpanProcessor`.
 
-### spanLimits
+#### spanLimits
 
 Configure tracing parameters. These are the same trace parameters used to [configure a tracer](../../../packages/opentelemetry-sdk-trace-base/src/types.ts#L71).
+
+#### tracerProviderFactory
+
+Use this to pass your own instance of a TracerProvider in case the default behaviors are not sufficient for your use case.
+
+```typescript
+const tracerProviderFactory = (resource: IResource) => {
+  // can configure this however you want; this runs during sdk.start()
+  const tp = YourTracerProvider({resource});
+  return tp;
+}
+```
 
 ### serviceName
 
@@ -159,17 +180,17 @@ This is an alternative to programmatically configuring an exporter or span proce
 
 ### Exporters
 
-| Environment variable | Description |
-|----------------------|-------------|
-| OTEL_TRACES_EXPORTER | List of exporters to be used for tracing, separated by commas. Options include `otlp`, `jaeger`, `zipkin`, and `none`. Default is `otlp`. `none` means no autoconfigured exporter.
+| Environment variable | Description                                                                                                                                                                        |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OTEL_TRACES_EXPORTER | List of exporters to be used for tracing, separated by commas. Options include `otlp`, `jaeger`, `zipkin`, and `none`. Default is `otlp`. `none` means no autoconfigured exporter. |
 
 ### OTLP Exporter
 
-| Environment variable | Description |
-|----------------------|-------------|
-| OTEL_EXPORTER_OTLP_PROTOCOL | The transport protocol to use on OTLP trace, metric, and log requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`. |
-| OTEL_EXPORTER_OTLP_TRACES_PROTOCOL | The transport protocol to use on OTLP trace requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`. |
-| OTEL_EXPORTER_OTLP_METRICS_PROTOCOL | The transport protocol to use on OTLP metric requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`. |
+| Environment variable                | Description                                                                                                                                                  |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| OTEL_EXPORTER_OTLP_PROTOCOL         | The transport protocol to use on OTLP trace, metric, and log requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`. |
+| OTEL_EXPORTER_OTLP_TRACES_PROTOCOL  | The transport protocol to use on OTLP trace requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`.                  |
+| OTEL_EXPORTER_OTLP_METRICS_PROTOCOL | The transport protocol to use on OTLP metric requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`.                 |
 
 Additionally, you can specify other applicable environment variables that apply to each exporter such as the following:
 

--- a/experimental/packages/opentelemetry-sdk-node/src/types.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/types.ts
@@ -26,6 +26,7 @@ import {
   SpanProcessor,
   IdGenerator,
 } from '@opentelemetry/sdk-trace-base';
+import { TracerProviderFactory } from './sdk';
 
 export interface NodeSDKConfiguration {
   autoDetectResources: boolean;
@@ -39,6 +40,7 @@ export interface NodeSDKConfiguration {
   resourceDetectors: Array<Detector | DetectorSync>;
   sampler: Sampler;
   serviceName?: string;
+  tracerProviderFactory?: TracerProviderFactory;
   spanProcessor: SpanProcessor;
   traceExporter: SpanExporter;
   spanLimits: SpanLimits;

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -57,6 +57,7 @@ import {
   envDetector,
   processDetector,
   Resource,
+  IResource
 } from '@opentelemetry/resources';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
@@ -731,6 +732,23 @@ describe('Node SDK', () => {
       assert.strictEqual(span.spanContext().spanId, 'constant-test-span-id');
       assert.strictEqual(span.spanContext().traceId, 'constant-test-trace-id');
     });
+  });
+
+  it('should register a tracer provider from factory if provided', async () => {
+    let instance: NodeTracerProvider | undefined;
+    const tracerProviderFactory = (resource: IResource) => {
+      instance = new NodeTracerProvider({resource});
+      return instance;
+    }
+
+    const sdk = new NodeSDK({
+      tracerProviderFactory
+    });
+    sdk.start();
+
+    const apiTracerProvider =
+      trace.getTracerProvider() as ProxyTracerProvider;
+    assert.strictEqual(apiTracerProvider.getDelegate(), instance);
   });
 });
 


### PR DESCRIPTION
## Which problem is this PR solving?

currently, if the sdk consumer chooses to configure the tracer-specific
config options, an opinionated tracer will be created for them using the
batch processor or exporter they specified.

if no such config is provided the default behavior is to use the
TracerProviderWithEnvExporter, which provides another opinionated implementation
of possibly multiple export formats derived from env.

however, sdk consumers may desire to configure the tracer provider themselves,
e.g., to export to two different otlp backends but utilizing that protocol
for each---this cannot currently be done.

## Short description of the changes

this commit adds support for specifying a factory method, which will be
invoked on start()---the factory method receives the Resource that was
detected in the start function, and creates a tracer provider from that input.
sdk consumers should be able to utilize this factory function to set any
additional configuration they desire.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

the PR contains a new test in the sdk unit test suite for this behavior; other 
tests pass.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
