### PR TITLE
fix: Add otel-api as dev dep for sandbox tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
-fix(opentelemetry-exporter-logs-otlp-http): Add otel-api as dev dep for tests as they are directly importing the api and which is breaking the web-sandbox tests which is using rollup
+* fix(opentelemetry-exporter-logs-otlp-http): Add otel-api as dev dep for tests as they are directly importing the api and which is breaking the web-sandbox tests which is using rollup
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+fix(opentelemetry-exporter-logs-otlp-http): Add otel-api as dev dep for tests as they are directly importing the api and which is breaking the web-sandbox tests which is using rollup
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -72,6 +72,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@babel/core": "7.22.9",
+    "@opentelemetry/api": "1.4.1",
     "@opentelemetry/api-logs": "0.41.1",
     "@opentelemetry/resources": "1.15.1",
     "@types/mocha": "10.0.1",


### PR DESCRIPTION
## Which problem is this PR solving?

This PR is adding the opentelemetry-api as a dev dependency to the exporter-logs-otlp-http as the tests are directly importing the otel-api and this is breaking when importing into the web-sandbox as the used dependency is not listed.

THe web-sandbox is using rollup for is packaging / bundling which requires all direct used dependencies to be listed

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested in a local web-sandbox repo adding the dev dependency and by adding and running all tests in the js repo
