### PR TITLE
feat(otlp-exporter-base): allow agent override in Node exporter

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to experimental packages in this project will be documented 
 
 * feat(otlp-grpc-exporters): add support for UDS endpoints. [#3853](https://github.com/open-telemetry/opentelemetry-js/pull/3853) @llc1123
 * feat(otlp-exporters): bump otlp proto to 0.20.0 [#3932](https://github.com/open-telemetry/opentelemetry-js/pull/3932) @pichlermarc
+* feat(otlp-exporter-base): allow agent override in Node exporter [#3935](https://github.com/open-telemetry/opentelemetry-js/pull/3935) @henrinormak
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
@@ -52,7 +52,17 @@ export abstract class OTLPExporterNodeBase<
       parseHeaders(config.headers),
       baggageUtils.parseKeyPairsIntoRecord(getEnv().OTEL_EXPORTER_OTLP_HEADERS)
     );
-    this.agent = createHttpAgent(config);
+
+    if (
+      config.httpAgent !== undefined &&
+      config.httpAgentOptions !== undefined
+    ) {
+      diag.warn(
+        'Both httpAgent and httpAgentOptions are set. Using httpAgent and ignoring httpAgentOptions'
+      );
+    }
+
+    this.agent = config.httpAgent ?? createHttpAgent(config);
     this.compression = configureCompression(config.compression);
   }
 

--- a/experimental/packages/otlp-exporter-base/src/platform/node/types.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/types.ts
@@ -25,6 +25,11 @@ export interface OTLPExporterNodeConfigBase extends OTLPExporterConfigBase {
   keepAlive?: boolean;
   compression?: CompressionAlgorithm;
   httpAgentOptions?: http.AgentOptions | https.AgentOptions;
+
+  /**
+   * If provided, httpAgentOptions are ignored, and this agent is used instead.
+   */
+  httpAgent?: http.Agent | https.Agent;
 }
 
 export enum CompressionAlgorithm {


### PR DESCRIPTION
## Which problem is this PR solving?

Currently, the OTLP HTTP exporters in Node environments only allow providing a configuration for the underlying Agent used when making the requests, however, there are instances in which one might want to opt-out of using the default node http/https Agent, and prefer using something like [agentkeepalive](https://github.com/node-modules/agentkeepalive/tree/master). One of these for example is in order to enforce a TTL on the sockets, which does not seem doable with the current setup.

## Short description of the changes

Allow providing an Agent directly, instead of only providing a way of providing a configuration for the agent. This comes as a change to the OTLPExporterNodeBase class and its' configuration type.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Currently not covered, looking for feedback on how this could be covered. One possibility is to do it via the various extensions on the base class, i.e OTLPTraceExporter?

## Checklist:

- [X] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [X] Documentation has been updated (Updated the types)
