### PR TITLE
fix(sdk-node)!: remove unused defaultAttributes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ These instrumentations are hosted at <https://github.com/open-telemetry/opentele
 
 ## Upgrade guidelines
 
+### 0.37.x to 0.38.0
+
+- `@opentelemetry/sdk-node` `NodeSDKConfiguration.defaultAttributes` has been unused and was removed as the concept does not exist in OpenTelemetry anymore
+  - Please use `NodeSDKConfiguration.resource` instead.
+
 ### 0.35.x to 0.36.0
 
 - `@opentelemetry/sdk-node` changed `await start()` to now be synchronous

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+* fix(sdk-node)!: remove unused defaultAttributes option [#3724](https://github.com/open-telemetry/opentelemetry-js/pull/3724) @pichlermarc
+  * Please use `NodeSDKConfiguration.resource` instead
+
 ### :rocket: (Enhancement)
 
 ### :bug: (Bug Fix)

--- a/experimental/packages/opentelemetry-sdk-node/src/types.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ContextManager, SpanAttributes } from '@opentelemetry/api';
+import type { ContextManager } from '@opentelemetry/api';
 import { TextMapPropagator } from '@opentelemetry/api';
 import { InstrumentationOption } from '@opentelemetry/instrumentation';
 import { Detector, DetectorSync, Resource } from '@opentelemetry/resources';
@@ -30,7 +30,6 @@ import {
 export interface NodeSDKConfiguration {
   autoDetectResources: boolean;
   contextManager: ContextManager;
-  defaultAttributes: SpanAttributes;
   textMapPropagator: TextMapPropagator;
   metricReader: MetricReader;
   views: View[];


### PR DESCRIPTION
# Which problem is this PR solving?

`NodeSDKConfiguration.defaultAttributes` was unused, this PR removes it and adds upgrade guidelines to `README.md`

Fixes #3717 

## Short description of the changes

## Type of change

- [x] Bug fix
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - `@opentelemetry/sdk-node` is still experimental
  - causes compilation errors when upgrading, and `NodeSDKConfiguration.defaultAttributes` is still used

## How Has This Been Tested?

- [x] Existing unit tests