### PR TITLE
fix(sdk-node) Remove @opentelemetry/exporter-jaeger explicit dependency

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(sdk-node): remove the explicit dependency on @opentelemetry/exporter-jaeger that was kept on the previous release
+  * '@opentelemetry/exporter-jaeger' is no longer be a dependency of this package. To continue using '@opentelemetry/exporter-jaeger', please install it manually.
+    * NOTE: `@opentelemetry/exporter-jaeger` is deprecated, consider switching to one of the alternatives described [here](https://www.npmjs.com/package/@opentelemetry/exporter-jaeger)
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "@opentelemetry/api-logs": "0.44.0",
     "@opentelemetry/core": "1.17.1",
-    "@opentelemetry/exporter-jaeger": "1.17.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.44.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.44.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.44.0",


### PR DESCRIPTION
## Which problem is this PR solving?

The `@opentelemetry/exporter-jaeger` explicit dependency isn't removed despite what the last [changelog says](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/CHANGELOG.md#0440)

This PR removes the dependency.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
