### PR TITLE
fix: Replace require with import

### DIFF
--- a/experimental/packages/otlp-proto-exporter-base/src/platform/node/OTLPProtoExporterNodeBase.ts
+++ b/experimental/packages/otlp-proto-exporter-base/src/platform/node/OTLPProtoExporterNodeBase.ts
@@ -22,6 +22,7 @@ import {
   OTLPExporterError,
   OTLPExporterNodeConfigBase,
 } from '@opentelemetry/otlp-exporter-base';
+import { send } from './util';
 
 type SendFn = <ExportItem, ServiceRequest>(
   collector: OTLPProtoExporterNodeBase<ExportItem, ServiceRequest>,
@@ -74,8 +75,6 @@ export abstract class OTLPProtoExporterNodeBase<
       // defer to next tick and lazy load to avoid loading protobufjs too early
       // and making this impossible to be instrumented
       setImmediate(() => {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const { send } = require('./util');
         this._send = send;
         this._sendPromise(objects, onSuccess, onError);
       });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Modernise by replacing `require` with `import`.

This may also solve the following error when running tests that execute instrumented code
that has at least one exporter configured:

    ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
