### PR TITLE
fix(sdk-node): lazy require @opentelemetry/exporter-jaeger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
-* fix(sdk-node): lazy require @opentelemetry/exporter-jaeger [#3739](https://github.com/open-telemetry/opentelemetry-js/pull/3739) @pichlermarc
+* fix(sdk-node): fix initialization in bundled environments by not loading @opentelemetry/exporter-jaeger [#3739](https://github.com/open-telemetry/opentelemetry-js/pull/3739) @pichlermarc
 
 ### :books: (Refine Doc)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+* fix(sdk-node): lazy require @opentelemetry/exporter-jaeger [#3739](https://github.com/open-telemetry/opentelemetry-js/pull/3739) @pichlermarc
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-sdk-node/src/TracerProviderWithEnvExporter.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/TracerProviderWithEnvExporter.ts
@@ -67,29 +67,28 @@ export class TracerProviderWithEnvExporters extends NodeTracerProvider {
     );
   }
 
+  private static configureJaeger() {
+    // The JaegerExporter does not support being required in bundled
+    // environments. By delaying the require statement to here, we only crash when
+    // the exporter is actually used in such an environment.
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
+      return new JaegerExporter();
+    } catch (e) {
+      throw new Error(
+        `Could not instantiate JaegerExporter. This could be due to the JaegerExporter's lack of support for bundling. If possible, use @opentelemetry/exporter-trace-otlp-proto instead. Original Error: ${e}`
+      );
+    }
+  }
+
   protected static override _registeredExporters = new Map<
     string,
     () => SpanExporter
   >([
     ['otlp', () => this.configureOtlp()],
     ['zipkin', () => new ZipkinExporter()],
-    [
-      'jaeger',
-      () => {
-        // The JaegerExporter does not support being required in bundled
-        // environments. By delaying the require statement to here, we only crash when
-        // the exporter is actually used in such an environment.
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-var-requires
-          const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
-          return new JaegerExporter();
-        } catch (e) {
-          throw new Error(
-            `Could not instantiate JaegerExporter. This could be due to the JaegerExporter's lack of support for bundling. If possible, use @opentelemetry/exporter-trace-otlp-proto instead. Original Error: ${e}`
-          );
-        }
-      },
-    ],
+    ['jaeger', () => this.configureJaeger()],
     ['console', () => new ConsoleSpanExporter()],
   ]);
 

--- a/experimental/packages/opentelemetry-sdk-node/src/TracerProviderWithEnvExporter.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/TracerProviderWithEnvExporter.ts
@@ -32,7 +32,6 @@ import { OTLPTraceExporter as OTLPProtoTraceExporter } from '@opentelemetry/expo
 import { OTLPTraceExporter as OTLPHttpTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { OTLPTraceExporter as OTLPGrpcTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { ZipkinExporter } from '@opentelemetry/exporter-zipkin';
-import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
 
 export class TracerProviderWithEnvExporters extends NodeTracerProvider {
   private _configuredExporters: SpanExporter[] = [];
@@ -74,7 +73,23 @@ export class TracerProviderWithEnvExporters extends NodeTracerProvider {
   >([
     ['otlp', () => this.configureOtlp()],
     ['zipkin', () => new ZipkinExporter()],
-    ['jaeger', () => new JaegerExporter()],
+    [
+      'jaeger',
+      () => {
+        // The JaegerExporter does not support being required in bundled
+        // environments. By delaying the require statement to here, we only crash when
+        // the exporter is actually used in such an environment.
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
+          return new JaegerExporter();
+        } catch (e) {
+          throw new Error(
+            `Could not instantiate JaegerExporter. This could be due to the JaegerExporter's lack of support for bundling. If possible, use @opentelemetry/exporter-trace-otlp-proto instead. Original Error: ${e}`
+          );
+        }
+      },
+    ],
     ['console', () => new ConsoleSpanExporter()],
   ]);
 

--- a/packages/opentelemetry-exporter-jaeger/README.md
+++ b/packages/opentelemetry-exporter-jaeger/README.md
@@ -9,6 +9,8 @@
 - `@opentelemetry/exporter-trace-otlp-grpc`
 - `@opentelemetry/exporter-trace-otlp-http`
 
+**NOTE: Bundling (with e.g. `webpack`, `rollup`, `esbuild`, ...) is not supported by this package. Please use `@opentelemetry/exporter-trace-otlp-proto` instead.**
+
 OpenTelemetry Jaeger Trace Exporter allows the user to send collected traces to Jaeger.
 
 [Jaeger](https://jaeger.readthedocs.io/en/latest/), inspired by [Dapper](https://research.google.com/pubs/pub36356.html) and [OpenZipkin](http://zipkin.io/), is a distributed tracing system released as open source by [Uber Technologies](http://uber.github.io/). It is used for monitoring and troubleshooting microservices-based distributed systems, including:


### PR DESCRIPTION
## Which problem is this PR solving?

The JaegerExporter currently does not support running in bundled environments, as requiring jaeger-client loads .thrift files from the file system. This causes problems in @opentelemetry/sdk-node as the JaegerExporter is required even though it is unused, see https://github.com/open-telemetry/opentelemetry-js/issues/3521).

To circumvent this problem, this PR changes the approach of always requiring `'@opentelemetry/exporter-jaeger'` to do it once before the constructor is actually called. Further added documentation to clarify that bundling is not supported with this package.

**This PR does not add support for running the JaegerExporter in a bundled environment.**

Fixes #3521
Supersedes #3728 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing using the repoducer from #3521 
- [x] Existing unit tests

## Alternatives I have considered

- Pulling in relevant code from `jaeger-client` and pre-generating JS code from the `.thrift` files.
  - I decided against doing this as it would increase the maintenance burden on this repo, and would require significantly more work to get right.
- Removing the `JaegerExporter` from `sdk-node`
  - The ~~`sdk-node`~~ `@opentelemetry/exporter-jaeger` package is deprecated, but I decided against doing this as it would break existing `JaegerExporter` users of the `sdk-node` package without warning.   
- Lazy requiring the `jaeger-client` library (see #3728)

