### PR TITLE
Update the Prometheus Exporter to by Default not Append Timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
-* fix(opentelemetry-exporter-prometheus): Update default PrometheusExporter to not append a timestamp to match the text based exposition format [#3961](https://github.com/open-telemetry/opentelemetry-js/pull/3961) @jacksonweber
+* fix(opentelemetry-exporter-prometheus): Update default PrometheusExporter to not append a timestamp to match the text based exposition format [#3961](https://github.com/open-telemetry/opentelemetry-js/pull/3961) @JacksonWeber
 * fix(sdk-metrics): Update default Histogram's boundary to match OTEL's spec [#3893](https://github.com/open-telemetry/opentelemetry-js/pull/3893/) @chigia001
 * fix(sdk-metrics): preserve startTime for cumulative ExponentialHistograms [#3934](https://github.com/open-telemetry/opentelemetry-js/pull/3934/) @aabmass
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
-* fix(opentelemetry-exporter-prometheus): Update default PrometheusExporter to not append a timestamp to match the text based exposition format [#3463] @jacksonweber
+* fix(opentelemetry-exporter-prometheus): Update default PrometheusExporter to not append a timestamp to match the text based exposition format [#3961](https://github.com/open-telemetry/opentelemetry-js/pull/3961) @jacksonweber
 * fix(sdk-metrics): Update default Histogram's boundary to match OTEL's spec [#3893](https://github.com/open-telemetry/opentelemetry-js/pull/3893/) @chigia001
 * fix(sdk-metrics): preserve startTime for cumulative ExponentialHistograms [#3934](https://github.com/open-telemetry/opentelemetry-js/pull/3934/) @aabmass
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+* fix(opentelemetry-exporter-prometheus): Update default PrometheusExporter to not append a timestamp to match the text based exposition format [#3463] @jacksonweber
 * fix(sdk-metrics): Update default Histogram's boundary to match OTEL's spec [#3893](https://github.com/open-telemetry/opentelemetry-js/pull/3893/) @chigia001
 * fix(sdk-metrics): preserve startTime for cumulative ExponentialHistograms [#3934](https://github.com/open-telemetry/opentelemetry-js/pull/3934/) @aabmass
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -33,7 +33,7 @@ export class PrometheusExporter extends MetricReader {
     port: 9464,
     endpoint: '/metrics',
     prefix: '',
-    appendTimestamp: true,
+    appendTimestamp: false,
   };
 
   private readonly _host?: string;
@@ -206,6 +206,7 @@ export class PrometheusExporter extends MetricReader {
             ...errors
           );
         }
+        console.log(this._serializer.serialize(resourceMetrics));
         response.end(this._serializer.serialize(resourceMetrics));
       },
       err => {

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -206,7 +206,6 @@ export class PrometheusExporter extends MetricReader {
             ...errors
           );
         }
-        console.log(this._serializer.serialize(resourceMetrics));
         response.end(this._serializer.serialize(resourceMetrics));
       },
       err => {

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -176,7 +176,7 @@ export class PrometheusSerializer {
   private _prefix: string | undefined;
   private _appendTimestamp: boolean;
 
-  constructor(prefix?: string, appendTimestamp = true) {
+  constructor(prefix?: string, appendTimestamp = false) {
     if (prefix) {
       this._prefix = prefix + '_';
     }

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -20,12 +20,7 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as http from 'http';
 import { PrometheusExporter } from '../src';
-import {
-  sdkLanguage,
-  sdkName,
-  sdkVersion,
-  serviceName,
-} from './util';
+import { sdkLanguage, sdkName, sdkVersion, serviceName } from './util';
 import { SinonStubbedInstance } from 'sinon';
 
 const infoLine = `target_info{service_name="${serviceName}",telemetry_sdk_language="${sdkLanguage}",telemetry_sdk_name="${sdkName}",telemetry_sdk_version="${sdkVersion}"} 1`;
@@ -285,7 +280,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP counter_total a test description',
         '# TYPE counter_total counter',
-        `counter_total{key1="attributeValue1"} 10`,
+        'counter_total{key1="attributeValue1"} 10',
         '',
       ]);
     });
@@ -315,7 +310,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP metric_observable_gauge a test description',
         '# TYPE metric_observable_gauge gauge',
-        `metric_observable_gauge{pid="123",core="1"} 0.999`,
+        'metric_observable_gauge{pid="123",core="1"} 0.999',
         '',
       ]);
     });
@@ -335,8 +330,8 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP counter_total a test description',
         '# TYPE counter_total counter',
-        `counter_total{counterKey1="attributeValue1"} 10`,
-        `counter_total{counterKey1="attributeValue2"} 20`,
+        'counter_total{counterKey1="attributeValue1"} 10',
+        'counter_total{counterKey1="attributeValue2"} 20',
         '',
       ]);
     });
@@ -384,7 +379,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP counter_total description missing',
         '# TYPE counter_total counter',
-        `counter_total{key1="attributeValue1"} 10`,
+        'counter_total{key1="attributeValue1"} 10',
         '',
       ]);
     });
@@ -401,7 +396,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP counter_bad_name_total description missing',
         '# TYPE counter_bad_name_total counter',
