### PR TITLE
fix(opentelemetry-semantic-conventions): update trace semantic conventions url

### DIFF
--- a/packages/opentelemetry-semantic-conventions/README.md
+++ b/packages/opentelemetry-semantic-conventions/README.md
@@ -38,4 +38,4 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [npm-url]: https://www.npmjs.com/package/@opentelemetry/semantic-conventions
 [npm-img]: https://badge.fury.io/js/%40opentelemetry%2Fsemantic-conventions.svg
 
-[trace-semantic_conventions]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/trace/semantic_conventions
+[trace-semantic_conventions]: https://github.com/open-telemetry/semantic-conventions/tree/main/specification/trace/semantic_conventions


### PR DESCRIPTION
## Which problem is this PR solving?

This PR fixes the OpenTelemetry Semantic Conventions URL used in the readme file of the `opentelemetry-semantic-conventions` package. In the last release (`v1.21.0`) of the [Opentelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification) the [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions) section was moved to a separate repository.

Fixes # (issue)

## Short description of the changes

Fix URL in readme file.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Validate link navigation in readme

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Documentation has been updated
