### PR TITLE
fix(instrumentation-http): no not mutate given headers object for outgoing http requests

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to experimental packages in this project will be documented 
 * fix(instrumentation-fetch): only access navigator if it is defined [#4063](https://github.com/open-telemetry/opentelemetry-js/pull/4063)
   * allows for experimental usage of this instrumentation with non-browser runtimes
 * fix(instrumentation-http): memory leak when responses are not resumed
+* fix(instrumentation-http): Do not mutate given headers object for outgoing http requests. Fixes aws-sdk signing error on retries.
 
 ## 0.45.1
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -675,6 +675,10 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
 
       if (!optionsParsed.headers) {
         optionsParsed.headers = {};
+      } else {
+        // Make a copy of the headers object to avoid mutating an object the
+        // caller might have a reference to.
+        optionsParsed.headers = Object.assign({}, optionsParsed.headers);
       }
       propagation.inject(requestContext, optionsParsed.headers);
 

--- a/experimental/packages/opentelemetry-instrumentation-http/test/integrations/http-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/integrations/http-enable.test.ts
@@ -269,6 +269,20 @@ describe('HttpInstrumentation Integration tests', () => {
       assertSpan(span, SpanKind.CLIENT, validations);
     });
 
+    it('should not mutate given headers object when adding propagation headers', async () => {
+      const spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 0);
+
+      const headers = { 'x-foo': 'foo' };
+      const result = await httpRequest.get(
+        new url.URL(`${protocol}://localhost:${mockServerPort}/?query=test`),
+        { headers }
+      );
+      assert.deepStrictEqual(headers, { 'x-foo': 'foo' });
+      assert.ok(result.reqHeaders[DummyPropagation.TRACE_CONTEXT_KEY]);
+      assert.ok(result.reqHeaders[DummyPropagation.SPAN_CONTEXT_KEY]);
+    });
+
     it('should create a span for GET requests and add propagation headers with Expect headers', async () => {
       let spans = memoryExporter.getFinishedSpans();
       assert.strictEqual(spans.length, 0);


### PR DESCRIPTION
Fixes: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1609

---

See explanation at https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1609#issuecomment-1826167348
This is an alternative to https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1813 for fixing the aws-sdk signing issue on retries.
