### PR TITLE
Logs version fixup

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to experimental packages in this project will be documented 
 * fix(sdk-node)!: remove unused defaultAttributes option [#3724](https://github.com/open-telemetry/opentelemetry-js/pull/3724) @pichlermarc
   * Please use `NodeSDKConfiguration.resource` instead
 
+### :rocket: (Enhancement)
+
+* feat(sdk-logs): use logs API 0.38
+
 ### :bug: (Bug Fix)
 
 * fix(sdk-node): only set DiagConsoleLogger when OTEL_LOG_LEVEL is set [#3693](https://github.com/open-telemetry/opentelemetry-js/pull/3672) @pichlermarc

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -32,6 +32,11 @@ All notable changes to experimental packages in this project will be documented 
 
 * fix: remove HTTP/HTTPS prefix from span name in instrumentation-xml-http-request [#3672](https://github.com/open-telemetry/opentelemetry-js/pull/3672) @jufab
 
+### :rocket: (Enhancement)
+
+* feat(api-logs): 1.`LogRecord` fields update: `traceFlags`/`traceId`/`spanId` -> `context`; 2.`Logger` supports configuring `includeTraceContext`; 3.The `onEmit` method of `LogRecordProcessor` supports the `context` field.  [#3549](https://github.com/open-telemetry/opentelemetry-js/pull/3549/) @fuaiyi
+* feat(sdk-logs): logs sdk implementation. [#3549](https://github.com/open-telemetry/opentelemetry-js/pull/3549/) @fuaiyi
+
 ## 0.36.0
 
 ### :boom: Breaking Change
@@ -47,8 +52,6 @@ All notable changes to experimental packages in this project will be documented 
 * feat(otlp-exporter-base): add retries [#3207](https://github.com/open-telemetry/opentelemetry-js/pull/3207) @svetlanabrennan
 * feat(sdk-node): override IdGenerator when using NodeSDK [#3645](https://github.com/open-telemetry/opentelemetry-js/pull/3645) @haddasbronfman
 * feat(otlp-transformer): expose dropped attributes, events and links counts on the transformed otlp span [#3576](https://github.com/open-telemetry/opentelemetry-js/pull/3576) @mohitk05
-* feat(api-logs): 1.`LogRecord` fields update: `traceFlags`/`traceId`/`spanId` -> `context`; 2.`Logger` supports configuring `includeTraceContext`; 3.The `onEmit` method of `LogRecordProcessor` supports the `context` field.  [#3549](https://github.com/open-telemetry/opentelemetry-js/pull/3549/) @fuaiyi
-* feat(sdk-logs): logs sdk implementation. [#3549](https://github.com/open-telemetry/opentelemetry-js/pull/3549/) @fuaiyi
 
 ### :bug: (Bug Fix)
 

--- a/experimental/examples/logs/package.json
+++ b/experimental/examples/logs/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.4.1",
-    "@opentelemetry/api-logs": "^0.37.0",
-    "@opentelemetry/sdk-logs": "^0.37.0"
+    "@opentelemetry/api-logs": "^0.38.0",
+    "@opentelemetry/sdk-logs": "^0.38.0"
   },
   "devDependencies": {
     "ts-node": "^10.9.1",

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-logs",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "publishConfig": {
     "access": "public"
   },
@@ -69,14 +69,14 @@
   "sideEffects": false,
   "peerDependencies": {
     "@opentelemetry/api": ">=1.4.0 <1.5.0",
-    "@opentelemetry/api-logs": ">=0.37.0"
+    "@opentelemetry/api-logs": ">=0.38.0"
   },
   "devDependencies": {
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
     "@opentelemetry/api": ">=1.4.0 <1.5.0",
-    "@opentelemetry/api-logs": ">=0.37.0",
+    "@opentelemetry/api-logs": ">=0.38.0",
     "codecov": "3.8.3",
     "karma": "6.3.16",
     "karma-chrome-launcher": "3.1.0",


### PR DESCRIPTION
After merging the release I noticed the new logs SDK didn't get its version bumped