### PR TITLE
fix(otlp-transformer): move api-logs to dependencies

### DIFF
--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -52,8 +52,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.3.0 <1.5.0",
-    "@opentelemetry/api-logs": "0.39.0"
+    "@opentelemetry/api": ">=1.3.0 <1.5.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",
@@ -78,6 +77,7 @@
   "dependencies": {
     "@opentelemetry/core": "1.13.0",
     "@opentelemetry/resources": "1.13.0",
+    "@opentelemetry/api-logs": "0.39.0",
     "@opentelemetry/sdk-logs": "0.39.0",
     "@opentelemetry/sdk-metrics": "1.13.0",
     "@opentelemetry/sdk-trace-base": "1.13.0"


### PR DESCRIPTION
## Which problem is this PR solving?

`@opentelemetry/otlp-transformer` declares a peer dependency on `@opentelemetry/api-logs` that causes the other signal-specific exporters not to work without it. So, we need to include it as a regular dependency, [as we did with metrics.](https://github.com/open-telemetry/opentelemetry-js/blob/0d4c71fc50f8be5fe85dc38eeb622580422d92cd/experimental/packages/otlp-transformer/package.json)

Fixes #3794 

## Short description of the changes

Removes peer dependency, adds a regular dependency.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Existing tests
