### PR TITLE
fix: VisibilityState type for typescript >4.6

### DIFF
--- a/experimental/packages/sdk-logs/test/browser/export/BatchLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/browser/export/BatchLogRecordProcessor.test.ts
@@ -24,8 +24,13 @@ import { InMemoryLogRecordExporter } from './../../../src/export/InMemoryLogReco
 const describeDocument =
   typeof document === 'object' ? describe : describe.skip;
 
+/**
+ * VisibilityState has been removed from TypeScript 4.6.0+
+ */
+type WebVisibilityState = 'visible' | 'hidden';
+
 describeDocument('BatchLogRecordProcessor - web main context', () => {
-  let visibilityState: VisibilityState = 'visible';
+  let visibilityState: WebVisibilityState = 'visible';
   let exporter: LogRecordExporter;
   let processor: BatchLogRecordProcessor;
   let forceFlushSpy: sinon.SinonStub;

--- a/experimental/packages/sdk-logs/test/browser/export/BatchLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/browser/export/BatchLogRecordProcessor.test.ts
@@ -30,6 +30,7 @@ const describeDocument =
 type WebVisibilityState = 'visible' | 'hidden';
 
 describeDocument('BatchLogRecordProcessor - web main context', () => {
+  // TODO: change to DocumentVisibilityState when TypeScript is upgraded to 4.6+
   let visibilityState: WebVisibilityState = 'visible';
   let exporter: LogRecordExporter;
   let processor: BatchLogRecordProcessor;

--- a/packages/opentelemetry-sdk-trace-base/test/browser/export/BatchSpanProcessor.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/browser/export/BatchSpanProcessor.test.ts
@@ -30,6 +30,7 @@ const describeDocument =
   typeof document === 'object' ? describe : describe.skip;
 
 describeDocument('BatchSpanProcessor - web main context', () => {
+  // TODO: change to DocumentVisibilityState when TypeScript is upgraded to 4.6+
   let visibilityState: WebVisibilityState = 'visible';
   let exporter: SpanExporter;
   let processor: BatchSpanProcessor;


### PR DESCRIPTION
This is the same fix as for BatchSpanProcessor tests in https://github.com/open-telemetry/opentelemetry-js/pull/3636, but for logs.

The VisibilityState type was renamed to DocumentVisibilityState in typescript 4.6. Once typescript is updated, we should change this temporary type to DocumentVisibilityState. The reason for adding this now is because packages from this repo are merged into the [sandbox repo](https://github.com/open-telemetry/opentelemetry-sandbox-web-js) which uses a newer version of typescript.