### PR TITLE
fix(sdk-node): use resource interface instead of concrete class

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(sdk-node): use resource interface instead of concrete class [#3803](https://github.com/open-telemetry/opentelemetry-js/pull/3803) @blumamir
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-sdk-node/src/types.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/types.ts
@@ -17,7 +17,7 @@
 import type { ContextManager } from '@opentelemetry/api';
 import { TextMapPropagator } from '@opentelemetry/api';
 import { InstrumentationOption } from '@opentelemetry/instrumentation';
-import { Detector, DetectorSync, Resource } from '@opentelemetry/resources';
+import { Detector, DetectorSync, IResource } from '@opentelemetry/resources';
 import { MetricReader, View } from '@opentelemetry/sdk-metrics';
 import {
   Sampler,
@@ -34,7 +34,7 @@ export interface NodeSDKConfiguration {
   metricReader: MetricReader;
   views: View[];
   instrumentations: InstrumentationOption[];
-  resource: Resource;
+  resource: IResource;
   resourceDetectors: Array<Detector | DetectorSync>;
   sampler: Sampler;
   serviceName?: string;


### PR DESCRIPTION
## Which problem is this PR solving?

~~contrib repo currently fails to build because of issue with `@opentelemetry/resource-detector-instana`:~~ (sorry that was not correct, I needed to update the branch, but the fix is relevant regardless).

```
test/InstanaAgentDetectorIntegrationTest.test.ts:62:7 - error TS2322: Type 'import("/Users/amirblum/repos/opentelemetry-js-contrib/node_modules/@opentelemetry/resources/build/src/Resource").Resource' is not assignable to type 'import("/Users/amirblum/repos/opentelemetry-js-contrib/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources/build/src/Resource").Resource'.
  Types have separate declarations of a private property '_syncAttributes'.

62       resource: globalResource,
         ~~~~~~~~

test/InstanaAgentDetectorIntegrationTest.test.ts:101:7 - error TS2322: Type 'import("/Users/amirblum/repos/opentelemetry-js-contrib/node_modules/@opentelemetry/resources/build/src/Resource").Resource' is not assignable to type 'import("/Users/amirblum/repos/opentelemetry-js-contrib/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/resources/build/src/Resource").Resource'.

101       resource: globalResource,
          ~~~~~~~~

```

We had this issue in the past. components should use interfaces and not concrete classes, as using concrete classes causes typescript to error when the classes have private properties when 2 different versions are used. 

Since `@opentelemetry/sdk-node` has a dependency on `"@opentelemetry/resources": "1.13.0"`, if it uses the `Resource` class which has private property `_syncAttributes`, then everyone using this component with a resource must use the exact same version as well, which is not good. 

The `class NodeSDK` already uses `IResource` and not `Resource` in other places [here](https://github.com/open-telemetry/opentelemetry-js/blob/758c7af0c183b36bbce0b0dfbda3dd43bdc0ca8d/experimental/packages/opentelemetry-sdk-node/src/sdk.ts#L76) and [here](https://github.com/open-telemetry/opentelemetry-js/blob/758c7af0c183b36bbce0b0dfbda3dd43bdc0ca8d/experimental/packages/opentelemetry-sdk-node/src/sdk.ts#L223), so this only aligns the constructor to use it as well

## Short description of the changes

Use the `IResource` interface instead of the concrete class `Resource`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Since `class Resource implements IResource` it shouldn't be a breaking change for any user to my understanding, but would appreciate other eyes on that.

## How Has This Been Tested?

It only changes typescript and I tested it compiles successfully.

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
