### PR TITLE
feat(sdk-logs): add droppedAttributesCount field to ReadableLogRecord

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :rocket: (Enhancement)
 
+* feat(sdk-logs): add droppedAttributesCount field to ReadableLogRecord
+
 ### :bug: (Bug Fix)
 
 * fix(sdk-logs): avoid map attribute set when count limit exceeded

--- a/experimental/packages/exporter-logs-otlp-grpc/test/logsHelper.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/test/logsHelper.ts
@@ -49,6 +49,7 @@ export const mockedReadableLogRecord: ReadableLogRecord = {
   attributes: {
     'some-attribute': 'some attribute value',
   },
+  droppedAttributesCount: 0,
   severityNumber: SeverityNumber.ERROR,
   severityText: 'error',
   body: 'some_log_body',

--- a/experimental/packages/exporter-logs-otlp-http/test/logHelper.ts
+++ b/experimental/packages/exporter-logs-otlp-http/test/logHelper.ts
@@ -44,6 +44,7 @@ export const mockedReadableLogRecord: ReadableLogRecord = {
   attributes: {
     'some-attribute': 'some attribute value',
   },
+  droppedAttributesCount: 0,
   severityNumber: SeverityNumber.ERROR,
   severityText: 'error',
   body: 'some_log_body',

--- a/experimental/packages/exporter-logs-otlp-proto/test/logHelper.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/test/logHelper.ts
@@ -45,6 +45,7 @@ export const mockedReadableLogRecord: ReadableLogRecord = {
   attributes: {
     'some-attribute': 'some attribute value',
   },
+  droppedAttributesCount: 0,
   severityNumber: SeverityNumber.ERROR,
   severityText: 'error',
   body: 'some_log_body',

--- a/experimental/packages/otlp-transformer/test/logs.test.ts
+++ b/experimental/packages/otlp-transformer/test/logs.test.ts
@@ -107,6 +107,7 @@ describe('Logs', () => {
         attributes: {
           'some-attribute': 'some attribute value',
         },
+        droppedAttributesCount: 0,
         severityNumber: SeverityNumber.ERROR,
         severityText: 'error',
         body: 'some_log_body',
@@ -122,6 +123,7 @@ describe('Logs', () => {
         attributes: {
           'another-attribute': 'another attribute value',
         },
+        droppedAttributesCount: 0,
       };
       log_1_1_1 = {
         ...log_fragment_1,

--- a/experimental/packages/sdk-logs/src/LogRecord.ts
+++ b/experimental/packages/sdk-logs/src/LogRecord.ts
@@ -39,6 +39,7 @@ export class LogRecord implements ReadableLogRecord {
   private _severityText?: string;
   private _severityNumber?: logsAPI.SeverityNumber;
   private _body?: string;
+  private totalAttributesCount: number = 0;
 
   private _isReadonly: boolean = false;
   private readonly _logRecordLimits: Required<LogRecordLimits>;
@@ -71,6 +72,10 @@ export class LogRecord implements ReadableLogRecord {
   }
   get body(): string | undefined {
     return this._body;
+  }
+
+  get droppedAttributesCount(): number {
+    return this.totalAttributesCount - Object.keys(this.attributes).length;
   }
 
   constructor(
@@ -129,6 +134,7 @@ export class LogRecord implements ReadableLogRecord {
       api.diag.warn(`Invalid attribute value set for key: ${key}`);
       return this;
     }
+    this.totalAttributesCount += 1;
     if (
       Object.keys(this.attributes).length >=
         this._logRecordLimits.attributeCountLimit &&

--- a/experimental/packages/sdk-logs/src/export/ReadableLogRecord.ts
+++ b/experimental/packages/sdk-logs/src/export/ReadableLogRecord.ts
@@ -29,4 +29,5 @@ export interface ReadableLogRecord {
   readonly resource: IResource;
   readonly instrumentationScope: InstrumentationScope;
   readonly attributes: LogAttributes;
+  readonly droppedAttributesCount: number;
 }

--- a/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
@@ -203,13 +203,14 @@ describe('LogRecord', () => {
         }
 
         it('should remove / drop all remaining values after the number of values exceeds this limit', () => {
-          const { attributes } = logRecord;
+          const { attributes, droppedAttributesCount } = logRecord;
           assert.strictEqual(Object.keys(attributes).length, 100);
           assert.strictEqual(attributes.foo0, 'bar0');
           assert.deepStrictEqual(attributes.foo98, { bar: 'bar98' });
           assert.strictEqual(attributes.foo147, undefined);
           assert.strictEqual(attributes.foo148, undefined);
           assert.strictEqual(attributes.foo149, undefined);
+          assert.strictEqual(droppedAttributesCount, 50);
         });
       });
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Add `droppedAttributesCount` field to `ReadableLogRecord` and `LogRecord`.

Fixes #3758 

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Add `droppedAttributesCount` checking in existing test case

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
