### PR TITLE
fix(instrumentation-http): resume responses when there is no response…

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to experimental packages in this project will be documented 
 * fix(sdk-logs): avoid map attribute set when count limit exceeded
 * fix(instrumentation-fetch): only access navigator if it is defined [#4063](https://github.com/open-telemetry/opentelemetry-js/pull/4063)
   * allows for experimental usage of this instrumentation with non-browser runtimes
+* fix(instrumentation-http): memory leak when responses are not resumed
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -330,6 +330,9 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       'response',
       (response: http.IncomingMessage & { aborted?: boolean }) => {
         this._diag.debug('outgoingRequest on response()');
+        if (request.listenerCount('request') <= 0) {
+          response.resume();
+        }
         const responseAttributes =
           utils.getOutgoingRequestAttributesOnResponse(response);
         span.setAttributes(responseAttributes);


### PR DESCRIPTION
Fixes #4316 

There is a memory leak in node 20 which is a manifestation of a problem that has been around for a while. If a user makes an http request and doesn't add a `response` listener to the request, the response body is typically dropped by the node runtime. The HTTP instrumentation adds a listener, which prevents the runtime from dropping the body. We should `resume` the response in order to put the stream back into flowing mode, which will cause the runtime to have the correct behavior after our callback returns.