### PR TITLE
fix(instrumentation): update dep require-in-the-middle to 7.0.1

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(instrumentation): update `require-in-the-middle` to v7.0.1 [#NNN](https://github.com/open-telemetry/opentelemetry-js/pull/NNN) @trentm
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
-* fix(instrumentation): update `require-in-the-middle` to v7.0.1 [#NNN](https://github.com/open-telemetry/opentelemetry-js/pull/NNN) @trentm
+* fix(instrumentation): update `require-in-the-middle` to v7.0.1 [#3743](https://github.com/open-telemetry/opentelemetry-js/pull/3743) @trentm
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -68,7 +68,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "require-in-the-middle": "^6.0.0",
+    "require-in-the-middle": "^7.0.1",
     "semver": "^7.3.2",
     "shimmer": "^1.2.1"
   },


### PR DESCRIPTION
This includes a RITM feature to allow reloading (and re-run of
the RITM hook) of non-core modules when deleting them from
'require.cache'.

Fixes: #3655
