### PR TITLE
feat(sdk-logs): export MultiLogRecordProcessor

### DIFF
--- a/experimental/packages/sdk-logs/src/index.ts
+++ b/experimental/packages/sdk-logs/src/index.ts
@@ -23,6 +23,7 @@ export {
 export { LoggerProvider } from './LoggerProvider';
 export { LogRecord } from './LogRecord';
 export { LogRecordProcessor } from './LogRecordProcessor';
+export { MultiLogRecordProcessor } from './MultiLogRecordProcessor';
 export { ReadableLogRecord } from './export/ReadableLogRecord';
 export { NoopLogRecordProcessor } from './export/NoopLogRecordProcessor';
 export { ConsoleLogRecordExporter } from './export/ConsoleLogRecordExporter';


### PR DESCRIPTION
This way library authors can reuse it in their packages.

Signed-off-by: Peter Somogyvari <peter.metz@unarin.com>

---

## Which problem is this PR solving?

Library authors can't re-use the multi log record processor in their code because it wasn't exported to the public API surface of the pacakge until now.

## Short description of the changes

Exported the MultiLogRecordProcessor

## How Has This Been Tested?

I verified that the project still compiles. 

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
