### PR TITLE
chore: prepare release 1.14 / 0.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 * feat(SpanExpoter): Add optional forceFlush to SpanExporter interface [#3753](https://github.com/open-telemetry/opentelemetry-js/pull/3753/) @sgracias1 @JacksonWeber
 
-
 ## 1.13.0
 
 ### :rocket: (Enhancement)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :rocket: (Enhancement)
 
-* feat(SpanExpoter): Add optional forceFlush to SpanExporter interface [#3753](https://github.com/open-telemetry/opentelemetry-js/pull/3753/) @sgracias1 @JacksonWeber
+* feat(SpanExporter): Add optional forceFlush to SpanExporter interface [#3753](https://github.com/open-telemetry/opentelemetry-js/pull/3753/) @sgracias1 @JacksonWeber
 
 ## 1.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,18 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :rocket: (Enhancement)
 
-* feat(SpanExpoter): Add optional forceFlush to SpanExporter interface [#3753](https://github.com/open-telemetry/opentelemetry-js/pull/3753/) @sgracias1 @JacksonWeber
-
 ### :bug: (Bug Fix)
 
 ### :books: (Refine Doc)
 
 ### :house: (Internal)
+
+## 1.14.0
+
+### :rocket: (Enhancement)
+
+* feat(SpanExpoter): Add optional forceFlush to SpanExporter interface [#3753](https://github.com/open-telemetry/opentelemetry-js/pull/3753/) @sgracias1 @JacksonWeber
+
 
 ## 1.13.0
 

--- a/examples/esm-http-ts/package.json
+++ b/examples/esm-http-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esm-http-ts",
   "private": true,
-  "version": "0.38.0",
+  "version": "0.40.0",
   "description": "Example of HTTP integration with OpenTelemetry using ESM and TypeScript",
   "main": "build/index.js",
   "type": "module",

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-example",
   "private": true,
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "Example of HTTP integration with OpenTelemetry",
   "main": "index.js",
   "scripts": {
@@ -29,14 +29,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-jaeger": "1.13.0",
-    "@opentelemetry/exporter-zipkin": "1.13.0",
-    "@opentelemetry/instrumentation": "0.39.1",
-    "@opentelemetry/instrumentation-http": "0.39.1",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
-    "@opentelemetry/sdk-trace-node": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/exporter-jaeger": "1.14.0",
+    "@opentelemetry/exporter-zipkin": "1.14.0",
+    "@opentelemetry/instrumentation": "0.40.0",
+    "@opentelemetry/instrumentation-http": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
+    "@opentelemetry/sdk-trace-node": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/http",
   "devDependencies": {

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,7 +1,7 @@
 {
   "name": "https-example",
   "private": true,
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "Example of HTTPs integration with OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -33,14 +33,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/exporter-jaeger": "1.13.0",
-    "@opentelemetry/exporter-zipkin": "1.13.0",
-    "@opentelemetry/instrumentation": "0.39.1",
-    "@opentelemetry/instrumentation-http": "0.39.1",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
-    "@opentelemetry/sdk-trace-node": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/exporter-jaeger": "1.14.0",
+    "@opentelemetry/exporter-zipkin": "1.14.0",
+    "@opentelemetry/instrumentation": "0.40.0",
+    "@opentelemetry/instrumentation-http": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
+    "@opentelemetry/sdk-trace-node": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-opentelemetry-example",
   "private": true,
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "Example of using @opentelemetry/sdk-trace-web and @opentelemetry/sdk-metrics in browser",
   "main": "index.js",
   "scripts": {
@@ -43,20 +43,20 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/context-zone": "1.13.0",
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.39.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.39.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.39.1",
-    "@opentelemetry/exporter-zipkin": "1.13.0",
-    "@opentelemetry/instrumentation": "0.39.1",
-    "@opentelemetry/instrumentation-fetch": "0.39.1",
-    "@opentelemetry/instrumentation-xml-http-request": "0.39.1",
-    "@opentelemetry/propagator-b3": "1.13.0",
-    "@opentelemetry/sdk-metrics": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
-    "@opentelemetry/sdk-trace-web": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/context-zone": "1.14.0",
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.40.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.40.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.40.0",
+    "@opentelemetry/exporter-zipkin": "1.14.0",
+    "@opentelemetry/instrumentation": "0.40.0",
+    "@opentelemetry/instrumentation-fetch": "0.40.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.40.0",
+    "@opentelemetry/propagator-b3": "1.14.0",
+    "@opentelemetry/sdk-metrics": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
+    "@opentelemetry/sdk-trace-web": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web"
 }

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-otlp-exporter-node",
   "private": true,
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
@@ -29,17 +29,17 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.39.1",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.39.1",
-    "@opentelemetry/exporter-metrics-otlp-proto": "0.39.1",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.39.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.39.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.39.1",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-metrics": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.40.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.40.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "0.40.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.40.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.40.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-metrics": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/otlp-exporter-node"
 }

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+### :rocket: (Enhancement)
+
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 0.40.0
+
+### :boom: Breaking Change
+
 * fix(exporter-logs-otlp-grpc): change OTLPLogsExporter to OTLPLogExporter [#3819](https://github.com/open-telemetry/opentelemetry-js/pull/3819) @fuaiyi
 * chore(instrumentation-grpc): add 'grpc' deprecation notice postinstall script [#3833](https://github.com/open-telemetry/opentelemetry-js/pull/3833) @pichlermarc
   * Support for telemetry generation for the [`grpc`](https://www.npmjs.com/package/grpc) module will be dropped in the next release as the package has been
@@ -25,10 +37,6 @@ All notable changes to experimental packages in this project will be documented 
 
 * fix(sdk-node): use resource interface instead of concrete class [#3803](https://github.com/open-telemetry/opentelemetry-js/pull/3803) @blumamir
 * fix(sdk-logs): remove includeTraceContext configuration and use LogRecord context when available  [#3817](https://github.com/open-telemetry/opentelemetry-js/pull/3817) @hectorhdzg
-
-### :books: (Refine Doc)
-
-### :house: (Internal)
 
 ## 0.39.1
 

--- a/experimental/backwards-compatability/node14/package.json
+++ b/experimental/backwards-compatability/node14/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node14",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "private": true,
   "description": "Backwards compatability app for node 14 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.39.1",
-    "@opentelemetry/sdk-trace-base": "1.13.0"
+    "@opentelemetry/sdk-node": "0.40.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0"
   },
   "devDependencies": {
     "@types/node": "14.18.25",

--- a/experimental/backwards-compatability/node16/package.json
+++ b/experimental/backwards-compatability/node16/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node16",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "private": true,
   "description": "Backwards compatability app for node 16 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.39.1",
-    "@opentelemetry/sdk-trace-base": "1.13.0"
+    "@opentelemetry/sdk-node": "0.40.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0"
   },
   "devDependencies": {
     "@types/node": "16.11.52",

--- a/experimental/examples/logs/package.json
+++ b/experimental/examples/logs/package.json
@@ -1,14 +1,14 @@
 {
   "name": "logs-example",
-  "version": "0.2.0",
+  "version": "0.40.0",
   "private": true,
   "scripts": {
     "start": "ts-node index.ts"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.4.1",
-    "@opentelemetry/api-logs": "0.39.1",
-    "@opentelemetry/sdk-logs": "0.39.1"
+    "@opentelemetry/api-logs": "0.40.0",
+    "@opentelemetry/sdk-logs": "0.40.0"
   },
   "devDependencies": {
     "@types/node": "18.6.5",

--- a/experimental/examples/prometheus/package.json
+++ b/experimental/examples/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prometheus-example",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "private": true,
   "description": "Example of using @opentelemetry/sdk-metrics and @opentelemetry/exporter-prometheus",
   "main": "index.js",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-prometheus": "0.39.1",
-    "@opentelemetry/sdk-metrics": "1.13.0"
+    "@opentelemetry/exporter-prometheus": "0.40.0",
+    "@opentelemetry/sdk-metrics": "1.14.0"
   }
 }

--- a/experimental/packages/api-events/package.json
+++ b/experimental/packages/api-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-events",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "Public events API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/api-logs/package.json
+++ b/experimental/packages/api-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-logs",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "Public logs API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-grpc",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected log records to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -51,9 +51,9 @@
     "@babel/core": "7.16.0",
     "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/api-logs": "0.39.1",
-    "@opentelemetry/otlp-exporter-base": "0.39.1",
-    "@opentelemetry/resources": "1.13.0",
+    "@opentelemetry/api-logs": "0.40.0",
+    "@opentelemetry/otlp-exporter-base": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -71,10 +71,10 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.39.1",
-    "@opentelemetry/otlp-transformer": "0.39.1",
-    "@opentelemetry/sdk-logs": "0.39.1"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.40.0",
+    "@opentelemetry/otlp-transformer": "0.40.0",
+    "@opentelemetry/sdk-logs": "0.40.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-http",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "publishConfig": {
     "access": "public"
   },
@@ -72,7 +72,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@babel/core": "7.16.0",
-    "@opentelemetry/api-logs": ">=0.38.0",
+    "@opentelemetry/api-logs": "0.40.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -101,9 +101,9 @@
     "@opentelemetry/api-logs": ">=0.38.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/otlp-exporter-base": "0.39.1",
-    "@opentelemetry/otlp-transformer": "0.39.1",
-    "@opentelemetry/sdk-logs": "0.39.1"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/otlp-exporter-base": "0.40.0",
+    "@opentelemetry/otlp-transformer": "0.40.0",
+    "@opentelemetry/sdk-logs": "0.40.0"
   }
 }

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-proto",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "An OTLP exporter to send logs using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -81,14 +81,14 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/otlp-transformer": "0.39.1",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
-    "@opentelemetry/api-logs": "^0.39.1",
-    "@opentelemetry/otlp-exporter-base": "0.39.1",
-    "@opentelemetry/otlp-proto-exporter-base": "0.39.1",
-    "@opentelemetry/sdk-logs": "^0.39.1"
+    "@opentelemetry/api-logs": "0.40.0",
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/otlp-exporter-base": "0.40.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.40.0",
+    "@opentelemetry/otlp-transformer": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-logs": "0.40.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-grpc",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,7 +50,7 @@
     "@babel/core": "7.16.0",
     "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/otlp-exporter-base": "0.39.1",
+    "@opentelemetry/otlp-exporter-base": "0.40.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -68,11 +68,11 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.39.1",
-    "@opentelemetry/otlp-transformer": "0.39.1",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.40.0",
+    "@opentelemetry/otlp-transformer": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-http",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry Collector Trace Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,11 +93,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/otlp-exporter-base": "0.39.1",
-    "@opentelemetry/otlp-transformer": "0.39.1",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/otlp-exporter-base": "0.40.0",
+    "@opentelemetry/otlp-transformer": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-proto",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -80,12 +80,12 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/otlp-exporter-base": "0.39.1",
-    "@opentelemetry/otlp-proto-exporter-base": "0.39.1",
-    "@opentelemetry/otlp-transformer": "0.39.1",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/otlp-exporter-base": "0.40.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.40.0",
+    "@opentelemetry/otlp-transformer": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/opentelemetry-browser-detector",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry Resource Detector for Browser",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -70,8 +70,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/browser-detector"
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -67,12 +67,12 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.39.1",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.39.1",
-    "@opentelemetry/otlp-transformer": "0.39.1",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-metrics": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.40.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.40.0",
+    "@opentelemetry/otlp-transformer": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-metrics": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-http",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,11 +93,11 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/otlp-exporter-base": "0.39.1",
-    "@opentelemetry/otlp-transformer": "0.39.1",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-metrics": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/otlp-exporter-base": "0.40.0",
+    "@opentelemetry/otlp-transformer": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-metrics": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-proto",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -65,13 +65,13 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.39.1",
-    "@opentelemetry/otlp-exporter-base": "0.39.1",
-    "@opentelemetry/otlp-proto-exporter-base": "0.39.1",
-    "@opentelemetry/otlp-transformer": "0.39.1",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-metrics": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.40.0",
+    "@opentelemetry/otlp-exporter-base": "0.40.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.40.0",
+    "@opentelemetry/otlp-transformer": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-metrics": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/semantic-conventions": "1.13.0",
+    "@opentelemetry/semantic-conventions": "1.14.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -59,9 +59,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-metrics": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-metrics": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-prometheus",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-fetch",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry fetch automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-zone": "1.13.0",
-    "@opentelemetry/propagator-b3": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
+    "@opentelemetry/context-zone": "1.14.0",
+    "@opentelemetry/propagator-b3": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -86,10 +86,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/instrumentation": "0.39.1",
-    "@opentelemetry/sdk-trace-web": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/instrumentation": "0.40.0",
+    "@opentelemetry/sdk-trace-web": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-grpc",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry grpc automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,10 +49,10 @@
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-async-hooks": "1.13.0",
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
-    "@opentelemetry/sdk-trace-node": "1.13.0",
+    "@opentelemetry/context-async-hooks": "1.14.0",
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
+    "@opentelemetry/sdk-trace-node": "1.14.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/semver": "7.3.9",
@@ -71,8 +71,8 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "0.39.1",
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/instrumentation": "0.40.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-http",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry http/https automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,10 +46,10 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-async-hooks": "1.13.0",
-    "@opentelemetry/sdk-metrics": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
-    "@opentelemetry/sdk-trace-node": "1.13.0",
+    "@opentelemetry/context-async-hooks": "1.14.0",
+    "@opentelemetry/sdk-metrics": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
+    "@opentelemetry/sdk-trace-node": "1.14.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/request-promise-native": "1.0.18",
@@ -72,9 +72,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/instrumentation": "0.39.1",
-    "@opentelemetry/semantic-conventions": "1.13.0",
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/instrumentation": "0.40.0",
+    "@opentelemetry/semantic-conventions": "1.14.0",
     "semver": "^7.3.5"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http",

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-xml-http-request",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry XMLHttpRequest automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-zone": "1.13.0",
-    "@opentelemetry/propagator-b3": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
+    "@opentelemetry/context-zone": "1.14.0",
+    "@opentelemetry/propagator-b3": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -86,10 +86,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/instrumentation": "0.39.1",
-    "@opentelemetry/sdk-trace-web": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/instrumentation": "0.40.0",
+    "@opentelemetry/sdk-trace-web": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "Base class for node which OpenTelemetry instrumentation modules extend",
   "author": "OpenTelemetry Authors",
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation",
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/sdk-metrics": "1.13.0",
+    "@opentelemetry/sdk-metrics": "1.14.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/semver": "7.3.9",

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-node",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry SDK for Node.js",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,25 +44,25 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/exporter-jaeger": "1.13.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.39.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.39.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.39.1",
-    "@opentelemetry/exporter-zipkin": "1.13.0",
-    "@opentelemetry/instrumentation": "0.39.1",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-metrics": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
-    "@opentelemetry/sdk-trace-node": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/exporter-jaeger": "1.14.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.40.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.40.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.40.0",
+    "@opentelemetry/exporter-zipkin": "1.14.0",
+    "@opentelemetry/instrumentation": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-metrics": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
+    "@opentelemetry/sdk-trace-node": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.3.0 <1.5.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-async-hooks": "1.13.0",
+    "@opentelemetry/context-async-hooks": "1.14.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/semver": "7.3.9",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-exporter-base",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry OTLP Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0"
+    "@opentelemetry/core": "1.14.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-grpc-exporter-base",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry OTLP-gRPC Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,9 +50,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/otlp-transformer": "0.39.1",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
+    "@opentelemetry/otlp-transformer": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -71,8 +71,8 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/otlp-exporter-base": "0.39.1",
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/otlp-exporter-base": "0.40.0",
     "protobufjs": "^7.2.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-grpc-exporter-base",

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-proto-exporter-base",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenTelemetry OTLP-HTTP-protobuf Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -77,8 +77,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/otlp-exporter-base": "0.39.1",
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/otlp-exporter-base": "0.40.0",
     "protobufjs": "^7.1.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-proto-exporter-base",

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "Transform OpenTelemetry SDK data into OTLP",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
@@ -76,12 +76,12 @@
     "webpack": "4.46.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.39.1",
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-logs": "0.39.1",
-    "@opentelemetry/sdk-metrics": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0"
+    "@opentelemetry/api-logs": "0.40.0",
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-logs": "0.40.0",
+    "@opentelemetry/sdk-metrics": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-transformer",
   "sideEffects": false

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-logs",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "publishConfig": {
     "access": "public"
   },
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.4.0 <1.5.0",
-    "@opentelemetry/api-logs": "0.39.1",
+    "@opentelemetry/api-logs": "0.40.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -91,7 +91,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/resources": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/resources": "1.14.0"
   }
 }

--- a/experimental/packages/shim-opencensus/package.json
+++ b/experimental/packages/shim-opencensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opencensus",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "OpenCensus to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,17 +44,17 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/context-async-hooks": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
     "@opencensus/core": "0.1.0",
     "@opentelemetry/api": "1.4.1",
+    "@opentelemetry/context-async-hooks": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
+    "@types/sinon": "10.0.13",
     "codecov": "3.8.3",
     "mocha": "10.0.0",
     "nyc": "15.1.0",
     "sinon": "15.0.0",
-    "@types/sinon": "10.0.13",
     "ts-mocha": "10.0.0",
     "typescript": "4.4.4"
   },
@@ -63,7 +63,7 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
+    "@opentelemetry/core": "1.14.0",
     "require-in-the-middle": "^7.0.0",
     "semver": "^7.3.5"
   },

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.13.0",
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
+    "@opentelemetry/context-async-hooks": "1.14.0",
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
     "axios": "1.4.0",
     "body-parser": "1.19.0",
     "express": "4.17.3"

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -73,7 +73,7 @@
     "webpack-merge": "5.8.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.13.0",
+    "@opentelemetry/context-zone-peer-dep": "1.14.0",
     "zone.js": "^0.11.0"
   },
   "sideEffects": true,

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -90,7 +90,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core",
   "sideEffects": false

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/resources": "1.13.0",
+    "@opentelemetry/resources": "1.14.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.13",
@@ -61,9 +61,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0",
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0",
     "jaeger-client": "^3.15.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -90,10 +90,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin",
   "sideEffects": false

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0"
+    "@opentelemetry/core": "1.14.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.5.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -79,7 +79,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0"
+    "@opentelemetry/core": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger",
   "sideEffects": false

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -89,8 +89,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,9 +91,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.5.0",
-    "@opentelemetry/resources": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "@types/semver": "7.3.9",
@@ -63,11 +63,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.13.0",
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/propagator-b3": "1.13.0",
-    "@opentelemetry/propagator-jaeger": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
+    "@opentelemetry/context-async-hooks": "1.14.0",
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/propagator-b3": "1.14.0",
+    "@opentelemetry/propagator-jaeger": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
     "semver": "^7.3.5"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,9 +57,9 @@
   "devDependencies": {
     "@babel/core": "7.16.0",
     "@opentelemetry/api": ">=1.0.0 <1.5.0",
-    "@opentelemetry/context-zone": "1.13.0",
-    "@opentelemetry/propagator-b3": "1.13.0",
-    "@opentelemetry/resources": "1.13.0",
+    "@opentelemetry/context-zone": "1.14.0",
+    "@opentelemetry/propagator-b3": "1.14.0",
+    "@opentelemetry/resources": "1.14.0",
     "@types/jquery": "3.5.8",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
@@ -90,9 +90,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0"
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web",
   "sideEffects": false

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -43,9 +43,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.5.0",
-    "@opentelemetry/propagator-b3": "1.13.0",
-    "@opentelemetry/propagator-jaeger": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
+    "@opentelemetry/propagator-b3": "1.14.0",
+    "@opentelemetry/propagator-jaeger": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
     "@types/mocha": "10.0.0",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
@@ -58,8 +58,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/semantic-conventions": "1.13.0",
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0",
     "opentracing": "^0.14.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing",

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -76,8 +76,8 @@
     "@opentelemetry/api": ">=1.3.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/resources": "1.13.0",
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/resources": "1.14.0",
     "lodash.merge": "4.6.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-metrics",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
@@ -56,16 +56,16 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.13.0",
-    "@opentelemetry/core": "1.13.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.39.1",
-    "@opentelemetry/exporter-zipkin": "1.13.0",
-    "@opentelemetry/instrumentation": "0.39.1",
-    "@opentelemetry/instrumentation-fetch": "0.39.1",
-    "@opentelemetry/instrumentation-xml-http-request": "0.39.1",
-    "@opentelemetry/sdk-metrics": "1.13.0",
-    "@opentelemetry/sdk-trace-base": "1.13.0",
-    "@opentelemetry/sdk-trace-web": "1.13.0",
+    "@opentelemetry/context-zone-peer-dep": "1.14.0",
+    "@opentelemetry/core": "1.14.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.40.0",
+    "@opentelemetry/exporter-zipkin": "1.14.0",
+    "@opentelemetry/instrumentation": "0.40.0",
+    "@opentelemetry/instrumentation-fetch": "0.40.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.40.0",
+    "@opentelemetry/sdk-metrics": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
+    "@opentelemetry/sdk-trace-web": "1.14.0",
     "zone.js": "0.11.4"
   }
 }


### PR DESCRIPTION
## 1.14.0

### :rocket: (Enhancement)

* feat(SpanExpoter): Add optional forceFlush to SpanExporter interface [#3753](https://github.com/open-telemetry/opentelemetry-js/pull/3753/) @sgracias1 @JacksonWeber

## 0.40.0

### :boom: Breaking Change

* fix(exporter-logs-otlp-grpc): change OTLPLogsExporter to OTLPLogExporter [#3819](https://github.com/open-telemetry/opentelemetry-js/pull/3819) @fuaiyi
* chore(instrumentation-grpc): add 'grpc' deprecation notice postinstall script [#3833](https://github.com/open-telemetry/opentelemetry-js/pull/3833) @pichlermarc
  * Support for telemetry generation for the [`grpc`](https://www.npmjs.com/package/grpc) module will be dropped in the next release as the package has been
    deprecated for over 1 year, please migrate to [`@grpc/grpc-js`](https://www.npmjs.com/package/@grpc/grpc-js) to continue receiving telemetry.
### :rocket: (Enhancement)
* feat(api-logs): support map in log attributes. [#3821](https://github.com/open-telemetry/opentelemetry-js/pull/3821) @Abinet18
* feat(instrumentation): add ESM support for instrumentation. [#3698](https://github.com/open-telemetry/opentelemetry-js/pull/3698) @JamieDanielson, @pkanal, @vmarchaud, @lizthegrey, @bengl
* feat(exporter-logs-otlp-http): otlp-http exporter for logs. [#3764](https://github.com/open-telemetry/opentelemetry-js/pull/3764/) @fuaiyi
* feat(otlp-trace-exporters): Add User-Agent header to OTLP trace exporters. [#3790](https://github.com/open-telemetry/opentelemetry-js/pull/3790) @JamieDanielson
* feat(otlp-metric-exporters): Add User-Agent header to OTLP metric exporters. [#3806](https://github.com/open-telemetry/opentelemetry-js/pull/3806) @JamieDanielson
* feat(opencensus-shim): add OpenCensus trace shim [#3809](https://github.com/open-telemetry/opentelemetry-js/pull/3809) @aabmass
* feat(exporter-logs-otlp-proto): protobuf exporter for logs. [#3779](https://github.com/open-telemetry/opentelemetry-js/pull/3779) @Abinet18
