### PR TITLE
fix(exporter-jaeger): lazy require jaeger-client

### DIFF
--- a/packages/opentelemetry-exporter-jaeger/src/types.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/types.ts
@@ -33,19 +33,6 @@ export interface ExporterConfig {
   password?: string;
 }
 
-// Below require is needed as jaeger-client types does not expose the thrift,
-// udp_sender, util etc. modules.
-
-/* eslint-disable @typescript-eslint/no-var-requires */
-export const UDPSender =
-  require('jaeger-client/dist/src/reporters/udp_sender').default;
-export const Utils = require('jaeger-client/dist/src/util').default;
-export const ThriftUtils = require('jaeger-client/dist/src/thrift').default;
-
-export const HTTPSender =
-  require('jaeger-client/dist/src/reporters/http_sender').default;
-/* eslint-enable @typescript-eslint/no-var-requires */
-
 export type TagValue = string | number | boolean;
 
 export interface Tag {

--- a/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
@@ -15,15 +15,20 @@
  */
 
 import * as assert from 'assert';
-import { spanToThrift } from '../src/transform';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { Resource } from '@opentelemetry/resources';
 import * as api from '@opentelemetry/api';
-import { ThriftUtils, Utils, ThriftReferenceType } from '../src/types';
+import { ThriftReferenceType } from '../src/types';
 import { hrTimeToMicroseconds } from '@opentelemetry/core';
 import { SpanStatusCode, TraceFlags } from '@opentelemetry/api';
+import { JaegerTransformer } from '../src/transform';
+
+const Utils = require('jaeger-client/dist/src/util').default;
+const ThriftUtils = require('jaeger-client/dist/src/thrift').default;
 
 describe('transform', () => {
+  const transformer = new JaegerTransformer();
+
   const spanContext = () => {
     return {
       traceId: 'd4cda95b652f4a1592b449d5929fda1b',
@@ -87,7 +92,7 @@ describe('transform', () => {
         droppedLinksCount: 0,
       };
 
-      const thriftSpan = spanToThrift(readableSpan);
+      const thriftSpan = transformer.spanToThrift(readableSpan);
       const result = ThriftUtils._thrift.Span.rw.toBuffer(thriftSpan);
       assert.strictEqual(result.err, null);
       assert.deepStrictEqual(thriftSpan.operationName, 'my-span');
@@ -187,7 +192,7 @@ describe('transform', () => {
         droppedLinksCount: 0,
       };
 
-      const thriftSpan = spanToThrift(readableSpan);
+      const thriftSpan = transformer.spanToThrift(readableSpan);
       const result = ThriftUtils._thrift.Span.rw.toBuffer(thriftSpan);
       assert.strictEqual(result.err, null);
       assert.deepStrictEqual(thriftSpan.operationName, 'my-span1');
@@ -257,7 +262,7 @@ describe('transform', () => {
         droppedLinksCount: 0,
       };
 
-      const thriftSpan = spanToThrift(readableSpan);
+      const thriftSpan = transformer.spanToThrift(readableSpan);
       const result = ThriftUtils._thrift.Span.rw.toBuffer(thriftSpan);
       assert.strictEqual(result.err, null);
       assert.deepStrictEqual(thriftSpan.operationName, 'my-span');
@@ -305,7 +310,7 @@ describe('transform', () => {
         droppedLinksCount: 0,
       };
 
-      const thriftSpan = spanToThrift(readableSpan);
+      const thriftSpan = transformer.spanToThrift(readableSpan);
 
       assert.strictEqual(
         thriftSpan.traceIdLow.toString('hex'),
@@ -369,7 +374,7 @@ describe('transform', () => {
         droppedEventsCount: 0,
         droppedLinksCount: 0,
       };
-      let thriftSpan = spanToThrift(readableSpan);
+      let thriftSpan = transformer.spanToThrift(readableSpan);
       assert.strictEqual(
         thriftSpan.tags.find(tag => tag.key === 'error'),
         undefined,
@@ -377,7 +382,7 @@ describe('transform', () => {
       );
 
       readableSpan.status.code = SpanStatusCode.UNSET;
-      thriftSpan = spanToThrift(readableSpan);
+      thriftSpan = transformer.spanToThrift(readableSpan);
       assert.strictEqual(
         thriftSpan.tags.find(tag => tag.key === 'error'),
         undefined,
@@ -385,7 +390,7 @@ describe('transform', () => {
       );
 
       readableSpan.status.code = SpanStatusCode.ERROR;
-      thriftSpan = spanToThrift(readableSpan);
+      thriftSpan = transformer.spanToThrift(readableSpan);
       const errorTag = thriftSpan.tags.find(tag => tag.key === 'error');
 
       assert.strictEqual(


### PR DESCRIPTION
## Which problem is this PR solving?

The `JaegerExporter` currently does not support running in bundled environments, as requiring `jaeger-client` loads `.thrift` files from the file system. This causes problems in `@opentelemetry/sdk-node` as the `JaegerExporter` is required even though it is not being used (see #3521).

To circumvent this problem, this PR changes the approach of always `require`ing `jaeger-client` to do it once the constructor is actually called. 

**This PR does not add support for running the `JaegerExporter` in a bundled environment.**

Fixes #3521 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing using the repoducer from #3521 
- [x] Existing unit tests

## Alternatives I have considered

- Pulling in relevant code from `jaeger-client` and pre-generating JS code from the `.thrift` files.
  - I decided against doing this as it would increase the maintenance burden on this repo, and would require significantly more work to get right.
- Removing the `JaegerExporter` from `sdk-node`
  - The `sdk-node` package is deprecated, but I decided against doing this as it would break existing `JaegerExporter` users of the `sdk-node` package without warning.   

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
