### PR TITLE
feat(http-instrumentation): allow filtering of host name on metrics

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -512,8 +512,15 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       };
 
       const startTime = hrTime();
-      const metricAttributes =
-        utils.getIncomingRequestMetricAttributes(spanAttributes);
+      const metricAttributes = utils.getIncomingRequestMetricAttributes(
+        spanAttributes,
+        request,
+        {
+          ignoreHostMetricAttribute:
+            instrumentation._getConfig()
+              .ignoreIncomingRequestHostMetricAttribute,
+        }
+      );
 
       const ctx = propagation.extract(ROOT_CONTEXT, headers);
       const span = instrumentation._startHttpSpan(method, spanOptions, ctx);

--- a/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
@@ -60,6 +60,10 @@ export interface IgnoreIncomingRequestFunction {
   (request: IncomingMessage): boolean;
 }
 
+export interface IgnoreIncomingRequestHostFunction {
+  (request: IncomingMessage, host: string): boolean;
+}
+
 export interface IgnoreOutgoingRequestFunction {
   (request: RequestOptions): boolean;
 }
@@ -119,6 +123,8 @@ export interface HttpInstrumentationConfig extends InstrumentationConfig {
     client?: { requestHeaders?: string[]; responseHeaders?: string[] };
     server?: { requestHeaders?: string[]; responseHeaders?: string[] };
   };
+  /** Function for adding filtering for incoming requests' host name which may have unbounded cardinality */
+  ignoreIncomingRequestHostMetricAttribute?: IgnoreIncomingRequestHostFunction;
 }
 
 export interface Err extends Error {

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -311,7 +311,7 @@ describe('Utility', () => {
       );
     });
 
-    it('should succesfully process without middleware stack', () => {
+    it('should successfully process without middleware stack', () => {
       const request = {
         socket: {},
       } as IncomingMessage;


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

i discovered that the metrics attribute `net.host.name` could be unbounded if a server on a single IP responds to multiple host headers. This would create additional metrics in various scenarios, such as multi tenant applications. 

*I would like validation on this approach before i write tests, thanks!*

For more concrete example

```
GET / HTTP/1.1
Host: request1.example.com
```

```
GET / HTTP/1.1
Host: request2.example.com
```

```
GET / HTTP/1.1
Host: request3.example.com
```

each of these requests would generate new metric values without any mechanism to curtail it. with this change, the consumer of `HttpInstrumentation` can decide whether or not to include the `net.host.name` attribute on their metrics.


## Short description of the changes

adds `ignoreIncomingRequestHostMetricAttribute` to the `HttpInstrumentationConfig`. Then uses that in the utilities for mapping from span to metric attribute.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
