### PR TITLE
[next] Add support for node 20

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node_version:
-          - 18
+          - 20
     runs-on: self-hosted
     timeout-minutes: 10
     env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         node_version:
           - "18"
-          # - "20" # disabled until http instrumentation can be fixed
+          - "20"
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_UNSAFE_PERM: true
@@ -40,7 +40,7 @@ jobs:
           npm run test
       - name: Report Coverage
         run: npm run codecov
-        if: ${{ matrix.node_version == '18' }}
+        if: ${{ matrix.node_version == '20' }}
   node-windows-tests:
     runs-on: windows-latest
     env:
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 20
 
       - run: npm install -g npm@latest
 
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Bootstrap
         run: npm ci
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v4.0.0
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Bootstrap
         run: npm ci

--- a/.github/workflows/w3c-integration-test.yml
+++ b/.github/workflows/w3c-integration-test.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install and Bootstrap 🔧
         run: npm ci

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -330,6 +330,9 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       'response',
       (response: http.IncomingMessage & { aborted?: boolean }) => {
         this._diag.debug('outgoingRequest on response()');
+        if (request.listenerCount('request') <= 0) {
+          response.resume();
+        }
         const responseAttributes =
           utils.getOutgoingRequestAttributesOnResponse(response);
         span.setAttributes(responseAttributes);

--- a/experimental/packages/opentelemetry-instrumentation-http/test/utils/rawRequest.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/utils/rawRequest.ts
@@ -22,7 +22,7 @@ export async function sendRequestTwice(
   port: number
 ): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    const request = 'GET /raw HTTP/1.1\n\n';
+    const request = `GET /raw HTTP/1.1\r\nHost: ${host}:${port}\r\n\r\n`;
     const socket = net.createConnection({ host, port }, () => {
       socket.write(`${request}${request}`, err => {
         if (err) reject(err);


### PR DESCRIPTION
One of these changes fixes a memory leak. It is implemented for `1.x` in #4332. The other is simply an HTTP specification fix which only affects testing.