### PR TITLE
Log name and ID on span end misuse

### DIFF
--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -216,7 +216,7 @@ export class Span implements APISpan, ReadableSpan {
 
   end(endTime?: TimeInput): void {
     if (this._isSpanEnded()) {
-      diag.error('You can only call end() on a span once.');
+      diag.error(`${this.name} ${this._spanContext.traceId}-${this._spanContext.spanId} - You can only call end() on a span once.`);
       return;
     }
     this._ended = true;


### PR DESCRIPTION
The current log `You can only call end() on a span once.` is not very helpful. Logging the span name and ids will help to track down which instrumentations caused the issue.