### PR TITLE
docs: add docker-compose to run prometheus for the experimental example

### DIFF
--- a/experimental/examples/prometheus/README.md
+++ b/experimental/examples/prometheus/README.md
@@ -11,16 +11,28 @@ This is a simple example that demonstrates basic metrics collection and exports 
 npm install
 ```
 
-Setup [Prometheus](https://prometheus.io/docs/prometheus/latest/getting_started/)
-
 ## Run the Application
-
-- Run the server
 
 ```sh
 # from this directory
 npm run start
 ```
+
+If you are using the default configurations, the metrics should be available at <http://localhost:9464/metrics>
+
+## Run Prometheus
+
+### With docker
+
+```sh
+# from this directory
+docker compose up
+```
+
+### With binary
+
+Setup [Prometheus](https://prometheus.io/docs/prometheus/latest/getting_started/)
+
 
 - Replace the `prometheus.yml` provided by the Prometheus installation with the following:
 
@@ -34,7 +46,6 @@ scrape_configs:
     # scheme defaults to 'http'.
     static_configs:
     - targets: ['localhost:9464']
-
 ```
 
 - Start Prometheus
@@ -44,7 +55,7 @@ scrape_configs:
 prometheus --config.file=prometheus.yml
 ```
 
-### Prometheus UI
+## Prometheus UI
 
 If you are using the default configurations, the prometheus client will be available at <http://localhost:9090>
 

--- a/experimental/examples/prometheus/README.md
+++ b/experimental/examples/prometheus/README.md
@@ -33,7 +33,6 @@ docker compose up
 
 Setup [Prometheus](https://prometheus.io/docs/prometheus/latest/getting_started/)
 
-
 - Replace the `prometheus.yml` provided by the Prometheus installation with the following:
 
 ```yaml

--- a/experimental/examples/prometheus/docker-compose.yaml
+++ b/experimental/examples/prometheus/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '3.7'
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.47.2
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    volumes:
+      - "./prometheus.docker.yml:/etc/prometheus/prometheus.yml"
+    ports:
+      - 9090:9090
+    restart: always

--- a/experimental/examples/prometheus/prometheus.docker.yml
+++ b/experimental/examples/prometheus/prometheus.docker.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s # Default is every 1 minute.
+
+scrape_configs:
+  - job_name: 'opentelemetry'
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+    static_configs:
+    - targets: ['host.docker.internal:9464']


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Make it way easier to visualise metrics scraping by prometheus with a docker-compose file. 

## Short description of the changes

- Add a docker-compose.yaml to the [experimental prometheus example](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/examples/prometheus)
- Update the [related README.md documentation](https://github.com/Lp-Francois/opentelemetry-js/blob/docs-add-docker-compose-to-run-prometheus-for-experiemental-example/experimental/examples/prometheus/README.md).

## How Has This Been Tested?

### Locally 

1. run `npm run install` and `npm run start` to start the web server from the directory.
2.  start prometheus with `docker compose up`
3. Go to `http://localhost:9090` and observe the prometheus UI with graphs

<img width="1512" alt="Screenshot 2023-11-08 at 20 45 50" src="https://github.com/open-telemetry/opentelemetry-js/assets/32224751/d15356e8-21b9-4f63-a04d-f928d9dc5717">


## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated
