### PR TITLE
Allow BatchSpanProcessor to send early when a full batch is ready

### DIFF
--- a/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
@@ -45,6 +45,7 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
   private _timer: NodeJS.Timeout | undefined;
   private _shutdownOnce: BindOnceFuture<void>;
   private _droppedSpansCount: number = 0;
+  private _isFlushInProgress: boolean = false;
 
   constructor(
     private readonly _exporter: SpanExporter,
@@ -139,7 +140,11 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
     }
 
     this._finishedSpans.push(span);
-    this._maybeStartTimer();
+    if (this._finishedSpans.length === this._maxExportBatchSize) {
+      this._flush();
+    } else {
+      this._maybeStartTimer();
+    }
   }
 
   /**
@@ -149,13 +154,16 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
    * */
   private _flushAll(): Promise<void> {
     return new Promise((resolve, reject) => {
+      this._clearTimer();
       const promises = [];
       // calculate number of batches
       const count = Math.ceil(
         this._finishedSpans.length / this._maxExportBatchSize
       );
       for (let i = 0, j = count; i < j; i++) {
-        promises.push(this._flushOneBatch());
+        const spans = this._finishedSpans.splice(0, this._maxExportBatchSize);
+        // run exports in parallel ignoring _isFlushInProgress
+        promises.push(this._export(spans));
       }
       Promise.all(promises)
         .then(() => {
@@ -165,9 +173,8 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
     });
   }
 
-  private _flushOneBatch(): Promise<void> {
-    this._clearTimer();
-    if (this._finishedSpans.length === 0) {
+  private _export(spans: ReadableSpan[]): Promise<void> {
+    if (spans.length === 0) {
       return Promise.resolve();
     }
     return new Promise((resolve, reject) => {
@@ -177,11 +184,6 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
       }, this._exportTimeoutMillis);
       // prevent downstream exporter calls from generating spans
       context.with(suppressTracing(context.active()), () => {
-        // Reset the finished spans buffer here because the next invocations of the _flush method
-        // could pass the same finished spans to the exporter if the buffer is cleared
-        // outside the execution of this callback.
-        const spans = this._finishedSpans.splice(0, this._maxExportBatchSize);
-
         const doExport = () =>
           this._exporter.export(spans, result => {
             clearTimeout(timer);
@@ -218,16 +220,7 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
   private _maybeStartTimer() {
     if (this._timer !== undefined) return;
     this._timer = setTimeout(() => {
-      this._flushOneBatch()
-        .then(() => {
-          if (this._finishedSpans.length > 0) {
-            this._clearTimer();
-            this._maybeStartTimer();
-          }
-        })
-        .catch(e => {
-          globalErrorHandler(e);
-        });
+      this._flush();
     }, this._scheduledDelayMillis);
     unrefTimer(this._timer);
   }
@@ -237,6 +230,34 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
       clearTimeout(this._timer);
       this._timer = undefined;
     }
+  }
+
+  private _flush() {
+    if (this._isFlushInProgress) {
+      return;
+    }
+    this._isFlushInProgress = true;
+    this._clearTimer();
+
+    const spans = this._finishedSpans.splice(0, this._maxExportBatchSize);
+    this._export(spans)
+      .then(() => {
+        this._isFlushInProgress = false;
+        if (this._finishedSpans.length >= this._maxExportBatchSize) {
+          this._flush();
+        } else if (this._finishedSpans.length > 0) {
+          this._maybeStartTimer();
+        }
+      })
+      .catch(e => {
+        this._isFlushInProgress = false;
+        globalErrorHandler(e);
+        if (this._finishedSpans.length >= this._maxExportBatchSize) {
+          this._flush();
+        } else if (this._finishedSpans.length > 0) {
+          this._maybeStartTimer();
+        }
+      });
   }
 
   protected abstract onShutdown(): void;

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/SimpleSpanProcessor.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/SimpleSpanProcessor.test.ts
@@ -200,7 +200,7 @@ describe('SimpleSpanProcessor', () => {
     });
 
     it('should await doExport() and delete from _unresolvedExports', async () => {
-      const testExporterWithDelay = new TestExporterWithDelay();
+      const testExporterWithDelay = new TestExporterWithDelay(1);
       const processor = new SimpleSpanProcessor(testExporterWithDelay);
 
       const providerWithAsyncResource = new BasicTracerProvider({

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/TestExporterWithDelay.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/TestExporterWithDelay.ts
@@ -22,16 +22,18 @@ import { InMemorySpanExporter, ReadableSpan } from '../../../src';
  */
 export class TestExporterWithDelay extends InMemorySpanExporter {
   private _exporterCreatedSpans: ReadableSpan[] = [];
+  private _delayMs: number;
 
-  constructor() {
+  constructor(delayMs: number) {
     super();
+    this._delayMs = delayMs;
   }
 
   override export(
     spans: ReadableSpan[],
     resultCallback: (result: ExportResult) => void
   ): void {
-    super.export(spans, () => setTimeout(resultCallback, 1));
+    setTimeout(() => super.export(spans, resultCallback), this._delayMs);
   }
 
   override shutdown(): Promise<void> {


### PR DESCRIPTION
## Which problem is this PR solving?

The `BatchSpanProcessor` waits `scheduledDelayMillis` (5000 by default) since the arrival of the first span, or since the last export before exporting. It never exports more than one batch of `maxExportBatchSize` (512 by default). If there's more than 512 spans produced per 5000 seconds the surplus starts building up in the queue, until it overflows and starts dropping spans. Which is observable though these logs: `Dropped 2576 spans because maxQueueSize reached`

## Short description of the changes

In comparision Java's `BatchSpanProcessor` also uses a configured delay and batch size, but will send the batch as soon as sufficient number of spans is enqueued (https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.java#L244). Therefore the delay doesn't limit the maximum throughput.

This PR implements similar logic in JS's BatchSpanProcessor.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- I've adapted all the relevant unit tests to this new behaviour
- I've run a nodejs lambda which produces ~10k spans in ~20s and observed spans dropped before the changes and no spans dropped after the changes.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
