### PR TITLE
deps(exporter-logs-otlp-http): remove unused rimraf devDependency

### DIFF
--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -89,7 +89,6 @@
     "karma-webpack": "4.0.2",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
-    "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-loader": "8.4.0",
     "ts-mocha": "10.0.0",


### PR DESCRIPTION
## Which problem is this PR solving?

Remove unused `rimraf` dependency, see #3738 #3737 