### PR TITLE
Require changelog entries for next branch

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,4 @@
-# This action requires that any PR targeting the main branch should touch at
+# This action requires that any PR targeting the main and next branch should touch at
 # least one CHANGELOG file. If a CHANGELOG entry is not required, add the "Skip
 # Changelog" label to disable this action.
 
@@ -9,6 +9,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+      - next
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -1,0 +1,11 @@
+## 2.0
+
+### :boom: Breaking Change
+
+### :rocket: (Enhancement)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+### :bug: (Bug Fix)


### PR DESCRIPTION
I'm adding a changelog file specifically for `next` changes so we can put together a reasonable changelog for the release.