### PR TITLE
Fixes detectResources deprecated typos

### DIFF
--- a/packages/opentelemetry-resources/src/detect-resources.ts
+++ b/packages/opentelemetry-resources/src/detect-resources.ts
@@ -26,7 +26,7 @@ import { IResource } from './IResource';
  * does not resolve until all the underlying detectors have resolved, unlike
  * detectResourcesSync.
  *
- * @deprecated use detectResourceSync() instead.
+ * @deprecated use detectResourcesSync() instead.
  * @param config Configuration for resource detection
  */
 export const detectResources = async (


### PR DESCRIPTION
The deprecated message for `detectResources` suggests to use `detectResourceSync()` instead, when the real method is called `detectResourcesSync()` (Resource**s** is plural)