### PR TITLE
chore(exporter-logs-otlp-http): commit missing generated changes to tsconfig.json

### DIFF
--- a/experimental/packages/exporter-logs-otlp-http/tsconfig.esm.json
+++ b/experimental/packages/exporter-logs-otlp-http/tsconfig.esm.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../../api"
+    },
+    {
       "path": "../../../packages/opentelemetry-core"
     },
     {

--- a/experimental/packages/exporter-logs-otlp-http/tsconfig.esnext.json
+++ b/experimental/packages/exporter-logs-otlp-http/tsconfig.esnext.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../../api"
+    },
+    {
       "path": "../../../packages/opentelemetry-core"
     },
     {

--- a/experimental/packages/exporter-logs-otlp-http/tsconfig.json
+++ b/experimental/packages/exporter-logs-otlp-http/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../../api"
+    },
+    {
       "path": "../../../packages/opentelemetry-core"
     },
     {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Running `npm install && npm run compile` in the repo at HEAD is missing some generated changes.

## Short description of the changes

Ran `git clean -fdx && npm install && npm run compile` at HEAD in the repo to re-generate files. This must have been missed from a previous commit.

## Type of change

Please delete options that are not relevant.

- chore

## How Has This Been Tested?

N/A

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated 