### PR TITLE
fix(sdk-metrics): allow instrument names to contain '/'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+* fix(sdk-metrics): allow instrument names to contain '/' [#4155](https://github.com/open-telemetry/opentelemetry-js/pull/4155)
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/packages/sdk-metrics/src/InstrumentDescriptor.ts
+++ b/packages/sdk-metrics/src/InstrumentDescriptor.ts
@@ -88,7 +88,7 @@ export function isDescriptorCompatibleWith(
 
 // ASCII string with a length no greater than 255 characters.
 // NB: the first character counted separately from the rest.
-const NAME_REGEXP = /^[a-z][a-z0-9_.-]{0,254}$/i;
+const NAME_REGEXP = /^[a-z][a-z0-9_.\-/]{0,254}$/i;
 export function isValidName(name: string): boolean {
   return name.match(NAME_REGEXP) != null;
 }

--- a/packages/sdk-metrics/test/util.ts
+++ b/packages/sdk-metrics/test/util.ts
@@ -67,7 +67,15 @@ export const defaultInstrumentationScope: InstrumentationScope = {
 };
 
 export const invalidNames = ['', 'a'.repeat(256), '1a', '-a', '.a', '_a'];
-export const validNames = ['a', 'a'.repeat(255), 'a1', 'a-1', 'a.1', 'a_1'];
+export const validNames = [
+  'a',
+  'a'.repeat(255),
+  'a1',
+  'a-1',
+  'a.1',
+  'a_1',
+  'a/1',
+];
 
 export const commonValues: number[] = [1, -1, 1.0, Infinity, -Infinity, NaN];
 export const commonAttributes: MetricAttributes[] = [


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #4141

## Short description of the changes

Allows the `/` character in metric instrument name validation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Updated existing test case

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated – N/A