### PR TITLE
fix(ci): ensure deploy workflow does not override benchmark data

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,7 +16,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: '18'
+          node-version: '20'
 
       - name: Install and Build 🔧
         run: |
@@ -29,8 +29,10 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=6144
 
       - name: Deploy Documentation 🚀
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@releases/v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: docs # The folder the action should deploy.
+          branch: gh-pages # The branch the action should deploy to.
+          folder: docs # The folder the action should deploy.
+          # ensure we don't override benchmark data
+          clean-exclude: |
+            benchmarks/**


### PR DESCRIPTION
## Which problem is this PR solving?

Currently out docs deploy workflow deletes the pre-existing benchmark data from the `benchmarks/` directory from the `gh-pages` branch (see 6cf6b679820f780675ddb78c50683f434f34bc27, b3a3d45f4d93666d4df76e5ab8c8146e31120311). 

To fix this, this PR:
- adds the `clean-exclude` option with `benchmarks/**` to ensure they are not deleted when the other docs data is `rsync`ed by the action.
- updates the deploy action to v4 (at least v4.2.0 is needed for wildcard matching in clean-exclude)
- updates the node version used in the workflow to v20 (so that we can use v4 of the deploy action)

## How Has This Been Tested?

- [x] Ran the workflow in a private repo where I pushed both the `main` and `gh-pages` branch.
