### PR TITLE
Supports gzip compression in the browser environment

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to experimental packages in this project will be documented 
 
 * feat(exporter-metrics-otlp-proto): add esm build [#4099](https://github.com/open-telemetry/opentelemetry-js/pull/4099) @pichlermarc
 * feat(opencensus-shim): implement OpenCensus metric producer [#4066](https://github.com/open-telemetry/opentelemetry-js/pull/4066) @aabmass
+* feat(otlp-exporter-base): supports gzip compression in the browser environment [#4162](https://github.com/open-telemetry/opentelemetry-js/pull/4162) @fuaiyi
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/exporter-logs-otlp-http/src/platform/browser/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-http/src/platform/browser/OTLPLogExporter.ts
@@ -39,8 +39,8 @@ export class OTLPLogExporter
       timeoutMillis: getEnv().OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
       ...config,
     });
-    this._headers = {
-      ...this._headers,
+    this.headers = {
+      ...this.headers,
       ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_LOGS_HEADERS
       ),

--- a/experimental/packages/exporter-logs-otlp-http/test/browser/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-http/test/browser/OTLPLogExporter.test.ts
@@ -47,7 +47,7 @@ describe('OTLPLogExporter', () => {
     it('should use headers defined via env', () => {
       envSource.OTEL_EXPORTER_OTLP_LOGS_HEADERS = 'foo=bar';
       const exporter = new OTLPLogExporter();
-      assert.strictEqual(exporter['_headers'].foo, 'bar');
+      assert.strictEqual(exporter['headers'].foo, 'bar');
       delete envSource.OTEL_EXPORTER_OTLP_LOGS_HEADERS;
     });
 

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/OTLPLogExporter.ts
@@ -46,8 +46,8 @@ export class OTLPLogExporter
 {
   constructor(config: OTLPExporterConfigBase = {}) {
     super(config);
-    this._headers = Object.assign(
-      this._headers,
+    this.headers = Object.assign(
+      this.headers,
       baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_LOGS_HEADERS
       )

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/browser/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/browser/OTLPTraceExporter.ts
@@ -39,8 +39,8 @@ export class OTLPTraceExporter
 {
   constructor(config: OTLPExporterConfigBase = {}) {
     super(config);
-    this._headers = Object.assign(
-      this._headers,
+    this.headers = Object.assign(
+      this.headers,
       baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_TRACES_HEADERS
       )

--- a/experimental/packages/exporter-trace-otlp-http/test/browser/CollectorTraceExporter.test.ts
+++ b/experimental/packages/exporter-trace-otlp-http/test/browser/CollectorTraceExporter.test.ts
@@ -566,18 +566,15 @@ describe('when configuring via environment', () => {
   it('should use headers defined via env', () => {
     envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar';
     const collectorExporter = new OTLPTraceExporter({ headers: {} });
-    // @ts-expect-error access internal property for testing
-    assert.strictEqual(collectorExporter._headers.foo, 'bar');
+    assert.strictEqual(collectorExporter.headers.foo, 'bar');
     envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
   });
   it('should override global headers config with signal headers defined via env', () => {
     envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar,bar=foo';
     envSource.OTEL_EXPORTER_OTLP_TRACES_HEADERS = 'foo=boo';
     const collectorExporter = new OTLPTraceExporter({ headers: {} });
-    // @ts-expect-error access internal property for testing
-    assert.strictEqual(collectorExporter._headers.foo, 'boo');
-    // @ts-expect-error access internal property for testing
-    assert.strictEqual(collectorExporter._headers.bar, 'foo');
+    assert.strictEqual(collectorExporter.headers.foo, 'boo');
+    assert.strictEqual(collectorExporter.headers.bar, 'foo');
     envSource.OTEL_EXPORTER_OTLP_TRACES_HEADERS = '';
     envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
   });

--- a/experimental/packages/exporter-trace-otlp-proto/src/platform/browser/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/src/platform/browser/OTLPTraceExporter.ts
@@ -42,8 +42,8 @@ export class OTLPTraceExporter
 {
   constructor(config: OTLPExporterConfigBase = {}) {
     super(config);
-    this._headers = Object.assign(
-      this._headers,
+    this.headers = Object.assign(
+      this.headers,
       baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_TRACES_HEADERS
       )

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/browser/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/browser/OTLPMetricExporter.ts
@@ -38,8 +38,8 @@ class OTLPExporterBrowserProxy extends OTLPExporterBrowserBase<
 > {
   constructor(config?: OTLPMetricExporterOptions & OTLPExporterConfigBase) {
     super(config);
-    this._headers = Object.assign(
-      this._headers,
+    this.headers = Object.assign(
+      this.headers,
       baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
       )

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/CollectorMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/CollectorMetricExporter.test.ts
@@ -521,7 +521,7 @@ describe('when configuring via environment', () => {
       temporalityPreference: AggregationTemporalityPreference.CUMULATIVE,
     });
     assert.strictEqual(
-      collectorExporter['_otlpExporter']['_headers'].foo,
+      collectorExporter['_otlpExporter']['headers'].foo,
       'bar'
     );
     envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
@@ -534,11 +534,11 @@ describe('when configuring via environment', () => {
       temporalityPreference: AggregationTemporalityPreference.CUMULATIVE,
     });
     assert.strictEqual(
-      collectorExporter['_otlpExporter']['_headers'].foo,
+      collectorExporter['_otlpExporter']['headers'].foo,
       'boo'
     );
     assert.strictEqual(
-      collectorExporter['_otlpExporter']['_headers'].bar,
+      collectorExporter['_otlpExporter']['headers'].bar,
       'foo'
     );
     envSource.OTEL_EXPORTER_OTLP_METRICS_HEADERS = '';

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -61,7 +61,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.17.0"
+    "@opentelemetry/core": "1.17.0",
+    "pako": "^2.1.0"
   },
   "devDependencies": {
     "@babel/core": "7.22.20",
@@ -69,6 +70,7 @@
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.16",
+    "@types/pako": "^2.0.0",
     "babel-plugin-istanbul": "6.1.1",
     "codecov": "3.8.3",
     "cross-var": "1.1.0",

--- a/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
@@ -18,12 +18,13 @@ import type * as http from 'http';
 import type * as https from 'https';
 
 import { OTLPExporterBase } from '../../OTLPExporterBase';
-import { OTLPExporterNodeConfigBase, CompressionAlgorithm } from './types';
+import { OTLPExporterNodeConfigBase } from './types';
 import * as otlpTypes from '../../types';
 import { parseHeaders } from '../../util';
 import { createHttpAgent, sendWithHttp, configureCompression } from './util';
 import { diag } from '@opentelemetry/api';
 import { getEnv, baggageUtils } from '@opentelemetry/core';
+import { CompressionAlgorithm } from '../../types';
 
 /**
  * Collector Metric Exporter abstract base class

--- a/experimental/packages/otlp-exporter-base/src/platform/node/index.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/index.ts
@@ -15,5 +15,7 @@
  */
 
 export { OTLPExporterNodeBase } from './OTLPExporterNodeBase';
-export { sendWithHttp, createHttpAgent, configureCompression } from './util';
-export { OTLPExporterNodeConfigBase, CompressionAlgorithm } from './types';
+export { sendWithHttp, createHttpAgent } from './util';
+export { configureCompression } from './util';
+export { OTLPExporterNodeConfigBase } from './types';
+export { CompressionAlgorithm } from '../../types';

--- a/experimental/packages/otlp-exporter-base/src/platform/node/types.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/types.ts
@@ -23,11 +23,5 @@ import { OTLPExporterConfigBase } from '../../types';
  */
 export interface OTLPExporterNodeConfigBase extends OTLPExporterConfigBase {
   keepAlive?: boolean;
-  compression?: CompressionAlgorithm;
   httpAgentOptions?: http.AgentOptions | https.AgentOptions;
-}
-
-export enum CompressionAlgorithm {
-  NONE = 'none',
-  GZIP = 'gzip',
 }

--- a/experimental/packages/otlp-exporter-base/src/platform/node/util.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/util.ts
@@ -21,9 +21,9 @@ import { Readable } from 'stream';
 import { OTLPExporterNodeBase } from './OTLPExporterNodeBase';
 import { OTLPExporterNodeConfigBase } from '.';
 import { diag } from '@opentelemetry/api';
-import { CompressionAlgorithm } from './types';
+import { CompressionAlgorithm, OTLPExporterError } from '../../types';
 import { getEnv } from '@opentelemetry/core';
-import { OTLPExporterError } from '../../types';
+
 import {
   DEFAULT_EXPORT_MAX_ATTEMPTS,
   DEFAULT_EXPORT_INITIAL_BACKOFF,

--- a/experimental/packages/otlp-exporter-base/src/types.ts
+++ b/experimental/packages/otlp-exporter-base/src/types.ts
@@ -49,7 +49,13 @@ export interface OTLPExporterConfigBase {
   hostname?: string;
   url?: string;
   concurrencyLimit?: number;
+  compression?: CompressionAlgorithm;
   /** Maximum time the OTLP exporter will wait for each batch export.
    * The default value is 10000ms. */
   timeoutMillis?: number;
+}
+
+export enum CompressionAlgorithm {
+  NONE = 'none',
+  GZIP = 'gzip',
 }

--- a/experimental/packages/otlp-exporter-base/test/node/util.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/node/util.test.ts
@@ -17,7 +17,7 @@
 import * as assert from 'assert';
 import { configureExporterTimeout, invalidTimeout } from '../../src/util';
 import { sendWithHttp } from '../../src/platform/node/util';
-import { CompressionAlgorithm } from '../../src/platform/node/types';
+import { CompressionAlgorithm } from '../../src/types';
 import { configureCompression } from '../../src/platform/node/util';
 import { diag } from '@opentelemetry/api';
 import * as sinon from 'sinon';

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -64,6 +64,7 @@
     "@types/mocha": "10.0.1",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.16",
+    "@types/pako": "^2.0.0",
     "codecov": "3.8.3",
     "cross-var": "1.1.0",
     "lerna": "7.1.5",
@@ -81,7 +82,8 @@
   "dependencies": {
     "@opentelemetry/core": "1.17.0",
     "@opentelemetry/otlp-exporter-base": "0.43.0",
-    "protobufjs": "^7.2.3"
+    "protobufjs": "^7.2.3",
+    "pako": "^2.1.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-proto-exporter-base",
   "sideEffects": false

--- a/experimental/packages/otlp-proto-exporter-base/src/platform/browser/OTLPProtoExporterBrowserBase.ts
+++ b/experimental/packages/otlp-proto-exporter-base/src/platform/browser/OTLPProtoExporterBrowserBase.ts
@@ -33,7 +33,10 @@ export abstract class OTLPProtoExporterBrowserBase<
   ServiceRequest,
 > extends OTLPExporterBaseMain<ExportItem, ServiceRequest> {
   constructor(config: OTLPExporterConfigBase = {}) {
-    super(config);
+    super({
+      headers: { Accept: 'application/x-protobuf', ...config.headers },
+      ...config,
+    });
   }
 
   override send(
@@ -55,18 +58,7 @@ export abstract class OTLPProtoExporterBrowserBase<
     if (message) {
       const body = exportRequestType.encode(message).finish();
       if (body) {
-        sendWithXhr(
-          new Blob([body], { type: 'application/x-protobuf' }),
-          this.url,
-          {
-            ...this._headers,
-            'Content-Type': 'application/x-protobuf',
-            Accept: 'application/x-protobuf',
-          },
-          this.timeoutMillis,
-          onSuccess,
-          onError
-        );
+        sendWithXhr(this, body, 'application/x-protobuf', onSuccess, onError);
       }
     } else {
       onError(new OTLPExporterError('No proto'));


### PR DESCRIPTION
## Which problem is this PR solving?
Supports gzip compression in the browser environment

## Short description of the changes
Implemented support for Gzip compression in the browser environment for otlp-exporter-base (previously only supported in Node.js environment), utilizing pako for Gzip compression capability.
Using Gzip compression can greatly reduce transmission and bandwidth costs. When combined with the pb (protobuf) protocol, there can be even greater improvements. Testing showed an improvement of 70% to 80% before and after the implementation (based on sample data, the specific compression ratio may vary depending on the characteristics of the data).

none: 
![image](https://github.com/open-telemetry/opentelemetry-js/assets/12229677/5073d07d-edde-402a-8f99-50d4ffe016ed)
pb:
![image](https://github.com/open-telemetry/opentelemetry-js/assets/12229677/9268a0ef-fad2-48d2-b6df-29c8716d56ce)
pb+gzip:
![image](https://github.com/open-telemetry/opentelemetry-js/assets/12229677/b51a9d1e-2c0a-43b7-9f01-11825f278d6d)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Unit Test

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated