### PR TITLE
fix(benchmark): write benchmark results to file

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Benchmark tests
         run: |
           npm run test:bench
-          find . -name benchmarks.txt -exec cat {} + > combined_benchmarks.txt
+          find . -name .benchmark-results.txt -exec cat {} + > combined_benchmarks.txt
 
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ package.json.lerna_backup
 #IDEA
 .idea
 *.iml
+
+# non-aggregated benchmark results
+.benchmark-results.txt

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -20,7 +20,7 @@
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts' --exclude 'test/browser/**/*.ts'",
     "test:browser": "karma start --single-run",
     "test:webworker": "karma start karma.worker.js --single-run",
-    "test:bench": "node test/performance/benchmark/index.js",
+    "test:bench": "node test/performance/benchmark/index.js | tee .benchmark-results.txt",
     "tdd": "npm run tdd:node",
     "tdd:node": "npm run test -- --watch-extensions ts --watch",
     "tdd:browser": "karma start",


### PR DESCRIPTION
## Which problem is this PR solving?

Benchmark workflow is currently failing because individual benchmark results are not written to file. This PR makes it so that benchmark results are written to `.benchmark-results.txt` and adds `.benchmark-results.txt` to `.gitignore`.

Related #4171 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)