### PR TITLE
fix(exporter-logs-otlp-grpc): change OTLPLogsExporter to OTLPLogExpo…

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+* fix(exporter-logs-otlp-grpc): change OTLPLogsExporter to OTLPLogExporter [#3819](https://github.com/open-telemetry/opentelemetry-js/pull/3819) @fuaiyi
+
 ### :rocket: (Enhancement)
 
 * feat(instrumentation): add ESM support for instrumentation. [#3698](https://github.com/open-telemetry/opentelemetry-js/pull/3698) @JamieDanielson, @pkanal, @vmarchaud, @lizthegrey, @bengl
@@ -15,7 +17,6 @@ All notable changes to experimental packages in this project will be documented 
 ### :bug: (Bug Fix)
 
 * fix(sdk-node): use resource interface instead of concrete class [#3803](https://github.com/open-telemetry/opentelemetry-js/pull/3803) @blumamir
-* fix(exporter-logs-otlp-grpc): change OTLPLogsExporter to OTLPLogExporter [#3819](https://github.com/open-telemetry/opentelemetry-js/pull/3819) @fuaiyi
 
 ### :books: (Refine Doc)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :bug: (Bug Fix)
 
 * fix(sdk-node): use resource interface instead of concrete class [#3803](https://github.com/open-telemetry/opentelemetry-js/pull/3803) @blumamir
+* fix(exporter-logs-otlp-grpc): change OTLPLogsExporter to OTLPLogExporter [#3819](https://github.com/open-telemetry/opentelemetry-js/pull/3819) @fuaiyi
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/exporter-logs-otlp-grpc/README.md
+++ b/experimental/packages/exporter-logs-otlp-grpc/README.md
@@ -22,7 +22,7 @@ To see documentation and sample code for the metric exporter, see the [exporter-
 
 ## Logs in Node - GRPC
 
-The OTLPLogsExporter in Node expects the URL to only be the hostname. It will not work with `/v1/logs`. All
+The OTLPLogExporter in Node expects the URL to only be the hostname. It will not work with `/v1/logs`. All
 options that work with trace also work with logs.
 
 ```js
@@ -30,14 +30,14 @@ import {
   LoggerProvider,
   BatchLogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
-import { OTLPLogsExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
 
 const collectorOptions = {
   // url is optional and can be omitted - default is http://localhost:4317
   url: 'http://<collector-hostname>:<port>',
 };
 
-const loggerExporter = new OTLPLogsExporter(collectorOptions);
+const loggerExporter = new OTLPLogExporter(collectorOptions);
 const loggerProvider = new LoggerProvider();
 
 loggerProvider.addLogRecordProcessor(

--- a/experimental/packages/exporter-logs-otlp-grpc/src/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/src/OTLPLogExporter.ts
@@ -32,7 +32,7 @@ import {
 /**
  * OTLP Logs Exporter for Node
  */
-export class OTLPLogsExporter
+export class OTLPLogExporter
   extends OTLPGRPCExporterNodeBase<ReadableLogRecord, IExportLogsServiceRequest>
   implements LogRecordExporter
 {

--- a/experimental/packages/exporter-logs-otlp-grpc/src/index.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/src/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './OTLPLogsExporter';
+export * from './OTLPLogExporter';

--- a/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
@@ -22,7 +22,7 @@ import * as fs from 'fs';
 import * as grpc from '@grpc/grpc-js';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import { OTLPLogsExporter } from '../src';
+import { OTLPLogExporter } from '../src';
 
 import {
   ensureExportedLogRecordIsCorrect,
@@ -55,10 +55,10 @@ const metadata = new grpc.Metadata();
 metadata.set('k', 'v');
 
 const testCollectorExporter = (params: TestParams) =>
-  describe(`OTLPLogsExporter - node ${
+  describe(`OTLPLogExporter - node ${
     params.useTLS ? 'with' : 'without'
   } TLS, ${params.metadata ? 'with' : 'without'} metadata`, () => {
-    let collectorExporter: OTLPLogsExporter;
+    let collectorExporter: OTLPLogExporter;
     let server: grpc.Server;
     let exportedData: IResourceLogs | undefined;
     let reqMetadata: grpc.Metadata | undefined;
@@ -122,7 +122,7 @@ const testCollectorExporter = (params: TestParams) =>
             fs.readFileSync('./test/certs/client.crt')
           )
         : grpc.credentials.createInsecure();
-      collectorExporter = new OTLPLogsExporter({
+      collectorExporter = new OTLPLogExporter({
         url: 'https://' + address,
         credentials,
         metadata: params.metadata,
@@ -140,7 +140,7 @@ const testCollectorExporter = (params: TestParams) =>
       it('should warn about headers when using grpc', () => {
         // Need to stub/spy on the underlying logger as the 'diag' instance is global
         const spyLoggerWarn = sinon.stub(diag, 'warn');
-        collectorExporter = new OTLPLogsExporter({
+        collectorExporter = new OTLPLogExporter({
           url: `http://${address}`,
           headers: {
             foo: 'bar',
@@ -151,7 +151,7 @@ const testCollectorExporter = (params: TestParams) =>
       });
       it('should warn about path in url', () => {
         const spyLoggerWarn = sinon.stub(diag, 'warn');
-        collectorExporter = new OTLPLogsExporter({
+        collectorExporter = new OTLPLogExporter({
           url: `http://${address}/v1/logs`,
         });
         const args = spyLoggerWarn.args[0];
@@ -198,7 +198,7 @@ const testCollectorExporter = (params: TestParams) =>
             )
           : grpc.credentials.createInsecure();
 
-        const collectorExporterWithTimeout = new OTLPLogsExporter({
+        const collectorExporterWithTimeout = new OTLPLogExporter({
           url: 'grpcs://' + address,
           credentials,
           metadata: params.metadata,
@@ -229,7 +229,7 @@ const testCollectorExporter = (params: TestParams) =>
               fs.readFileSync('./test/certs/client.crt')
             )
           : grpc.credentials.createInsecure();
-        collectorExporter = new OTLPLogsExporter({
+        collectorExporter = new OTLPLogExporter({
           url: 'https://' + address,
           credentials,
           metadata: params.metadata,
@@ -272,7 +272,7 @@ const testCollectorExporter = (params: TestParams) =>
           : grpc.credentials.createInsecure();
 
         envSource.OTEL_EXPORTER_OTLP_COMPRESSION = 'gzip';
-        collectorExporter = new OTLPLogsExporter({
+        collectorExporter = new OTLPLogExporter({
           url: 'https://' + address,
           credentials,
           metadata: params.metadata,
@@ -286,9 +286,9 @@ const testCollectorExporter = (params: TestParams) =>
     });
   });
 
-describe('OTLPLogsExporter - node (getDefaultUrl)', () => {
+describe('OTLPLogExporter - node (getDefaultUrl)', () => {
   it('should default to localhost', done => {
-    const collectorExporter = new OTLPLogsExporter({});
+    const collectorExporter = new OTLPLogExporter({});
     setTimeout(() => {
       assert.strictEqual(collectorExporter['url'], 'localhost:4317');
       done();
@@ -296,7 +296,7 @@ describe('OTLPLogsExporter - node (getDefaultUrl)', () => {
   });
   it('should keep the URL if included', done => {
     const url = 'http://foo.bar.com';
-    const collectorExporter = new OTLPLogsExporter({ url });
+    const collectorExporter = new OTLPLogExporter({ url });
     setTimeout(() => {
       assert.strictEqual(collectorExporter['url'], 'foo.bar.com');
       done();
@@ -308,21 +308,21 @@ describe('when configuring via environment', () => {
   const envSource = process.env;
   it('should use url defined in env', () => {
     envSource.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://foo.bar';
-    const collectorExporter = new OTLPLogsExporter();
+    const collectorExporter = new OTLPLogExporter();
     assert.strictEqual(collectorExporter.url, 'foo.bar');
     envSource.OTEL_EXPORTER_OTLP_ENDPOINT = '';
   });
   it('should override global exporter url with signal url defined in env', () => {
     envSource.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://foo.bar';
     envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = 'http://foo.logs';
-    const collectorExporter = new OTLPLogsExporter();
+    const collectorExporter = new OTLPLogExporter();
     assert.strictEqual(collectorExporter.url, 'foo.logs');
     envSource.OTEL_EXPORTER_OTLP_ENDPOINT = '';
     envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = '';
   });
   it('should use headers defined via env', () => {
     envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar';
-    const collectorExporter = new OTLPLogsExporter();
+    const collectorExporter = new OTLPLogExporter();
     assert.deepStrictEqual(collectorExporter.metadata?.get('foo'), ['bar']);
     envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
   });
@@ -332,7 +332,7 @@ describe('when configuring via environment', () => {
     metadata.set('goo', 'lol');
     envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=jar,bar=foo';
     envSource.OTEL_EXPORTER_OTLP_LOGS_HEADERS = 'foo=boo';
-    const collectorExporter = new OTLPLogsExporter({ metadata });
+    const collectorExporter = new OTLPLogExporter({ metadata });
     assert.deepStrictEqual(collectorExporter.metadata?.get('foo'), ['boo']);
     assert.deepStrictEqual(collectorExporter.metadata?.get('bar'), ['foo']);
     assert.deepStrictEqual(collectorExporter.metadata?.get('goo'), ['lol']);

--- a/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
@@ -55,9 +55,9 @@ const metadata = new grpc.Metadata();
 metadata.set('k', 'v');
 
 const testCollectorExporter = (params: TestParams) =>
-  describe(`OTLPLogExporter - node ${
-    params.useTLS ? 'with' : 'without'
-  } TLS, ${params.metadata ? 'with' : 'without'} metadata`, () => {
+  describe(`OTLPLogExporter - node ${params.useTLS ? 'with' : 'without'} TLS, ${
+    params.metadata ? 'with' : 'without'
+  } metadata`, () => {
     let collectorExporter: OTLPLogExporter;
     let server: grpc.Server;
     let exportedData: IResourceLogs | undefined;


### PR DESCRIPTION
## Which problem is this PR solving?

feat(exporter-logs-otlp-grpc): change OTLPLogsExporter to OTLPLogExpo…

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/3812

## Short description of the changes
Update logs gRPC exporter class name to singular OTLPLogExporter #3812

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x]  Run the included unit tests.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
