### PR TITLE
feat(exporter-trace-otlp-http): allow dynamic http headers (rebased)

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -153,6 +153,7 @@ All notable changes to experimental packages in this project will be documented 
 * feat(otlp-exporter-base): add retries [#3207](https://github.com/open-telemetry/opentelemetry-js/pull/3207) @svetlanabrennan
 * feat(sdk-node): override IdGenerator when using NodeSDK [#3645](https://github.com/open-telemetry/opentelemetry-js/pull/3645) @haddasbronfman
 * feat(otlp-transformer): expose dropped attributes, events and links counts on the transformed otlp span [#3576](https://github.com/open-telemetry/opentelemetry-js/pull/3576) @mohitk05
+* feat(exporter-trace-otlp-http): allow dynamic headers in HTTP exporter [#2903](https://github.com/open-telemetry/opentelemetry-js/issues/2903)
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/exporter-trace-otlp-http/test/browser/CollectorTraceExporter.test.ts
+++ b/experimental/packages/exporter-trace-otlp-http/test/browser/CollectorTraceExporter.test.ts
@@ -374,18 +374,31 @@ describe('OTLPTraceExporter - web', () => {
 
         collectorTraceExporter = new OTLPTraceExporter(collectorExporterConfig);
       });
-      it('should successfully send custom headers using XMLHTTPRequest', done => {
-        collectorTraceExporter.export(spans, () => {});
 
-        queueMicrotask(() => {
-          const [{ requestHeaders }] = server.requests;
+      const tests = [{ withStaticHeaders: true }, { withStaticHeaders: false }];
+      tests.forEach(({ withStaticHeaders }) => {
+        it(`should successfully send custom ${
+          withStaticHeaders ? '' : 'dynamic '
+        } headers using XMLHTTPRequest`, done => {
+          const collectorExporterConfigWithHeaders = {
+            headers: withStaticHeaders ? customHeaders : () => customHeaders,
+          };
+          const collectorTraceExporterWithHeaders = new OTLPTraceExporter(
+            collectorExporterConfigWithHeaders
+          );
 
-          ensureHeadersContain(requestHeaders, customHeaders);
-          assert.strictEqual(stubBeacon.callCount, 0);
-          assert.strictEqual(stubOpen.callCount, 0);
+          collectorTraceExporterWithHeaders.export(spans, () => {});
 
-          clock.restore();
-          done();
+          queueMicrotask(() => {
+            const [{ requestHeaders }] = server.requests;
+
+            ensureHeadersContain(requestHeaders, customHeaders);
+            assert.strictEqual(stubBeacon.callCount, 0);
+            assert.strictEqual(stubOpen.callCount, 0);
+
+            clock.restore();
+            done();
+          });
         });
       });
     });
@@ -401,18 +414,30 @@ describe('OTLPTraceExporter - web', () => {
         collectorTraceExporter = new OTLPTraceExporter(collectorExporterConfig);
       });
 
-      it('should successfully send spans using XMLHttpRequest', done => {
-        collectorTraceExporter.export(spans, () => {});
+      const tests = [{ withStaticHeaders: true }, { withStaticHeaders: false }];
+      tests.forEach(({ withStaticHeaders }) => {
+        it(`should successfully send spans using XMLHttpRequest with custom ${
+          withStaticHeaders ? '' : 'dynamic '
+        } headers`, done => {
+          const collectorExporterConfigWithHeaders = {
+            headers: withStaticHeaders ? customHeaders : () => customHeaders,
+          };
+          const collectorTraceExporterWithHeaders = new OTLPTraceExporter(
+            collectorExporterConfigWithHeaders
+          );
 
-        queueMicrotask(() => {
-          const [{ requestHeaders }] = server.requests;
+          collectorTraceExporterWithHeaders.export(spans, () => {});
 
-          ensureHeadersContain(requestHeaders, customHeaders);
-          assert.strictEqual(stubBeacon.callCount, 0);
-          assert.strictEqual(stubOpen.callCount, 0);
+          queueMicrotask(() => {
+            const [{ requestHeaders }] = server.requests;
 
-          clock.restore();
-          done();
+            ensureHeadersContain(requestHeaders, customHeaders);
+            assert.strictEqual(stubBeacon.callCount, 0);
+            assert.strictEqual(stubOpen.callCount, 0);
+
+            clock.restore();
+            done();
+          });
         });
       });
       it('should log the timeout request error message', done => {

--- a/experimental/packages/exporter-trace-otlp-http/test/node/CollectorTraceExporter.test.ts
+++ b/experimental/packages/exporter-trace-otlp-http/test/node/CollectorTraceExporter.test.ts
@@ -244,6 +244,35 @@ describe('OTLPTraceExporter - node with json over http', () => {
       });
     });
 
+    it('should set dynamic custom headers', done => {
+      const customHeaders = {
+        foo: 'dynamic',
+      };
+      const collectorExporterConfigWithDynamicHeaders = {
+        headers: () => customHeaders,
+        hostname: 'foo',
+        url: 'http://foo.bar.com',
+        keepAlive: true,
+        httpAgentOptions: { keepAliveMsecs: 2000 },
+      };
+      const collectorExporterWithDynamicHeaders = new OTLPTraceExporter(
+        collectorExporterConfigWithDynamicHeaders
+      );
+      collectorExporterWithDynamicHeaders.export(spans, () => {});
+
+      setTimeout(() => {
+        const mockRes = new MockedResponse(200);
+        const args = stubRequest.args[0];
+        const callback = args[1];
+        callback(mockRes);
+        mockRes.send('success');
+
+        const options = args[0];
+        assert.strictEqual(options.headers['foo'], 'dynamic');
+        done();
+      });
+    });
+
     it('should not have Content-Encoding header', done => {
       collectorExporter.export(spans, () => {});
 

--- a/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
@@ -41,12 +41,16 @@ export abstract class OTLPExporterBrowserBase<
     this._useXHR =
       !!config.headers || typeof navigator.sendBeacon !== 'function';
     if (config.headers && typeof config.headers === 'function') {
-      this._getHeaders = config.headers as () => Record<string, string>;
+      this._getHeaders = config.headers;
     }
     if (this._useXHR) {
       this._headers = Object.assign(
         {},
-        parseHeaders(config.headers),
+        parseHeaders(
+          typeof config.headers === 'function'
+            ? config.headers()
+            : config.headers
+        ),
         baggageUtils.parseKeyPairsIntoRecord(
           getEnv().OTEL_EXPORTER_OTLP_HEADERS
         )

--- a/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
@@ -41,7 +41,7 @@ export abstract class OTLPExporterBrowserBase<
     super(config);
     this._useXHR =
       !!config.headers || typeof navigator.sendBeacon !== 'function';
-    if (config.headers && config.headers instanceof Function) {
+    if (config.headers && typeof config.headers === 'function') {
       this._hasDynamicHeaders = true;
       this._getHeaders = config.headers as () => Record<string, string>;
     }

--- a/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
@@ -41,7 +41,7 @@ export abstract class OTLPExporterBrowserBase<
     this._useXHR =
       !!config.headers || typeof navigator.sendBeacon !== 'function';
     if (config.headers && typeof config.headers === 'function') {
-      this._getHeaders = config.headers;
+      this._getHeaders = config.headers as () => Record<string, string>;
     }
     if (this._useXHR) {
       this._headers = Object.assign(

--- a/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
@@ -30,9 +30,8 @@ export abstract class OTLPExporterBrowserBase<
   ServiceRequest
 > extends OTLPExporterBase<OTLPExporterConfigBase, ExportItem, ServiceRequest> {
   protected _headers: Record<string, string>;
-  private _getHeaders: () => Record<string, string> = () => ({});
+  private _getHeaders?: () => Record<string, string>;
   private _useXHR: boolean = false;
-  private _hasDynamicHeaders: boolean = false;
 
   /**
    * @param config
@@ -42,7 +41,6 @@ export abstract class OTLPExporterBrowserBase<
     this._useXHR =
       !!config.headers || typeof navigator.sendBeacon !== 'function';
     if (config.headers && typeof config.headers === 'function') {
-      this._hasDynamicHeaders = true;
       this._getHeaders = config.headers as () => Record<string, string>;
     }
     if (this._useXHR) {
@@ -83,7 +81,7 @@ export abstract class OTLPExporterBrowserBase<
         sendWithXhr(
           body,
           this.url,
-          this._hasDynamicHeaders
+          this._getHeaders
             ? { ...this._headers, ...parseHeaders(this._getHeaders()) }
             : this._headers,
           this.timeoutMillis,

--- a/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
@@ -41,7 +41,7 @@ export abstract class OTLPExporterBrowserBase<
     this._useXHR =
       !!config.headers || typeof navigator.sendBeacon !== 'function';
     if (config.headers && typeof config.headers === 'function') {
-      this._getHeaders = config.headers as () => Record<string, string>;
+      this._getHeaders = config.headers;
     }
     if (this._useXHR) {
       this._headers = Object.assign(

--- a/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
@@ -38,6 +38,7 @@ export abstract class OTLPExporterNodeBase<
 > {
   DEFAULT_HEADERS: Record<string, string> = {};
   headers: Record<string, string>;
+  getHeaders?: () => Record<string, string>;
   agent: http.Agent | https.Agent | undefined;
   compression: CompressionAlgorithm;
 
@@ -47,6 +48,10 @@ export abstract class OTLPExporterNodeBase<
     if ((config as any).metadata) {
       diag.warn('Metadata cannot be set when using http');
     }
+    if (config.headers && config.headers instanceof Function) {
+      this.getHeaders = config.headers as () => Record<string, string>;
+    }
+
     this.headers = Object.assign(
       this.DEFAULT_HEADERS,
       parseHeaders(config.headers),

--- a/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
@@ -48,7 +48,7 @@ export abstract class OTLPExporterNodeBase<
     if ((config as any).metadata) {
       diag.warn('Metadata cannot be set when using http');
     }
-    if (config.headers && config.headers instanceof Function) {
+    if (config.headers && typeof config.headers === 'function') {
       this.getHeaders = config.headers as () => Record<string, string>;
     }
 

--- a/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
@@ -49,12 +49,14 @@ export abstract class OTLPExporterNodeBase<
       diag.warn('Metadata cannot be set when using http');
     }
     if (config.headers && typeof config.headers === 'function') {
-      this.getHeaders = config.headers as () => Record<string, string>;
+      this.getHeaders = config.headers;
     }
 
     this.headers = Object.assign(
       this.DEFAULT_HEADERS,
-      parseHeaders(config.headers),
+      parseHeaders(
+        typeof config.headers === 'function' ? config.headers() : config.headers
+      ),
       baggageUtils.parseKeyPairsIntoRecord(getEnv().OTEL_EXPORTER_OTLP_HEADERS)
     );
     this.agent = createHttpAgent(config);

--- a/experimental/packages/otlp-exporter-base/src/platform/node/util.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/util.ts
@@ -76,6 +76,7 @@ export function sendWithHttp<ExportItem, ServiceRequest>(
     headers: {
       'Content-Type': contentType,
       ...collector.headers,
+      ...(collector.getHeaders ? collector.getHeaders() : {}),
     },
     agent: collector.agent,
   };

--- a/experimental/packages/otlp-exporter-base/src/types.ts
+++ b/experimental/packages/otlp-exporter-base/src/types.ts
@@ -45,7 +45,7 @@ export interface ExportServiceError {
  * Collector Exporter base config
  */
 export interface OTLPExporterConfigBase {
-  headers?: Record<string, unknown> | () => Record<string, string>;
+  headers?: Partial<Record<string, unknown> | (() => Record<string, string>)>;
   hostname?: string;
   url?: string;
   concurrencyLimit?: number;

--- a/experimental/packages/otlp-exporter-base/src/types.ts
+++ b/experimental/packages/otlp-exporter-base/src/types.ts
@@ -45,7 +45,7 @@ export interface ExportServiceError {
  * Collector Exporter base config
  */
 export interface OTLPExporterConfigBase {
-  headers?: Partial<Record<string, unknown>>;
+  headers?: Partial<Record<string, unknown> | (() => Record<string, string>)>;
   hostname?: string;
   url?: string;
   concurrencyLimit?: number;

--- a/experimental/packages/otlp-exporter-base/src/types.ts
+++ b/experimental/packages/otlp-exporter-base/src/types.ts
@@ -45,7 +45,7 @@ export interface ExportServiceError {
  * Collector Exporter base config
  */
 export interface OTLPExporterConfigBase {
-  headers?: Partial<Record<string, unknown> | (() => Record<string, string>)>;
+  headers?: Record<string, unknown> | (() => Record<string, string>);
   hostname?: string;
   url?: string;
   concurrencyLimit?: number;

--- a/experimental/packages/otlp-exporter-base/src/types.ts
+++ b/experimental/packages/otlp-exporter-base/src/types.ts
@@ -45,7 +45,7 @@ export interface ExportServiceError {
  * Collector Exporter base config
  */
 export interface OTLPExporterConfigBase {
-  headers?: Partial<Record<string, unknown> | (() => Record<string, string>)>;
+  headers?: Record<string, unknown> | () => Record<string, string>;
   hostname?: string;
   url?: string;
   concurrencyLimit?: number;

--- a/experimental/packages/otlp-exporter-base/src/util.ts
+++ b/experimental/packages/otlp-exporter-base/src/util.ts
@@ -28,7 +28,7 @@ export const DEFAULT_EXPORT_BACKOFF_MULTIPLIER = 1.5;
  * @param partialHeaders
  */
 export function parseHeaders(
-  partialHeaders: Partial<Record<string, unknown>> = {}
+  partialHeaders: Record<string, unknown> = {}
 ): Record<string, string> {
   const headers: Record<string, string> = {};
   Object.entries(partialHeaders).forEach(([key, value]) => {


### PR DESCRIPTION

## Which problem is this PR solving?

This PR is actually this [old, existing PR](https://github.com/open-telemetry/opentelemetry-js/pull/3662), just rebased on current `main` branch, to hopefully merge.

Allow headers to by dynamically set per request

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/2903
