### PR TITLE
fix(core): stop rounding to nearest int in hrTimeTo*seconds() functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+* fix(core): stop rounding to nearest int in hrTimeTo*seconds() functions [#4014](https://github.com/open-telemetry/opentelemetry-js/pull/4014/) @aabmass
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/packages/opentelemetry-core/src/common/time.ts
+++ b/packages/opentelemetry-core/src/common/time.ts
@@ -129,7 +129,7 @@ export function hrTimeToNanoseconds(time: api.HrTime): number {
  * @param time
  */
 export function hrTimeToMilliseconds(time: api.HrTime): number {
-  return Math.round(time[0] * 1e3 + time[1] / 1e6);
+  return time[0] * 1e3 + time[1] / 1e6;
 }
 
 /**
@@ -137,7 +137,7 @@ export function hrTimeToMilliseconds(time: api.HrTime): number {
  * @param time
  */
 export function hrTimeToMicroseconds(time: api.HrTime): number {
-  return Math.round(time[0] * 1e6 + time[1] / 1e3);
+  return time[0] * 1e6 + time[1] / 1e3;
 }
 
 /**

--- a/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
+++ b/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
@@ -261,7 +261,7 @@ describe('OpenTracing Shim', () => {
         assert.strictEqual(otSpan.links.length, 1);
         assert.deepStrictEqual(
           hrTimeToMilliseconds(otSpan.startTime),
-          Math.round(now + adjustment + performance.timeOrigin)
+          now + adjustment + performance.timeOrigin
         );
         assert.deepStrictEqual(otSpan.attributes, opentracingOptions.tags);
       });
@@ -495,7 +495,7 @@ describe('OpenTracing Shim', () => {
       const adjustment = otSpan['_performanceOffset'];
       assert.deepStrictEqual(
         hrTimeToMilliseconds(otSpan.endTime),
-        Math.round(now + adjustment + performance.timeOrigin)
+        now + adjustment + performance.timeOrigin
       );
     });
 


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/3986

## Short description of the changes

Remove `Math.round()` calls from `hrTimeTo{Milli,Micro}seconds()` functions in order to preserve higher precision from floating point parts.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Existing tests are all passing
- Would like to test this against contrib repo but not sure how to do that

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated 