### PR TITLE
Add Trent Mick to approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 - [Neville Wylie](https://github.com/MSNev), Microsoft
 - [Purvi Kanal](https://github.com/pkanal), Honeycomb
 - [Svetlana Brennan](https://github.com/svetlanabrennan), New Relic
+- [Trent Mick](https://github.com/trentm), Elastic
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).*
 


### PR DESCRIPTION
In recognition of his great work and valuable insights, I propose to add @trentm to the list of JS approvers.