### PR TITLE
test: make rawRequest HTTP-compliant

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-http/test/utils/rawRequest.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/utils/rawRequest.ts
@@ -22,7 +22,7 @@ export async function sendRequestTwice(
   port: number
 ): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    const request = 'GET /raw HTTP/1.1\n\n';
+    const request = `GET /raw HTTP/1.1\r\nHost: ${host}:${port}\r\n\r\n`;
     const socket = net.createConnection({ host, port }, () => {
       socket.write(`${request}${request}`, err => {
         if (err) reject(err);


### PR DESCRIPTION
This causes node 20 tests to fail on the `next` branch. Fixing here because it is required by HTTP spec.