### PR TITLE
fix(sdk-node): move @opentelemetry/exporter-jaeger to dev dependencies

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :bug: (Bug Fix)
 
 * fix(exporter-logs-otlp-http): add @opentelemetry/api-logs as dependency
+* fix(sdk-node): remove explicit dependency on @opentelemetry/exporter-jaeger.
 
 ## 0.41.2
 

--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -36,6 +36,7 @@ Before any other module in your application is loaded, you must initialize the S
 If you fail to initialize the SDK or initialize it too late, no-op implementations will be provided to any library which acquires a tracer or meter from the API.
 
 This example uses Jaeger and Prometheus, but exporters exist for [other tracing backends][other-tracing-backends].
+As shown in the installation instructions, exporters passed to the SDK must be installed alongside `@opentelemetry/sdk-node`.
 
 ```javascript
 const opentelemetry = require("@opentelemetry/sdk-node");

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.6.0",
     "@opentelemetry/context-async-hooks": "1.17.0",
+    "@opentelemetry/exporter-jaeger": "1.17.0",
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.1",


### PR DESCRIPTION
## Which problem is this PR solving?

`@opentelemetry/sdk-node` depends on `@opentelemetry/exporter-jaeger` despite never using it directly.
This increases the number of dependencies required to install `@opentelemetry/sdk-node` even if
`@opentelemetry/exporter-jaeger` is not used.

Fixes #3759

## Short description of the changes

The change moves `@opentelemetry/exporter-jaeger` to the dev dependencies to resolve it in tests
but avoid requiring it for general usage of `@opentelemetry/sdk-node`. This is consistent with the
`@opentelemetry/sdk-node` [documentation](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-sdk-node/README.md#installation) which states
that exporters must be explicit dependencies. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Locally building and testing the package after running `npm install` in `opentelemetry-js/experimental/packages/opentelemetry-sdk-node`.

<img width="607" alt="Screenshot 2023-08-09 at 5 58 43 PM" src="https://github.com/open-telemetry/opentelemetry-js/assets/1351531/67347b43-adf5-40aa-a183-9da7ce89c1cc">

<img width="945" alt="Screenshot 2023-08-09 at 5 58 08 PM" src="https://github.com/open-telemetry/opentelemetry-js/assets/1351531/30ab33ef-fc8a-4635-826f-091a636506d3">

## Checklist:

- [X] Followed the style guidelines of this project
- [ ] Unit tests have been added - N/A
- [ ] Documentation has been updated - NA (already consistent)
