### PR TITLE
fix(sdk-trace-base): processor onStart called with a span having empty attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+* fix(sdk-trace-base): processor onStart called with a span having empty attributes
+
 ## 1.18.1
 
 ### :bug: (Bug Fix)

--- a/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
@@ -236,6 +236,40 @@ describe('transform', () => {
         version: '1',
       });
     });
+    it('should map OpenTelemetry constructor attributes to a Zipkin tag', () => {
+      const span = new Span(
+        tracer,
+        api.ROOT_CONTEXT,
+        'my-span',
+        spanContext,
+        api.SpanKind.SERVER,
+        parentId,
+        [],
+        undefined,
+        undefined,
+        {
+          key1: 'value1',
+          key2: 'value2',
+        }
+      );
+      const tags: zipkinTypes.Tags = _toZipkinTags(
+        span,
+        defaultStatusCodeTagName,
+        defaultStatusErrorTagName
+      );
+
+      assert.deepStrictEqual(tags, {
+        key1: 'value1',
+        key2: 'value2',
+        [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
+        'telemetry.sdk.language': language,
+        'telemetry.sdk.name': 'opentelemetry',
+        'telemetry.sdk.version': VERSION,
+        cost: '112.12',
+        service: 'ui',
+        version: '1',
+      });
+    });
     it('should map OpenTelemetry SpanStatus.code to a Zipkin tag', () => {
       const span = new Span(
         tracer,

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -100,7 +100,8 @@ export class Span implements APISpan, ReadableSpan {
     parentSpanId?: string,
     links: Link[] = [],
     startTime?: TimeInput,
-    _deprecatedClock?: unknown // keeping this argument even though it is unused to ensure backwards compatibility
+    _deprecatedClock?: unknown, // keeping this argument even though it is unused to ensure backwards compatibility
+    initAttributes?: SpanAttributes
   ) {
     this.name = spanName;
     this._spanContext = spanContext;
@@ -119,6 +120,11 @@ export class Span implements APISpan, ReadableSpan {
     this.resource = parentTracer.resource;
     this.instrumentationLibrary = parentTracer.instrumentationLibrary;
     this._spanLimits = parentTracer.getSpanLimits();
+
+    if (initAttributes != null) {
+      this.setAttributes(initAttributes);
+    }
+
     this._spanProcessor = parentTracer.getActiveSpanProcessor();
     this._spanProcessor.onStart(this, context);
     this._attributeValueLengthLimit =

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -101,7 +101,7 @@ export class Span implements APISpan, ReadableSpan {
     links: Link[] = [],
     startTime?: TimeInput,
     _deprecatedClock?: unknown, // keeping this argument even though it is unused to ensure backwards compatibility
-    initAttributes?: SpanAttributes
+    attributes?: SpanAttributes
   ) {
     this.name = spanName;
     this._spanContext = spanContext;
@@ -121,8 +121,8 @@ export class Span implements APISpan, ReadableSpan {
     this.instrumentationLibrary = parentTracer.instrumentationLibrary;
     this._spanLimits = parentTracer.getSpanLimits();
 
-    if (initAttributes != null) {
-      this.setAttributes(initAttributes);
+    if (attributes != null) {
+      this.setAttributes(attributes);
     }
 
     this._spanProcessor = parentTracer.getActiveSpanProcessor();

--- a/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
@@ -132,6 +132,12 @@ export class Tracer implements api.Tracer {
       return nonRecordingSpan;
     }
 
+    // Set initial span attributes. The attributes object may have been mutated
+    // by the sampler, so we sanitize the merged attributes before setting them.
+    const initAttributes = sanitizeAttributes(
+      Object.assign(attributes, samplingResult.attributes)
+    );
+
     const span = new Span(
       this,
       context,
@@ -140,14 +146,10 @@ export class Tracer implements api.Tracer {
       spanKind,
       parentSpanId,
       links,
-      options.startTime
+      options.startTime,
+      undefined,
+      initAttributes
     );
-    // Set initial span attributes. The attributes object may have been mutated
-    // by the sampler, so we sanitize the merged attributes before setting them.
-    const initAttributes = sanitizeAttributes(
-      Object.assign(attributes, samplingResult.attributes)
-    );
-    span.setAttributes(initAttributes);
     return span;
   }
 

--- a/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
@@ -1054,6 +1054,27 @@ describe('Span', () => {
       assert.ok(started);
     });
 
+    it('should call onStart synchronously when span is started with initial attributes', () => {
+      let initAttributes;
+      const processor: SpanProcessor = {
+        onStart: span => {
+          initAttributes = { ...span.attributes };
+        },
+        forceFlush: () => Promise.resolve(),
+        onEnd() {},
+        shutdown: () => Promise.resolve(),
+      };
+
+      const provider = new BasicTracerProvider();
+
+      provider.addSpanProcessor(processor);
+
+      provider
+        .getTracer('default')
+        .startSpan('test', { attributes: { foo: 'bar' } });
+      assert.deepStrictEqual(initAttributes, { foo: 'bar' });
+    });
+
     it('should call onEnd synchronously when span is ended', () => {
       let ended = false;
       const processor: SpanProcessor = {
@@ -1220,6 +1241,24 @@ describe('Span', () => {
         assert.deepStrictEqual(event.attributes, {
           [SemanticAttributes.EXCEPTION_TYPE]: '12',
         });
+      });
+    });
+
+    describe('when initial attributes are specified', () => {
+      it('should store specified attributes', () => {
+        const span = new Span(
+          tracer,
+          ROOT_CONTEXT,
+          name,
+          spanContext,
+          SpanKind.CLIENT,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { foo: 'bar' }
+        );
+        assert.deepStrictEqual(span.attributes, { foo: 'bar' });
       });
     });
   });

--- a/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
@@ -1054,7 +1054,7 @@ describe('Span', () => {
       assert.ok(started);
     });
 
-    it('include attributes in onStart', () => {
+    it('should include attributes in onStart', () => {
       let attributes;
       const processor: SpanProcessor = {
         onStart: span => {

--- a/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
@@ -1054,11 +1054,11 @@ describe('Span', () => {
       assert.ok(started);
     });
 
-    it('include initial attributes in onStart', () => {
-      let initAttributes;
+    it('include attributes in onStart', () => {
+      let attributes;
       const processor: SpanProcessor = {
         onStart: span => {
-          initAttributes = { ...span.attributes };
+          attributes = { ...span.attributes };
         },
         forceFlush: () => Promise.resolve(),
         onEnd() {},
@@ -1072,7 +1072,7 @@ describe('Span', () => {
       provider
         .getTracer('default')
         .startSpan('test', { attributes: { foo: 'bar' } });
-      assert.deepStrictEqual(initAttributes, { foo: 'bar' });
+      assert.deepStrictEqual(attributes, { foo: 'bar' });
     });
 
     it('should call onEnd synchronously when span is ended', () => {
@@ -1244,7 +1244,7 @@ describe('Span', () => {
       });
     });
 
-    describe('when initial attributes are specified', () => {
+    describe('when attributes are specified', () => {
       it('should store specified attributes', () => {
         const span = new Span(
           tracer,

--- a/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
@@ -1054,7 +1054,7 @@ describe('Span', () => {
       assert.ok(started);
     });
 
-    it('should call onStart synchronously when span is started with initial attributes', () => {
+    it('include initial attributes in onStart', () => {
       let initAttributes;
       const processor: SpanProcessor = {
         onStart: span => {


### PR DESCRIPTION
## Which problem is this PR solving?

This PR fixes issue https://github.com/open-telemetry/opentelemetry-js/issues/4188 in which the span processor on start method lacks attributes since they are set after with an accessor method (setAttributes) and not on the constructor itself.

This is a follow up of #4206. I will address any review asap as I'm need of this fix with urgency.

Fixes #4188

## Short description of the changes

The PR adds constructor attributes to the span which are optional and if they are added from this layer the spanProcessor.onStart method will have context of attributes whenever it is called, this doest not break compatibility since setAttributes is still a valid public method and also the changes needed on wrappers like the Tracer are done.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x]  United tested over the build

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
