### PR TITLE
chore: type reference on zone.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :house: (Internal)
 
+* chore: type reference on zone.js [#4257](https://github.com/open-telemetry/opentelemetry-js/pull/4257) @legendecas
+
 ## 1.18.0
 
 ### :rocket: (Enhancement)

--- a/packages/opentelemetry-context-zone-peer-dep/src/ZoneContextManager.ts
+++ b/packages/opentelemetry-context-zone-peer-dep/src/ZoneContextManager.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+/// <reference types="zone.js" />
 import { Context, ContextManager, ROOT_CONTEXT } from '@opentelemetry/api';
 import { TargetWithEvents } from './types';
 import { isListenerObject } from './util';

--- a/packages/opentelemetry-context-zone-peer-dep/tsconfig.esm.json
+++ b/packages/opentelemetry-context-zone-peer-dep/tsconfig.esm.json
@@ -5,9 +5,6 @@
     "rootDir": "src",
     "tsBuildInfoFile": "build/esm/tsconfig.esm.tsbuildinfo"
   },
-  "files": [
-    "node_modules/zone.js/dist/zone.js.d.ts"
-  ],
   "include": [
     "src/**/*.ts"
   ],

--- a/packages/opentelemetry-context-zone-peer-dep/tsconfig.esnext.json
+++ b/packages/opentelemetry-context-zone-peer-dep/tsconfig.esnext.json
@@ -5,9 +5,6 @@
     "rootDir": "src",
     "tsBuildInfoFile": "build/esnext/tsconfig.esnext.tsbuildinfo"
   },
-  "files": [
-    "node_modules/zone.js/dist/zone.js.d.ts"
-  ],
   "include": [
     "src/**/*.ts"
   ],

--- a/packages/opentelemetry-context-zone-peer-dep/tsconfig.json
+++ b/packages/opentelemetry-context-zone-peer-dep/tsconfig.json
@@ -4,9 +4,6 @@
     "outDir": "build",
     "rootDir": "."
   },
-  "files": [
-    "node_modules/zone.js/dist/zone.js.d.ts"
-  ],
   "include": [
     "src/**/*.ts",
     "test/**/*.ts"


### PR DESCRIPTION
## Which problem is this PR solving?

Avoid hardcoding the `node_modules` path in `tsconfig.json` as packages may be hoisted by package managers.

[Type references](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-types-) resolves these package names in the similar process of resolving module names in an `import` statement.

## Type of change

- [x] Internal house keeping

## How Has This Been Tested?

- [x] Existing packages can be compiled successfully.

## Checklist:

- [x] Followed the style guidelines of this project