-        `counter_bad_name_total{key1="attributeValue1"} 10`,
+        'counter_bad_name_total{key1="attributeValue1"} 10',
         '',
       ]);
     });
@@ -419,7 +414,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP counter a test description',
         '# TYPE counter gauge',
-        `counter{key1="attributeValue1"} 20`,
+        'counter{key1="attributeValue1"} 20',
         '',
       ]);
     });
@@ -448,7 +443,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP metric_observable_counter a test description',
         '# TYPE metric_observable_counter counter',
-        `metric_observable_counter{key1="attributeValue1"} 20`,
+        'metric_observable_counter{key1="attributeValue1"} 20',
         '',
       ]);
     });
@@ -479,7 +474,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP metric_observable_up_down_counter a test description',
         '# TYPE metric_observable_up_down_counter gauge',
-        `metric_observable_up_down_counter{key1="attributeValue1"} 20`,
+        'metric_observable_up_down_counter{key1="attributeValue1"} 20',
         '',
       ]);
     });
@@ -498,24 +493,24 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP test_histogram a test description',
         '# TYPE test_histogram histogram',
-        `test_histogram_count{key1="attributeValue1"} 1`,
-        `test_histogram_sum{key1="attributeValue1"} 20`,
-        `test_histogram_bucket{key1="attributeValue1",le="0"} 0`,
-        `test_histogram_bucket{key1="attributeValue1",le="5"} 0`,
-        `test_histogram_bucket{key1="attributeValue1",le="10"} 0`,
-        `test_histogram_bucket{key1="attributeValue1",le="25"} 1`,
-        `test_histogram_bucket{key1="attributeValue1",le="50"} 1`,
-        `test_histogram_bucket{key1="attributeValue1",le="75"} 1`,
-        `test_histogram_bucket{key1="attributeValue1",le="100"} 1`,
-        `test_histogram_bucket{key1="attributeValue1",le="250"} 1`,
-        `test_histogram_bucket{key1="attributeValue1",le="500"} 1`,
-        `test_histogram_bucket{key1="attributeValue1",le="750"} 1`,
-        `test_histogram_bucket{key1="attributeValue1",le="1000"} 1`,
-        `test_histogram_bucket{key1="attributeValue1",le="2500"} 1`,
-        `test_histogram_bucket{key1="attributeValue1",le="5000"} 1`,
-        `test_histogram_bucket{key1="attributeValue1",le="7500"} 1`,
-        `test_histogram_bucket{key1="attributeValue1",le="10000"} 1`,
-        `test_histogram_bucket{key1="attributeValue1",le="+Inf"} 1`,
+        'test_histogram_count{key1="attributeValue1"} 1',
+        'test_histogram_sum{key1="attributeValue1"} 20',
+        'test_histogram_bucket{key1="attributeValue1",le="0"} 0',
+        'test_histogram_bucket{key1="attributeValue1",le="5"} 0',
+        'test_histogram_bucket{key1="attributeValue1",le="10"} 0',
+        'test_histogram_bucket{key1="attributeValue1",le="25"} 1',
+        'test_histogram_bucket{key1="attributeValue1",le="50"} 1',
+        'test_histogram_bucket{key1="attributeValue1",le="75"} 1',
+        'test_histogram_bucket{key1="attributeValue1",le="100"} 1',
+        'test_histogram_bucket{key1="attributeValue1",le="250"} 1',
+        'test_histogram_bucket{key1="attributeValue1",le="500"} 1',
+        'test_histogram_bucket{key1="attributeValue1",le="750"} 1',
+        'test_histogram_bucket{key1="attributeValue1",le="1000"} 1',
+        'test_histogram_bucket{key1="attributeValue1",le="2500"} 1',
+        'test_histogram_bucket{key1="attributeValue1",le="5000"} 1',
+        'test_histogram_bucket{key1="attributeValue1",le="7500"} 1',
+        'test_histogram_bucket{key1="attributeValue1",le="10000"} 1',
+        'test_histogram_bucket{key1="attributeValue1",le="+Inf"} 1',
         '',
       ]);
     });
@@ -557,7 +552,7 @@ describe('PrometheusExporter', () => {
                   ...serializedDefaultResourceLines,
                   '# HELP test_prefix_counter_total description missing',
                   '# TYPE test_prefix_counter_total counter',
-                  `test_prefix_counter_total{key1="attributeValue1"} 10`,
+                  'test_prefix_counter_total{key1="attributeValue1"} 10',
                   '',
                 ]);
 
@@ -586,7 +581,7 @@ describe('PrometheusExporter', () => {
                   ...serializedDefaultResourceLines,
                   '# HELP counter_total description missing',
                   '# TYPE counter_total counter',
-                  `counter_total{key1="attributeValue1"} 10`,
+                  'counter_total{key1="attributeValue1"} 10',
                   '',
                 ]);
 
@@ -615,7 +610,7 @@ describe('PrometheusExporter', () => {
                   ...serializedDefaultResourceLines,
                   '# HELP counter_total description missing',
                   '# TYPE counter_total counter',
-                  `counter_total{key1="attributeValue1"} 10`,
+                  'counter_total{key1="attributeValue1"} 10',
                   '',
                 ]);
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -20,7 +20,14 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as http from 'http';
 import { PrometheusExporter } from '../src';
-import { sdkLanguage, sdkName, sdkVersion, serviceName } from './util';
+import {
+  mockHrTime,
+  sdkLanguage,
+  sdkName,
+  sdkVersion,
+  serviceName,
+  mockedHrTimeMs,
+} from './util';
 import { SinonStubbedInstance } from 'sinon';
 
 const infoLine = `target_info{service_name="${serviceName}",telemetry_sdk_language="${sdkLanguage}",telemetry_sdk_name="${sdkName}",telemetry_sdk_version="${sdkVersion}"} 1`;
@@ -32,6 +39,9 @@ const serializedDefaultResourceLines = [
 ];
 
 describe('PrometheusExporter', () => {
+  beforeEach(() => {
+    mockHrTime();
+  });
   afterEach(() => {
     sinon.restore();
   });
@@ -622,10 +632,10 @@ describe('PrometheusExporter', () => {
       );
     });
 
-    it('should export a metric without timestamp', done => {
+    it('should export a metric with timestamp', done => {
       exporter = new PrometheusExporter(
         {
-          appendTimestamp: false,
+          appendTimestamp: true,
         },
         async () => {
           setup(exporter);
@@ -639,7 +649,7 @@ describe('PrometheusExporter', () => {
                   ...serializedDefaultResourceLines,
                   '# HELP counter_total description missing',
                   '# TYPE counter_total counter',
-                  'counter_total{key1="attributeValue1"} 10',
+                  `counter_total{key1="attributeValue1"} 10 ${mockedHrTimeMs}`,
                   '',
                 ]);
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -21,8 +21,6 @@ import * as sinon from 'sinon';
 import * as http from 'http';
 import { PrometheusExporter } from '../src';
 import {
-  mockedHrTimeMs,
-  mockHrTime,
   sdkLanguage,
   sdkName,
   sdkVersion,
@@ -39,9 +37,6 @@ const serializedDefaultResourceLines = [
 ];
 
 describe('PrometheusExporter', () => {
-  beforeEach(() => {
-    mockHrTime();
-  });
   afterEach(() => {
     sinon.restore();
   });
@@ -290,7 +285,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP counter_total a test description',
         '# TYPE counter_total counter',
-        `counter_total{key1="attributeValue1"} 10 ${mockedHrTimeMs}`,
+        `counter_total{key1="attributeValue1"} 10`,
         '',
       ]);
     });
@@ -320,7 +315,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP metric_observable_gauge a test description',
         '# TYPE metric_observable_gauge gauge',
-        `metric_observable_gauge{pid="123",core="1"} 0.999 ${mockedHrTimeMs}`,
+        `metric_observable_gauge{pid="123",core="1"} 0.999`,
         '',
       ]);
     });
@@ -340,8 +335,8 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP counter_total a test description',
         '# TYPE counter_total counter',
-        `counter_total{counterKey1="attributeValue1"} 10 ${mockedHrTimeMs}`,
-        `counter_total{counterKey1="attributeValue2"} 20 ${mockedHrTimeMs}`,
+        `counter_total{counterKey1="attributeValue1"} 10`,
+        `counter_total{counterKey1="attributeValue2"} 20`,
         '',
       ]);
     });
@@ -389,7 +384,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP counter_total description missing',
         '# TYPE counter_total counter',
-        `counter_total{key1="attributeValue1"} 10 ${mockedHrTimeMs}`,
+        `counter_total{key1="attributeValue1"} 10`,
         '',
       ]);
     });
@@ -406,7 +401,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP counter_bad_name_total description missing',
         '# TYPE counter_bad_name_total counter',
-        `counter_bad_name_total{key1="attributeValue1"} 10 ${mockedHrTimeMs}`,
+        `counter_bad_name_total{key1="attributeValue1"} 10`,
         '',
       ]);
     });
@@ -424,7 +419,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP counter a test description',
         '# TYPE counter gauge',
-        `counter{key1="attributeValue1"} 20 ${mockedHrTimeMs}`,
+        `counter{key1="attributeValue1"} 20`,
         '',
       ]);
     });
@@ -453,7 +448,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP metric_observable_counter a test description',
         '# TYPE metric_observable_counter counter',
-        `metric_observable_counter{key1="attributeValue1"} 20 ${mockedHrTimeMs}`,
+        `metric_observable_counter{key1="attributeValue1"} 20`,
         '',
       ]);
     });
@@ -484,7 +479,7 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP metric_observable_up_down_counter a test description',
         '# TYPE metric_observable_up_down_counter gauge',
-        `metric_observable_up_down_counter{key1="attributeValue1"} 20 ${mockedHrTimeMs}`,
+        `metric_observable_up_down_counter{key1="attributeValue1"} 20`,
         '',
       ]);
     });
