### PR TITLE
docs: add example of exponential histogram metric

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -20,7 +20,7 @@ _Metrics API Reference: <https://open-telemetry.github.io/opentelemetry-js/class
   - [Customizing the metric attributes of instrument](#customizing-the-metric-attributes-of-instrument)
 - [Exporting measurements](#exporting-measurements)
   - [Exporting measurements to Prometheus](#exporting-measurements-to-prometheus)
-  - [Exporting measurements to Opentelemetry Protocol](#exporting-measurements-to-opentelemetry-protocol)
+  - [Exporting measurements to OpenTelemetry Protocol](#exporting-measurements-to-opentelemetry-protocol)
 
 ## Getting Started
 
@@ -266,7 +266,7 @@ Most of the time, instruments will be used to measure operations in your applica
 
 ```typescript
 async function myTask() {
-  const histogram = meter.createHistogram("taks.duration");
+  const histogram = meter.createHistogram("task.duration");
   const startTime = new Date().getTime()
   try {
     // Wait for five seconds before continuing code execution
@@ -479,7 +479,7 @@ new View({
 
 After you have instrumented your application with metrics, you also need to make
 sure that the metrics get collected by your metrics backend. The most common formats
-that are used are Prometheus and OLTP.
+that are used are Prometheus and OTLP.
 
 The latter is the [OpenTelemetry protocol format](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md)
 which is supported by the OpenTelemetry Collector. The former is based on the [OpenMetrics
@@ -528,7 +528,7 @@ at: <https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/e
 ## Exporting measurements to OpenTelemetry Protocol
 
 OpenTelemetry JavaScript comes with three different kinds of exporters that export
-the OTLP protocol, a) [over HTTP](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http), b) [over GRPC](https://www.npmjs.com/package/@opentelemetry/exporter-metrics-otlp-grpc), c) [over Protofbuf](https://www.npmjs.com/package/@opentelemetry/exporter-metrics-otlp-proto).
+the OTLP protocol, a) [over HTTP](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http), b) [over GRPC](https://www.npmjs.com/package/@opentelemetry/exporter-metrics-otlp-grpc), c) [over Protobuf](https://www.npmjs.com/package/@opentelemetry/exporter-metrics-otlp-proto).
 
 The example below shows how you can configure OpenTelemetry JavaScript to use
 the OTLP exporter using http/protobuf.

--- a/examples/otlp-exporter-node/metrics.js
+++ b/examples/otlp-exporter-node/metrics.js
@@ -4,25 +4,50 @@ const { DiagConsoleLogger, DiagLogLevel, diag } = require('@opentelemetry/api');
 const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-http');
 // const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-grpc');
 // const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-proto');
-const { MeterProvider, PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics');
+// const { ConsoleMetricExporter } = require('@opentelemetry/sdk-metrics');
+const {
+  ExponentialHistogramAggregation,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+  View,
+} = require('@opentelemetry/sdk-metrics');
 const { Resource } = require('@opentelemetry/resources');
-const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
+const {
+  SemanticResourceAttributes,
+} = require('@opentelemetry/semantic-conventions');
 
 // Optional and only needed to see the internal diagnostic logging (during development)
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 
-const metricExporter = new OTLPMetricExporter({});
+const metricExporter = new OTLPMetricExporter({
+  // headers: {
+  //   foo: 'bar'
+  // },
+});
 
+// Define view for the exponential histogram metric
+const expHistogramView = new View({
+  aggregation: new ExponentialHistogramAggregation(),
+  instrumentName: 'test_exponential_histogram',
+});
+// Note, the instrumentName is the same as the name that has been passed for
+// the Meter#createHistogram function for exponentialHistogram.
+
+// Create an instance of the metric provider
 const meterProvider = new MeterProvider({
   resource: new Resource({
     [SemanticResourceAttributes.SERVICE_NAME]: 'basic-metric-service',
   }),
+  views: [expHistogramView],
 });
 
-meterProvider.addMetricReader(new PeriodicExportingMetricReader({
-  exporter: metricExporter,
-  exportIntervalMillis: 1000,
-}));
+meterProvider.addMetricReader(
+  new PeriodicExportingMetricReader({
+    exporter: metricExporter,
+    // exporter: new ConsoleMetricExporter(),
+    exportIntervalMillis: 1000,
+  })
+);
 
 const meter = meterProvider.getMeter('example-exporter-collector');
 
@@ -36,6 +61,11 @@ const upDownCounter = meter.createUpDownCounter('test_up_down_counter', {
 
 const histogram = meter.createHistogram('test_histogram', {
   description: 'Example of a Histogram',
+  boundaries: [0, 10, 100, 1000],
+});
+
+const exponentialHistogram = meter.createHistogram('test_exp_histogram', {
+  description: 'Example of an ExponentialHistogram',
 });
 
 const attributes = { pid: process.pid, environment: 'staging' };
@@ -44,4 +74,5 @@ setInterval(() => {
   requestCounter.add(1, attributes);
   upDownCounter.add(Math.random() > 0.5 ? 1 : -1, attributes);
   histogram.record(Math.random(), attributes);
+  exponentialHistogram.record(Math.random(), attributes);
 }, 1000);


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3852 

## Short description of the changes

- Adds example of Exponential Histogram metric to existing metric example app.
- Also adds a (commented-out) `ConsoleMetricExporter` for quick dev testing
- Updates a few typos while I was in the area

I didn't update the `metrics.md` with the specific example because that didn't seem to have all the specific examples; I will look to update the public website next though (`opentelemetry.io`)

## Type of change

- [x] Other; this is a documentation/example update

## How Has This Been Tested?

- [x] Run the example app with the `ConsoleMetricExporter` (comment out or don't use the `OTLPMetricExporter`) and see the example metric in the console. Run with debug to see all the extra datapoints 

```sh
{
  descriptor: {
    name: 'test_exponential_histogram',
    description: 'Example of an ExponentialHistogram',
    type: 'HISTOGRAM',
    unit: '',
    valueType: 1
  },
  dataPointType: 1,
  dataPoints: [
    {
      attributes: [Object],
      startTime: [Array],
      endTime: [Array],
      value: [Object]
    }
  ]
}
```

![exponential-histogram-datapoints](https://github.com/open-telemetry/opentelemetry-js/assets/29520003/7ad5a6a1-a270-4c17-b4a8-dc3a5d16d00a)

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added (N/A)
- [x] Documentation has been updated (N/A)
