### PR TITLE
fix(renovate): remove faulty '@types/node' rule and explicitly apply it to the whole repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,14 +19,9 @@
     {
       "matchPackageNames": ["typescript", "webpack", "webpack-cli"],
       "dependencyDashboardApproval": true
-    },
-    {
-      "matchPaths": ["experimental/backwards-compatibility/**"],
-      "matchPackageNames": ["@types/node"],
-      "enabled": false
     }
   ],
-  "ignoreDeps": ["@opentelemetry/api", "@opentelemetry/resources_1.9.0"],
+  "ignoreDeps": ["@opentelemetry/api", "@opentelemetry/resources_1.9.0", "@types/node"],
   "assignees": ["@blumamir", "@dyladan", "@legendecas", "@pichlermarc"],
   "labels": ["dependencies"]
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Looks like the `@types/node` rule that was intended for `experimental/backwards-compatibility` only was applied to `@types/node` for the whole repo. As we do not want to update `@types/node` anyway (to ensure we dont accidentally use newer features that are unsupported by older runtimes), this PR moves '@types/node' to the `ignoreDeps` array instead.

This PR should not have any impact how the config is applied, as we were mistakingly using `matchPaths` which is not a valid config option ('includePaths' would be the right one).

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] internal 

