### PR TITLE
fix(api-logs): allow passing in TimeInput for LogRecord

### DIFF
--- a/experimental/packages/api-logs/src/types/LogRecord.ts
+++ b/experimental/packages/api-logs/src/types/LogRecord.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { AttributeValue, Context } from '@opentelemetry/api';
+import { AttributeValue, Context, TimeInput } from '@opentelemetry/api';
 
 export type LogAttributeValue = AttributeValue | LogAttributes;
 export interface LogAttributes {
@@ -53,12 +53,12 @@ export interface LogRecord {
   /**
    * The time when the log record occurred as UNIX Epoch time in nanoseconds.
    */
-  timestamp?: number;
+  timestamp?: TimeInput;
 
   /**
    * Time when the event was observed by the collection system.
    */
-  observedTimestamp?: number;
+  observedTimestamp?: TimeInput;
 
   /**
    * Numerical value of the severity.


### PR DESCRIPTION
By the specification LogRecord [timestamps should allow for UNIX nanosecond timestamps](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-timestamp), with the current API types `HrTime` can't be passed in, even though [logs SDK converts both `timestamp` and `observedTimestamp` from `TimeInput` to `HrTime`](https://github.com/open-telemetry/opentelemetry-js/blob/9e9453649d6ef3b3c27629cd2fb442d7f41a030c/experimental/packages/sdk-logs/src/LogRecord.ts#L92-L93).