### PR TITLE
fix(instrumentation): do not export Node.js types for Browser users

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(instrumentation): do not export Node.js-specific types for Browser users [#4378](https://github.com/open-telemetry/opentelemetry-js/pull/4378) @pichlermarc
+  * Fixes a bug where `InstrumentationNodeModuleFile` and `InstrumentationNodeModuleDefinition` were exported even if using the package in a browser context
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-instrumentation/src/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/index.ts
@@ -15,9 +15,8 @@
  */
 
 export * from './autoLoader';
-export { InstrumentationBase } from './platform/index';
-export { InstrumentationNodeModuleDefinition } from './instrumentationNodeModuleDefinition';
-export { InstrumentationNodeModuleFile } from './instrumentationNodeModuleFile';
+// Exports for Node.js and Browser are different, therefore exporting *
+export * from './platform/index';
 export * from './types';
 export * from './types_internal';
 export * from './utils';

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/index.ts
@@ -14,4 +14,8 @@
  * limitations under the License.
  */
 
-export { InstrumentationBase } from './node';
+export {
+  InstrumentationNodeModuleFile,
+  InstrumentationNodeModuleDefinition,
+  InstrumentationBase,
+} from './node';

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/index.ts
@@ -14,3 +14,5 @@
  * limitations under the License.
  */
 export { InstrumentationBase } from './instrumentation';
+export { InstrumentationNodeModuleFile } from './instrumentationNodeModuleFile';
+export { InstrumentationNodeModuleDefinition } from './instrumentationNodeModuleDefinition';

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentationNodeModuleDefinition.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentationNodeModuleDefinition.ts
@@ -14,19 +14,22 @@
  * limitations under the License.
  */
 
-import { InstrumentationModuleFile } from './types';
-import { normalize } from 'path';
+import {
+  InstrumentationModuleDefinition,
+  InstrumentationModuleFile,
+} from '../../types';
 
-export class InstrumentationNodeModuleFile<T>
-  implements InstrumentationModuleFile<T>
+export class InstrumentationNodeModuleDefinition<T>
+  implements InstrumentationModuleDefinition<T>
 {
-  public name: string;
+  files: InstrumentationModuleFile<T>[];
   constructor(
-    name: string,
+    public name: string,
     public supportedVersions: string[],
-    public patch: (moduleExports: T, moduleVersion?: string) => T,
-    public unpatch: (moduleExports?: T, moduleVersion?: string) => void
+    public patch?: (exports: T, moduleVersion?: string) => T,
+    public unpatch?: (exports: T, moduleVersion?: string) => void,
+    files?: InstrumentationModuleFile<any>[]
   ) {
-    this.name = normalize(name);
+    this.files = files || [];
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentationNodeModuleFile.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentationNodeModuleFile.ts
@@ -14,22 +14,19 @@
  * limitations under the License.
  */
 
-import {
-  InstrumentationModuleDefinition,
-  InstrumentationModuleFile,
-} from './types';
+import { InstrumentationModuleFile } from '../../types';
+import { normalize } from 'path';
 
-export class InstrumentationNodeModuleDefinition<T>
-  implements InstrumentationModuleDefinition<T>
+export class InstrumentationNodeModuleFile<T>
+  implements InstrumentationModuleFile<T>
 {
-  files: InstrumentationModuleFile<T>[];
+  public name: string;
   constructor(
-    public name: string,
+    name: string,
     public supportedVersions: string[],
-    public patch?: (exports: T, moduleVersion?: string) => T,
-    public unpatch?: (exports: T, moduleVersion?: string) => void,
-    files?: InstrumentationModuleFile<any>[]
+    public patch: (moduleExports: T, moduleVersion?: string) => T,
+    public unpatch: (moduleExports?: T, moduleVersion?: string) => void
   ) {
-    this.files = files || [];
+    this.name = normalize(name);
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation/test/node/EsmInstrumentation.test.mjs
+++ b/experimental/packages/opentelemetry-instrumentation/test/node/EsmInstrumentation.test.mjs
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
-} from '../../build/src/index.js';
+} from '../../build/src/platform/index.js';
 import * as exported from 'test-esm-module';
 
 class TestInstrumentationWrapFn extends InstrumentationBase {


### PR DESCRIPTION
## Which problem is this PR solving?

`InstrumentationNodeModuleFile` and `InstrumentationNodeModuleDefinition` were exported even if the `@opentelemetry/instrumentation` package is used in a browser context. This PR changes it so that the Node type are not exported for Browser users anymore.

Fixes #4373 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Testing locally against a project using `webpack` and including the setup provided in #4373. I installed the `@opentelemetry/instrumentation` dependency as a packaged file that includes the changes from this PR.