### PR TITLE
chore: fix misaligned dependency versions

### DIFF
--- a/examples/esm-http-ts/package.json
+++ b/examples/esm-http-ts/package.json
@@ -30,13 +30,13 @@
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/",
   "dependencies": {
-    "@opentelemetry/api": "1.4.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.38.0",
-    "@opentelemetry/instrumentation": "0.38.0",
-    "@opentelemetry/instrumentation-http": "0.38.0",
-    "@opentelemetry/resources": "1.9.1",
-    "@opentelemetry/sdk-trace-base": "1.9.1",
-    "@opentelemetry/sdk-trace-node": "1.9.1",
-    "@opentelemetry/semantic-conventions": "1.9.1"
+    "@opentelemetry/api": "1.4.1",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.40.0",
+    "@opentelemetry/instrumentation": "0.40.0",
+    "@opentelemetry/instrumentation-http": "0.40.0",
+    "@opentelemetry/resources": "1.14.0",
+    "@opentelemetry/sdk-trace-base": "1.14.0",
+    "@opentelemetry/sdk-trace-node": "1.14.0",
+    "@opentelemetry/semantic-conventions": "1.14.0"
   }
 }

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -58,7 +58,6 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/sdk-logs": "0.40.0",
     "@types/mocha": "10.0.1",
     "@types/webpack-env": "1.16.3",
     "codecov": "3.8.3",

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -58,8 +58,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/api-logs": "0.39.1",
-    "@opentelemetry/sdk-logs": "0.39.1",
+    "@opentelemetry/sdk-logs": "0.40.0",
     "@types/mocha": "10.0.1",
     "@types/webpack-env": "1.16.3",
     "codecov": "3.8.3",


### PR DESCRIPTION
## Which problem is this PR solving?

Some versions are not aligned with the most recent version of the `@opentelemetry/*` packages. This PR aligns these versions in preparation for #3894, as `npm` workspaces do not allow multiple versions of a locally linked package. 

## Type of change

- [x] internal (examples/devDependencies only)

## How Has This Been Tested?

- [x] ran existing tests
