### PR TITLE
fix(example-opencensus-shim): avoid OpenCensus auto instrumentations

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to experimental packages in this project will be documented 
 
 * fix(exporter-logs-otlp-http): set useHex to true [#3875](https://github.com/open-telemetry/opentelemetry-js/pull/3875) @Nico385412
   fix(otlp-proto-exporter-base): add missing type import [#3937](https://github.com/open-telemetry/opentelemetry-js/pull/3937) @pichlermarc
+* fix(example-opencensus-shim): avoid OpenCensus auto instrumentations [#3951](https://github.com/open-telemetry/opentelemetry-js/pull/3951) @llc1123
 
 ### :books: (Refine Doc)
 

--- a/experimental/examples/opencensus-shim/package.json
+++ b/experimental/examples/opencensus-shim/package.json
@@ -30,7 +30,7 @@
     "@opentelemetry/api": "1.4.1",
     "@opentelemetry/sdk-trace-node": "1.14.0",
     "@opencensus/core": "0.1.0",
-    "@opencensus/nodejs": "0.1.0",
+    "@opencensus/nodejs-base": "0.1.0",
     "@opentelemetry/semantic-conventions": "1.14.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.40.0",
     "@opentelemetry/resources": "1.14.0",

--- a/experimental/examples/opencensus-shim/setup.js
+++ b/experimental/examples/opencensus-shim/setup.js
@@ -29,7 +29,7 @@ const {
 } = require('@opentelemetry/semantic-conventions');
 
 module.exports = function setup(serviceName) {
-  const tracing = require('@opencensus/nodejs');
+  const tracing = require('@opencensus/nodejs-base');
 
   diag.setLogger(new DiagConsoleLogger(), { logLevel: DiagLogLevel.ALL });
   const provider = new NodeTracerProvider({


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Currently the opencensus-shim example imports `@opencensus/nodejs` which also imports `@opencensus/instrumentation-all` and `grpc` and causes build fails on many platforms.

## Short description of the changes

Changed `@opencensus/nodejs` to `@opencensus/nodejs-base` which does not include instrumentations. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Followed the style guidelines of this project
