### PR TITLE
Switching to a default import from 'import-in-the-middle'

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -25,7 +25,7 @@ import {
   Hooked,
 } from './RequireInTheMiddleSingleton';
 import type { HookFn } from 'import-in-the-middle';
-import * as ImportInTheMiddle from 'import-in-the-middle';
+import ImportInTheMiddle from 'import-in-the-middle';
 import { InstrumentationModuleDefinition } from './types';
 import { diag } from '@opentelemetry/api';
 import type { OnRequireFn } from 'require-in-the-middle';


### PR DESCRIPTION
## Which problem is this PR solving?

I started a Remix project from scratch. It relies on https://github.com/highlight/highlight, which in turn, relies on OTel.

The Remix bundler pitched a fit about this import: `import * as ImportInTheMiddle from 'import-in-the-middle';`

The Remix bundler didn't like the `*` import. I manually edited the file in my `node_modules` to `import ImportInTheMiddle from 'import-in-the-middle';`. Remix was happy and everything bundled up nicely.

Fixes #3954 

## Short description of the changes

Changed a single import statement.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This change works on a local project of mine that depends on OTel.
