### PR TITLE
fix(exporter-logs-otlp-http): bump version to 0.39.1

### DIFF
--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-http",
-  "version": "0.38.0",
+  "version": "0.39.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Which problem is this PR solving?

Realized just after I merged #3764 that the version was still at `0.38.0` :disappointed: 

## Short description of the changes

This PR bumps the version to `0.39.1`