### PR TITLE
chore(deps): update prettier to v3 and prettier-plugin-eslint to v5

### DIFF
--- a/api/src/metrics/Meter.ts
+++ b/api/src/metrics/Meter.ts
@@ -85,7 +85,7 @@ export interface Meter {
    * @param [options] the metric options.
    */
   createUpDownCounter<
-    AttributesTypes extends MetricAttributes = MetricAttributes
+    AttributesTypes extends MetricAttributes = MetricAttributes,
   >(
     name: string,
     options?: MetricOptions
@@ -100,7 +100,7 @@ export interface Meter {
    * @param [options] the metric options.
    */
   createObservableGauge<
-    AttributesTypes extends MetricAttributes = MetricAttributes
+    AttributesTypes extends MetricAttributes = MetricAttributes,
   >(
     name: string,
     options?: MetricOptions
@@ -115,7 +115,7 @@ export interface Meter {
    * @param [options] the metric options.
    */
   createObservableCounter<
-    AttributesTypes extends MetricAttributes = MetricAttributes
+    AttributesTypes extends MetricAttributes = MetricAttributes,
   >(
     name: string,
     options?: MetricOptions
@@ -130,7 +130,7 @@ export interface Meter {
    * @param [options] the metric options.
    */
   createObservableUpDownCounter<
-    AttributesTypes extends MetricAttributes = MetricAttributes
+    AttributesTypes extends MetricAttributes = MetricAttributes,
   >(
     name: string,
     options?: MetricOptions
@@ -151,7 +151,7 @@ export interface Meter {
    * @param observables the observables associated with this batch observable callback
    */
   addBatchObservableCallback<
-    AttributesTypes extends MetricAttributes = MetricAttributes
+    AttributesTypes extends MetricAttributes = MetricAttributes,
   >(
     callback: BatchObservableCallback<AttributesTypes>,
     observables: Observable<AttributesTypes>[]
@@ -167,7 +167,7 @@ export interface Meter {
    * @param observables the observables associated with this batch observable callback
    */
   removeBatchObservableCallback<
-    AttributesTypes extends MetricAttributes = MetricAttributes
+    AttributesTypes extends MetricAttributes = MetricAttributes,
   >(
     callback: BatchObservableCallback<AttributesTypes>,
     observables: Observable<AttributesTypes>[]

--- a/api/src/metrics/Metric.ts
+++ b/api/src/metrics/Metric.ts
@@ -63,7 +63,7 @@ export enum ValueType {
  * <ol>
  */
 export interface Counter<
-  AttributesTypes extends MetricAttributes = MetricAttributes
+  AttributesTypes extends MetricAttributes = MetricAttributes,
 > {
   /**
    * Increment value of counter by the input. Inputs must not be negative.
@@ -72,7 +72,7 @@ export interface Counter<
 }
 
 export interface UpDownCounter<
-  AttributesTypes extends MetricAttributes = MetricAttributes
+  AttributesTypes extends MetricAttributes = MetricAttributes,
 > {
   /**
    * Increment value of counter by the input. Inputs may be negative.
@@ -81,7 +81,7 @@ export interface UpDownCounter<
 }
 
 export interface Histogram<
-  AttributesTypes extends MetricAttributes = MetricAttributes
+  AttributesTypes extends MetricAttributes = MetricAttributes,
 > {
   /**
    * Records a measurement. Value of the measurement must not be negative.
@@ -103,7 +103,7 @@ export type MetricAttributeValue = AttributeValue;
  * The observable callback for Observable instruments.
  */
 export type ObservableCallback<
-  AttributesTypes extends MetricAttributes = MetricAttributes
+  AttributesTypes extends MetricAttributes = MetricAttributes,
 > = (
   observableResult: ObservableResult<AttributesTypes>
 ) => void | Promise<void>;
@@ -112,13 +112,13 @@ export type ObservableCallback<
  * The observable callback for a batch of Observable instruments.
  */
 export type BatchObservableCallback<
-  AttributesTypes extends MetricAttributes = MetricAttributes
+  AttributesTypes extends MetricAttributes = MetricAttributes,
 > = (
   observableResult: BatchObservableResult<AttributesTypes>
 ) => void | Promise<void>;
 
 export interface Observable<
-  AttributesTypes extends MetricAttributes = MetricAttributes
+  AttributesTypes extends MetricAttributes = MetricAttributes,
 > {
   /**
    * Sets up a function that will be called whenever a metric collection is initiated.
@@ -134,11 +134,11 @@ export interface Observable<
 }
 
 export type ObservableCounter<
-  AttributesTypes extends MetricAttributes = MetricAttributes
+  AttributesTypes extends MetricAttributes = MetricAttributes,
 > = Observable<AttributesTypes>;
 export type ObservableUpDownCounter<
-  AttributesTypes extends MetricAttributes = MetricAttributes
+  AttributesTypes extends MetricAttributes = MetricAttributes,
 > = Observable<AttributesTypes>;
 export type ObservableGauge<
-  AttributesTypes extends MetricAttributes = MetricAttributes
+  AttributesTypes extends MetricAttributes = MetricAttributes,
 > = Observable<AttributesTypes>;

--- a/api/src/metrics/ObservableResult.ts
+++ b/api/src/metrics/ObservableResult.ts
@@ -20,7 +20,7 @@ import { MetricAttributes, Observable } from './Metric';
  * Interface that is being used in callback function for Observable Metric.
  */
 export interface ObservableResult<
-  AttributesTypes extends MetricAttributes = MetricAttributes
+  AttributesTypes extends MetricAttributes = MetricAttributes,
 > {
   /**
    * Observe a measurement of the value associated with the given attributes.
@@ -41,7 +41,7 @@ export interface ObservableResult<
  * Interface that is being used in batch observable callback function.
  */
 export interface BatchObservableResult<
-  AttributesTypes extends MetricAttributes = MetricAttributes
+  AttributesTypes extends MetricAttributes = MetricAttributes,
 > {
   /**
    * Observe a measurement of the value associated with the given attributes.

--- a/experimental/packages/exporter-logs-otlp-http/test/node/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-http/test/node/OTLPLogExporter.test.ts
@@ -35,7 +35,10 @@ import { ExportResultCode } from '@opentelemetry/core';
 let fakeRequest: PassThrough;
 
 class MockedResponse extends Stream {
-  constructor(private _code: number, private _msg?: string) {
+  constructor(
+    private _code: number,
+    private _msg?: string
+  ) {
     super();
   }
 

--- a/experimental/packages/exporter-logs-otlp-proto/test/logHelper.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/test/logHelper.ts
@@ -167,7 +167,10 @@ export function ensureExportLogsServiceRequestIsSet(
 }
 
 export class MockedResponse extends Stream {
-  constructor(private _code: number, private _msg?: string) {
+  constructor(
+    private _code: number,
+    private _msg?: string
+  ) {
     super();
   }
 

--- a/experimental/packages/exporter-trace-otlp-http/test/node/nodeHelpers.ts
+++ b/experimental/packages/exporter-trace-otlp-http/test/node/nodeHelpers.ts
@@ -17,7 +17,10 @@
 import { Stream } from 'stream';
 
 export class MockedResponse extends Stream {
-  constructor(private _code: number, private _msg?: string) {
+  constructor(
+    private _code: number,
+    private _msg?: string
+  ) {
     super();
   }
 

--- a/experimental/packages/exporter-trace-otlp-proto/test/traceHelper.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/test/traceHelper.ts
@@ -261,7 +261,10 @@ export function ensureExportTraceServiceRequestIsSet(
 }
 
 export class MockedResponse extends Stream {
-  constructor(private _code: number, private _msg?: string) {
+  constructor(
+    private _code: number,
+    private _msg?: string
+  ) {
     super();
   }
 

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/OTLPMetricExporterBase.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/OTLPMetricExporterBase.ts
@@ -109,7 +109,7 @@ export class OTLPMetricExporterBase<
     OTLPMetricExporterOptions,
     ResourceMetrics,
     IExportMetricsServiceRequest
-  >
+  >,
 > implements PushMetricExporter
 {
   public _otlpExporter: T;

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/nodeHelpers.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/nodeHelpers.ts
@@ -17,7 +17,10 @@
 import { Stream } from 'stream';
 
 export class MockedResponse extends Stream {
-  constructor(private _code: number, private _msg?: string) {
+  constructor(
+    private _code: number,
+    private _msg?: string
+  ) {
     super();
   }
 

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/metricsHelper.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/metricsHelper.ts
@@ -224,7 +224,10 @@ export function ensureExportMetricsServiceRequestIsSet(
 }
 
 export class MockedResponse extends Stream {
-  constructor(private _code: number, private _msg?: string) {
+  constructor(
+    private _code: number,
+    private _msg?: string
+  ) {
     super();
   }
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -105,7 +105,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
 
   init(): [
     InstrumentationNodeModuleDefinition<Https>,
-    InstrumentationNodeModuleDefinition<Http>
+    InstrumentationNodeModuleDefinition<Http>,
   ] {
     return [this._getHttpsInstrumentation(), this._getHttpInstrumentation()];
   }
@@ -237,7 +237,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       // https://nodejs.org/dist/latest/docs/api/http.html#http_http_get_options_callback
       // https://github.com/googleapis/cloud-trace-nodejs/blob/master/src/instrumentations/instrumentation-http.ts#L198
       return function outgoingGetRequest<
-        T extends http.RequestOptions | string | url.URL
+        T extends http.RequestOptions | string | url.URL,
       >(options: T, ...args: HttpRequestArgs): http.ClientRequest {
         const req = clientRequest(options, ...args);
         req.end();

--- a/experimental/packages/otlp-exporter-base/src/OTLPExporterBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/OTLPExporterBase.ts
@@ -33,7 +33,7 @@ import { configureExporterTimeout } from './util';
 export abstract class OTLPExporterBase<
   T extends OTLPExporterConfigBase,
   ExportItem,
-  ServiceRequest
+  ServiceRequest,
 > {
   public readonly url: string;
   public readonly hostname: string | undefined;

--- a/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
@@ -27,7 +27,7 @@ import { getEnv, baggageUtils } from '@opentelemetry/core';
  */
 export abstract class OTLPExporterBrowserBase<
   ExportItem,
-  ServiceRequest
+  ServiceRequest,
 > extends OTLPExporterBase<OTLPExporterConfigBase, ExportItem, ServiceRequest> {
   protected _headers: Record<string, string>;
   private _useXHR: boolean = false;

--- a/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
@@ -30,7 +30,7 @@ import { getEnv, baggageUtils } from '@opentelemetry/core';
  */
 export abstract class OTLPExporterNodeBase<
   ExportItem,
-  ServiceRequest
+  ServiceRequest,
 > extends OTLPExporterBase<
   OTLPExporterNodeConfigBase,
   ExportItem,

--- a/experimental/packages/otlp-grpc-exporter-base/src/OTLPGRPCExporterNodeBase.ts
+++ b/experimental/packages/otlp-grpc-exporter-base/src/OTLPGRPCExporterNodeBase.ts
@@ -34,7 +34,7 @@ import {
  */
 export abstract class OTLPGRPCExporterNodeBase<
   ExportItem,
-  ServiceRequest
+  ServiceRequest,
 > extends OTLPExporterBase<
   OTLPGRPCExporterConfigNode,
   ExportItem,

--- a/experimental/packages/otlp-proto-exporter-base/src/platform/browser/OTLPProtoExporterBrowserBase.ts
+++ b/experimental/packages/otlp-proto-exporter-base/src/platform/browser/OTLPProtoExporterBrowserBase.ts
@@ -30,7 +30,7 @@ import { getExportRequestProto } from '../util';
  */
 export abstract class OTLPProtoExporterBrowserBase<
   ExportItem,
-  ServiceRequest
+  ServiceRequest,
 > extends OTLPExporterBaseMain<ExportItem, ServiceRequest> {
   constructor(config: OTLPExporterConfigBase = {}) {
     super(config);

--- a/experimental/packages/otlp-proto-exporter-base/src/platform/node/OTLPProtoExporterNodeBase.ts
+++ b/experimental/packages/otlp-proto-exporter-base/src/platform/node/OTLPProtoExporterNodeBase.ts
@@ -36,7 +36,7 @@ type SendFn = <ExportItem, ServiceRequest>(
  */
 export abstract class OTLPProtoExporterNodeBase<
   ExportItem,
-  ServiceRequest
+  ServiceRequest,
 > extends OTLPExporterBaseMain<ExportItem, ServiceRequest> {
   private _send!: SendFn;
 

--- a/experimental/packages/sdk-logs/src/export/BatchLogRecordProcessorBase.ts
+++ b/experimental/packages/sdk-logs/src/export/BatchLogRecordProcessorBase.ts
@@ -42,7 +42,10 @@ export abstract class BatchLogRecordProcessorBase<T extends BufferConfig>
   private _timer: NodeJS.Timeout | undefined;
   private _shutdownOnce: BindOnceFuture<void>;
 
-  constructor(private readonly _exporter: LogRecordExporter, config?: T) {
+  constructor(
+    private readonly _exporter: LogRecordExporter,
+    config?: T
+  ) {
     const env = getEnv();
     this._maxExportBatchSize =
       config?.maxExportBatchSize ?? env.OTEL_BLRP_MAX_EXPORT_BATCH_SIZE;

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-node": "11.1.0",
-    "eslint-plugin-prettier": "4.2.1",
+    "eslint-plugin-prettier": "5.0.0",
     "gh-pages": "5.0.0",
     "lerna": "7.1.4",
     "@lerna/legacy-package-management": "7.1.4",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@lerna/legacy-package-management": "7.1.4",
     "linkinator": "5.0.1",
     "markdownlint-cli": "0.35.0",
-    "prettier": "2.8.8",
+    "prettier": "3.0.2",
     "semver": "7.5.4",
     "typedoc": "0.22.18",
     "typedoc-plugin-missing-exports": "1.0.0",

--- a/packages/opentelemetry-core/src/utils/callback.ts
+++ b/packages/opentelemetry-core/src/utils/callback.ts
@@ -22,11 +22,14 @@ import { Deferred } from './promise';
 export class BindOnceFuture<
   R,
   This = unknown,
-  T extends (this: This, ...args: unknown[]) => R = () => R
+  T extends (this: This, ...args: unknown[]) => R = () => R,
 > {
   private _isCalled = false;
   private _deferred = new Deferred<R>();
-  constructor(private _callback: T, private _that: This) {}
+  constructor(
+    private _callback: T,
+    private _that: This
+  ) {}
 
   get isCalled() {
     return this._isCalled;

--- a/packages/opentelemetry-core/test/utils/merge.test.ts
+++ b/packages/opentelemetry-core/test/utils/merge.test.ts
@@ -272,7 +272,10 @@ class A {
 }
 
 class B extends A {
-  constructor(name = 'foo', private _ver = 1) {
+  constructor(
+    name = 'foo',
+    private _ver = 1
+  ) {
     super(name);
   }
   getVer() {

--- a/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
@@ -46,7 +46,10 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
   private _shutdownOnce: BindOnceFuture<void>;
   private _droppedSpansCount: number = 0;
 
-  constructor(private readonly _exporter: SpanExporter, config?: T) {
+  constructor(
+    private readonly _exporter: SpanExporter,
+    config?: T
+  ) {
     const env = getEnv();
     this._maxExportBatchSize =
       typeof config?.maxExportBatchSize === 'number'
@@ -200,8 +203,8 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
           doExport();
         } else {
           Promise.all(
-            pendingResources.map(resource =>
-              resource.waitForAsyncAttributes?.()
+            pendingResources.map(
+              resource => resource.waitForAsyncAttributes?.()
             )
           ).then(doExport, err => {
             globalErrorHandler(err);

--- a/packages/sdk-metrics/src/aggregator/ExponentialHistogram.ts
+++ b/packages/sdk-metrics/src/aggregator/ExponentialHistogram.ts
@@ -52,7 +52,10 @@ class HighLow {
   static combine(h1: HighLow, h2: HighLow): HighLow {
     return new HighLow(Math.min(h1.low, h2.low), Math.max(h1.high, h2.high));
   }
-  constructor(public low: number, public high: number) {}
+  constructor(
+    public low: number,
+    public high: number
+  ) {}
 }
 
 const MAX_SCALE = 20;

--- a/packages/sdk-metrics/src/state/MeterSharedState.ts
+++ b/packages/sdk-metrics/src/state/MeterSharedState.ts
@@ -110,7 +110,7 @@ export class MeterSharedState {
 
   private _registerMetricStorage<
     MetricStorageType extends MetricStorageConstructor,
-    R extends InstanceType<MetricStorageType>
+    R extends InstanceType<MetricStorageType>,
   >(
     descriptor: InstrumentDescriptor,
     MetricStorageType: MetricStorageType

--- a/packages/sdk-metrics/src/view/Aggregation.ts
+++ b/packages/sdk-metrics/src/view/Aggregation.ts
@@ -125,7 +125,10 @@ export class ExplicitBucketHistogramAggregation extends Aggregation {
    * @param boundaries the bucket boundaries of the histogram aggregation
    * @param _recordMinMax If set to true, min and max will be recorded. Otherwise, min and max will not be recorded.
    */
-  constructor(boundaries: number[], private readonly _recordMinMax = true) {
+  constructor(
+    boundaries: number[],
+    private readonly _recordMinMax = true
+  ) {
     super();
     if (boundaries === undefined || boundaries.length === 0) {
       throw new Error('HistogramAggregator should be created with boundaries.');


### PR DESCRIPTION
## Which problem is this PR solving?

`prettier` and `prettier-plugin-eslint` were outdated. This PR updates them and applies style rules.

Supersedes #3978 