### PR TITLE
fix(instrumentation): bump import-in-the-middle to 1.7.2

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@types/shimmer": "^1.0.2",
-    "import-in-the-middle": "1.7.1",
+    "import-in-the-middle": "1.7.2",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2",
     "shimmer": "^1.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3105,7 +3105,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.1",
+        "import-in-the-middle": "1.7.2",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -19475,9 +19475,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.2.tgz",
+      "integrity": "sha512-coz7AjRnPyKW36J6JX5Bjz1mcX7MX1H2XsEGseVcnXMdzsAbbAu0HBZhiAem+3SAmuZdi+p8OwoB2qUpTRgjOQ==",
       "dependencies": {
         "acorn": "^8.8.2",
         "acorn-import-assertions": "^1.9.0",
@@ -40765,7 +40765,7 @@
         "codecov": "3.8.3",
         "cpx": "1.5.0",
         "cross-var": "1.1.0",
-        "import-in-the-middle": "1.7.1",
+        "import-in-the-middle": "1.7.2",
         "karma": "6.4.2",
         "karma-chrome-launcher": "3.1.0",
         "karma-coverage": "2.2.1",
@@ -50051,9 +50051,9 @@
       }
     },
     "import-in-the-middle": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.2.tgz",
+      "integrity": "sha512-coz7AjRnPyKW36J6JX5Bjz1mcX7MX1H2XsEGseVcnXMdzsAbbAu0HBZhiAem+3SAmuZdi+p8OwoB2qUpTRgjOQ==",
       "requires": {
         "acorn": "^8.8.2",
         "acorn-import-assertions": "^1.9.0",


### PR DESCRIPTION
## Which problem is this PR solving?

Bump import-in-the-middle to 1.7.2.
Fixes the issue: https://github.com/DataDog/import-in-the-middle/issues/31

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
