### PR TITLE
fix(sdk-metrics): hand-roll MetricAdvice type as older API versions do not include it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+fix(sdk-metrics): hand-roll MetricAdvice type as older API versions do not include it #4260
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/packages/sdk-metrics/src/InstrumentDescriptor.ts
+++ b/packages/sdk-metrics/src/InstrumentDescriptor.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  MetricAdvice,
-  MetricOptions,
-  ValueType,
-  diag,
-} from '@opentelemetry/api';
+import { MetricOptions, ValueType, diag } from '@opentelemetry/api';
 import { View } from './view/View';
 import { equalsCaseInsensitive } from './utils';
 
@@ -49,8 +44,17 @@ export interface InstrumentDescriptor {
   readonly valueType: ValueType;
   /**
    * @experimental
+   *
+   * This is intentionally not using the API's type as it's only available from @opentelemetry/api 1.7.0 and up.
+   * In SDK 2.0 we'll be able to bump the minimum API version and remove this workaround.
    */
-  readonly advice: MetricAdvice;
+  readonly advice: {
+    /**
+     * Hint the explicit bucket boundaries for SDK if the metric has been
+     * aggregated with a HistogramAggregator.
+     */
+    explicitBucketBoundaries?: number[];
+  };
 }
 
 export function createInstrumentDescriptor(


### PR DESCRIPTION
## Which problem is this PR solving?

Older versions of `@opentelemetry-api` do not contain the `MetricAdvice` type. As it's used in the public interface, this type is needed at compile time. This PR hand-rolls the type again in the SDK, so that we can maintain backwards compatibility with older API versions.

In 2.0 we'll be able to bump the minimum API version and remove this workaround. Also in 2.0 `InstrumentDescriptor` will become an intnernal interface, so additions to it will not be part of the public interface anymore.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Tested manually by compiliing with API 1.6.0
