### PR TITLE
Revert "fix(example-opencensus-shim): avoid OpenCensus auto instrumentations (#3951)"

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* Revert "fix(example-opencensus-shim): avoid OpenCensus auto instrumentations (#3951)" [#4072](https://github.com/open-telemetry/opentelemetry-js/pull/4072) @aabmass
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/examples/opencensus-shim/package.json
+++ b/experimental/examples/opencensus-shim/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@opencensus/core": "0.1.0",
-    "@opencensus/nodejs-base": "0.1.0",
+    "@opencensus/nodejs": "0.1.0",
     "@opentelemetry/api": "1.4.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.41.2",
     "@opentelemetry/resources": "1.15.2",

--- a/experimental/examples/opencensus-shim/setup.js
+++ b/experimental/examples/opencensus-shim/setup.js
@@ -29,7 +29,7 @@ const {
 } = require('@opentelemetry/semantic-conventions');
 
 module.exports = function setup(serviceName) {
-  const tracing = require('@opencensus/nodejs-base');
+  const tracing = require('@opencensus/nodejs');
 
   diag.setLogger(new DiagConsoleLogger(), { logLevel: DiagLogLevel.ALL });
   const provider = new NodeTracerProvider({


### PR DESCRIPTION
This reverts https://github.com/open-telemetry/opentelemetry-js/pull/3951

After https://github.com/open-telemetry/opentelemetry-js/pull/3951, the example isn't working. From https://github.com/open-telemetry/opentelemetry-js/pull/3951:

> Currently the opencensus-shim example imports @opencensus/nodejs which also imports @opencensus/instrumentation-all and grpc and causes build fails on many platforms.

It's not clear to me how the example would be run causing build failures. @llc1123 hoping to get your input.

## Which problem is this PR solving?

Fixes the example

## Short description of the changes

```
git revert 15ede47
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

CI is passing with existing tests.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated 