### PR TITLE
chore(deps): update dependency linkinator to v5

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
 
       - uses: actions/checkout@v3
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-prettier": "4.2.1",
     "gh-pages": "5.0.0",
     "lerna": "6.0.3",
-    "linkinator": "4.0.3",
+    "linkinator": "5.0.1",
     "markdownlint-cli": "0.32.2",
     "prettier": "2.8.0",
     "semver": "7.3.5",


### PR DESCRIPTION
## Which problem is this PR solving?

Replaces https://github.com/open-telemetry/opentelemetry-js/pull/3850. Linkinator v5 requires Node.js v16 and up.

## Type of change

- [x] Internal house keeping.

## Checklist:

- [x] Followed the style guidelines of this project