@@ -503,24 +498,24 @@ describe('PrometheusExporter', () => {
         ...serializedDefaultResourceLines,
         '# HELP test_histogram a test description',
         '# TYPE test_histogram histogram',
-        `test_histogram_count{key1="attributeValue1"} 1 ${mockedHrTimeMs}`,
-        `test_histogram_sum{key1="attributeValue1"} 20 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="0"} 0 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="5"} 0 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="10"} 0 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="25"} 1 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="50"} 1 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="75"} 1 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="100"} 1 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="250"} 1 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="500"} 1 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="750"} 1 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="1000"} 1 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="2500"} 1 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="5000"} 1 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="7500"} 1 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="10000"} 1 ${mockedHrTimeMs}`,
-        `test_histogram_bucket{key1="attributeValue1",le="+Inf"} 1 ${mockedHrTimeMs}`,
+        `test_histogram_count{key1="attributeValue1"} 1`,
+        `test_histogram_sum{key1="attributeValue1"} 20`,
+        `test_histogram_bucket{key1="attributeValue1",le="0"} 0`,
+        `test_histogram_bucket{key1="attributeValue1",le="5"} 0`,
+        `test_histogram_bucket{key1="attributeValue1",le="10"} 0`,
+        `test_histogram_bucket{key1="attributeValue1",le="25"} 1`,
+        `test_histogram_bucket{key1="attributeValue1",le="50"} 1`,
+        `test_histogram_bucket{key1="attributeValue1",le="75"} 1`,
+        `test_histogram_bucket{key1="attributeValue1",le="100"} 1`,
+        `test_histogram_bucket{key1="attributeValue1",le="250"} 1`,
+        `test_histogram_bucket{key1="attributeValue1",le="500"} 1`,
+        `test_histogram_bucket{key1="attributeValue1",le="750"} 1`,
+        `test_histogram_bucket{key1="attributeValue1",le="1000"} 1`,
+        `test_histogram_bucket{key1="attributeValue1",le="2500"} 1`,
+        `test_histogram_bucket{key1="attributeValue1",le="5000"} 1`,
+        `test_histogram_bucket{key1="attributeValue1",le="7500"} 1`,
+        `test_histogram_bucket{key1="attributeValue1",le="10000"} 1`,
+        `test_histogram_bucket{key1="attributeValue1",le="+Inf"} 1`,
         '',
       ]);
     });
@@ -562,7 +557,7 @@ describe('PrometheusExporter', () => {
                   ...serializedDefaultResourceLines,
                   '# HELP test_prefix_counter_total description missing',
                   '# TYPE test_prefix_counter_total counter',
-                  `test_prefix_counter_total{key1="attributeValue1"} 10 ${mockedHrTimeMs}`,
+                  `test_prefix_counter_total{key1="attributeValue1"} 10`,
                   '',
                 ]);
 
@@ -591,7 +586,7 @@ describe('PrometheusExporter', () => {
                   ...serializedDefaultResourceLines,
                   '# HELP counter_total description missing',
                   '# TYPE counter_total counter',
-                  `counter_total{key1="attributeValue1"} 10 ${mockedHrTimeMs}`,
+                  `counter_total{key1="attributeValue1"} 10`,
                   '',
                 ]);
 
@@ -620,7 +615,7 @@ describe('PrometheusExporter', () => {
                   ...serializedDefaultResourceLines,
                   '# HELP counter_total description missing',
                   '# TYPE counter_total counter',
-                  `counter_total{key1="attributeValue1"} 10 ${mockedHrTimeMs}`,
+                  `counter_total{key1="attributeValue1"} 10`,
                   '',
                 ]);
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -179,17 +179,17 @@ describe('PrometheusSerializer', () => {
         );
       });
 
-      it('serialize metric record with sum aggregator without timestamp', async () => {
-        const serializer = new PrometheusSerializer(undefined, false);
+      it('serialize metric record with sum aggregator with timestamp', async () => {
+        const serializer = new PrometheusSerializer(undefined, true);
         const result = await testSerializer(serializer);
         assert.strictEqual(
           result,
-          'test_count{foo1="bar1",foo2="bar2"} 1\n' +
-            'test_sum{foo1="bar1",foo2="bar2"} 5\n' +
-            'test_bucket{foo1="bar1",foo2="bar2",le="1"} 0\n' +
-            'test_bucket{foo1="bar1",foo2="bar2",le="10"} 1\n' +
-            'test_bucket{foo1="bar1",foo2="bar2",le="100"} 1\n' +
-            'test_bucket{foo1="bar1",foo2="bar2",le="+Inf"} 1\n'
+          `test_count{foo1="bar1",foo2="bar2"} 1 ${mockedHrTimeMs}\n` +
+            `test_sum{foo1="bar1",foo2="bar2"} 5 ${mockedHrTimeMs}\n` +
+            `test_bucket{foo1="bar1",foo2="bar2",le="1"} 0 ${mockedHrTimeMs}\n` +
+            `test_bucket{foo1="bar1",foo2="bar2",le="10"} 1 ${mockedHrTimeMs}\n` +
+            `test_bucket{foo1="bar1",foo2="bar2",le="100"} 1 ${mockedHrTimeMs}\n` +
+            `test_bucket{foo1="bar1",foo2="bar2",le="+Inf"} 1 ${mockedHrTimeMs}\n`
         );
       });
     });
@@ -238,15 +238,15 @@ describe('PrometheusSerializer', () => {
         );
       });
 
-      it('should serialize metric record without timestamp', async () => {
-        const serializer = new PrometheusSerializer(undefined, false);
+      it('should serialize metric record with timestamp', async () => {
+        const serializer = new PrometheusSerializer(undefined, true);
         const result = await testSerializer(serializer);
         assert.strictEqual(
           result,
           '# HELP test_total foobar\n' +
             '# TYPE test_total counter\n' +
-            'test_total{val="1"} 1\n' +
-            'test_total{val="2"} 1\n'
+            `test_total{val="1"} 1 ${mockedHrTimeMs}\n` +
+            `test_total{val="2"} 1 ${mockedHrTimeMs}\n`
         );
       });
     });
