### PR TITLE
fix: programmatic url and headers take precedence in metric exporters…

### DIFF
--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/OTLPMetricExporter.ts
@@ -49,6 +49,7 @@ class OTLPMetricExporterProxy extends OTLPGRPCExporterNodeBase<
       ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
       ),
+      ...config?.headers,
     };
 
     this.metadata ||= new Metadata();

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/test/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/test/OTLPMetricExporter.test.ts
@@ -322,6 +322,18 @@ describe('when configuring via environment', () => {
     envSource.OTEL_EXPORTER_OTLP_ENDPOINT = '';
     envSource.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = '';
   });
+  it('should use override url defined in env with url defined in constructor', () => {
+    envSource.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://foo.bar/v1/metrics';
+    const constructorDefinedEndpoint = 'http://constructor/v1/metrics';
+    const collectorExporter = new OTLPMetricExporter({
+      url: constructorDefinedEndpoint,
+    });
+    assert.strictEqual(
+      collectorExporter._otlpExporter.url,
+      constructorDefinedEndpoint
+    );
+    envSource.OTEL_EXPORTER_OTLP_ENDPOINT = '';
+  });
   it('should use headers defined via env', () => {
     envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar';
     const collectorExporter = new OTLPMetricExporter();
@@ -361,6 +373,23 @@ describe('when configuring via environment', () => {
       ['lol']
     );
     envSource.OTEL_EXPORTER_OTLP_METRICS_HEADERS = '';
+    envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
+  });
+  it('should override headers defined via env with headers defined in constructor', () => {
+    envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar,bar=foo';
+    const collectorExporter = new OTLPMetricExporter({
+      headers: {
+        foo: 'constructor',
+      },
+    });
+    assert.deepStrictEqual(
+      collectorExporter._otlpExporter.metadata?.get('foo'),
+      ['constructor']
+    );
+    assert.deepStrictEqual(
+      collectorExporter._otlpExporter.metadata?.get('bar'),
+      ['foo']
+    );
     envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
   });
 });

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/OTLPMetricExporter.ts
@@ -48,6 +48,7 @@ class OTLPExporterNodeProxy extends OTLPExporterNodeBase<
       ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
       ),
+      ...config?.headers,
     };
   }
 

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/CollectorMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/CollectorMetricExporter.test.ts
@@ -296,6 +296,18 @@ describe('OTLPMetricExporter - node with json over http', () => {
       );
       envSource.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = '';
     });
+    it('should use override url defined in env with url defined in constructor', () => {
+      envSource.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://foo.bar/v1/metrics';
+      const constructorDefinedEndpoint = 'http://constructor/v1/metrics';
+      const collectorExporter = new OTLPMetricExporter({
+        url: constructorDefinedEndpoint,
+      });
+      assert.strictEqual(
+        collectorExporter._otlpExporter.url,
+        constructorDefinedEndpoint
+      );
+      envSource.OTEL_EXPORTER_OTLP_ENDPOINT = '';
+    });
     it('should use headers defined via env', () => {
       envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar';
       const collectorExporter = new OTLPMetricExporter();
@@ -316,6 +328,20 @@ describe('OTLPMetricExporter - node with json over http', () => {
       assert.strictEqual(collectorExporter._otlpExporter.headers.foo, 'boo');
       assert.strictEqual(collectorExporter._otlpExporter.headers.bar, 'foo');
       envSource.OTEL_EXPORTER_OTLP_METRICS_HEADERS = '';
+      envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
+    });
+    it('should override headers defined via env with headers defined in constructor', () => {
+      envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar,bar=foo';
+      const collectorExporter = new OTLPMetricExporter({
+        headers: {
+          foo: 'constructor',
+        },
+      });
+      assert.strictEqual(
+        collectorExporter._otlpExporter.headers.foo,
+        'constructor'
+      );
+      assert.strictEqual(collectorExporter._otlpExporter.headers.bar, 'foo');
       envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
     });
     it('should use delta temporality defined via env', () => {

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/OTLPMetricExporter.ts
@@ -51,6 +51,7 @@ class OTLPMetricExporterNodeProxy extends OTLPProtoExporterNodeBase<
       ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
       ),
+      ...config?.headers,
     };
   }
 

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/OTLPMetricExporter.test.ts
@@ -148,6 +148,18 @@ describe('OTLPMetricExporter - node with proto over http', () => {
       );
       envSource.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = '';
     });
+    it('should use override url defined in env with url defined in constructor', () => {
+      envSource.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://foo.bar/v1/metrics';
+      const constructorDefinedEndpoint = 'http://constructor/v1/metrics';
+      const collectorExporter = new OTLPMetricExporter({
+        url: constructorDefinedEndpoint,
+      });
+      assert.strictEqual(
+        collectorExporter._otlpExporter.url,
+        constructorDefinedEndpoint
+      );
+      envSource.OTEL_EXPORTER_OTLP_ENDPOINT = '';
+    });
     it('should use headers defined via env', () => {
       envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar';
       const collectorExporter = new OTLPMetricExporter();
@@ -161,6 +173,20 @@ describe('OTLPMetricExporter - node with proto over http', () => {
       assert.strictEqual(collectorExporter._otlpExporter.headers.foo, 'boo');
       assert.strictEqual(collectorExporter._otlpExporter.headers.bar, 'foo');
       envSource.OTEL_EXPORTER_OTLP_METRICS_HEADERS = '';
+      envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
+    });
+    it('should override headers defined via env with headers defined in constructor', () => {
+      envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar,bar=foo';
+      const collectorExporter = new OTLPMetricExporter({
+        headers: {
+          foo: 'constructor',
+        },
+      });
+      assert.strictEqual(
+        collectorExporter._otlpExporter.headers.foo,
+        'constructor'
+      );
+      assert.strictEqual(collectorExporter._otlpExporter.headers.bar, 'foo');
       envSource.OTEL_EXPORTER_OTLP_HEADERS = '';
     });
   });


### PR DESCRIPTION
… (#2370)

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Exporters are not respecting the documented behaviour ([link](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto)) when it comes to headers.

_Settings configured programmatically take precedence over environment variables. Per-signal environment variables take precedence over non-per-signal environment variables._


This MR solves the problem for the metrics exporters only. I can expand the scope of the PR to include other signals too.

I believe this is the expected behaviour for all the exporters (for traces and logs too) and is in the docs for most of them. 

It is explicitly stated in [exporter-logs-otlp-proto](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/exporter-logs-otlp-proto/README.md), but I believe it should've been for consistency.

Fixes #2370 

## Short description of the changes

override OTEL_EXPORTER_OTLP_METRICS_HEADERS and OTEL_EXPORTER_OTLP_HEADERS with config.headers supplied to OTLPMetricExporter

Applied to:

- opentelemetry-exporter-metrics-otlp-grpc
- opentelemetry-exporter-metrics-otlp-proto
- opentelemetry-exporter-metrics-otlp-http

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Added additional tests testing that the programmatic settings take precedence. 
- [x] for headers
- [x] for url, which was already working per spec but was not covered with unit tests

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
