### PR TITLE
fix(instrumentation): use caret range on import-in-the-middle

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+fix(instrumentation): use caret range on import-in-the-middle [#4380](https://github.com/open-telemetry/opentelemetry-js/pull/4380) @pichlermarc
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@types/shimmer": "^1.0.2",
-    "import-in-the-middle": "1.7.2",
+    "import-in-the-middle": "^1.7.2",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2",
     "shimmer": "^1.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3105,7 +3105,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.2",
+        "import-in-the-middle": "^1.7.2",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -40765,7 +40765,7 @@
         "codecov": "3.8.3",
         "cpx": "1.5.0",
         "cross-var": "1.1.0",
-        "import-in-the-middle": "1.7.2",
+        "import-in-the-middle": "^1.7.2",
         "karma": "6.4.2",
         "karma-chrome-launcher": "3.1.0",
         "karma-coverage": "2.2.1",


### PR DESCRIPTION
## Which problem is this PR solving?

`import-in-the-middle` is having a lot of changes right now to keep up with changes in Node.js. This PR unpins `import-in-the-middle` to ensure our users can also keep up without requiring a new `@opentelemetry/instrumentation` release each time.

This PR is intended as more of a discussion-starter. There are a few pros and cons to both sides (keeping it pinned vs. unpinning it)

## Type of change

- [x] Bug fix? (non-breaking change which fixes an issue)