@@ -292,15 +292,15 @@ describe('PrometheusSerializer', () => {
         );
       });
 
-      it('serialize metric record without timestamp', async () => {
-        const serializer = new PrometheusSerializer(undefined, false);
+      it('serialize metric record with timestamp', async () => {
+        const serializer = new PrometheusSerializer(undefined, true);
         const result = await testSerializer(serializer);
         assert.strictEqual(
           result,
           '# HELP test_total foobar\n' +
             '# TYPE test_total gauge\n' +
-            'test_total{val="1"} 1\n' +
-            'test_total{val="2"} 1\n'
+            `test_total{val="1"} 1 ${mockedHrTimeMs}\n` +
+            `test_total{val="2"} 1 ${mockedHrTimeMs}\n`
         );
       });
     });
@@ -346,15 +346,15 @@ describe('PrometheusSerializer', () => {
         );
       });
 
-      it('serialize metric record without timestamp', async () => {
-        const serializer = new PrometheusSerializer(undefined, false);
+      it('serialize metric record with timestamp', async () => {
+        const serializer = new PrometheusSerializer(undefined, true);
         const result = await testSerializer(serializer);
         assert.strictEqual(
           result,
           '# HELP test_total foobar\n' +
             '# TYPE test_total gauge\n' +
-            'test_total{val="1"} 1\n' +
-            'test_total{val="2"} 1\n'
+            `test_total{val="1"} 1 ${mockedHrTimeMs}\n` +
+            `test_total{val="2"} 1 ${mockedHrTimeMs}\n`
         );
       });
     });

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -118,16 +118,16 @@ describe('PrometheusSerializer', () => {
       it('should serialize metrics with singular data type', async () => {
         const serializer = new PrometheusSerializer();
         const result = await testSerializer(serializer);
-        assert.strictEqual(
-          result,
-          `test_total{foo1="bar1",foo2="bar2"} 1\n`
-        );
+        assert.strictEqual(result, 'test_total{foo1="bar1",foo2="bar2"} 1\n');
       });
 
       it('should serialize metrics with singular data type with timestamp', async () => {
         const serializer = new PrometheusSerializer(undefined, true);
         const result = await testSerializer(serializer);
-        assert.strictEqual(result, `test_total{foo1="bar1",foo2="bar2"} 1 ${mockedHrTimeMs}\n`);
+        assert.strictEqual(
+          result,
+          `test_total{foo1="bar1",foo2="bar2"} 1 ${mockedHrTimeMs}\n`
+        );
       });
     });
 
@@ -170,12 +170,12 @@ describe('PrometheusSerializer', () => {
         const result = await testSerializer(serializer);
         assert.strictEqual(
           result,
-          `test_count{foo1="bar1",foo2="bar2"} 1\n` +
-            `test_sum{foo1="bar1",foo2="bar2"} 5\n` +
-            `test_bucket{foo1="bar1",foo2="bar2",le="1"} 0\n` +
-            `test_bucket{foo1="bar1",foo2="bar2",le="10"} 1\n` +
-            `test_bucket{foo1="bar1",foo2="bar2",le="100"} 1\n` +
-            `test_bucket{foo1="bar1",foo2="bar2",le="+Inf"} 1\n`
+          'test_count{foo1="bar1",foo2="bar2"} 1\n' +
+            'test_sum{foo1="bar1",foo2="bar2"} 5\n' +
+            'test_bucket{foo1="bar1",foo2="bar2",le="1"} 0\n' +
+            'test_bucket{foo1="bar1",foo2="bar2",le="10"} 1\n' +
+            'test_bucket{foo1="bar1",foo2="bar2",le="100"} 1\n' +
+            'test_bucket{foo1="bar1",foo2="bar2",le="+Inf"} 1\n'
         );
       });
 
@@ -233,8 +233,8 @@ describe('PrometheusSerializer', () => {
           result,
           '# HELP test_total foobar\n' +
             '# TYPE test_total counter\n' +
-            `test_total{val="1"} 1\n` +
-            `test_total{val="2"} 1\n`
+            'test_total{val="1"} 1\n' +
+            'test_total{val="2"} 1\n'
         );
       });
 
@@ -287,8 +287,8 @@ describe('PrometheusSerializer', () => {
           result,
           '# HELP test_total foobar\n' +
             '# TYPE test_total gauge\n' +
-            `test_total{val="1"} 1\n` +
-            `test_total{val="2"} 1\n`
+            'test_total{val="1"} 1\n' +
+            'test_total{val="2"} 1\n'
         );
       });
 
@@ -341,8 +341,8 @@ describe('PrometheusSerializer', () => {
           result,
           '# HELP test_total foobar\n' +
             '# TYPE test_total gauge\n' +
-            `test_total{val="1"} 1\n` +
-            `test_total{val="2"} 1\n`
+            'test_total{val="1"} 1\n' +
+            'test_total{val="2"} 1\n'
         );
       });
 
