### PR TITLE
feat(otlp-metric-exporters): Add User-Agent header to OTLP metric exporters

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :rocket: (Enhancement)
 
 * feat(otlp-trace-exporters): Add User-Agent header to OTLP trace exporters. [#3790](https://github.com/open-telemetry/opentelemetry-js/pull/3790) @JamieDanielson
+* feat(otlp-metric-exporters): Add User-Agent header to OTLP metric exporters. @JamieDanielson
 
 ### :boom: Breaking Change
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :rocket: (Enhancement)
 
 * feat(otlp-trace-exporters): Add User-Agent header to OTLP trace exporters. [#3790](https://github.com/open-telemetry/opentelemetry-js/pull/3790) @JamieDanielson
-* feat(otlp-metric-exporters): Add User-Agent header to OTLP metric exporters. @JamieDanielson
+* feat(otlp-metric-exporters): Add User-Agent header to OTLP metric exporters. [#3806](https://github.com/open-telemetry/opentelemetry-js/pull/3806) @JamieDanielson
 
 ### :boom: Breaking Change
 

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/OTLPMetricExporter.ts
@@ -32,6 +32,11 @@ import {
   createExportMetricsServiceRequest,
   IExportMetricsServiceRequest,
 } from '@opentelemetry/otlp-transformer';
+import { VERSION } from './version';
+
+const USER_AGENT = {
+  'User-Agent': `OTel-OTLP-Exporter-JavaScript/${VERSION}`,
+};
 
 class OTLPMetricExporterProxy extends OTLPGRPCExporterNodeBase<
   ResourceMetrics,
@@ -39,9 +44,13 @@ class OTLPMetricExporterProxy extends OTLPGRPCExporterNodeBase<
 > {
   constructor(config?: OTLPGRPCExporterConfigNode & OTLPMetricExporterOptions) {
     super(config);
-    const headers = baggageUtils.parseKeyPairsIntoRecord(
-      getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
-    );
+    const headers = {
+      ...USER_AGENT,
+      ...baggageUtils.parseKeyPairsIntoRecord(
+        getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
+      ),
+    };
+
     this.metadata ||= new Metadata();
     for (const [k, v] of Object.entries(headers)) {
       this.metadata.set(k, v);

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/test/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/test/OTLPMetricExporter.test.ts
@@ -43,6 +43,7 @@ import {
   IExportMetricsServiceRequest,
   IResourceMetrics,
 } from '@opentelemetry/otlp-transformer';
+import { VERSION } from '../src/version';
 
 const metricsServiceProtoPath =
   'opentelemetry/proto/collector/metrics/v1/metrics_service.proto';
@@ -313,6 +314,13 @@ describe('when configuring via environment', () => {
       ['bar']
     );
     envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
+  });
+  it('should include user agent in header', () => {
+    const collectorExporter = new OTLPMetricExporter();
+    assert.deepStrictEqual(
+      collectorExporter._otlpExporter.metadata?.get('User-Agent'),
+      [`OTel-OTLP-Exporter-JavaScript/${VERSION}`]
+    );
   });
   it('should override global headers config with signal headers defined via env', () => {
     const metadata = new grpc.Metadata();

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/OTLPMetricExporter.ts
@@ -28,9 +28,13 @@ import {
   createExportMetricsServiceRequest,
   IExportMetricsServiceRequest,
 } from '@opentelemetry/otlp-transformer';
+import { VERSION } from '../../version';
 
 const DEFAULT_COLLECTOR_RESOURCE_PATH = 'v1/metrics';
 const DEFAULT_COLLECTOR_URL = `http://localhost:4318/${DEFAULT_COLLECTOR_RESOURCE_PATH}`;
+const USER_AGENT = {
+  'User-Agent': `OTel-OTLP-Exporter-JavaScript/${VERSION}`,
+};
 
 class OTLPExporterNodeProxy extends OTLPExporterNodeBase<
   ResourceMetrics,
@@ -38,12 +42,13 @@ class OTLPExporterNodeProxy extends OTLPExporterNodeBase<
 > {
   constructor(config?: OTLPExporterNodeConfigBase & OTLPMetricExporterOptions) {
     super(config);
-    this.headers = Object.assign(
-      this.headers,
-      baggageUtils.parseKeyPairsIntoRecord(
+    this.headers = {
+      ...this.headers,
+      ...USER_AGENT,
+      ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
-      )
-    );
+      ),
+    };
   }
 
   convert(metrics: ResourceMetrics[]): IExportMetricsServiceRequest {

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/CollectorMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/CollectorMetricExporter.test.ts
@@ -50,6 +50,7 @@ import {
   OTLPExporterNodeConfigBase,
 } from '@opentelemetry/otlp-exporter-base';
 import { IExportMetricsServiceRequest } from '@opentelemetry/otlp-transformer';
+import { VERSION } from '../../src/version';
 
 let fakeRequest: PassThrough;
 
@@ -187,6 +188,13 @@ describe('OTLPMetricExporter - node with json over http', () => {
       const collectorExporter = new OTLPMetricExporter();
       assert.strictEqual(collectorExporter._otlpExporter.headers.foo, 'bar');
       envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
+    });
+    it('should include user agent in header', () => {
+      const collectorExporter = new OTLPMetricExporter();
+      assert.strictEqual(
+        collectorExporter._otlpExporter.headers['User-Agent'],
+        `OTel-OTLP-Exporter-JavaScript/${VERSION}`
+      );
     });
     it('should override global headers config with signal headers defined via env', () => {
       envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar,bar=foo';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/OTLPMetricExporter.ts
@@ -31,9 +31,13 @@ import {
   createExportMetricsServiceRequest,
   IExportMetricsServiceRequest,
 } from '@opentelemetry/otlp-transformer';
+import { VERSION } from './version';
 
 const DEFAULT_COLLECTOR_RESOURCE_PATH = 'v1/metrics';
 const DEFAULT_COLLECTOR_URL = `http://localhost:4318/${DEFAULT_COLLECTOR_RESOURCE_PATH}`;
+const USER_AGENT = {
+  'User-Agent': `OTel-OTLP-Exporter-JavaScript/${VERSION}`,
+};
 
 class OTLPMetricExporterNodeProxy extends OTLPProtoExporterNodeBase<
   ResourceMetrics,
@@ -41,12 +45,13 @@ class OTLPMetricExporterNodeProxy extends OTLPProtoExporterNodeBase<
 > {
   constructor(config?: OTLPExporterNodeConfigBase & OTLPMetricExporterOptions) {
     super(config);
-    this.headers = Object.assign(
-      this.headers,
-      baggageUtils.parseKeyPairsIntoRecord(
+    this.headers = {
+      ...this.headers,
+      ...USER_AGENT,
+      ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
-      )
-    );
+      ),
+    };
   }
 
   convert(metrics: ResourceMetrics[]): IExportMetricsServiceRequest {

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/OTLPMetricExporter.test.ts
@@ -46,6 +46,7 @@ import { OTLPMetricExporterOptions } from '@opentelemetry/exporter-metrics-otlp-
 import { Stream, PassThrough } from 'stream';
 import { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
 import { IExportMetricsServiceRequest } from '@opentelemetry/otlp-transformer';
+import { VERSION } from '../src/version';
 
 let fakeRequest: PassThrough;
 
@@ -58,6 +59,16 @@ describe('OTLPMetricExporter - node with proto over http', () => {
   afterEach(() => {
     fakeRequest = new Stream.PassThrough();
     sinon.restore();
+  });
+
+  describe('default behavior for headers', () => {
+    const collectorExporter = new OTLPMetricExporter();
+    it('should include user agent in header', () => {
+      assert.strictEqual(
+        collectorExporter._otlpExporter.headers['User-Agent'],
+        `OTel-OTLP-Exporter-JavaScript/${VERSION}`
+      );
+    });
   });
 
   describe('when configuring via environment', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

Updates #3291 

## Short description of the changes

- add user agent to otlp grpc metric exporter
- add user agent to otlp http/json metric exporter
- add user agent to otlp http/proto metric exporter
- add unit tests for the above changes

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
