### PR TITLE
fix(exporter-logs-otlp-http): update tsconfigs

### DIFF
--- a/experimental/packages/exporter-logs-otlp-http/tsconfig.esm.json
+++ b/experimental/packages/exporter-logs-otlp-http/tsconfig.esm.json
@@ -13,6 +13,9 @@
       "path": "../../../packages/opentelemetry-core"
     },
     {
+      "path": "../../../packages/opentelemetry-resources"
+    },
+    {
       "path": "../api-logs"
     },
     {

--- a/experimental/packages/exporter-logs-otlp-http/tsconfig.esnext.json
+++ b/experimental/packages/exporter-logs-otlp-http/tsconfig.esnext.json
@@ -13,6 +13,9 @@
       "path": "../../../packages/opentelemetry-core"
     },
     {
+      "path": "../../../packages/opentelemetry-resources"
+    },
+    {
       "path": "../api-logs"
     },
     {

--- a/experimental/packages/exporter-logs-otlp-http/tsconfig.json
+++ b/experimental/packages/exporter-logs-otlp-http/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../../../packages/opentelemetry-core"
     },
     {
+      "path": "../../../packages/opentelemetry-resources"
+    },
+    {
       "path": "../api-logs"
     },
     {
@@ -23,9 +26,6 @@
     },
     {
       "path": "../sdk-logs"
-    },
-    {
-      "path": "../../../packages/opentelemetry-resources"
-    },
+    }
   ]
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Our `tsconfig.json` are out of sync with the ones generated via the `update-ts-versions.js` script. This PR fixes that by regenerating the changes made by the script.

## Type of change

- [ ] internal 