@@ -399,18 +399,18 @@ describe('PrometheusSerializer', () => {
           result,
           '# HELP test foobar\n' +
             '# TYPE test histogram\n' +
-            `test_count{val="1"} 3\n` +
-            `test_sum{val="1"} 175\n` +
-            `test_bucket{val="1",le="1"} 0\n` +
-            `test_bucket{val="1",le="10"} 1\n` +
-            `test_bucket{val="1",le="100"} 2\n` +
-            `test_bucket{val="1",le="+Inf"} 3\n` +
-            `test_count{val="2"} 1\n` +
-            `test_sum{val="2"} 5\n` +
-            `test_bucket{val="2",le="1"} 0\n` +
-            `test_bucket{val="2",le="10"} 1\n` +
-            `test_bucket{val="2",le="100"} 1\n` +
-            `test_bucket{val="2",le="+Inf"} 1\n`
+            'test_count{val="1"} 3\n' +
+            'test_sum{val="1"} 175\n' +
+            'test_bucket{val="1",le="1"} 0\n' +
+            'test_bucket{val="1",le="10"} 1\n' +
+            'test_bucket{val="1",le="100"} 2\n' +
+            'test_bucket{val="1",le="+Inf"} 3\n' +
+            'test_count{val="2"} 1\n' +
+            'test_sum{val="2"} 5\n' +
+            'test_bucket{val="2",le="1"} 0\n' +
+            'test_bucket{val="2",le="10"} 1\n' +
+            'test_bucket{val="2",le="100"} 1\n' +
+            'test_bucket{val="2",le="+Inf"} 1\n'
         );
       });
 
@@ -448,16 +448,16 @@ describe('PrometheusSerializer', () => {
           result,
           '# HELP test foobar\n' +
             '# TYPE test histogram\n' +
-            `test_count{val="1"} 3\n` +
-            `test_bucket{val="1",le="1"} 0\n` +
-            `test_bucket{val="1",le="10"} 1\n` +
-            `test_bucket{val="1",le="100"} 2\n` +
-            `test_bucket{val="1",le="+Inf"} 3\n` +
-            `test_count{val="2"} 1\n` +
-            `test_bucket{val="2",le="1"} 0\n` +
-            `test_bucket{val="2",le="10"} 1\n` +
-            `test_bucket{val="2",le="100"} 1\n` +
-            `test_bucket{val="2",le="+Inf"} 1\n`
+            'test_count{val="1"} 3\n' +
+            'test_bucket{val="1",le="1"} 0\n' +
+            'test_bucket{val="1",le="10"} 1\n' +
+            'test_bucket{val="1",le="100"} 2\n' +
+            'test_bucket{val="1",le="+Inf"} 3\n' +
+            'test_count{val="2"} 1\n' +
+            'test_bucket{val="2",le="1"} 0\n' +
+            'test_bucket{val="2",le="10"} 1\n' +
+            'test_bucket{val="2",le="100"} 1\n' +
+            'test_bucket{val="2",le="+Inf"} 1\n'
         );
       });
     });
@@ -518,7 +518,7 @@ describe('PrometheusSerializer', () => {
           '# HELP test_total description missing\n' +
           `# UNIT test_total ${unitOfMetric}\n` +
           '# TYPE test_total counter\n' +
-          `test_total 1\n`
+          'test_total 1\n'
       );
     });
 
@@ -533,7 +533,7 @@ describe('PrometheusSerializer', () => {
         serializedDefaultResource +
           '# HELP test_total description missing\n' +
           '# TYPE test_total counter\n' +
-          `test_total 1\n`
+          'test_total 1\n'
       );
     });
 
@@ -541,14 +541,14 @@ describe('PrometheusSerializer', () => {
       const serializer = new PrometheusSerializer();
 
       const result = await getCounterResult('test', serializer);
-      assert.strictEqual(result, `test_total 1\n`);
+      assert.strictEqual(result, 'test_total 1\n');
     });
 
     it('should not rename metric of type counter when name contains _total suffix', async () => {
       const serializer = new PrometheusSerializer();
       const result = await getCounterResult('test_total', serializer);
 
-      assert.strictEqual(result, `test_total 1\n`);
+      assert.strictEqual(result, 'test_total 1\n');
     });
   });
 
@@ -594,7 +594,7 @@ describe('PrometheusSerializer', () => {
         counter.add(1);
       });
 
-      assert.strictEqual(result, `test_total 1\n`);
+      assert.strictEqual(result, 'test_total 1\n');
     });
 
     it('should serialize non-string attribute values in JSON representations', async () => {
@@ -615,7 +615,7 @@ describe('PrometheusSerializer', () => {
 
       assert.strictEqual(
         result,
-        `test_total{true="true",false="false",array="[1,null,null,2]",object="{}",Infinity="null",NaN="null",null="null",undefined=""} 1\n`
+        'test_total{true="true",false="false",array="[1,null,null,2]",object="{}",Infinity="null",NaN="null",null="null",undefined=""} 1\n'
       );
     });
 
@@ -662,7 +662,7 @@ describe('PrometheusSerializer', () => {
           'backslashN="\u005c\u005c\u006e",' +
           'backslashDoubleQuote="\u005c\u005c\u005c\u0022",' +
           'backslashLineFeed="\u005c\u005c\u005c\u006e"' +
-          `} 1\n`
+          '} 1\n'
       );
     });
 
@@ -678,10 +678,7 @@ describe('PrometheusSerializer', () => {
         } as unknown as MetricAttributes);
       });
 
