### PR TITLE
fix(otlp-proto-exporter-base): add missing type import

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :bug: (Bug Fix)
 
 * fix(exporter-logs-otlp-http): set useHex to true [#3875](https://github.com/open-telemetry/opentelemetry-js/pull/3875) @Nico385412
+  fix(otlp-proto-exporter-base): add missing type import [#3937](https://github.com/open-telemetry/opentelemetry-js/pull/3937) @pichlermarc
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/otlp-proto-exporter-base/src/platform/util.ts
+++ b/experimental/packages/otlp-proto-exporter-base/src/platform/util.ts
@@ -16,6 +16,7 @@
 
 import * as root from '../generated/root';
 import { ServiceClientType } from './types';
+import type * as protobuf from 'protobufjs';
 
 export interface ExportRequestType<T, R = T & { toJSON: () => unknown }> {
   create(properties?: T): R;


### PR DESCRIPTION
## Which problem is this PR solving?

See #3921, a type import is missing that causes compilation to fail when using any proto exporters.

Fixes #3921 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing