### PR TITLE
chore: prepare release 1.15.2/0.41.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,16 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
-* fix(opentelemetry-exporter-logs-otlp-http): Add otel-api as dev dep for tests as they are directly importing the api and which is breaking the web-sandbox tests which is using rollup
-* fix(core): stop rounding to nearest int in hrTimeTo*seconds() functions [#4014](https://github.com/open-telemetry/opentelemetry-js/pull/4014/) @aabmass
-* fix(sdk-metrics): ignore invalid metric values [#3988](https://github.com/open-telemetry/opentelemetry-js/pull/3988) @legendecas
-
 ### :books: (Refine Doc)
 
 ### :house: (Internal)
+
+## 1.15.2
+
+### :bug: (Bug Fix)
+
+* fix(core): stop rounding to nearest int in hrTimeTo*seconds() functions [#4014](https://github.com/open-telemetry/opentelemetry-js/pull/4014/) @aabmass
+* fix(sdk-metrics): ignore invalid metric values [#3988](https://github.com/open-telemetry/opentelemetry-js/pull/3988) @legendecas
 
 ## 1.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 * fix(core): stop rounding to nearest int in hrTimeTo*seconds() functions [#4014](https://github.com/open-telemetry/opentelemetry-js/pull/4014/) @aabmass
 * fix(sdk-metrics): ignore invalid metric values [#3988](https://github.com/open-telemetry/opentelemetry-js/pull/3988) @legendecas
+* fix(core): add baggage support for values containing an equals sign [#3975](https://github.com/open-telemetry/opentelemetry-js/pull/3975) @krosenk729
 
 ## 1.15.1
 
@@ -39,7 +40,6 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * fix(sdk-metrics): Update default Histogram's boundary to match OTEL's spec [#3893](https://github.com/open-telemetry/opentelemetry-js/pull/3893/) @chigia001
 * fix(sdk-metrics): preserve startTime for cumulative ExponentialHistograms [#3934](https://github.com/open-telemetry/opentelemetry-js/pull/3934/) @aabmass
 * fix(sdk-trace-web): add secureConnectionStart to https only [#3879](https://github.com/open-telemetry/opentelemetry-js/pull/3879) @Abinet18
-* fix(core): add baggage support for values containing an equals sign [#3975](https://github.com/open-telemetry/opentelemetry-js/pull/3975) @krosenk729
 
 ### :house: (Internal)
 

--- a/examples/esm-http-ts/package.json
+++ b/examples/esm-http-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esm-http-ts",
   "private": true,
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "Example of HTTP integration with OpenTelemetry using ESM and TypeScript",
   "main": "build/index.js",
   "type": "module",
@@ -31,12 +31,12 @@
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/",
   "dependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.41.1",
-    "@opentelemetry/instrumentation": "0.41.1",
-    "@opentelemetry/instrumentation-http": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
-    "@opentelemetry/sdk-trace-node": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/exporter-trace-otlp-proto": "0.41.2",
+    "@opentelemetry/instrumentation": "0.41.2",
+    "@opentelemetry/instrumentation-http": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
+    "@opentelemetry/sdk-trace-node": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   }
 }

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-example",
   "private": true,
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "Example of HTTP integration with OpenTelemetry",
   "main": "index.js",
   "scripts": {
@@ -29,14 +29,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-jaeger": "1.15.1",
-    "@opentelemetry/exporter-zipkin": "1.15.1",
-    "@opentelemetry/instrumentation": "0.41.1",
-    "@opentelemetry/instrumentation-http": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
-    "@opentelemetry/sdk-trace-node": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/exporter-jaeger": "1.15.2",
+    "@opentelemetry/exporter-zipkin": "1.15.2",
+    "@opentelemetry/instrumentation": "0.41.2",
+    "@opentelemetry/instrumentation-http": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
+    "@opentelemetry/sdk-trace-node": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/http",
   "devDependencies": {

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,7 +1,7 @@
 {
   "name": "https-example",
   "private": true,
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "Example of HTTPs integration with OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -33,14 +33,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/exporter-jaeger": "1.15.1",
-    "@opentelemetry/exporter-zipkin": "1.15.1",
-    "@opentelemetry/instrumentation": "0.41.1",
-    "@opentelemetry/instrumentation-http": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
-    "@opentelemetry/sdk-trace-node": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/exporter-jaeger": "1.15.2",
+    "@opentelemetry/exporter-zipkin": "1.15.2",
+    "@opentelemetry/instrumentation": "0.41.2",
+    "@opentelemetry/instrumentation-http": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
+    "@opentelemetry/sdk-trace-node": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-opentelemetry-example",
   "private": true,
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "Example of using @opentelemetry/sdk-trace-web and @opentelemetry/sdk-metrics in browser",
   "main": "index.js",
   "scripts": {
@@ -43,20 +43,20 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/context-zone": "1.15.1",
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.41.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.41.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.41.1",
-    "@opentelemetry/exporter-zipkin": "1.15.1",
-    "@opentelemetry/instrumentation": "0.41.1",
-    "@opentelemetry/instrumentation-fetch": "0.41.1",
-    "@opentelemetry/instrumentation-xml-http-request": "0.41.1",
-    "@opentelemetry/propagator-b3": "1.15.1",
-    "@opentelemetry/sdk-metrics": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
-    "@opentelemetry/sdk-trace-web": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/context-zone": "1.15.2",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.41.2",
+    "@opentelemetry/exporter-trace-otlp-http": "0.41.2",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.41.2",
+    "@opentelemetry/exporter-zipkin": "1.15.2",
+    "@opentelemetry/instrumentation": "0.41.2",
+    "@opentelemetry/instrumentation-fetch": "0.41.2",
+    "@opentelemetry/instrumentation-xml-http-request": "0.41.2",
+    "@opentelemetry/propagator-b3": "1.15.2",
+    "@opentelemetry/sdk-metrics": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
+    "@opentelemetry/sdk-trace-web": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web"
 }

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-otlp-exporter-node",
   "private": true,
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
@@ -29,17 +29,17 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.41.1",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.41.1",
-    "@opentelemetry/exporter-metrics-otlp-proto": "0.41.1",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.41.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.41.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-metrics": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.41.2",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.41.2",
+    "@opentelemetry/exporter-metrics-otlp-proto": "0.41.2",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.41.2",
+    "@opentelemetry/exporter-trace-otlp-http": "0.41.2",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-metrics": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/otlp-exporter-node"
 }

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,11 +12,15 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
-### :bug: (Bug Fix)
-
 ### :books: (Refine Doc)
 
 ### :house: (Internal)
+
+## 0.42.2
+
+### :bug: (Bug Fix)
+
+* fix(opentelemetry-exporter-logs-otlp-http): Add otel-api as dev dep for tests as they are directly importing the api and which is breaking the web-sandbox tests which is using rollup
 
 ## 0.41.1
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :bug: (Bug Fix)
 
 * fix(opentelemetry-exporter-logs-otlp-http): Add otel-api as dev dep for tests as they are directly importing the api and which is breaking the web-sandbox tests which is using rollup
+* fix(instrumentation-grpc): instrument @grpc/grpc-js Client methods [#3804](https://github.com/open-telemetry/opentelemetry-js/pull/3804) @pichlermarc
 
 ## 0.41.1
 
@@ -85,7 +86,6 @@ All notable changes to experimental packages in this project will be documented 
 
 * fix(sdk-node): use resource interface instead of concrete class [#3803](https://github.com/open-telemetry/opentelemetry-js/pull/3803) @blumamir
 * fix(sdk-logs): remove includeTraceContext configuration and use LogRecord context when available  [#3817](https://github.com/open-telemetry/opentelemetry-js/pull/3817) @hectorhdzg
-* fix(instrumentation-grpc): instrument @grpc/grpc-js Client methods [#3804](https://github.com/open-telemetry/opentelemetry-js/pull/3804) @pichlermarc
 
 ## 0.39.1
 

--- a/experimental/backwards-compatibility/node14/package.json
+++ b/experimental/backwards-compatibility/node14/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node14",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "private": true,
   "description": "Backwards compatibility app for node 14 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.41.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1"
+    "@opentelemetry/sdk-node": "0.41.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2"
   },
   "devDependencies": {
     "@types/node": "14.18.25",

--- a/experimental/backwards-compatibility/node16/package.json
+++ b/experimental/backwards-compatibility/node16/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node16",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "private": true,
   "description": "Backwards compatibility app for node 16 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.41.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1"
+    "@opentelemetry/sdk-node": "0.41.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2"
   },
   "devDependencies": {
     "@types/node": "16.11.52",

--- a/experimental/examples/logs/package.json
+++ b/experimental/examples/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logs-example",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "private": true,
   "scripts": {
     "start": "ts-node index.ts"

--- a/experimental/examples/opencensus-shim/package.json
+++ b/experimental/examples/opencensus-shim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencensus-shim",
   "private": true,
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "Example of using @opentelemetry/shim-opencensus in Node.js",
   "main": "index.js",
   "scripts": {
@@ -30,11 +30,11 @@
     "@opencensus/core": "0.1.0",
     "@opencensus/nodejs-base": "0.1.0",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-trace-node": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1",
-    "@opentelemetry/shim-opencensus": "0.41.1"
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-trace-node": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2",
+    "@opentelemetry/shim-opencensus": "0.41.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/examples/opencensus-shim"
 }

--- a/experimental/examples/prometheus/package.json
+++ b/experimental/examples/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prometheus-example",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "private": true,
   "description": "Example of using @opentelemetry/sdk-metrics and @opentelemetry/exporter-prometheus",
   "main": "index.js",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-prometheus": "0.41.1",
-    "@opentelemetry/sdk-metrics": "1.15.1"
+    "@opentelemetry/exporter-prometheus": "0.41.2",
+    "@opentelemetry/sdk-metrics": "1.15.2"
   }
 }

--- a/experimental/packages/api-events/package.json
+++ b/experimental/packages/api-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-events",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "Public events API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/api-logs/package.json
+++ b/experimental/packages/api-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-logs",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "Public logs API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-grpc",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry Collector Exporter allows user to send collected log records to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -51,9 +51,9 @@
     "@babel/core": "7.22.9",
     "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/api-logs": "0.41.1",
-    "@opentelemetry/otlp-exporter-base": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
+    "@opentelemetry/api-logs": "0.41.2",
+    "@opentelemetry/otlp-exporter-base": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.16",
@@ -73,10 +73,10 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.41.1",
-    "@opentelemetry/otlp-transformer": "0.41.1",
-    "@opentelemetry/sdk-logs": "0.41.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.41.2",
+    "@opentelemetry/otlp-transformer": "0.41.2",
+    "@opentelemetry/sdk-logs": "0.41.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-http",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "publishConfig": {
     "access": "public"
   },
@@ -73,8 +73,8 @@
   "devDependencies": {
     "@babel/core": "7.22.9",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/api-logs": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
+    "@opentelemetry/api-logs": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.16",
@@ -105,9 +105,9 @@
     "@opentelemetry/api-logs": ">=0.38.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/otlp-exporter-base": "0.41.1",
-    "@opentelemetry/otlp-transformer": "0.41.1",
-    "@opentelemetry/sdk-logs": "0.41.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/otlp-exporter-base": "0.41.2",
+    "@opentelemetry/otlp-transformer": "0.41.2",
+    "@opentelemetry/sdk-logs": "0.41.2"
   }
 }

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-proto",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "An OTLP exporter to send logs using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,14 +93,14 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.41.1",
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/otlp-exporter-base": "0.41.1",
-    "@opentelemetry/otlp-proto-exporter-base": "0.41.1",
-    "@opentelemetry/otlp-transformer": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-logs": "0.41.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1"
+    "@opentelemetry/api-logs": "0.41.2",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/otlp-exporter-base": "0.41.2",
+    "@opentelemetry/otlp-proto-exporter-base": "0.41.2",
+    "@opentelemetry/otlp-transformer": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-logs": "0.41.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-grpc",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,7 +50,7 @@
     "@babel/core": "7.22.9",
     "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/otlp-exporter-base": "0.41.1",
+    "@opentelemetry/otlp-exporter-base": "0.41.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.16",
@@ -70,11 +70,11 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.41.1",
-    "@opentelemetry/otlp-transformer": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.41.2",
+    "@opentelemetry/otlp-transformer": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-http",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry Collector Trace Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -95,11 +95,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/otlp-exporter-base": "0.41.1",
-    "@opentelemetry/otlp-transformer": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/otlp-exporter-base": "0.41.2",
+    "@opentelemetry/otlp-transformer": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-proto",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -92,12 +92,12 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/otlp-exporter-base": "0.41.1",
-    "@opentelemetry/otlp-proto-exporter-base": "0.41.1",
-    "@opentelemetry/otlp-transformer": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/otlp-exporter-base": "0.41.2",
+    "@opentelemetry/otlp-proto-exporter-base": "0.41.2",
+    "@opentelemetry/otlp-transformer": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/opentelemetry-browser-detector",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry Resource Detector for Browser",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -82,8 +82,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/browser-detector"
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -69,12 +69,12 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.41.1",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.41.1",
-    "@opentelemetry/otlp-transformer": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-metrics": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.41.2",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.41.2",
+    "@opentelemetry/otlp-transformer": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-metrics": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-http",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -95,11 +95,11 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/otlp-exporter-base": "0.41.1",
-    "@opentelemetry/otlp-transformer": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-metrics": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/otlp-exporter-base": "0.41.2",
+    "@opentelemetry/otlp-transformer": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-metrics": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-proto",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -67,13 +67,13 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.41.1",
-    "@opentelemetry/otlp-exporter-base": "0.41.1",
-    "@opentelemetry/otlp-proto-exporter-base": "0.41.1",
-    "@opentelemetry/otlp-transformer": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-metrics": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.41.2",
+    "@opentelemetry/otlp-exporter-base": "0.41.2",
+    "@opentelemetry/otlp-proto-exporter-base": "0.41.2",
+    "@opentelemetry/otlp-transformer": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-metrics": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/semantic-conventions": "1.15.1",
+    "@opentelemetry/semantic-conventions": "1.15.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.16",
@@ -61,9 +61,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-metrics": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-metrics": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-prometheus",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-fetch",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry fetch automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.22.9",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-zone": "1.15.1",
-    "@opentelemetry/propagator-b3": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
+    "@opentelemetry/context-zone": "1.15.2",
+    "@opentelemetry/propagator-b3": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.16",
@@ -88,10 +88,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/instrumentation": "0.41.1",
-    "@opentelemetry/sdk-trace-web": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/instrumentation": "0.41.2",
+    "@opentelemetry/sdk-trace-web": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-grpc",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry grpc automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -47,16 +47,16 @@
   },
   "devDependencies": {
     "@bufbuild/buf": "1.21.0-1",
-    "@protobuf-ts/grpc-transport": "2.9.1",
-    "@protobuf-ts/runtime-rpc": "2.9.1",
-    "@protobuf-ts/runtime": "2.9.1",
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.3",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-async-hooks": "1.15.1",
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
-    "@opentelemetry/sdk-trace-node": "1.15.1",
+    "@opentelemetry/context-async-hooks": "1.15.2",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
+    "@opentelemetry/sdk-trace-node": "1.15.2",
+    "@protobuf-ts/grpc-transport": "2.9.1",
+    "@protobuf-ts/runtime": "2.9.1",
+    "@protobuf-ts/runtime-rpc": "2.9.1",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.0",
@@ -75,8 +75,8 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "0.41.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/instrumentation": "0.41.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-http",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry http/https automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,10 +46,10 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-async-hooks": "1.15.1",
-    "@opentelemetry/sdk-metrics": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
-    "@opentelemetry/sdk-trace-node": "1.15.1",
+    "@opentelemetry/context-async-hooks": "1.15.2",
+    "@opentelemetry/sdk-metrics": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
+    "@opentelemetry/sdk-trace-node": "1.15.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/request-promise-native": "1.0.18",
@@ -74,9 +74,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/instrumentation": "0.41.1",
-    "@opentelemetry/semantic-conventions": "1.15.1",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/instrumentation": "0.41.2",
+    "@opentelemetry/semantic-conventions": "1.15.2",
     "semver": "^7.5.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http",

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-xml-http-request",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry XMLHttpRequest automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.22.9",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-zone": "1.15.1",
-    "@opentelemetry/propagator-b3": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
+    "@opentelemetry/context-zone": "1.15.2",
+    "@opentelemetry/propagator-b3": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.16",
@@ -88,10 +88,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/instrumentation": "0.41.1",
-    "@opentelemetry/sdk-trace-web": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/instrumentation": "0.41.2",
+    "@opentelemetry/sdk-trace-web": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "Base class for node which OpenTelemetry instrumentation modules extend",
   "author": "OpenTelemetry Authors",
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation",
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@babel/core": "7.22.9",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/sdk-metrics": "1.15.1",
+    "@opentelemetry/sdk-metrics": "1.15.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.0",

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-node",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry SDK for Node.js",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,27 +44,27 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.41.1",
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/exporter-jaeger": "1.15.1",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.41.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.41.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.41.1",
-    "@opentelemetry/exporter-zipkin": "1.15.1",
-    "@opentelemetry/instrumentation": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-logs": "0.41.1",
-    "@opentelemetry/sdk-metrics": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
-    "@opentelemetry/sdk-trace-node": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/api-logs": "0.41.2",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/exporter-jaeger": "1.15.2",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.41.2",
+    "@opentelemetry/exporter-trace-otlp-http": "0.41.2",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.41.2",
+    "@opentelemetry/exporter-zipkin": "1.15.2",
+    "@opentelemetry/instrumentation": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-logs": "0.41.2",
+    "@opentelemetry/sdk-metrics": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
+    "@opentelemetry/sdk-trace-node": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.3.0 <1.5.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-async-hooks": "1.15.1",
+    "@opentelemetry/context-async-hooks": "1.15.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.0",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-exporter-base",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry OTLP Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1"
+    "@opentelemetry/core": "1.15.2"
   },
   "devDependencies": {
     "@babel/core": "7.22.9",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-grpc-exporter-base",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry OTLP-gRPC Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,9 +50,9 @@
   "devDependencies": {
     "@babel/core": "7.22.9",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/otlp-transformer": "0.41.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
+    "@opentelemetry/otlp-transformer": "0.41.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.16",
@@ -73,8 +73,8 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/otlp-exporter-base": "0.41.1",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/otlp-exporter-base": "0.41.2",
     "protobufjs": "^7.2.3"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-grpc-exporter-base",

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-proto-exporter-base",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenTelemetry OTLP-HTTP-protobuf Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -79,8 +79,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/otlp-exporter-base": "0.41.1",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/otlp-exporter-base": "0.41.2",
     "protobufjs": "^7.2.3"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-proto-exporter-base",

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "Transform OpenTelemetry SDK data into OTLP",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
@@ -78,12 +78,12 @@
     "webpack": "4.46.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.41.1",
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-logs": "0.41.1",
-    "@opentelemetry/sdk-metrics": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1"
+    "@opentelemetry/api-logs": "0.41.2",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-logs": "0.41.2",
+    "@opentelemetry/sdk-metrics": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-transformer",
   "sideEffects": false

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-logs",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "publishConfig": {
     "access": "public"
   },
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@babel/core": "7.22.9",
     "@opentelemetry/api": ">=1.4.0 <1.5.0",
-    "@opentelemetry/api-logs": "0.41.1",
+    "@opentelemetry/api-logs": "0.41.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.16",
@@ -99,7 +99,7 @@
     "webpack-merge": "5.9.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/resources": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/resources": "1.15.2"
   }
 }

--- a/experimental/packages/shim-opencensus/package.json
+++ b/experimental/packages/shim-opencensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opencensus",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "description": "OpenCensus to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,8 +50,8 @@
   "devDependencies": {
     "@opencensus/core": "0.1.0",
     "@opentelemetry/api": "1.4.1",
-    "@opentelemetry/context-async-hooks": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
+    "@opentelemetry/context-async-hooks": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.16",
@@ -69,7 +69,7 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
+    "@opentelemetry/core": "1.15.2",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.1"
   },

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.15.1",
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
+    "@opentelemetry/context-async-hooks": "1.15.2",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
     "axios": "1.4.0",
     "body-parser": "1.19.0",
     "express": "4.17.3"

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -75,7 +75,7 @@
     "webpack-merge": "5.9.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.15.1",
+    "@opentelemetry/context-zone-peer-dep": "1.15.2",
     "zone.js": "^0.11.0"
   },
   "sideEffects": true,

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,7 +91,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core",
   "sideEffects": false

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/resources": "1.15.1",
+    "@opentelemetry/resources": "1.15.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.16",
@@ -63,9 +63,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2",
     "jaeger-client": "^3.15.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -92,10 +92,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin",
   "sideEffects": false

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1"
+    "@opentelemetry/core": "1.15.2"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.5.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -81,7 +81,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1"
+    "@opentelemetry/core": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger",
   "sideEffects": false

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,8 +91,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,9 +93,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.5.0",
-    "@opentelemetry/resources": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1",
+    "@opentelemetry/resources": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.0",
@@ -65,11 +65,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.15.1",
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/propagator-b3": "1.15.1",
-    "@opentelemetry/propagator-jaeger": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
+    "@opentelemetry/context-async-hooks": "1.15.2",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/propagator-b3": "1.15.2",
+    "@opentelemetry/propagator-jaeger": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
     "semver": "^7.5.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,9 +57,9 @@
   "devDependencies": {
     "@babel/core": "7.22.9",
     "@opentelemetry/api": ">=1.0.0 <1.5.0",
-    "@opentelemetry/context-zone": "1.15.1",
-    "@opentelemetry/propagator-b3": "1.15.1",
-    "@opentelemetry/resources": "1.15.1",
+    "@opentelemetry/context-zone": "1.15.2",
+    "@opentelemetry/propagator-b3": "1.15.2",
+    "@opentelemetry/resources": "1.15.2",
     "@types/jquery": "3.5.16",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
@@ -92,9 +92,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1"
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web",
   "sideEffects": false

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -43,9 +43,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.5.0",
-    "@opentelemetry/propagator-b3": "1.15.1",
-    "@opentelemetry/propagator-jaeger": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
+    "@opentelemetry/propagator-b3": "1.15.2",
+    "@opentelemetry/propagator-jaeger": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
@@ -60,8 +60,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/semantic-conventions": "1.15.1",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/semantic-conventions": "1.15.2",
     "opentracing": "^0.14.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing",

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -84,8 +84,8 @@
     "@opentelemetry/api": ">=1.3.0 <1.5.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/resources": "1.15.1",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/resources": "1.15.2",
     "lodash.merge": "^4.6.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-metrics",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
@@ -56,16 +56,16 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.15.1",
-    "@opentelemetry/core": "1.15.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.41.1",
-    "@opentelemetry/exporter-zipkin": "1.15.1",
-    "@opentelemetry/instrumentation": "0.41.1",
-    "@opentelemetry/instrumentation-fetch": "0.41.1",
-    "@opentelemetry/instrumentation-xml-http-request": "0.41.1",
-    "@opentelemetry/sdk-metrics": "1.15.1",
-    "@opentelemetry/sdk-trace-base": "1.15.1",
-    "@opentelemetry/sdk-trace-web": "1.15.1",
+    "@opentelemetry/context-zone-peer-dep": "1.15.2",
+    "@opentelemetry/core": "1.15.2",
+    "@opentelemetry/exporter-trace-otlp-http": "0.41.2",
+    "@opentelemetry/exporter-zipkin": "1.15.2",
+    "@opentelemetry/instrumentation": "0.41.2",
+    "@opentelemetry/instrumentation-fetch": "0.41.2",
+    "@opentelemetry/instrumentation-xml-http-request": "0.41.2",
+    "@opentelemetry/sdk-metrics": "1.15.2",
+    "@opentelemetry/sdk-trace-base": "1.15.2",
+    "@opentelemetry/sdk-trace-web": "1.15.2",
     "zone.js": "0.11.4"
   }
 }


### PR DESCRIPTION
## 1.15.2

### :bug: (Bug Fix)

* fix(core): stop rounding to nearest int in hrTimeTo*seconds() functions [#4014](https://github.com/open-telemetry/opentelemetry-js/pull/4014/) @aabmass
* fix(sdk-metrics): ignore invalid metric values [#3988](https://github.com/open-telemetry/opentelemetry-js/pull/3988) @legendecas
* fix(core): add baggage support for values containing an equals sign [#3975](https://github.com/open-telemetry/opentelemetry-js/pull/3975) @krosenk729

## 0.42.2

### :bug: (Bug Fix)

* fix(opentelemetry-exporter-logs-otlp-http): Add otel-api as dev dep for tests as they are directly importing the api and which is breaking the web-sandbox tests which is using rollup
* fix(instrumentation-grpc): instrument @grpc/grpc-js Client methods [#3804](https://github.com/open-telemetry/opentelemetry-js/pull/3804) @pichlermarc

