### PR TITLE
fix(instrumentation): allow different export types for files within a Node module

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(instrumentation): allow different export types for files within a Node module [#4046](https://github.com/open-telemetry/opentelemetry-js/pull/4046) @haines
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-instrumentation/src/instrumentationNodeModuleDefinition.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/instrumentationNodeModuleDefinition.ts
@@ -22,7 +22,7 @@ import {
 export class InstrumentationNodeModuleDefinition<T>
   implements InstrumentationModuleDefinition<T>
 {
-  files: InstrumentationModuleFile<T>[];
+  files: InstrumentationModuleFile<any>[];
   constructor(
     public name: string,
     public supportedVersions: string[],


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The `InstrumentationModuleDefinition<T>` interface defines a property `files: InstrumentationModuleFile<any>[]`.

`InstrumentationNodeModuleDefinition<T>` implements this interface but defines the property as `files: InstrumentationModuleFile<T>[]`. This implies that all files within the module have the same exports type, which is unlikely! As a result, you cannot (for example) call `.push()` on the files field without type casting.

## Short description of the changes

This PR changes the type of the property in the class to match the interface it implements.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`npm run compile`

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] ~Unit tests have been added~
- [ ] ~Documentation has been updated~
