### PR TITLE
Add Jamie to approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 
 - [Gerhard Stöbich](https://github.com/Flarna), Dynatrace
 - [Haddas Bronfman](https://github.com/haddasbronfman), Cisco
+- [Jamie Danielson](https://github.com/JamieDanielson), Honeycomb
 - [John Bley](https://github.com/johnbley), Splunk
 - [Mark Wolff](https://github.com/markwolff), Microsoft
 - [Martin Kuba](https://github.com/martinkuba), Lightstep


### PR DESCRIPTION
Adding @JamieDanielson to the approvers list in recognition of her ongoing work in OpenTelemetry JS.