### PR TITLE
chore(deps): replace semver with compare-versions to reduce bundle size

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/index.ts
@@ -97,7 +97,7 @@ export class GrpcJsInstrumentation extends InstrumentationBase {
     return [
       new InstrumentationNodeModuleDefinition<typeof grpcJs>(
         '@grpc/grpc-js',
-        ['^1.*'],
+        ['1.*'],
         (moduleExports, version) => {
           this._diag.debug(`Applying patch for @grpc/grpc-js@${version}`);
           if (isWrapped(moduleExports.Server.prototype.register)) {

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/grpc-js/index.ts
@@ -97,7 +97,7 @@ export class GrpcJsInstrumentation extends InstrumentationBase {
     return [
       new InstrumentationNodeModuleDefinition<typeof grpcJs>(
         '@grpc/grpc-js',
-        ['1.*'],
+        ['^1.*'],
         (moduleExports, version) => {
           this._diag.debug(`Applying patch for @grpc/grpc-js@${version}`);
           if (isWrapped(moduleExports.Server.prototype.register)) {

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -77,7 +77,7 @@
     "@opentelemetry/core": "1.17.0",
     "@opentelemetry/instrumentation": "0.43.0",
     "@opentelemetry/semantic-conventions": "1.17.0",
-    "semver": "^7.5.2"
+    "compare-versions": "^6.1.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -38,7 +38,7 @@ import {
 import type * as http from 'http';
 import type * as https from 'https';
 import { Socket } from 'net';
-import * as semver from 'semver';
+import { compare } from 'compare-versions';
 import * as url from 'url';
 import {
   Err,
@@ -396,7 +396,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
 
         response.on('end', endHandler);
         // See https://github.com/open-telemetry/opentelemetry-js/pull/3625#issuecomment-1475673533
-        if (semver.lt(process.version, '16.0.0')) {
+        if (compare(process.version, '16.0.0', '<')) {
           response.on('close', endHandler);
         }
         response.on(errorMonitor, (error: Err) => {
@@ -583,7 +583,6 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       );
     };
   }
-
   private _outgoingRequestFunction(
     component: 'http' | 'https',
     original: Func<http.ClientRequest>
@@ -613,7 +612,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
        */
       if (
         component === 'http' &&
-        semver.lt(process.version, '9.0.0') &&
+        compare(process.version, '9.0.0', '<') &&
         optionsParsed.protocol === 'https:'
       ) {
         return original.apply(this, [optionsParsed, ...args]);

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -72,9 +72,9 @@
   },
   "dependencies": {
     "@types/shimmer": "^1.0.2",
+    "compare-versions": "^6.1.0",
     "import-in-the-middle": "1.4.2",
     "require-in-the-middle": "^7.1.1",
-    "semver": "^7.5.2",
     "shimmer": "^1.2.1"
   },
   "peerDependencies": {

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -36,8 +36,7 @@ import { Hook } from 'require-in-the-middle';
  */
 export abstract class InstrumentationBase<T = any>
   extends InstrumentationAbstract
-  implements types.Instrumentation
-{
+  implements types.Instrumentation {
   private _modules: InstrumentationModuleDefinition<T>[];
   private _hooks: (Hooked | Hook)[] = [];
   private _requireInTheMiddleSingleton: RequireInTheMiddleSingleton =
@@ -62,8 +61,8 @@ export abstract class InstrumentationBase<T = any>
     if (this._modules.length === 0) {
       diag.debug(
         'No modules instrumentation has been defined for ' +
-          `'${this.instrumentationName}@${this.instrumentationVersion}'` +
-          ', nothing will be patched'
+        `'${this.instrumentationName}@${this.instrumentationVersion}'` +
+        ', nothing will be patched'
       );
     }
 
@@ -309,6 +308,6 @@ function isSupported(
   }
 
   return supportedVersions.some(supportedVersion => {
-    return satisfies(version, supportedVersion);
+    return supportedVersion === '*' || satisfies(version, supportedVersion);
   });
 }

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -17,7 +17,7 @@
 import * as types from '../../types';
 import * as path from 'path';
 import { types as utilTypes } from 'util';
-import { satisfies } from 'semver';
+import { satisfies } from 'compare-versions';
 import { wrap, unwrap, massWrap, massUnwrap } from 'shimmer';
 import { InstrumentationAbstract } from '../../instrumentation';
 import {
@@ -191,7 +191,7 @@ export abstract class InstrumentationBase<T = any>
     if (module.name === name) {
       // main module
       if (
-        isSupported(module.supportedVersions, version, module.includePrerelease)
+        isSupported(module.supportedVersions, version)
       ) {
         if (typeof module.patch === 'function') {
           module.moduleExports = exports;
@@ -207,7 +207,7 @@ export abstract class InstrumentationBase<T = any>
     const supportedFileInstrumentations = files
       .filter(f => f.name === name)
       .filter(f =>
-        isSupported(f.supportedVersions, version, module.includePrerelease)
+        isSupported(f.supportedVersions, version)
       );
     return supportedFileInstrumentations.reduce<T>((patchedExports, file) => {
       file.moduleExports = patchedExports;
@@ -301,8 +301,7 @@ export abstract class InstrumentationBase<T = any>
 
 function isSupported(
   supportedVersions: string[],
-  version?: string,
-  includePrerelease?: boolean
+  version?: string
 ): boolean {
   if (typeof version === 'undefined') {
     // If we don't have the version, accept the wildcard case only
@@ -310,6 +309,6 @@ function isSupported(
   }
 
   return supportedVersions.some(supportedVersion => {
-    return satisfies(version, supportedVersion, { includePrerelease });
+    return satisfies(version, supportedVersion);
   });
 }

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -36,7 +36,8 @@ import { Hook } from 'require-in-the-middle';
  */
 export abstract class InstrumentationBase<T = any>
   extends InstrumentationAbstract
-  implements types.Instrumentation {
+  implements types.Instrumentation
+{
   private _modules: InstrumentationModuleDefinition<T>[];
   private _hooks: (Hooked | Hook)[] = [];
   private _requireInTheMiddleSingleton: RequireInTheMiddleSingleton =
@@ -61,8 +62,8 @@ export abstract class InstrumentationBase<T = any>
     if (this._modules.length === 0) {
       diag.debug(
         'No modules instrumentation has been defined for ' +
-        `'${this.instrumentationName}@${this.instrumentationVersion}'` +
-        ', nothing will be patched'
+          `'${this.instrumentationName}@${this.instrumentationVersion}'` +
+          ', nothing will be patched'
       );
     }
 
@@ -189,9 +190,7 @@ export abstract class InstrumentationBase<T = any>
     module.moduleVersion = version;
     if (module.name === name) {
       // main module
-      if (
-        isSupported(module.supportedVersions, version)
-      ) {
+      if (isSupported(module.supportedVersions, version)) {
         if (typeof module.patch === 'function') {
           module.moduleExports = exports;
           if (this._enabled) {
@@ -205,9 +204,7 @@ export abstract class InstrumentationBase<T = any>
     const files = module.files ?? [];
     const supportedFileInstrumentations = files
       .filter(f => f.name === name)
-      .filter(f =>
-        isSupported(f.supportedVersions, version)
-      );
+      .filter(f => isSupported(f.supportedVersions, version));
     return supportedFileInstrumentations.reduce<T>((patchedExports, file) => {
       file.moduleExports = patchedExports;
       if (this._enabled) {
@@ -298,10 +295,7 @@ export abstract class InstrumentationBase<T = any>
   }
 }
 
-function isSupported(
-  supportedVersions: string[],
-  version?: string
-): boolean {
+function isSupported(supportedVersions: string[], version?: string): boolean {
   if (typeof version === 'undefined') {
     // If we don't have the version, accept the wildcard case only
     return supportedVersions.includes('*');

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -70,7 +70,7 @@
     "@opentelemetry/propagator-b3": "1.17.0",
     "@opentelemetry/propagator-jaeger": "1.17.0",
     "@opentelemetry/sdk-trace-base": "1.17.0",
-    "semver": "^7.5.2"
+    "compare-versions": "^6.1.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-node/src/NodeTracerProvider.ts
+++ b/packages/opentelemetry-sdk-trace-node/src/NodeTracerProvider.ts
@@ -23,7 +23,7 @@ import {
   PROPAGATOR_FACTORY,
   SDKRegistrationConfig,
 } from '@opentelemetry/sdk-trace-base';
-import * as semver from 'semver';
+import { compare } from 'compare-versions'
 import { NodeTracerConfig } from './config';
 import { JaegerPropagator } from '@opentelemetry/propagator-jaeger';
 
@@ -58,7 +58,7 @@ export class NodeTracerProvider extends BasicTracerProvider {
 
   override register(config: SDKRegistrationConfig = {}): void {
     if (config.contextManager === undefined) {
-      const ContextManager = semver.gte(process.version, '14.8.0')
+      const ContextManager = compare(process.version, '14.8.0', '>=')
         ? AsyncLocalStorageContextManager
         : AsyncHooksContextManager;
       config.contextManager = new ContextManager();

--- a/packages/opentelemetry-sdk-trace-node/src/NodeTracerProvider.ts
+++ b/packages/opentelemetry-sdk-trace-node/src/NodeTracerProvider.ts
@@ -23,7 +23,7 @@ import {
   PROPAGATOR_FACTORY,
   SDKRegistrationConfig,
 } from '@opentelemetry/sdk-trace-base';
-import { compare } from 'compare-versions'
+import { compare } from 'compare-versions';
 import { NodeTracerConfig } from './config';
 import { JaegerPropagator } from '@opentelemetry/propagator-jaeger';
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Semver makes up 1/4 of the output of our bundled opentelemetry distribution whilst not providing much utility.

In aws-lambda environments, this contributes significantly to the coldstart (about 30ms) 

![image](https://github.com/open-telemetry/opentelemetry-js/assets/7361428/272e303d-67b6-4227-be01-b939a9fbf939)



Fixes # (issue)
https://github.com/open-telemetry/opentelemetry-js/issues/3537

## Short description of the changes
replaces semver with compare-versions in 

* instrumentation-http
* instrumentation
* sdk-base-node

The API should be comparable and behaviour should be very similar. 

With the changes in instrumentation, the prerelease flag is no longer needed because this is a default of the satisfies method is not broken by prerelease tags

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
