### PR TITLE
chore(exporter-logs-otlp-proto): rename OTLPLogsExporter to OTLPLogEx…

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+* fix(exporter-logs-otlp-proto): change OTLPLogExporter to OTLPLogExporter [#4140](https://github.com/open-telemetry/opentelemetry-js/pull/4140) @Vunovati
+
 ### :rocket: (Enhancement)
 
 ### :bug: (Bug Fix)

--- a/experimental/packages/exporter-logs-otlp-proto/README.md
+++ b/experimental/packages/exporter-logs-otlp-proto/README.md
@@ -22,7 +22,7 @@ To see documentation and sample code for the metric exporter, see the [exporter-
 
 ```js
 const { LoggerProvider, SimpleLogRecordProcessor } = require('@opentelemetry/sdk-logs');
-const { OTLPLogsExporter } =  require('@opentelemetry/exporter-logs-otlp-proto');
+const { OTLPLogExporter } =  require('@opentelemetry/exporter-logs-otlp-proto');
 
 const collectorOptions = {
   url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:4318/v1/logs
@@ -32,7 +32,7 @@ const collectorOptions = {
 };
 
 const logProvider = new LoggerProvider({resource: new Resource({'service.name': 'testApp'})});
-const logExporter = new OTLPLogsExporter(collectorOptions);
+const logExporter = new OTLPLogExporter(collectorOptions);
 logProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(exporter));
 
 const logger = logProvider.getLogger('test_log_instrumentation');
@@ -44,7 +44,7 @@ logger.emit({
 
 ## Exporter Timeout Configuration
 
-The OTLPLogsExporter has a timeout configuration option which is the maximum time, in milliseconds, the OTLP exporter will wait for each batch export. The default value is 10000ms.
+The OTLPLogExporter has a timeout configuration option which is the maximum time, in milliseconds, the OTLP exporter will wait for each batch export. The default value is 10000ms.
 
 To override the default timeout duration, use the following options:
 
@@ -57,7 +57,7 @@ To override the default timeout duration, use the following options:
 
   > `OTEL_EXPORTER_OTLP_LOGS_TIMEOUT` takes precedence and overrides `OTEL_EXPORTER_OTLP_TIMEOUT`.
 
-+ Provide `timeoutMillis` to OTLPLogsExporter with `collectorOptions`:
++ Provide `timeoutMillis` to OTLPLogExporter with `collectorOptions`:
 
   ```js
   const collectorOptions = {
@@ -68,7 +68,7 @@ To override the default timeout duration, use the following options:
     }, //an optional object containing custom headers to be sent with each request will only work with http
   };
 
-  const exporter = new OTLPLogsExporter(collectorOptions);
+  const exporter = new OTLPLogExporter(collectorOptions);
   ```
 
   > Providing `timeoutMillis` with `collectorOptions` takes precedence and overrides timeout set with environment variables.

--- a/experimental/packages/exporter-logs-otlp-proto/src/index.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/index.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { OTLPLogsExporter } from './platform';
+export { OTLPLogExporter } from './platform';

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/OTLPLogExporter.ts
@@ -21,7 +21,7 @@ import {
   appendRootPathToUrlIfNeeded,
 } from '@opentelemetry/otlp-exporter-base';
 import {
-  OTLPProtoExporterNodeBase,
+  OTLPProtoExporterBrowserBase,
   ServiceClientType,
 } from '@opentelemetry/otlp-proto-exporter-base';
 import {
@@ -35,10 +35,10 @@ const DEFAULT_COLLECTOR_RESOURCE_PATH = 'v1/logs';
 const DEFAULT_COLLECTOR_URL = `http://localhost:4318/${DEFAULT_COLLECTOR_RESOURCE_PATH}`;
 
 /**
- * Collector Trace Exporter for Node
+ * Collector Trace Exporter for Web
  */
-export class OTLPLogsExporter
-  extends OTLPProtoExporterNodeBase<
+export class OTLPLogExporter
+  extends OTLPProtoExporterBrowserBase<
     ReadableLogRecord,
     IExportLogsServiceRequest
   >
@@ -46,8 +46,8 @@ export class OTLPLogsExporter
 {
   constructor(config: OTLPExporterConfigBase = {}) {
     super(config);
-    this.headers = Object.assign(
-      this.headers,
+    this._headers = Object.assign(
+      this._headers,
       baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_LOGS_HEADERS
       )

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/index.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/index.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { OTLPLogsExporter } from './OTLPLogsExporter';
+export { OTLPLogExporter } from './OTLPLogExporter';

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/index.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/index.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { OTLPLogsExporter } from './node';
+export { OTLPLogExporter } from './node';

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
@@ -21,7 +21,7 @@ import {
   appendRootPathToUrlIfNeeded,
 } from '@opentelemetry/otlp-exporter-base';
 import {
-  OTLPProtoExporterBrowserBase,
+  OTLPProtoExporterNodeBase,
   ServiceClientType,
 } from '@opentelemetry/otlp-proto-exporter-base';
 import {
@@ -35,10 +35,10 @@ const DEFAULT_COLLECTOR_RESOURCE_PATH = 'v1/logs';
 const DEFAULT_COLLECTOR_URL = `http://localhost:4318/${DEFAULT_COLLECTOR_RESOURCE_PATH}`;
 
 /**
- * Collector Trace Exporter for Web
+ * Collector Trace Exporter for Node
  */
-export class OTLPLogsExporter
-  extends OTLPProtoExporterBrowserBase<
+export class OTLPLogExporter
+  extends OTLPProtoExporterNodeBase<
     ReadableLogRecord,
     IExportLogsServiceRequest
   >
@@ -46,8 +46,8 @@ export class OTLPLogsExporter
 {
   constructor(config: OTLPExporterConfigBase = {}) {
     super(config);
-    this._headers = Object.assign(
-      this._headers,
+    this.headers = Object.assign(
+      this.headers,
       baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_LOGS_HEADERS
       )

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/node/index.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/node/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { OTLPLogsExporter } from './OTLPLogsExporter';
+export { OTLPLogExporter } from './OTLPLogExporter';

--- a/experimental/packages/exporter-logs-otlp-proto/test/browser/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/test/browser/OTLPLogExporter.test.ts
@@ -16,19 +16,19 @@
 
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { OTLPLogsExporter } from '../../src/platform/browser/index';
+import { OTLPLogExporter } from '../../src/platform/browser/index';
 
-describe('OTLPLogsExporter - web', () => {
-  let collectorLogsExporter: OTLPLogsExporter;
+describe('OTLPLogExporter - web', () => {
+  let collectorLogsExporter: OTLPLogExporter;
   describe('constructor', () => {
     let onInitSpy: any;
     beforeEach(() => {
-      onInitSpy = sinon.stub(OTLPLogsExporter.prototype, 'onInit');
+      onInitSpy = sinon.stub(OTLPLogExporter.prototype, 'onInit');
       const collectorExporterConfig = {
         hostname: 'foo',
         url: 'http://foo.bar.com',
       };
-      collectorLogsExporter = new OTLPLogsExporter(collectorExporterConfig);
+      collectorLogsExporter = new OTLPLogExporter(collectorExporterConfig);
     });
     afterEach(() => {
       sinon.restore();

--- a/experimental/packages/exporter-logs-otlp-proto/test/node/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/test/node/OTLPLogExporter.test.ts
@@ -21,7 +21,7 @@ import * as http from 'http';
 import * as sinon from 'sinon';
 import { Stream, PassThrough } from 'stream';
 import * as zlib from 'zlib';
-import { OTLPLogsExporter } from '../../src';
+import { OTLPLogExporter } from '../../src';
 import {
   ensureExportLogsServiceRequestIsSet,
   ensureExportedLogRecordIsCorrect,
@@ -42,8 +42,8 @@ import { ReadableLogRecord } from '@opentelemetry/sdk-logs';
 
 let fakeRequest: PassThrough;
 
-describe('OTLPLogsExporter - node with proto over http', () => {
-  let collectorExporter: OTLPLogsExporter;
+describe('OTLPLogExporter - node with proto over http', () => {
+  let collectorExporter: OTLPLogExporter;
   let collectorExporterConfig: OTLPExporterNodeConfigBase;
   let logs: ReadableLogRecord[];
 
@@ -56,7 +56,7 @@ describe('OTLPLogsExporter - node with proto over http', () => {
     const envSource = process.env;
     it('should use url defined in env that ends with root path and append version and signal path', () => {
       envSource.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://foo.bar/';
-      const collectorExporter = new OTLPLogsExporter();
+      const collectorExporter = new OTLPLogExporter();
       assert.strictEqual(
         collectorExporter.url,
         `${envSource.OTEL_EXPORTER_OTLP_ENDPOINT}v1/logs`
@@ -65,7 +65,7 @@ describe('OTLPLogsExporter - node with proto over http', () => {
     });
     it('should use url defined in env without checking if path is already present', () => {
       envSource.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://foo.bar/v1/logs';
-      const collectorExporter = new OTLPLogsExporter();
+      const collectorExporter = new OTLPLogExporter();
       assert.strictEqual(
         collectorExporter.url,
         `${envSource.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/logs`
@@ -74,7 +74,7 @@ describe('OTLPLogsExporter - node with proto over http', () => {
     });
     it('should use url defined in env and append version and signal', () => {
       envSource.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://foo.bar';
-      const collectorExporter = new OTLPLogsExporter();
+      const collectorExporter = new OTLPLogExporter();
       assert.strictEqual(
         collectorExporter.url,
         `${envSource.OTEL_EXPORTER_OTLP_ENDPOINT}/v1/logs`
@@ -84,7 +84,7 @@ describe('OTLPLogsExporter - node with proto over http', () => {
     it('should override global exporter url with signal url defined in env', () => {
       envSource.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://foo.bar/';
       envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = 'http://foo.logs/';
-      const collectorExporter = new OTLPLogsExporter();
+      const collectorExporter = new OTLPLogExporter();
       assert.strictEqual(
         collectorExporter.url,
         envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
@@ -94,7 +94,7 @@ describe('OTLPLogsExporter - node with proto over http', () => {
     });
     it('should add root path when signal url defined in env contains no path and no root path', () => {
       envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = 'http://foo.bar';
-      const collectorExporter = new OTLPLogsExporter();
+      const collectorExporter = new OTLPLogExporter();
       assert.strictEqual(
         collectorExporter.url,
         `${envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT}/`
@@ -103,7 +103,7 @@ describe('OTLPLogsExporter - node with proto over http', () => {
     });
     it('should not add root path when signal url defined in env contains root path but no path', () => {
       envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = 'http://foo.bar/';
-      const collectorExporter = new OTLPLogsExporter();
+      const collectorExporter = new OTLPLogExporter();
       assert.strictEqual(
         collectorExporter.url,
         `${envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT}`
@@ -112,7 +112,7 @@ describe('OTLPLogsExporter - node with proto over http', () => {
     });
     it('should not add root path when signal url defined in env contains path', () => {
       envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = 'http://foo.bar/v1/logs';
-      const collectorExporter = new OTLPLogsExporter();
+      const collectorExporter = new OTLPLogExporter();
       assert.strictEqual(
         collectorExporter.url,
         `${envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT}`
@@ -121,7 +121,7 @@ describe('OTLPLogsExporter - node with proto over http', () => {
     });
     it('should not add root path when signal url defined in env contains path and ends in /', () => {
       envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = 'http://foo.bar/v1/logs/';
-      const collectorExporter = new OTLPLogsExporter();
+      const collectorExporter = new OTLPLogExporter();
       assert.strictEqual(
         collectorExporter.url,
         `${envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT}`
@@ -130,14 +130,14 @@ describe('OTLPLogsExporter - node with proto over http', () => {
     });
     it('should use headers defined via env', () => {
       envSource.OTEL_EXPORTER_OTLP_LOGS_HEADERS = 'foo=bar';
-      const collectorExporter = new OTLPLogsExporter();
+      const collectorExporter = new OTLPLogExporter();
       assert.strictEqual(collectorExporter.headers.foo, 'bar');
       envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
     });
     it('should override global headers config with signal headers defined via env', () => {
       envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar,bar=foo';
       envSource.OTEL_EXPORTER_OTLP_LOGS_HEADERS = 'foo=boo';
-      const collectorExporter = new OTLPLogsExporter();
+      const collectorExporter = new OTLPLogExporter();
       assert.strictEqual(collectorExporter.headers.foo, 'boo');
       assert.strictEqual(collectorExporter.headers.bar, 'foo');
       envSource.OTEL_EXPORTER_OTLP_LOGS_HEADERS = '';
@@ -156,7 +156,7 @@ describe('OTLPLogsExporter - node with proto over http', () => {
         keepAlive: true,
         httpAgentOptions: { keepAliveMsecs: 2000 },
       };
-      collectorExporter = new OTLPLogsExporter(collectorExporterConfig);
+      collectorExporter = new OTLPLogExporter(collectorExporterConfig);
       logs = [];
       logs.push(Object.assign({}, mockedReadableLogRecord));
     });
@@ -286,7 +286,7 @@ describe('OTLPLogsExporter - node with proto over http', () => {
         compression: CompressionAlgorithm.GZIP,
         httpAgentOptions: { keepAliveMsecs: 2000 },
       };
-      collectorExporter = new OTLPLogsExporter(collectorExporterConfig);
+      collectorExporter = new OTLPLogExporter(collectorExporterConfig);
       logs = [];
       logs.push(Object.assign({}, mockedReadableLogRecord));
     });
@@ -331,7 +331,7 @@ describe('OTLPLogsExporter - node with proto over http', () => {
 });
 
 describe('export - real http request destroyed before response received', () => {
-  let collectorExporter: OTLPLogsExporter;
+  let collectorExporter: OTLPLogExporter;
   let collectorExporterConfig: OTLPExporterNodeConfigBase;
   let logs: ReadableLogRecord[];
   const server = http.createServer((_, res) => {
@@ -351,7 +351,7 @@ describe('export - real http request destroyed before response received', () => 
       url: 'http://localhost:8082',
       timeoutMillis: 1,
     };
-    collectorExporter = new OTLPLogsExporter(collectorExporterConfig);
+    collectorExporter = new OTLPLogExporter(collectorExporterConfig);
     logs = [];
     logs.push(Object.assign({}, mockedReadableLogRecord));
 
@@ -368,7 +368,7 @@ describe('export - real http request destroyed before response received', () => 
       url: 'http://localhost:8082',
       timeoutMillis: 100,
     };
-    collectorExporter = new OTLPLogsExporter(collectorExporterConfig);
+    collectorExporter = new OTLPLogExporter(collectorExporterConfig);
     logs = [];
     logs.push(Object.assign({}, mockedReadableLogRecord));
 
@@ -383,7 +383,7 @@ describe('export - real http request destroyed before response received', () => 
 });
 
 describe('export - real http request destroyed after response received', () => {
-  let collectorExporter: OTLPLogsExporter;
+  let collectorExporter: OTLPLogExporter;
   let collectorExporterConfig: OTLPExporterNodeConfigBase;
   let logs: ReadableLogRecord[];
 
@@ -401,7 +401,7 @@ describe('export - real http request destroyed after response received', () => {
       url: 'http://localhost:8082',
       timeoutMillis: 300,
     };
-    collectorExporter = new OTLPLogsExporter(collectorExporterConfig);
+    collectorExporter = new OTLPLogExporter(collectorExporterConfig);
     logs = [];
     logs.push(Object.assign({}, mockedReadableLogRecord));
 


### PR DESCRIPTION
…porter for consistency

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The class name is inconsistent with other log exporter classes. I was working on a [package](https://github.com/Vunovati/pino-opentelemetry-transport/blob/31acee463f1f9f5b720d539e003cf0dd029c935b/create-log-processor.js#L97), which needed to instantiate the exporters and had to add a workaround for this inconsistency. Then it became apparent that this is not per spec. https://github.com/open-telemetry/opentelemetry-js/pull/3764#discussion_r1194453361

Fixes #4139

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran npm test in `experimental/packages/exporter-logs-otlp-proto`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
