### PR TITLE
fix(ci): don't collect coverage for eol tests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -201,4 +201,9 @@ jobs:
 
       - name: Test
         working-directory: ./api
-        run: npm test
+        # running test:eol as node 8 is not supported anymore by the version of nyc we use, as we don't report coverage
+        # for this step we leave it out.
+        # Details: nyc requires istanbul-lib-report, which silently dropped support for Node.js v8 when going from
+        # 3.0.0 to 3.0.1 by requiring make-dir@^4.0.0 to fix https://github.com/advisories/GHSA-c2qf-rxjj-qqgw.
+        # make-dir does not support Node.js v8 anymore.
+        run: npm run test:eol

--- a/api/package.json
+++ b/api/package.json
@@ -25,6 +25,7 @@
     "lint": "eslint . --ext .ts",
     "test:browser": "karma start --single-run",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
+    "test:eol": "ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "test:webworker": "karma start karma.worker.js --single-run",
     "cycle-check": "dpdm --exit-code circular:1 src/index.ts",
     "version": "node ../scripts/version-update.js",


### PR DESCRIPTION
## Which problem is this PR solving?

`nyc` requires `istanbul-lib-report`, which silently dropped support for Node.js v8 when going from
`3.0.0` to `3.0.1` by requiring make-dir@^4.0.0 to fix https://github.com/advisories/GHSA-c2qf-rxjj-qqgw. `make-dir@4.0.0` does not support Node.js v8 anymore, which causes the eol tests to fail.

As we don't report the coverage in these tests, I opted to run the tests without `nyc` instead of pinning the package (as pinning would mean we're stuck with that version, which may prevent us from updating in the future, even though we don't use it).

## Short description of the changes

- Introduced `test:eol` script which runs tests, but does not run them with `nyc`
- adapted the github workflow to use that script instead

## Type of change

- [x] internal change (does not affect users)
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] manual testing
- [x] running in CI 
