### PR TITLE
deps(sdk-logs): remove unused rimraf dev dependency

### DIFF
--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -86,7 +86,6 @@
     "karma-webpack": "4.0.2",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
-    "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
     "typescript": "4.4.4"


### PR DESCRIPTION
## Which problem is this PR solving?

Looks like I missed one unused `rimraf` dev dependency in #3737 in `sdk-logs`. :sweat: 
Removing it in this PR. Sorry about the noise.

## Type of change

- dependencies/internal