### PR TITLE
fix(sdk-trace-base): log error and dont reject promise  if batch send fail

### DIFF
--- a/experimental/packages/sdk-logs/src/export/BatchLogRecordProcessorBase.ts
+++ b/experimental/packages/sdk-logs/src/export/BatchLogRecordProcessorBase.ts
@@ -101,7 +101,7 @@ export abstract class BatchLogRecordProcessorBase<T extends BufferConfig>
    * for all other cases _flush should be used
    * */
   private _flushAll(): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       const promises = [];
       const batchCount = Math.ceil(
         this._finishedLogRecords.length / this._maxExportBatchSize
@@ -113,7 +113,7 @@ export abstract class BatchLogRecordProcessorBase<T extends BufferConfig>
         .then(() => {
           resolve();
         })
-        .catch(reject);
+        .catch(e => globalErrorHandler(e));
     });
   }
 

--- a/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
@@ -145,7 +145,7 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
    * for all other cases _flush should be used
    * */
   private _flushAll(): Promise<void> {
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       const promises = [];
       // calculate number of batches
       const count = Math.ceil(
@@ -154,11 +154,12 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
       for (let i = 0, j = count; i < j; i++) {
         promises.push(this._flushOneBatch());
       }
+
       Promise.all(promises)
         .then(() => {
           resolve();
         })
-        .catch(reject);
+        .catch(e => globalErrorHandler(e));
     });
   }
 


### PR DESCRIPTION
`BatchSpanProcessorBase`: Do the same for `_flushOneBatch` and `_flushAll`: log exception and don't reject the promise.

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Spans are flushed when switching tabs(visibilitychange). In this scenario:
- inside an angular app
- with zipkin the receiver not up
- if the send request  fails, a rejected promised is returned which is then returned to the angular errorHandler.

When it happens, the errorHandler receives a promise and we get an error like this:
```
Error: Uncaught (in promise): Error: Got unexpected status code from zipkin: 0
Error: Got unexpected status code from zipkin: 0
    at y.onreadystatechange [as __zone_symbol__ON_PROPERTYreadystatechange] (https://xxx/main.63dec52c6a026954.js:1:1203924)
    at XMLHttpRequest.We (https://xxx/polyfills.f94734761644b5ed.js:1:11497)
    at v.invokeTask (https://xxx/polyfills.f94734761644b5ed.js:1:7185)
    at Object.onInvokeTask (https://xxx/main.63dec52c6a026954.js:1:1642148)
    at v.invokeTask (https://xxx/polyfills.f94734761644b5ed.js:1:7106)
    at M.runTask (https://xxx/polyfills.f94734761644b5ed.js:1:2580)
    at m.invokeTask [as invoke] (https://xxx/polyfills.f94734761644b5ed.js:1:8236)
    at Z (https://xxx/polyfills.f94734761644b5ed.js:1:20799)
    at N (https://xxx/polyfills.f94734761644b5ed.js:1:21092)
    at XMLHttpRequest.B (https://xxx/polyfills.f94734761644b5ed.js:1:21358)
    at z (https://xxx/polyfills.f94734761644b5ed.js:1:15956)
    at https://xxx/polyfills.f94734761644b5ed.js:1:15035
    at https://xxx/polyfills.f94734761644b5ed.js:1:15141
    at v.invoke (https://xxx/polyfills.f94734761644b5ed.js:1:6567)
    at Object.onInvoke (https://xxx/main.63dec52c6a026954.js:1:1642333)
    at v.invoke (https://xxx/polyfills.f94734761644b5ed.js:1:6507)
    at M.run (https://xxx/polyfills.f94734761644b5ed.js:1:1963)
    at https://xxx/polyfills.f94734761644b5ed.js:1:16764
    at v.invokeTask (https://xxx/polyfills.f94734761644b5ed.js:1:7185)
    at Object.onInvokeTask (https://xxx/main.63dec52c6a026954.js:1:1642148)
```
## Short description of the changes

The behaviour has been aligned between the periodic batch send and the visibilitychange batch send: in both cases, if the request fails, a log is written and nothing more.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Test suite rerun

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
