### PR TITLE
Add MESSAGING_DESTINATION_NAME attribute

### DIFF
--- a/packages/opentelemetry-semantic-conventions/src/trace/SemanticAttributes.ts
+++ b/packages/opentelemetry-semantic-conventions/src/trace/SemanticAttributes.ts
@@ -576,9 +576,11 @@ the closest proxy.
   MESSAGING_DESTINATION: 'messaging.destination',
 
   /**
-   * The message destination name.
-   * Note: Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
-   * the broker does not have such notion, the destination name SHOULD uniquely identify the broker.
+   * Represents the name of the message destination.
+   *
+   * Note: The destination name should provide a unique identifier for a specific queue, topic, or other entity within
+   * the broker. If the broker does not support this concept, the destination name should uniquely identify the broker
+   * itself.
    */
   MESSAGING_DESTINATION_NAME: "messaging.destination.name",
 

--- a/packages/opentelemetry-semantic-conventions/src/trace/SemanticAttributes.ts
+++ b/packages/opentelemetry-semantic-conventions/src/trace/SemanticAttributes.ts
@@ -576,6 +576,13 @@ the closest proxy.
   MESSAGING_DESTINATION: 'messaging.destination',
 
   /**
+   * The message destination name.
+   * Note: Destination name SHOULD uniquely identify a specific queue, topic or other entity within the broker. If
+   * the broker does not have such notion, the destination name SHOULD uniquely identify the broker.
+   */
+  MESSAGING_DESTINATION_NAME: "messaging.destination.name",
+
+  /**
    * The kind of message destination.
    */
   MESSAGING_DESTINATION_KIND: 'messaging.destination_kind',


### PR DESCRIPTION
## Problem

This PR introduces a new Semantic attribute `MESSAGING_DESTINATION_NAME`. 
The motivation for this change is to address a scenario where the existing
`MESSAGING_DESTINATION` attribute may not uniquely identify the destination
when different accounts have the same topic name. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Followed the style guidelines of this project
