### PR TITLE
Add Hector to approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 
 - [Gerhard Stöbich](https://github.com/Flarna), Dynatrace
 - [Haddas Bronfman](https://github.com/haddasbronfman), Cisco
+- [Hector Hernandez](https://github.com/hectorhdzg), Microsoft
 - [John Bley](https://github.com/johnbley), Splunk
 - [Mark Wolff](https://github.com/markwolff), Microsoft
 - [Martin Kuba](https://github.com/martinkuba), Lightstep


### PR DESCRIPTION
Adding @hectorhdzg to the approvers list in recognition of his ongoing work in OpenTelemetry JS.