### PR TITLE
fix(ci): remove token setup via environment variable from .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 lockfile-version=2


### PR DESCRIPTION
## Which problem is this PR solving?

This change has been causing trouble in #4271. It not used in any of the automations.
I've been meaning to use it for releases, but there are other ways to do it.