-      assert.strictEqual(
-        result,
-        `test_total{account_id="123456"} 1\n`
-      );
+      assert.strictEqual(result, 'test_total{account_id="123456"} 1\n');
     });
   });
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -120,14 +120,14 @@ describe('PrometheusSerializer', () => {
         const result = await testSerializer(serializer);
         assert.strictEqual(
           result,
-          `test_total{foo1="bar1",foo2="bar2"} 1 ${mockedHrTimeMs}\n`
+          `test_total{foo1="bar1",foo2="bar2"} 1\n`
         );
       });
 
-      it('should serialize metrics with singular data type without timestamp', async () => {
-        const serializer = new PrometheusSerializer(undefined, false);
+      it('should serialize metrics with singular data type with timestamp', async () => {
+        const serializer = new PrometheusSerializer(undefined, true);
         const result = await testSerializer(serializer);
-        assert.strictEqual(result, 'test_total{foo1="bar1",foo2="bar2"} 1\n');
+        assert.strictEqual(result, `test_total{foo1="bar1",foo2="bar2"} 1 ${mockedHrTimeMs}\n`);
       });
     });
 
@@ -170,12 +170,12 @@ describe('PrometheusSerializer', () => {
         const result = await testSerializer(serializer);
         assert.strictEqual(
           result,
-          `test_count{foo1="bar1",foo2="bar2"} 1 ${mockedHrTimeMs}\n` +
-            `test_sum{foo1="bar1",foo2="bar2"} 5 ${mockedHrTimeMs}\n` +
-            `test_bucket{foo1="bar1",foo2="bar2",le="1"} 0 ${mockedHrTimeMs}\n` +
-            `test_bucket{foo1="bar1",foo2="bar2",le="10"} 1 ${mockedHrTimeMs}\n` +
-            `test_bucket{foo1="bar1",foo2="bar2",le="100"} 1 ${mockedHrTimeMs}\n` +
-            `test_bucket{foo1="bar1",foo2="bar2",le="+Inf"} 1 ${mockedHrTimeMs}\n`
+          `test_count{foo1="bar1",foo2="bar2"} 1\n` +
+            `test_sum{foo1="bar1",foo2="bar2"} 5\n` +
+            `test_bucket{foo1="bar1",foo2="bar2",le="1"} 0\n` +
+            `test_bucket{foo1="bar1",foo2="bar2",le="10"} 1\n` +
+            `test_bucket{foo1="bar1",foo2="bar2",le="100"} 1\n` +
+            `test_bucket{foo1="bar1",foo2="bar2",le="+Inf"} 1\n`
         );
       });
 
@@ -233,8 +233,8 @@ describe('PrometheusSerializer', () => {
           result,
           '# HELP test_total foobar\n' +
             '# TYPE test_total counter\n' +
-            `test_total{val="1"} 1 ${mockedHrTimeMs}\n` +
-            `test_total{val="2"} 1 ${mockedHrTimeMs}\n`
+            `test_total{val="1"} 1\n` +
+            `test_total{val="2"} 1\n`
         );
       });
 
@@ -287,8 +287,8 @@ describe('PrometheusSerializer', () => {
           result,
           '# HELP test_total foobar\n' +
             '# TYPE test_total gauge\n' +
-            `test_total{val="1"} 1 ${mockedHrTimeMs}\n` +
-            `test_total{val="2"} 1 ${mockedHrTimeMs}\n`
+            `test_total{val="1"} 1\n` +
+            `test_total{val="2"} 1\n`
         );
       });
 
@@ -341,8 +341,8 @@ describe('PrometheusSerializer', () => {
           result,
           '# HELP test_total foobar\n' +
             '# TYPE test_total gauge\n' +
-            `test_total{val="1"} 1 ${mockedHrTimeMs}\n` +
-            `test_total{val="2"} 1 ${mockedHrTimeMs}\n`
+            `test_total{val="1"} 1\n` +
+            `test_total{val="2"} 1\n`
         );
       });
 
@@ -399,18 +399,18 @@ describe('PrometheusSerializer', () => {
           result,
           '# HELP test foobar\n' +
             '# TYPE test histogram\n' +
-            `test_count{val="1"} 3 ${mockedHrTimeMs}\n` +
-            `test_sum{val="1"} 175 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="1",le="1"} 0 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="1",le="10"} 1 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="1",le="100"} 2 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="1",le="+Inf"} 3 ${mockedHrTimeMs}\n` +
-            `test_count{val="2"} 1 ${mockedHrTimeMs}\n` +
-            `test_sum{val="2"} 5 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="2",le="1"} 0 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="2",le="10"} 1 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="2",le="100"} 1 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="2",le="+Inf"} 1 ${mockedHrTimeMs}\n`
+            `test_count{val="1"} 3\n` +
+            `test_sum{val="1"} 175\n` +
+            `test_bucket{val="1",le="1"} 0\n` +
+            `test_bucket{val="1",le="10"} 1\n` +
+            `test_bucket{val="1",le="100"} 2\n` +
+            `test_bucket{val="1",le="+Inf"} 3\n` +
+            `test_count{val="2"} 1\n` +
+            `test_sum{val="2"} 5\n` +
+            `test_bucket{val="2",le="1"} 0\n` +
+            `test_bucket{val="2",le="10"} 1\n` +
+            `test_bucket{val="2",le="100"} 1\n` +
+            `test_bucket{val="2",le="+Inf"} 1\n`
         );
       });
 
