### PR TITLE
chore: no need for 'packages' in "lerna.json"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ fix(sdk-metrics): hand-roll MetricAdvice type as older API versions do not inclu
 
 ### :house: (Internal)
 
+* chore: no need for 'packages' in lerna.json [#4264](https://github.com/open-telemetry/opentelemetry-js/pull/4264) @trentm
+
 ## 1.18.0
 
 ### :rocket: (Enhancement)

--- a/lerna.json
+++ b/lerna.json
@@ -1,20 +1,5 @@
 {
   "version": "independent",
   "npmClient": "npm",
-  "useWorkspaces": true,
-  "// packages": "Please sync with package.json#workspaces",
-  "packages": [
-    "api",
-    "packages/*",
-    "experimental/packages/*",
-    "experimental/examples/*",
-    "experimental/backwards-compatibility/*",
-    "integration-tests/*",
-    "selenium-tests",
-    "examples/otlp-exporter-node",
-    "examples/opentelemetry-web",
-    "examples/http",
-    "examples/https",
-    "examples/esm-http-ts"
-  ]
+  "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     },
     "cacheDir": ".changelog"
   },
-  "// workspaces": "Please sync with lerna.json#packages",
   "workspaces": [
     "api",
     "packages/*",


### PR DESCRIPTION
With lerna@6 and "useWorkspaces" it will use "workspaces" from
package.json.

See request for this at https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1771#discussion_r1385900274
