### PR TITLE
fix(opentelemetry-sdk-trace-web): don't crash in runtimes where location isn't defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 ### :bug: (Bug Fix)
 
 * fix(instrumentation-http): fixed description for http.server.duration metric [#3710](https://github.com/open-telemetry/opentelemetry-js/pull/3710)
+* fix(opentelemetry-sdk-trace-web): don't crash in runtimes where location isn't defined [#3715](https://github.com/open-telemetry/opentelemetry-js/pull/3715)
 
 ### :books: (Refine Doc)
 

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -307,7 +307,11 @@ export function parseUrl(url: string): URLLike {
   if (typeof URL === 'function') {
     return new URL(
       url,
-      typeof document !== 'undefined' ? document.baseURI : (typeof location !== 'undefined' ? location.href : undefined)
+      typeof document !== 'undefined'
+        ? document.baseURI
+        : typeof location !== 'undefined'
+        ? location.href
+        : undefined
     );
   }
   const element = getUrlNormalizingAnchor();

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -307,7 +307,7 @@ export function parseUrl(url: string): URLLike {
   if (typeof URL === 'function') {
     return new URL(
       url,
-      typeof document !== 'undefined' ? document.baseURI : location.href
+      typeof document !== 'undefined' ? document.baseURI : (typeof location !== 'undefined' ? location.href : undefined)
     );
   }
   const element = getUrlNormalizingAnchor();

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -309,7 +309,7 @@ export function parseUrl(url: string): URLLike {
       url,
       typeof document !== 'undefined'
         ? document.baseURI
-        : typeof location !== 'undefined'
+        : typeof location !== 'undefined' // Some JS runtimes (e.g. Deno) don't define this
         ? location.href
         : undefined
     );

--- a/packages/opentelemetry-sdk-trace-web/test/utils.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/utils.test.ts
@@ -495,21 +495,6 @@ describe('utils', () => {
         assert.strictEqual(typeof url[field], 'string');
       });
     });
-
-    // Deno is an example of this
-    it('should parse url in runtimes where global location is not defined', () => {
-      const actualLocationObj = globalThis.location;
-      globalThis.location = undefined as any; // undefined is not allowed as a value normally, hence the any
-
-      try {
-        const url = parseUrl('https://opentelemetry.io/foo');
-        urlFields.forEach(field => {
-          assert.strictEqual(typeof url[field], 'string');
-        });
-      } finally {
-        globalThis.location = actualLocationObj;
-      }
-    });
   });
 
   describe('normalizeUrl', () => {

--- a/packages/opentelemetry-sdk-trace-web/test/utils.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/utils.test.ts
@@ -499,8 +499,8 @@ describe('utils', () => {
     // Deno is an example of this
     it('should parse url in runtimes where global location is not defined', () => {
       const actualLocationObj = globalThis.location;
-      globalThis.location = undefined as any;
-      
+      globalThis.location = undefined as any; // undefined is not allowed as a value normally, hence the any
+
       try {
         const url = parseUrl('https://opentelemetry.io/foo');
         urlFields.forEach(field => {

--- a/packages/opentelemetry-sdk-trace-web/test/utils.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/utils.test.ts
@@ -495,6 +495,21 @@ describe('utils', () => {
         assert.strictEqual(typeof url[field], 'string');
       });
     });
+
+    // Deno is an example of this
+    it('should parse url in runtimes where global location is not defined', () => {
+      const actualLocationObj = globalThis.location;
+      globalThis.location = undefined as any;
+      
+      try {
+        const url = parseUrl('https://opentelemetry.io/foo');
+        urlFields.forEach(field => {
+          assert.strictEqual(typeof url[field], 'string');
+        });
+      } finally {
+        globalThis.location = actualLocationObj;
+      }
+    });
   });
 
   describe('normalizeUrl', () => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fetch autoinstrumentation currently always pulls in opentelemetry-sdk-trace-web, where it calls into code that tries to access `location.href`

This is fine in browser contexts, but in server runtimes where `location` isn't defined (e.g. Node, Deno) this crashes.

https://github.com/open-telemetry/opentelemetry-js/issues/3413 tracks the broader work to make Fetch autoinstrumentation isomorphic, but I figured getting this one piece fixed for Deno couldn't hurt.

Fixes a subpiece of #3413 

## Short description of the changes

Checks if `location` exists before accessing it

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

~~- [ ] I added 1 new test simulating the problem but wasn't able to figure out how to run Karma from Github Codespaces, so I never actually ran it~~ I removed the test, see comment below

## Checklist:

- [ x ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
