### PR TITLE
fix(otlp-exporter-base): replaced usage of window with _globalThis

### DIFF
--- a/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/browser/OTLPExporterBrowserBase.ts
@@ -20,7 +20,7 @@ import * as otlpTypes from '../../types';
 import { parseHeaders } from '../../util';
 import { sendWithBeacon, sendWithXhr } from './util';
 import { diag } from '@opentelemetry/api';
-import { getEnv, baggageUtils } from '@opentelemetry/core';
+import { getEnv, baggageUtils, _globalThis } from '@opentelemetry/core';
 
 /**
  * Collector Metric Exporter abstract base class
@@ -53,11 +53,11 @@ export abstract class OTLPExporterBrowserBase<
   }
 
   onInit(): void {
-    window.addEventListener('unload', this.shutdown);
+    _globalThis.addEventListener('unload', this.shutdown);
   }
 
   onShutdown(): void {
-    window.removeEventListener('unload', this.shutdown);
+    _globalThis.removeEventListener('unload', this.shutdown);
   }
 
   send(


### PR DESCRIPTION
## Which problem is this PR solving?

The issue being fixed is an error being thrown when trying to export logs from code running in a web worker. I noticed that the exporter is using the 'window' object instead of globalThis (or the _globalThis instance provided by the otlp lib). The 'window' is not available to code running in a worker, only to the main app thread.
Please see this issue https://github.com/open-telemetry/opentelemetry-js/issues/3991

Fixes # (issue)

## Short description of the changes

Replaced the usage of 'window' with the '_globalThis' instance exposed by @opentelemetry/core

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

In order to reproduce the issue, try to export logs from code running in a web worker. You would get an error indicating that 'window' is not defined.
I have a patched version replacing 'window' with 'globalThis' in which the issue no longer occurs.
I also ran the 'compile' and 'test' scripts before and after my changes and observed the same results.


## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
