### PR TITLE
fix(benchmark): bring back accidentally deleted data

### DIFF
--- a/benchmarks/data.js
+++ b/benchmarks/data.js
@@ -6,6 +6,2570 @@ window.BENCHMARK_DATA = {
       {
         "commit": {
           "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "868f75e448c7c3a0efd75d72c448269f1375a996",
+          "message": "fix(benchmark): write benchmark results to file (#4172)",
+          "timestamp": "2023-10-01T22:00:15+02:00",
+          "tree_id": "d5dad24288d8d5d3e6f93f4ee28033e021585101",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/868f75e448c7c3a0efd75d72c448269f1375a996"
+        },
+        "date": 1696190499861,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 774752,
+            "range": "±0.17%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "bot@renovateapp.com",
+            "name": "Mend Renovate",
+            "username": "renovate-bot"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "5af865386ad40d85daf94c45926521ffc6df7a18",
+          "message": "chore(deps): update dependency @types/sinon to v10.0.18 (#4179)",
+          "timestamp": "2023-10-03T15:59:56+02:00",
+          "tree_id": "e0502e5babbbf2aeebe9108aefcca8d3a9338a9b",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/5af865386ad40d85daf94c45926521ffc6df7a18"
+        },
+        "date": 1696341687223,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 773990,
+            "range": "±0.56%",
+            "unit": "ops/sec",
+            "extra": "94 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "martin@martinkuba.com",
+            "name": "Martin Kuba",
+            "username": "martinkuba"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "5ce32c0fe53dc3c1c49e88961ee7cc223255ad70",
+          "message": "Added performance benchmarking doc (#4169)\n\nCo-authored-by: Tyler Benson <tylerbenson@gmail.com>\r\nCo-authored-by: Marc Pichler <marc.pichler@dynatrace.com>",
+          "timestamp": "2023-10-04T09:02:25+02:00",
+          "tree_id": "8aac14043884009d754afe0e25500ee309a2106a",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/5ce32c0fe53dc3c1c49e88961ee7cc223255ad70"
+        },
+        "date": 1696403016974,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 737739,
+            "range": "±0.21%",
+            "unit": "ops/sec",
+            "extra": "93 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "gloogankle@gmail.com",
+            "name": "Einar Norðfjörð",
+            "username": "nordfjord"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "912256184c07e9f510f4166e41d8b6e131e9446a",
+          "message": "fix: BatchExporter should export continuously when batch size is reached (#3958)\n\n* fix: BathExporter should export continuously when batch size is reached\r\n\r\n* fix: add tests\r\n\r\n* lintfix\r\n\r\n* add changelog\r\n\r\n* add test for concurrency\r\n\r\n* Update CHANGELOG.md\r\n\r\n* Apply suggestions from code review\r\n\r\n* Lint and fix browser tests\r\n\r\n* fix: lint\r\n\r\n---------\r\n\r\nCo-authored-by: Daniel Dyla <dyladan@users.noreply.github.com>\r\nCo-authored-by: Marc Pichler <marc.pichler@dynatrace.com>",
+          "timestamp": "2023-10-06T10:27:47-04:00",
+          "tree_id": "afea10697db5270e2fc4c027033e3cbe8dbc9882",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/912256184c07e9f510f4166e41d8b6e131e9446a"
+        },
+        "date": 1696602667956,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 809279,
+            "range": "±0.38%",
+            "unit": "ops/sec",
+            "extra": "95 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "bot@renovateapp.com",
+            "name": "Mend Renovate",
+            "username": "renovate-bot"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "84861cd82722d507906a64016ef59b35bf7770ed",
+          "message": "chore(deps): update dependency @types/jquery to v3.5.21 (#4187)\n\nCo-authored-by: Daniel Dyla <dyladan@users.noreply.github.com>",
+          "timestamp": "2023-10-06T10:30:35-04:00",
+          "tree_id": "f56cd4f431a7966473947b9741051d508034d522",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/84861cd82722d507906a64016ef59b35bf7770ed"
+        },
+        "date": 1696603253953,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 785190,
+            "range": "±0.29%",
+            "unit": "ops/sec",
+            "extra": "95 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "5fd3737aa3c4f27fd68bb06bfb435d8badae63f0",
+          "message": "chore: remove outdated and empty docs (#4181)",
+          "timestamp": "2023-10-07T17:40:54+08:00",
+          "tree_id": "38368c5e6682a7b9b24937e784671538b04e750a",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/5fd3737aa3c4f27fd68bb06bfb435d8badae63f0"
+        },
+        "date": 1696671731262,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 731833,
+            "range": "±0.17%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "dyladan@users.noreply.github.com",
+            "name": "Daniel Dyla",
+            "username": "dyladan"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "c320c981c5b8cd9c42d65183c2c2c5b737a0b2a1",
+          "message": "deps: update proto-loader (#4192)",
+          "timestamp": "2023-10-07T17:53:41+08:00",
+          "tree_id": "29cbf846515e22c9ce692aa5b0f03edef19b560d",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/c320c981c5b8cd9c42d65183c2c2c5b737a0b2a1"
+        },
+        "date": 1696672501351,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 753400,
+            "range": "±0.25%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "4eb10f7c9dbdc1075d2705bb7c305c063b86a2f9",
+          "message": "fix(sdk-metrics): prevent per-reader storages from keeping unreported accumulations in memory (#4163)",
+          "timestamp": "2023-10-10T15:27:12+02:00",
+          "tree_id": "02e65c14508848e33b9a814bdc044bfd018e64ee",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/4eb10f7c9dbdc1075d2705bb7c305c063b86a2f9"
+        },
+        "date": 1696944511230,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 741622,
+            "range": "±0.18%",
+            "unit": "ops/sec",
+            "extra": "101 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "f8e187b473274cc2011e7385992f07d319d667dc",
+          "message": "chore: release SDK 1.17.1/Experimental 0.44.0 (#4183)",
+          "timestamp": "2023-10-10T15:46:49+02:00",
+          "tree_id": "c663a17a9beca2a158fc5f1447dc0d0f45630af0",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/f8e187b473274cc2011e7385992f07d319d667dc"
+        },
+        "date": 1696945690445,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 705811,
+            "range": "±0.19%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "legendecas@gmail.com",
+            "name": "Chengzhong Wu",
+            "username": "legendecas"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "b6e532bf52c9553e51aa6d3375e85f0dd9bd67c1",
+          "message": "feat(metrics): prototype experimental advice support (#3876)\n\nCo-authored-by: Marc Pichler <marc.pichler@dynatrace.com>",
+          "timestamp": "2023-10-11T10:05:03+02:00",
+          "tree_id": "74fe3a870c6238109b0a32e614bf13eb6699f042",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/b6e532bf52c9553e51aa6d3375e85f0dd9bd67c1"
+        },
+        "date": 1697011579208,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 726527,
+            "range": "±0.18%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "bot@renovateapp.com",
+            "name": "Mend Renovate",
+            "username": "renovate-bot"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "00e78efd840d3f49d9d4b025a9965e8d3f2913ad",
+          "message": "chore(deps): update all patch versions (#4194)",
+          "timestamp": "2023-10-17T12:36:24+02:00",
+          "tree_id": "8129b9daefce9e57ab364786406e0aa4d8b5ebb0",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/00e78efd840d3f49d9d4b025a9965e8d3f2913ad"
+        },
+        "date": 1697539061986,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 735352,
+            "range": "±0.14%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "7f52f70d22ab1b1a4411b4a6b1a2528f182b2b7b",
+          "message": "fix: bump deploy docs workflow to node 18 (#4199)",
+          "timestamp": "2023-10-18T13:57:07+02:00",
+          "tree_id": "45e925a5a4aa48c095bfba50e2dd2cf21d6b4b62",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/7f52f70d22ab1b1a4411b4a6b1a2528f182b2b7b"
+        },
+        "date": 1697630309965,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 758651,
+            "range": "±0.22%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "luismi.ramirez@protonmail.com",
+            "name": "Luismi Ramírez",
+            "username": "luismiramirez"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "1c7d7a354281c720e7229d3d5498bbec8d3b2b8d",
+          "message": "fix(sdk-node) Remove @opentelemetry/exporter-jaeger explicit dependency (#4214)",
+          "timestamp": "2023-10-19T08:14:18+02:00",
+          "tree_id": "1aa3ebe84bd53cf07d95641b4f6cd8b9f62bdb4d",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/1c7d7a354281c720e7229d3d5498bbec8d3b2b8d"
+        },
+        "date": 1697697332434,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 778971,
+            "range": "±0.32%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "legendecas@gmail.com",
+            "name": "Chengzhong Wu",
+            "username": "legendecas"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "e9328abb689f48b81731c653036f1637a1320a7f",
+          "message": "chore: track package-lock.json (#4238)\n\n* chore: track package-lock.json\r\n\r\n* Pin to old versions for node 14\r\n\r\n* Use version range\r\n\r\n* Remove unused cached directories\r\n\r\n* Temporarily disable other tests\r\n\r\n* Temporarily enable only api test\r\n\r\n* Enable only some packages\r\n\r\n* Test only api packages\r\n\r\n* Test trace exporters\r\n\r\n* Fix line ordering\r\n\r\n* Test all packages except otlp exporters\r\n\r\n* Add trace http exporter\r\n\r\n* Add trace proto exporter\r\n\r\n* Test all but grpc exporters\r\n\r\n* chore: use npm workspaces and degrade lerna to v6\r\n\r\n* chore: get rid of lerna bootstrap\r\n\r\n* chore: use npx\r\n\r\n* chore: allow install scripts to setup buf\r\n\r\n* chore: fix w3c-integration-test cache key\r\n\r\n* chore: fix cache key\r\n\r\n* chore: disable resource compat test\r\n\r\n* chore: fix node_modules assumptions\r\n\r\n* chore: fix hoisted karma issue\r\n\r\n* chore: fix markdown linter complaints\r\n\r\n* chore: lock @grpc/grpc-js to v1.8.21\r\n\r\n* Break caches\r\n\r\n* chore: remove cache\r\n\r\n* chore: fixup inline commands\r\n\r\n---------\r\n\r\nCo-authored-by: Daniel Dyla <dyladan@users.noreply.github.com>",
+          "timestamp": "2023-11-01T19:51:24-04:00",
+          "tree_id": "c0ca10a5cae1169581d05005a32685c41ab5007c",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/e9328abb689f48b81731c653036f1637a1320a7f"
+        },
+        "date": 1698884176622,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 759253,
+            "range": "±0.30%",
+            "unit": "ops/sec",
+            "extra": "94 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "martin@martinkuba.com",
+            "name": "Martin Kuba",
+            "username": "martinkuba"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "95471d1cce457bf3880caef56fe6f960336217cd",
+          "message": "docs: fixed link to benchmark results (#4233)\n\nCo-authored-by: Chengzhong Wu <legendecas@gmail.com>",
+          "timestamp": "2023-11-02T11:08:17+08:00",
+          "tree_id": "9aa54c64c5e9760a1dde73c348ff8fc8e4ea9fe9",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/95471d1cce457bf3880caef56fe6f960336217cd"
+        },
+        "date": 1698894558212,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 749805,
+            "range": "±0.21%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "bot@renovateapp.com",
+            "name": "Mend Renovate",
+            "username": "renovate-bot"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "586def466b8722200c084a1400798fad8f68dc6f",
+          "message": "chore(deps): update all patch versions (#4215)",
+          "timestamp": "2023-11-06T11:27:06+01:00",
+          "tree_id": "09ec97227a51174ef4bc4dbbaf24dc8945b1ed78",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/586def466b8722200c084a1400798fad8f68dc6f"
+        },
+        "date": 1699266492060,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 766179,
+            "range": "±0.27%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "siimkallas@gmail.com",
+            "name": "Siim Kallas",
+            "username": "seemk"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "9db6352d305d207b96f55d41095a41a34711405d",
+          "message": "fix: otlp json encoding (#4220)\n\nCo-authored-by: Marc Pichler <marc.pichler@dynatrace.com>",
+          "timestamp": "2023-11-06T16:09:52+01:00",
+          "tree_id": "0e341b8ac5e01147e76e9635b5274283ca549d42",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/9db6352d305d207b96f55d41095a41a34711405d"
+        },
+        "date": 1699283453759,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 759369,
+            "range": "±0.51%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "david.luna@elastic.co",
+            "name": "David Luna",
+            "username": "david-luna"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "cd232cde144ca31126db33b44e9041277f579f66",
+          "message": "fix: remove duplicate export star from version.ts (#4225)\n\nCo-authored-by: Marc Pichler <marc.pichler@dynatrace.com>",
+          "timestamp": "2023-11-06T16:11:05+01:00",
+          "tree_id": "fccd2e26f796ac6a86ea54421a29a6ee2af677fb",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/cd232cde144ca31126db33b44e9041277f579f66"
+        },
+        "date": 1699283526201,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 732065,
+            "range": "±0.56%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "dinko.osrecki@emarsys.com",
+            "name": "Dinko Osrecki",
+            "username": "edosrecki"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "d434f8425334049d668ab69aaf369b6896f990c3",
+          "message": "docs: fix sdk-node config instructions (#4249)\n\nCo-authored-by: Marc Pichler <marc.pichler@dynatrace.com>",
+          "timestamp": "2023-11-06T16:13:09+01:00",
+          "tree_id": "b2216e9c063e72173bbed6ce470f61abf6537746",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/d434f8425334049d668ab69aaf369b6896f990c3"
+        },
+        "date": 1699283663603,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 746078,
+            "range": "±0.30%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "legendecas@gmail.com",
+            "name": "Chengzhong Wu",
+            "username": "legendecas"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "9fd1948e0d0b073ea6183987fd06e256f5a36220",
+          "message": "feat(api): publish api esnext target (#4231)",
+          "timestamp": "2023-11-07T10:25:33+01:00",
+          "tree_id": "ab91f26f7705b3fb28d2633028271ce10fc592c3",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/9fd1948e0d0b073ea6183987fd06e256f5a36220"
+        },
+        "date": 1699349193260,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 759839,
+            "range": "±0.21%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "73b446688f10fd8dc4cf403a085f0a39070df7b4",
+          "message": "chore: release API 1.7.0/Core 1.18.0/Experimental 0.45.0 (#4254)",
+          "timestamp": "2023-11-07T11:25:24+01:00",
+          "tree_id": "56dec4f7498b184237894a0494a9c41383ba2658",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/73b446688f10fd8dc4cf403a085f0a39070df7b4"
+        },
+        "date": 1699352785356,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 720305,
+            "range": "±0.59%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "c7c1867c829b92e23f8793422ab8b42979cdc2d7",
+          "message": "fix(sdk-metrics): hand-roll MetricAdvice type as older API versions do not include it (#4260)",
+          "timestamp": "2023-11-08T12:56:29+01:00",
+          "tree_id": "8bab1a239079444e81be4166ff84d4b4a0536aef",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/c7c1867c829b92e23f8793422ab8b42979cdc2d7"
+        },
+        "date": 1699446399461,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 730267,
+            "range": "±0.64%",
+            "unit": "ops/sec",
+            "extra": "95 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "f665499096189390e691cf1a772e677fa67812d7",
+          "message": "chore: prepare release 1.18.1/0.45.1 (#4261)",
+          "timestamp": "2023-11-08T18:51:43+01:00",
+          "tree_id": "219e74d0332c27a3f0824c70d4863a5b74739f74",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/f665499096189390e691cf1a772e677fa67812d7"
+        },
+        "date": 1699467911124,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 724329,
+            "range": "±1.36%",
+            "unit": "ops/sec",
+            "extra": "92 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "trentm@gmail.com",
+            "name": "Trent Mick",
+            "username": "trentm"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "c478c11975a3ab124822cb1dc9033a2adb21f44c",
+          "message": "chore: no need for 'packages' in \"lerna.json\" (#4264)",
+          "timestamp": "2023-11-09T14:32:18+01:00",
+          "tree_id": "680d1c638e619a0c89d0231db8191e7a507fa683",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/c478c11975a3ab124822cb1dc9033a2adb21f44c"
+        },
+        "date": 1699536798290,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "create spans (10 attributes)",
+            "value": 726370,
+            "range": "±0.19%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "martin@martinkuba.com",
+            "name": "Martin Kuba",
+            "username": "martinkuba"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "654638a430a3a3ea6cc3a83e54674b18eb90ecca",
+          "message": "Benchmark tests for trace OTLP transform and BatchSpanProcessor (#4218)\n\nCo-authored-by: Marc Pichler <marc.pichler@dynatrace.com>",
+          "timestamp": "2023-11-09T14:57:00+01:00",
+          "tree_id": "09443c8736510acec5b46eb9360031fc7872bc3f",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/654638a430a3a3ea6cc3a83e54674b18eb90ecca"
+        },
+        "date": 1699538297745,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 697822,
+            "range": "±0.30%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 7964,
+            "range": "±0.29%",
+            "unit": "ops/sec",
+            "extra": "93 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 674400,
+            "range": "±0.36%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 643360,
+            "range": "±0.64%",
+            "unit": "ops/sec",
+            "extra": "95 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "legendecas@gmail.com",
+            "name": "Chengzhong Wu",
+            "username": "legendecas"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "f2b447dad543ec57af17372411bf11b6e731f813",
+          "message": "chore: type reference on zone.js (#4257)\n\nCo-authored-by: Marc Pichler <marc.pichler@dynatrace.com>",
+          "timestamp": "2023-11-09T15:25:11+01:00",
+          "tree_id": "f290adc36515b1b162b97f210598825ae0d118eb",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/f2b447dad543ec57af17372411bf11b6e731f813"
+        },
+        "date": 1699539988485,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 708768,
+            "range": "±0.19%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8750,
+            "range": "±0.24%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 664021,
+            "range": "±0.20%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 642171,
+            "range": "±0.69%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "32224751+Lp-Francois@users.noreply.github.com",
+            "name": "François",
+            "username": "Lp-Francois"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "40fde0f69f6c7e1917ed0809e05ef5b865c6fd8b",
+          "message": "docs: add docker-compose to run prometheus for the experimental example (#4268)\n\nCo-authored-by: Marc Pichler <marc.pichler@dynatrace.com>",
+          "timestamp": "2023-11-09T17:17:44+01:00",
+          "tree_id": "549f7b5130247e4c9850a18abb9b14086bedbc4e",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/40fde0f69f6c7e1917ed0809e05ef5b865c6fd8b"
+        },
+        "date": 1699546741751,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 707349,
+            "range": "±0.23%",
+            "unit": "ops/sec",
+            "extra": "101 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8285,
+            "range": "±0.44%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 644186,
+            "range": "±0.55%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 640885,
+            "range": "±0.58%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "hyunnoh01@gmail.com",
+            "name": "Hyun Oh",
+            "username": "HyunnoH"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "f5ef8de1cc92ad22d7d95df6a5f585f9d64ddef1",
+          "message": "fix(sdk-logs): avoid map attribute set when count limit exceeded (#4195)\n\nCo-authored-by: Marc Pichler <marc.pichler@dynatrace.com>",
+          "timestamp": "2023-11-09T17:19:46+01:00",
+          "tree_id": "9466c25d60205e2f395f3709225475abf5aa1355",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/f5ef8de1cc92ad22d7d95df6a5f585f9d64ddef1"
+        },
+        "date": 1699546863467,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 685368,
+            "range": "±0.33%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8268,
+            "range": "±0.21%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 696804,
+            "range": "±0.16%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 648171,
+            "range": "±0.28%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "bot@renovateapp.com",
+            "name": "Mend Renovate",
+            "username": "renovate-bot"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "b41cada2d2e17034fc7db058eda34ca3df76213d",
+          "message": "chore(deps): update dependency chromedriver to v119 [security] (#4280)",
+          "timestamp": "2023-11-13T14:55:15+01:00",
+          "tree_id": "e4660f4ad9a645812b62dbedc28562c105a4616a",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/b41cada2d2e17034fc7db058eda34ca3df76213d"
+        },
+        "date": 1699883793569,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 704404,
+            "range": "±0.24%",
+            "unit": "ops/sec",
+            "extra": "101 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8123,
+            "range": "±0.38%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 657066,
+            "range": "±0.17%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 657511,
+            "range": "±0.25%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "bot@renovateapp.com",
+            "name": "Mend Renovate",
+            "username": "renovate-bot"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "b0c0ace8fc45f1d67d448c065b376d850c47f407",
+          "message": "chore(deps): update actions/setup-node action to v4 (#4236)",
+          "timestamp": "2023-11-14T08:56:13+01:00",
+          "tree_id": "e904e8131ffa621d0e47eeb5fe381dc966bc0e39",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/b0c0ace8fc45f1d67d448c065b376d850c47f407"
+        },
+        "date": 1699949162294,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 703703,
+            "range": "±0.22%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 7700,
+            "range": "±0.16%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 706283,
+            "range": "±0.20%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 643247,
+            "range": "±0.65%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "andremiguelcruz@msn.com",
+            "name": "André Cruz",
+            "username": "satazor"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "10f6c46057b2aa43f756d6d26fb7c960d9476365",
+          "message": "fix(sdk-trace-base): processor onStart called with a span having empty attributes (#4277)\n\nCo-authored-by: artahmetaj <artahmetaj@yahoo.com>",
+          "timestamp": "2023-11-15T15:28:45+01:00",
+          "tree_id": "5884a6ca809a99f4e1a130ae4dbc648b21d085f3",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/10f6c46057b2aa43f756d6d26fb7c960d9476365"
+        },
+        "date": 1700058607162,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 698551,
+            "range": "±0.27%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 7787,
+            "range": "±0.17%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 648809,
+            "range": "±0.62%",
+            "unit": "ops/sec",
+            "extra": "93 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 641332,
+            "range": "±0.21%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "82601620+drewcorlin1@users.noreply.github.com",
+            "name": "drewcorlin1",
+            "username": "drewcorlin1"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "5ed54c8a0964fd685d722770dcbe7fae61a12937",
+          "message": "Update fetch instrumentation to be runtime agnostic (#4063)\n\nCo-authored-by: Marc Pichler <marc.pichler@dynatrace.com>",
+          "timestamp": "2023-11-15T17:09:15+01:00",
+          "tree_id": "6c0c5a583e4014f15909bcc0f9e6ed0eeac8bd3b",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/5ed54c8a0964fd685d722770dcbe7fae61a12937"
+        },
+        "date": 1700064633082,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 705553,
+            "range": "±0.28%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8767,
+            "range": "±0.31%",
+            "unit": "ops/sec",
+            "extra": "95 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 678319,
+            "range": "±0.16%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 659087,
+            "range": "±0.61%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "2c7d5c427fa01ed3b8d46d801eb282ca4b648ef1",
+          "message": "chore: fix npm release preparation scripts, add .npmrc and release script (#4275)\n\nCo-authored-by: Trent Mick <trentm@gmail.com>",
+          "timestamp": "2023-11-15T18:44:57+01:00",
+          "tree_id": "0066df768ec9ac3973ac9a4bd25e2c4fa0d31862",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/2c7d5c427fa01ed3b8d46d801eb282ca4b648ef1"
+        },
+        "date": 1700070373651,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 688950,
+            "range": "±0.22%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8140,
+            "range": "±0.20%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 669378,
+            "range": "±0.15%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 642194,
+            "range": "±0.21%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "bot@renovateapp.com",
+            "name": "Mend Renovate",
+            "username": "renovate-bot"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "4eddf51eb96fba8702b845508af594fd5ef4480a",
+          "message": "chore(deps): update all patch versions (#4255)",
+          "timestamp": "2023-11-15T15:32:57-05:00",
+          "tree_id": "3968c592f6614fb65607d08240cdda6e6469d2d7",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/4eddf51eb96fba8702b845508af594fd5ef4480a"
+        },
+        "date": 1700080455581,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 706844,
+            "range": "±0.44%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8738,
+            "range": "±0.20%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 685465,
+            "range": "±0.51%",
+            "unit": "ops/sec",
+            "extra": "91 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 669147,
+            "range": "±0.31%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "dyladan@users.noreply.github.com",
+            "name": "Daniel Dyla",
+            "username": "dyladan"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "51be418b3dbc0b804ed42c74415d9e26ea60ff31",
+          "message": "Execute binaries from root node modules (#4302)",
+          "timestamp": "2023-11-16T15:56:26-05:00",
+          "tree_id": "40ba2c461566d0c20066f5ec1ae7e85353eb400f",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/51be418b3dbc0b804ed42c74415d9e26ea60ff31"
+        },
+        "date": 1700168273887,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 678769,
+            "range": "±0.22%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 7952,
+            "range": "±0.36%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 658988,
+            "range": "±0.59%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 636262,
+            "range": "±0.57%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "dyladan@users.noreply.github.com",
+            "name": "Daniel Dyla",
+            "username": "dyladan"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "079c1f547a32b84e775f1df850b8e66f575ed7ca",
+          "message": "Add Trent to approvers (#4311)",
+          "timestamp": "2023-11-20T10:33:26-05:00",
+          "tree_id": "034d2380e0bfbcf0f4e72107a431846593ac64e3",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/079c1f547a32b84e775f1df850b8e66f575ed7ca"
+        },
+        "date": 1700494482751,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 695431,
+            "range": "±0.25%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8457,
+            "range": "±0.18%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 682013,
+            "range": "±0.58%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 650109,
+            "range": "±0.54%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "b3a539d301c267866b5081a2bb15663b4171a43e",
+          "message": "chore(renovate): require dashboard approval for lerna updates (#4276)",
+          "timestamp": "2023-11-22T06:55:04+01:00",
+          "tree_id": "d12eb8bc53770d2a60037e822e083ce52a2052ac",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/b3a539d301c267866b5081a2bb15663b4171a43e"
+        },
+        "date": 1700632578206,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 714532,
+            "range": "±0.25%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 7688,
+            "range": "±0.19%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 659643,
+            "range": "±0.18%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 653091,
+            "range": "±0.26%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "133362191+strivly@users.noreply.github.com",
+            "name": "strivly",
+            "username": "strivly"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "8067d9721021cb25f94534a27cd2e6298ef7f6a2",
+          "message": "chore(ci): install semver globally to speed up \"peer-api\" workflow (#4270)\n\nCloses: #4242",
+          "timestamp": "2023-11-23T15:54:44-08:00",
+          "tree_id": "ebf014a05df6da8bd46b2e152f9949cbc7ffb072",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/8067d9721021cb25f94534a27cd2e6298ef7f6a2"
+        },
+        "date": 1700785954148,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 709321,
+            "range": "±0.26%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8496,
+            "range": "±0.51%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 701095,
+            "range": "±0.21%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 643699,
+            "range": "±0.21%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "38db748685ed8745438b3b8ba99ec5e38ef551e5",
+          "message": "fix(ci): remove token setup via environment variable from .npmrc (#4329)",
+          "timestamp": "2023-11-29T17:28:21+01:00",
+          "tree_id": "7187910a71415aeb207c84f28e92c673e0d06ca2",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/38db748685ed8745438b3b8ba99ec5e38ef551e5"
+        },
+        "date": 1701275376772,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 718653,
+            "range": "±0.30%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8747,
+            "range": "±0.18%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 667255,
+            "range": "±0.25%",
+            "unit": "ops/sec",
+            "extra": "95 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 651003,
+            "range": "±0.30%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "f6546365029a8f700a0096af396914d6b703c824",
+          "message": "feat: add script to update changelogs on release preparation (#4315)\n\n* feat: add script to update changelogs on releases\r\n\r\n* fix: address comments\r\n\r\n* Apply suggestions from code review\r\n\r\nCo-authored-by: Trent Mick <trentm@gmail.com>\r\n\r\n* fix: apply suggestions from code review\r\n\r\n* fix: use packageJson.version instead of version\r\n\r\n---------\r\n\r\nCo-authored-by: Trent Mick <trentm@gmail.com>",
+          "timestamp": "2023-11-30T08:50:29+01:00",
+          "tree_id": "be041aa01b7770f987903350eacba1871cc5f1f4",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/f6546365029a8f700a0096af396914d6b703c824"
+        },
+        "date": 1701330704438,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 705678,
+            "range": "±0.19%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8504,
+            "range": "±0.25%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 659180,
+            "range": "±0.44%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 628902,
+            "range": "±0.66%",
+            "unit": "ops/sec",
+            "extra": "92 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "dyladan@users.noreply.github.com",
+            "name": "Daniel Dyla",
+            "username": "dyladan"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "cc4ff2d15897ec3315aaf59728b0247864ed494a",
+          "message": "Merge pull request #4332 from dyladan/node-20-leak\n\nfix(instrumentation-http): resume responses when there is no response…",
+          "timestamp": "2023-11-30T09:10:53-05:00",
+          "tree_id": "dc35be4b6250cc6372c2cf8a2fefb09e8b9ba48f",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/cc4ff2d15897ec3315aaf59728b0247864ed494a"
+        },
+        "date": 1701353526937,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 696544,
+            "range": "±0.33%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 7771,
+            "range": "±0.16%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 669047,
+            "range": "±0.17%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 649577,
+            "range": "±0.58%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "dyladan@users.noreply.github.com",
+            "name": "Daniel Dyla",
+            "username": "dyladan"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "593d220465c92393a7be9d099f27488c11ea42d6",
+          "message": "Merge pull request #4335 from dyladan/node-20-test\n\ntest: make rawRequest HTTP-compliant",
+          "timestamp": "2023-11-30T09:22:44-05:00",
+          "tree_id": "3e710b24d5d0a12bfc639a3fde53b8dec03023df",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/593d220465c92393a7be9d099f27488c11ea42d6"
+        },
+        "date": 1701354238378,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 709302,
+            "range": "±0.23%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8680,
+            "range": "±0.24%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 673661,
+            "range": "±1.61%",
+            "unit": "ops/sec",
+            "extra": "91 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 649926,
+            "range": "±0.63%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "dyladan@users.noreply.github.com",
+            "name": "Daniel Dyla",
+            "username": "dyladan"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "6dd075cdf66d93aae43c647999d7bd5f885651ba",
+          "message": "Merge pull request #4336 from dyladan/test-20\n\nAdd node 20 to test matrix",
+          "timestamp": "2023-12-01T11:20:54-05:00",
+          "tree_id": "1e77f826f76b4647ed402e8b9bbf50191ca80959",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/6dd075cdf66d93aae43c647999d7bd5f885651ba"
+        },
+        "date": 1701449100997,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 687127,
+            "range": "±0.24%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 7870,
+            "range": "±0.34%",
+            "unit": "ops/sec",
+            "extra": "95 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 660514,
+            "range": "±0.17%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 643146,
+            "range": "±0.25%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "34400837+lyzlisa@users.noreply.github.com",
+            "name": "lyzlisa",
+            "username": "lyzlisa"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "9e9453649d6ef3b3c27629cd2fb442d7f41a030c",
+          "message": "ci: add npm cache in actions/setup-node (#4271)",
+          "timestamp": "2023-12-01T10:30:50-08:00",
+          "tree_id": "c3ef046e239574398591491bb6de9f438903508f",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/9e9453649d6ef3b3c27629cd2fb442d7f41a030c"
+        },
+        "date": 1701455525727,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 692302,
+            "range": "±0.25%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8060,
+            "range": "±0.46%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 681070,
+            "range": "±0.33%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 641665,
+            "range": "±0.86%",
+            "unit": "ops/sec",
+            "extra": "93 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "hyunnoh01@gmail.com",
+            "name": "Hyun Oh",
+            "username": "HyunnoH"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "dcf93e85065a2cb2d255278421d39a7b57941b72",
+          "message": "feat(sdk-logs): add droppedAttributesCount field to ReadableLogRecord (#4289)\n\n* feat(sdk-logs): add droppedAttributesCount field to ReadableLogRecord\r\n\r\n* chore: check droppedAttributesCount value in test case\r\n\r\n* feat(otlp-transformer): make toLogRecord() use ReadableLogRecord.droppedAttributesCount\r\n\r\n---------\r\n\r\nCo-authored-by: Marc Pichler <marc.pichler@dynatrace.com>",
+          "timestamp": "2023-12-05T08:48:21-05:00",
+          "tree_id": "5171e97169b8460b78430d8196e538b73c9ec8ef",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/dcf93e85065a2cb2d255278421d39a7b57941b72"
+        },
+        "date": 1701787579679,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 698146,
+            "range": "±0.20%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 7585,
+            "range": "±0.21%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 693755,
+            "range": "±0.16%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 645495,
+            "range": "±0.65%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "siimkallas@gmail.com",
+            "name": "Siim Kallas",
+            "username": "seemk"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "104a5e88673f52af76383665b5157c1c81316d7b",
+          "message": "fix(api-logs): allow passing in TimeInput for LogRecord (#4345)\n\n* fix: allow passing in TimeInput for LogRecord\r\n\r\n* chore: update changelog",
+          "timestamp": "2023-12-06T10:14:24+01:00",
+          "tree_id": "d26c6fa8c879eb49abf80ea2ddc2ec3ac5734feb",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/104a5e88673f52af76383665b5157c1c81316d7b"
+        },
+        "date": 1701854149142,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 696900,
+            "range": "±0.29%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8434,
+            "range": "±0.17%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 660332,
+            "range": "±0.45%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 640835,
+            "range": "±0.49%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "441333+Vunovati@users.noreply.github.com",
+            "name": "Vladimir Adamić",
+            "username": "Vunovati"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "4daa2640d2e2312974f6b1cfdebb44f6d02cf046",
+          "message": "fix: programmatic url and headers take precedence in metric exporters… (#4334)\n\n* fix: programmatic url and headers take precedence in metric exporters (#2370)\r\n\r\n* chore: adjust grpc exporter metrics test\r\n\r\n* chore(changelog): update changelog",
+          "timestamp": "2023-12-06T11:51:17+01:00",
+          "tree_id": "4f5b30c0d4d08f582ddf67cc6de9e05508e06984",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/4daa2640d2e2312974f6b1cfdebb44f6d02cf046"
+        },
+        "date": 1701859958854,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 706031,
+            "range": "±0.25%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8671,
+            "range": "±0.25%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 683143,
+            "range": "±0.17%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 671636,
+            "range": "±0.22%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "trentm@gmail.com",
+            "name": "Trent Mick",
+            "username": "trentm"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "5b0fb7b40dd6809dc9c362378b90e0ee8fa45f62",
+          "message": "fix(instrumentation-http): do not mutate given headers object for outgoing http requests (#4346)\n\nFixes: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1609",
+          "timestamp": "2023-12-06T08:08:18-08:00",
+          "tree_id": "f6f7ee7711c94c2c0fb5391769264c2ca07a0126",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/5b0fb7b40dd6809dc9c362378b90e0ee8fa45f62"
+        },
+        "date": 1701879335983,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 692361,
+            "range": "±0.25%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 7614,
+            "range": "±0.20%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 666590,
+            "range": "±0.41%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 645402,
+            "range": "±0.71%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "bot@renovateapp.com",
+            "name": "Mend Renovate",
+            "username": "renovate-bot"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "4e77c1dee61c7554d172b533829f4b209358a328",
+          "message": "chore(deps): update actions/stale action to v9 (#4353)",
+          "timestamp": "2023-12-12T13:54:48+01:00",
+          "tree_id": "9f4670811875c55a7d617d9bde14bdb5315e3ebc",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/4e77c1dee61c7554d172b533829f4b209358a328"
+        },
+        "date": 1702386144990,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 725623,
+            "range": "±0.24%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8741,
+            "range": "±0.20%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 658622,
+            "range": "±0.18%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 637660,
+            "range": "±0.23%",
+            "unit": "ops/sec",
+            "extra": "94 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "bot@renovateapp.com",
+            "name": "Mend Renovate",
+            "username": "renovate-bot"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "9349c68c2fc87d3c8c4104a866cbe94921c2a8f8",
+          "message": "fix(deps): update dependency import-in-the-middle to v1.6.0 (#4357)",
+          "timestamp": "2023-12-12T14:16:42+01:00",
+          "tree_id": "cf5d7c73fbd379cffb67f39f629b196797993119",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/9349c68c2fc87d3c8c4104a866cbe94921c2a8f8"
+        },
+        "date": 1702387326018,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 699157,
+            "range": "±0.31%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 7739,
+            "range": "±0.27%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 670161,
+            "range": "±0.23%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 650795,
+            "range": "±0.25%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "bot@renovateapp.com",
+            "name": "Mend Renovate",
+            "username": "renovate-bot"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "237c757242af1c3d6fa48016928a2a6fc68ee959",
+          "message": "chore(deps): update all patch versions (#4306)",
+          "timestamp": "2023-12-12T16:43:29+01:00",
+          "tree_id": "05a40b600c0ac4307a51de54f8cfb07c7b0b8c1f",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/237c757242af1c3d6fa48016928a2a6fc68ee959"
+        },
+        "date": 1702396214541,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 690688,
+            "range": "±0.22%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8305,
+            "range": "±0.25%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 662960,
+            "range": "±0.16%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 643526,
+            "range": "±0.58%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "6be10fbd8de2a6d50cd1442379a95c7ad52f8b03",
+          "message": "chore(ci): use node 20 in lint workflow (#4359)",
+          "timestamp": "2023-12-12T16:53:35+01:00",
+          "tree_id": "891bd98ddef208f7db7ec938d21899768fbc8371",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/6be10fbd8de2a6d50cd1442379a95c7ad52f8b03"
+        },
+        "date": 1702396679738,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 721769,
+            "range": "±0.26%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8321,
+            "range": "±0.29%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 647230,
+            "range": "±0.43%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 631555,
+            "range": "±0.52%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "bot@renovateapp.com",
+            "name": "Mend Renovate",
+            "username": "renovate-bot"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "dddab06aa48b6d70da4c9f0c0a9faaf3646a77ef",
+          "message": "chore(deps): update dependency linkinator to v6 (#4237)",
+          "timestamp": "2023-12-12T17:04:22+01:00",
+          "tree_id": "ae9f6e2328ea731969856a473976822c6e5f80f3",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/dddab06aa48b6d70da4c9f0c0a9faaf3646a77ef"
+        },
+        "date": 1702397304755,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 706666,
+            "range": "±0.22%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8719,
+            "range": "±0.22%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 654729,
+            "range": "±0.64%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 656360,
+            "range": "±0.55%",
+            "unit": "ops/sec",
+            "extra": "92 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "af4f7a9daf07c738193daf5eaa921398b4b2b952",
+          "message": "fix(otlp-exporter-base): decrease default concurrency limit to 30 (#4211)\n\n* fix(otlp-exporter-base): decrease concurrency limit to 30\r\n\r\n* fix(changelog): add changelog entry",
+          "timestamp": "2023-12-13T16:47:52+08:00",
+          "tree_id": "33c48c3499e7aa374d36e24c6fce5438d13e6547",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/af4f7a9daf07c738193daf5eaa921398b4b2b952"
+        },
+        "date": 1702480311735,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 697141,
+            "range": "±0.26%",
+            "unit": "ops/sec",
+            "extra": "101 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 7943,
+            "range": "±0.20%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 683283,
+            "range": "±0.16%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 640095,
+            "range": "±0.19%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "4fe1ae8aaf39dc310f8fd242405a13e1456239db",
+          "message": "chore(deps): use actions/checkout >4 instead of 4.0.0 exactly (#4361)",
+          "timestamp": "2023-12-13T10:16:19+01:00",
+          "tree_id": "ed83aa2ba3d529f26971fb522c5a1851b3066e74",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/4fe1ae8aaf39dc310f8fd242405a13e1456239db"
+        },
+        "date": 1702480397373,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 708795,
+            "range": "±0.26%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8530,
+            "range": "±0.20%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 673653,
+            "range": "±0.59%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 668619,
+            "range": "±0.26%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "dyladan@users.noreply.github.com",
+            "name": "Daniel Dyla",
+            "username": "dyladan"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "1cbaaf08b2dd0c2a9721bdd552e94f874a3f13f3",
+          "message": "chore(deps): update webpack to latest (#4340)\n\n* Update webpack to latest\r\n\r\n* Skip tree shake test on node 8\r\n\r\n* Update webpack utility modules\r\n\r\n* lint\r\n\r\n* Apply review comments\r\n\r\n* Invert test skip\r\n\r\n* Use process.versions.node\r\n\r\n* Remove approval requirement for webpack",
+          "timestamp": "2023-12-13T14:36:54-05:00",
+          "tree_id": "e8dd329d7d4eed88e244803d0649a23fd2fff391",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/1cbaaf08b2dd0c2a9721bdd552e94f874a3f13f3"
+        },
+        "date": 1702519665146,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 688249,
+            "range": "±0.21%",
+            "unit": "ops/sec",
+            "extra": "101 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 7795,
+            "range": "±0.34%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 668454,
+            "range": "±0.54%",
+            "unit": "ops/sec",
+            "extra": "95 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 652574,
+            "range": "±0.27%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "bot@renovateapp.com",
+            "name": "Mend Renovate",
+            "username": "renovate-bot"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "d286bf6498248136e59ab1c0efd4b5be8b4cefe8",
+          "message": "fix(deps): update dependency import-in-the-middle to v1.7.1 (#4367)",
+          "timestamp": "2023-12-14T09:57:42+01:00",
+          "tree_id": "39aa1a5f7a5c0b114caef70e949bde435052bd09",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/d286bf6498248136e59ab1c0efd4b5be8b4cefe8"
+        },
+        "date": 1702544351030,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 687105,
+            "range": "±0.26%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 7760,
+            "range": "±0.26%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 669951,
+            "range": "±0.69%",
+            "unit": "ops/sec",
+            "extra": "97 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 649630,
+            "range": "±0.22%",
+            "unit": "ops/sec",
+            "extra": "98 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "bot@renovateapp.com",
+            "name": "Mend Renovate",
+            "username": "renovate-bot"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "02de4ab72062308ebff18ff79048c72dfd5dfac0",
+          "message": "chore(deps): update dependency @types/webpack to v5 (#4368)",
+          "timestamp": "2023-12-14T10:35:52+01:00",
+          "tree_id": "72730c6ac4e54622ab8d38791577f3e36ae3f768",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/02de4ab72062308ebff18ff79048c72dfd5dfac0"
+        },
+        "date": 1702546643633,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 725628,
+            "range": "±0.27%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8827,
+            "range": "±0.15%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 660483,
+            "range": "±0.24%",
+            "unit": "ops/sec",
+            "extra": "93 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 648233,
+            "range": "±0.29%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
+            "email": "marc.pichler@dynatrace.com",
+            "name": "Marc Pichler",
+            "username": "pichlermarc"
+          },
+          "committer": {
+            "email": "noreply@github.com",
+            "name": "GitHub",
+            "username": "web-flow"
+          },
+          "distinct": true,
+          "id": "d3c311aec24137084dc820805a2597e120335672",
+          "message": "chore: prepare release 1.19.0/0.46.0 (#4358)\n\n* chore: prepare release 1.19.0/0.46.0\r\n\r\n* fix(changelog): move entry",
+          "timestamp": "2023-12-14T13:17:38+01:00",
+          "tree_id": "ee705d0da00c9dcac6f204fdfcb35754234f98a5",
+          "url": "https://github.com/open-telemetry/opentelemetry-js/commit/d3c311aec24137084dc820805a2597e120335672"
+        },
+        "date": 1702556346240,
+        "tool": "benchmarkjs",
+        "benches": [
+          {
+            "name": "transform 1 span",
+            "value": 734293,
+            "range": "±0.33%",
+            "unit": "ops/sec",
+            "extra": "96 samples"
+          },
+          {
+            "name": "transform 100 spans",
+            "value": 8481,
+            "range": "±0.18%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "create spans (10 attributes)",
+            "value": 671243,
+            "range": "±0.34%",
+            "unit": "ops/sec",
+            "extra": "99 samples"
+          },
+          {
+            "name": "BatchSpanProcessor process span",
+            "value": 653655,
+            "range": "±0.26%",
+            "unit": "ops/sec",
+            "extra": "100 samples"
+          }
+        ]
+      },
+      {
+        "commit": {
+          "author": {
             "email": "39923391+hectorhdzg@users.noreply.github.com",
             "name": "Hector Hernandez",
             "username": "hectorhdzg"


### PR DESCRIPTION
## Which problem is this PR solving?

Our docs deploy workflow deleted some benchmark data on every release. This PR brings back the old data - I went trough the commit history and manually added the entries back. This should be merged before #4376 as merging any PR will mean that there will be merge conflicts.  #4376 will fix the workflow problem.

Thanks to @martinkuba for initially noticing this.