@@ -448,16 +448,16 @@ describe('PrometheusSerializer', () => {
           result,
           '# HELP test foobar\n' +
             '# TYPE test histogram\n' +
-            `test_count{val="1"} 3 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="1",le="1"} 0 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="1",le="10"} 1 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="1",le="100"} 2 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="1",le="+Inf"} 3 ${mockedHrTimeMs}\n` +
-            `test_count{val="2"} 1 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="2",le="1"} 0 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="2",le="10"} 1 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="2",le="100"} 1 ${mockedHrTimeMs}\n` +
-            `test_bucket{val="2",le="+Inf"} 1 ${mockedHrTimeMs}\n`
+            `test_count{val="1"} 3\n` +
+            `test_bucket{val="1",le="1"} 0\n` +
+            `test_bucket{val="1",le="10"} 1\n` +
+            `test_bucket{val="1",le="100"} 2\n` +
+            `test_bucket{val="1",le="+Inf"} 3\n` +
+            `test_count{val="2"} 1\n` +
+            `test_bucket{val="2",le="1"} 0\n` +
+            `test_bucket{val="2",le="10"} 1\n` +
+            `test_bucket{val="2",le="100"} 1\n` +
+            `test_bucket{val="2",le="+Inf"} 1\n`
         );
       });
     });
@@ -518,7 +518,7 @@ describe('PrometheusSerializer', () => {
           '# HELP test_total description missing\n' +
           `# UNIT test_total ${unitOfMetric}\n` +
           '# TYPE test_total counter\n' +
-          `test_total 1 ${mockedHrTimeMs}\n`
+          `test_total 1\n`
       );
     });
 
@@ -533,7 +533,7 @@ describe('PrometheusSerializer', () => {
         serializedDefaultResource +
           '# HELP test_total description missing\n' +
           '# TYPE test_total counter\n' +
-          `test_total 1 ${mockedHrTimeMs}\n`
+          `test_total 1\n`
       );
     });
 
@@ -541,14 +541,14 @@ describe('PrometheusSerializer', () => {
       const serializer = new PrometheusSerializer();
 
       const result = await getCounterResult('test', serializer);
-      assert.strictEqual(result, `test_total 1 ${mockedHrTimeMs}\n`);
+      assert.strictEqual(result, `test_total 1\n`);
     });
 
     it('should not rename metric of type counter when name contains _total suffix', async () => {
       const serializer = new PrometheusSerializer();
       const result = await getCounterResult('test_total', serializer);
 
-      assert.strictEqual(result, `test_total 1 ${mockedHrTimeMs}\n`);
+      assert.strictEqual(result, `test_total 1\n`);
     });
   });
 
@@ -594,7 +594,7 @@ describe('PrometheusSerializer', () => {
         counter.add(1);
       });
 
-      assert.strictEqual(result, `test_total 1 ${mockedHrTimeMs}\n`);
+      assert.strictEqual(result, `test_total 1\n`);
     });
 
     it('should serialize non-string attribute values in JSON representations', async () => {
@@ -615,7 +615,7 @@ describe('PrometheusSerializer', () => {
 
       assert.strictEqual(
         result,
-        `test_total{true="true",false="false",array="[1,null,null,2]",object="{}",Infinity="null",NaN="null",null="null",undefined=""} 1 ${mockedHrTimeMs}\n`
+        `test_total{true="true",false="false",array="[1,null,null,2]",object="{}",Infinity="null",NaN="null",null="null",undefined=""} 1\n`
       );
     });
 
@@ -634,7 +634,7 @@ describe('PrometheusSerializer', () => {
 
         assert.strictEqual(
           result,
-          `test{foo1="bar1",foo2="bar2"} ${esac[1]} ${mockedHrTimeMs}\n`
+          `test{foo1="bar1",foo2="bar2"} ${esac[1]}\n`
         );
       }
     });
@@ -662,7 +662,7 @@ describe('PrometheusSerializer', () => {
           'backslashN="\u005c\u005c\u006e",' +
           'backslashDoubleQuote="\u005c\u005c\u005c\u0022",' +
           'backslashLineFeed="\u005c\u005c\u005c\u006e"' +
-          `} 1 ${mockedHrTimeMs}\n`
+          `} 1\n`
       );
     });
 
@@ -680,7 +680,7 @@ describe('PrometheusSerializer', () => {
 
       assert.strictEqual(
         result,
-        `test_total{account_id="123456"} 1 ${mockedHrTimeMs}\n`
+        `test_total{account_id="123456"} 1\n`
       );
     });
   });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This PR amends the Prometheus Exporter to be in line with the [text based exposition format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#text-based-format).

Fixes #3463 

## Short description of the changes
Updates the default mode of the Prometheus Exporter to not append timestamp.

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix (Bringing us up to spec)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] PrometheusExporter.tests
- [x] PrometheusSerializer.tests

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
