### PR TITLE
feat(instrumentation-http): Add API for adding custom metric attributes

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-http/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-http/README.md
@@ -57,6 +57,7 @@ Http instrumentation has few options available to choose from. You can set the f
 | [`startOutgoingSpanHook`](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-http/src/types.ts#L99) | `StartOutgoingSpanCustomAttributeFunction` | Function for adding custom attributes before a span is started in outgoingRequest |
 | `ignoreIncomingRequestHook` | `IgnoreIncomingRequestFunction` | Http instrumentation will not trace all incoming requests that matched with custom function |
 | `ignoreOutgoingRequestHook` | `IgnoreOutgoingRequestFunction` | Http instrumentation will not trace all outgoing requests that matched with custom function |
+| `customMetricAttributes` | `CustomMetricAttributeFunction` | Function for adding custom metric attributes on all recorded metrics |
 | [`serverName`](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-http/src/types.ts#L101) | `string` | The primary server name of the matched virtual host. |
 | [`requireParentforOutgoingSpans`](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-http/src/types.ts#L103) | Boolean | Require that is a parent span to create new span for outgoing requests. |
 | [`requireParentforIncomingSpans`](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-http/src/types.ts#L105) | Boolean | Require that is a parent span to create new span for incoming requests. |

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -512,8 +512,10 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       };
 
       const startTime = hrTime();
-      const metricAttributes =
-        utils.getIncomingRequestMetricAttributes(spanAttributes);
+      const metricAttributes: MetricAttributes = Object.assign(
+        utils.getIncomingRequestMetricAttributes(spanAttributes),
+        instrumentation._getConfig().customMetricAttributes?.()
+      );
 
       const ctx = propagation.extract(ROOT_CONTEXT, headers);
       const span = instrumentation._startHttpSpan(method, spanOptions, ctx);
@@ -658,8 +660,10 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       });
 
       const startTime = hrTime();
-      const metricAttributes: MetricAttributes =
-        utils.getOutgoingRequestMetricAttributes(attributes);
+      const metricAttributes: MetricAttributes = Object.assign(
+        utils.getOutgoingRequestMetricAttributes(attributes),
+        instrumentation._getConfig().customMetricAttributes?.()
+      );
 
       const spanOptions: SpanOptions = {
         kind: SpanKind.CLIENT,

--- a/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Span, SpanAttributes } from '@opentelemetry/api';
+import { MetricAttributes, Span, SpanAttributes } from '@opentelemetry/api';
 import type * as http from 'http';
 import type * as https from 'https';
 import {
@@ -80,6 +80,10 @@ export interface StartOutgoingSpanCustomAttributeFunction {
   (request: RequestOptions): SpanAttributes;
 }
 
+export interface CustomMetricAttributeFunction {
+  (): MetricAttributes;
+}
+
 /**
  * Options available for the HTTP instrumentation (see [documentation](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-instrumentation-http#http-instrumentation-options))
  */
@@ -108,6 +112,8 @@ export interface HttpInstrumentationConfig extends InstrumentationConfig {
   startIncomingSpanHook?: StartIncomingSpanCustomAttributeFunction;
   /** Function for adding custom attributes before a span is started in outgoingRequest */
   startOutgoingSpanHook?: StartOutgoingSpanCustomAttributeFunction;
+  /** Function for adding custom metric attributes on all recorded metrics */
+  customMetricAttributes?: CustomMetricAttributeFunction;
   /** The primary server name of the matched virtual host. */
   serverName?: string;
   /** Require parent to create span for outgoing requests */

--- a/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { MetricAttributes, Span, SpanAttributes } from '@opentelemetry/api';
+import { Attributes, Span } from '@opentelemetry/api';
 import type * as http from 'http';
 import type * as https from 'https';
 import {
@@ -73,15 +73,15 @@ export interface HttpResponseCustomAttributeFunction {
 }
 
 export interface StartIncomingSpanCustomAttributeFunction {
-  (request: IncomingMessage): SpanAttributes;
+  (request: IncomingMessage): Attributes;
 }
 
 export interface StartOutgoingSpanCustomAttributeFunction {
-  (request: RequestOptions): SpanAttributes;
+  (request: RequestOptions): Attributes;
 }
 
 export interface CustomMetricAttributeFunction {
-  (): MetricAttributes;
+  (): Attributes;
 }
 
 /**

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
@@ -26,7 +26,14 @@ import { HttpInstrumentation } from '../../src/http';
 import { httpRequest } from '../utils/httpRequest';
 import { TestMetricReader } from '../utils/TestMetricReader';
 
-const instrumentation = new HttpInstrumentation();
+const instrumentation = new HttpInstrumentation({
+  customMetricAttributes: () => {
+    return {
+      foo: 'bar',
+    };
+  },
+});
+
 instrumentation.enable();
 instrumentation.disable();
 
@@ -115,6 +122,8 @@ describe('metrics', () => {
       metrics[0].dataPoints[0].attributes[SemanticAttributes.NET_HOST_PORT],
       22346
     );
+    // Custom attributes
+    assert.strictEqual(metrics[0].dataPoints[0].attributes['foo'], 'bar');
 
     assert.strictEqual(metrics[1].dataPointType, DataPointType.HISTOGRAM);
     assert.strictEqual(
@@ -148,5 +157,7 @@ describe('metrics', () => {
       metrics[1].dataPoints[0].attributes[SemanticAttributes.HTTP_FLAVOR],
       '1.1'
     );
+    // Custom attributes
+    assert.strictEqual(metrics[1].dataPoints[0].attributes['foo'], 'bar');
   });
 });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Add a clear and intuitive API to configure custom metric attributes that a user may inject (unrelated to span context).

Fixes #4107 
Related discussion: https://github.com/open-telemetry/opentelemetry-js/discussions/4088

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

There are only two metrics recorded, they should both get the custom attributes:

- [x] Unit test assertion: Ensure custom metric attributes are added to client http bucket
- [x] Unit test assertion: Ensure custom metric attributes are added to server http bucket

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
