### PR TITLE
fix(changelog): fix incorrect version for latest experimental release

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :house: (Internal)
 
-## 0.42.2
+## 0.41.2
 
 ### :bug: (Bug Fix)
 


### PR DESCRIPTION
Looks like I made a typo while creating the latest release. This PR fixes that, sorry for the noise.