### PR TITLE
chore: prepare release 1.20.0/0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,18 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :rocket: (Enhancement)
 
-* perf(otlp-transformer): skip unnecessary base64 encode of span contexts [#4343](https://github.com/open-telemetry/opentelemetry-js/pull/4343) @seemk
-* feat(sdk-trace-base): improve log messages when dropping span events [#4223](https://github.com/open-telemetry/opentelemetry-js/pull/4223) @mkubliniak
-
 ### :bug: (Bug Fix)
 
 ### :books: (Refine Doc)
 
 ### :house: (Internal)
+
+## 1.20.0
+
+### :rocket: (Enhancement)
+
+* perf(otlp-transformer): skip unnecessary base64 encode of span contexts [#4343](https://github.com/open-telemetry/opentelemetry-js/pull/4343) @seemk
+* feat(sdk-trace-base): improve log messages when dropping span events [#4223](https://github.com/open-telemetry/opentelemetry-js/pull/4223) @mkubliniak
 
 ## 1.19.0
 

--- a/examples/esm-http-ts/package.json
+++ b/examples/esm-http-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esm-http-ts",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Example of HTTP integration with OpenTelemetry using ESM and TypeScript",
   "main": "build/index.js",
   "type": "module",
@@ -31,12 +31,12 @@
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/",
   "dependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.46.0",
-    "@opentelemetry/instrumentation": "0.46.0",
-    "@opentelemetry/instrumentation-http": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
-    "@opentelemetry/sdk-trace-node": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+    "@opentelemetry/instrumentation": "0.47.0",
+    "@opentelemetry/instrumentation-http": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/sdk-trace-node": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   }
 }

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-example",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Example of HTTP integration with OpenTelemetry",
   "main": "index.js",
   "scripts": {
@@ -29,14 +29,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-jaeger": "1.19.0",
-    "@opentelemetry/exporter-zipkin": "1.19.0",
-    "@opentelemetry/instrumentation": "0.46.0",
-    "@opentelemetry/instrumentation-http": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
-    "@opentelemetry/sdk-trace-node": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/exporter-jaeger": "1.20.0",
+    "@opentelemetry/exporter-zipkin": "1.20.0",
+    "@opentelemetry/instrumentation": "0.47.0",
+    "@opentelemetry/instrumentation-http": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/sdk-trace-node": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/http",
   "devDependencies": {

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,7 +1,7 @@
 {
   "name": "https-example",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Example of HTTPs integration with OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -33,14 +33,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/exporter-jaeger": "1.19.0",
-    "@opentelemetry/exporter-zipkin": "1.19.0",
-    "@opentelemetry/instrumentation": "0.46.0",
-    "@opentelemetry/instrumentation-http": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
-    "@opentelemetry/sdk-trace-node": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/exporter-jaeger": "1.20.0",
+    "@opentelemetry/exporter-zipkin": "1.20.0",
+    "@opentelemetry/instrumentation": "0.47.0",
+    "@opentelemetry/instrumentation-http": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/sdk-trace-node": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-opentelemetry-example",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Example of using @opentelemetry/sdk-trace-web and @opentelemetry/sdk-metrics in browser",
   "main": "index.js",
   "scripts": {
@@ -43,20 +43,20 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/context-zone": "1.19.0",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.46.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.46.0",
-    "@opentelemetry/exporter-zipkin": "1.19.0",
-    "@opentelemetry/instrumentation": "0.46.0",
-    "@opentelemetry/instrumentation-fetch": "0.46.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.46.0",
-    "@opentelemetry/propagator-b3": "1.19.0",
-    "@opentelemetry/sdk-metrics": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
-    "@opentelemetry/sdk-trace-web": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/context-zone": "1.20.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+    "@opentelemetry/exporter-zipkin": "1.20.0",
+    "@opentelemetry/instrumentation": "0.47.0",
+    "@opentelemetry/instrumentation-fetch": "0.47.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.47.0",
+    "@opentelemetry/propagator-b3": "1.20.0",
+    "@opentelemetry/sdk-metrics": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/sdk-trace-web": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web"
 }

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-otlp-exporter-node",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
@@ -29,17 +29,17 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.46.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.46.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "0.46.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.46.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-metrics": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.47.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "0.47.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-metrics": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/otlp-exporter-node"
 }

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
-fix(instrumentation): use caret range on import-in-the-middle [#4380](https://github.com/open-telemetry/opentelemetry-js/pull/4380) @pichlermarc
+* fix(instrumentation): use caret range on import-in-the-middle [#4380](https://github.com/open-telemetry/opentelemetry-js/pull/4380) @pichlermarc
 
 ## 0.46.0
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,11 +10,15 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
-fix(instrumentation): use caret range on import-in-the-middle [#4380](https://github.com/open-telemetry/opentelemetry-js/pull/4380) @pichlermarc
-
 ### :books: (Refine Doc)
 
 ### :house: (Internal)
+
+## 0.47.0
+
+### :bug: (Bug Fix)
+
+fix(instrumentation): use caret range on import-in-the-middle [#4380](https://github.com/open-telemetry/opentelemetry-js/pull/4380) @pichlermarc
 
 ## 0.46.0
 

--- a/experimental/backwards-compatibility/node14/package.json
+++ b/experimental/backwards-compatibility/node14/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node14",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "private": true,
   "description": "Backwards compatibility app for node 14 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.46.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0"
+    "@opentelemetry/sdk-node": "0.47.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0"
   },
   "devDependencies": {
     "@types/node": "14.18.25",

--- a/experimental/backwards-compatibility/node16/package.json
+++ b/experimental/backwards-compatibility/node16/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node16",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "private": true,
   "description": "Backwards compatibility app for node 16 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.46.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0"
+    "@opentelemetry/sdk-node": "0.47.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0"
   },
   "devDependencies": {
     "@types/node": "16.11.52",

--- a/experimental/examples/logs/package.json
+++ b/experimental/examples/logs/package.json
@@ -1,14 +1,14 @@
 {
   "name": "logs-example",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "private": true,
   "scripts": {
     "start": "ts-node index.ts"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/api-logs": "0.46.0",
-    "@opentelemetry/sdk-logs": "0.46.0"
+    "@opentelemetry/api-logs": "0.47.0",
+    "@opentelemetry/sdk-logs": "0.47.0"
   },
   "devDependencies": {
     "@types/node": "18.6.5",

--- a/experimental/examples/opencensus-shim/package.json
+++ b/experimental/examples/opencensus-shim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencensus-shim",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Example of using @opentelemetry/shim-opencensus in Node.js",
   "main": "index.js",
   "scripts": {
@@ -31,13 +31,13 @@
     "@opencensus/instrumentation-http": "0.1.0",
     "@opencensus/nodejs-base": "0.1.0",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/exporter-prometheus": "0.46.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-metrics": "1.19.0",
-    "@opentelemetry/sdk-trace-node": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0",
-    "@opentelemetry/shim-opencensus": "0.46.0"
+    "@opentelemetry/exporter-prometheus": "0.47.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-metrics": "1.20.0",
+    "@opentelemetry/sdk-trace-node": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0",
+    "@opentelemetry/shim-opencensus": "0.47.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/examples/opencensus-shim"
 }

--- a/experimental/examples/prometheus/package.json
+++ b/experimental/examples/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prometheus-example",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "private": true,
   "description": "Example of using @opentelemetry/sdk-metrics and @opentelemetry/exporter-prometheus",
   "main": "index.js",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-prometheus": "0.46.0",
-    "@opentelemetry/sdk-metrics": "1.19.0"
+    "@opentelemetry/exporter-prometheus": "0.47.0",
+    "@opentelemetry/sdk-metrics": "1.20.0"
   }
 }

--- a/experimental/packages/api-events/package.json
+++ b/experimental/packages/api-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-events",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Public events API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/api-logs/package.json
+++ b/experimental/packages/api-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-logs",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Public logs API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-grpc",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected log records to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -51,9 +51,9 @@
     "@babel/core": "7.23.6",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/api-logs": "0.46.0",
-    "@opentelemetry/otlp-exporter-base": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
+    "@opentelemetry/api-logs": "0.47.0",
+    "@opentelemetry/otlp-exporter-base": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -73,10 +73,10 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
-    "@opentelemetry/otlp-transformer": "0.46.0",
-    "@opentelemetry/sdk-logs": "0.46.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
+    "@opentelemetry/otlp-transformer": "0.47.0",
+    "@opentelemetry/sdk-logs": "0.47.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-http",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "publishConfig": {
     "access": "public"
   },
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/resources": "1.19.0",
+    "@opentelemetry/resources": "1.20.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -104,10 +104,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.46.0",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/otlp-exporter-base": "0.46.0",
-    "@opentelemetry/otlp-transformer": "0.46.0",
-    "@opentelemetry/sdk-logs": "0.46.0"
+    "@opentelemetry/api-logs": "0.47.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/otlp-exporter-base": "0.47.0",
+    "@opentelemetry/otlp-transformer": "0.47.0",
+    "@opentelemetry/sdk-logs": "0.47.0"
   }
 }

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-proto",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "An OTLP exporter to send logs using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,14 +93,14 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.46.0",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/otlp-exporter-base": "0.46.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.46.0",
-    "@opentelemetry/otlp-transformer": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-logs": "0.46.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0"
+    "@opentelemetry/api-logs": "0.47.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/otlp-exporter-base": "0.47.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
+    "@opentelemetry/otlp-transformer": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-logs": "0.47.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-grpc",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,7 +50,7 @@
     "@babel/core": "7.23.6",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/otlp-exporter-base": "0.46.0",
+    "@opentelemetry/otlp-exporter-base": "0.47.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -70,11 +70,11 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
-    "@opentelemetry/otlp-transformer": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
+    "@opentelemetry/otlp-transformer": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-http",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry Collector Trace Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -95,11 +95,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/otlp-exporter-base": "0.46.0",
-    "@opentelemetry/otlp-transformer": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/otlp-exporter-base": "0.47.0",
+    "@opentelemetry/otlp-transformer": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-proto",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -92,12 +92,12 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/otlp-exporter-base": "0.46.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.46.0",
-    "@opentelemetry/otlp-transformer": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/otlp-exporter-base": "0.47.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
+    "@opentelemetry/otlp-transformer": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/opentelemetry-browser-detector",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry Resource Detector for Browser",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -82,8 +82,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/browser-detector"
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -69,12 +69,12 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.46.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
-    "@opentelemetry/otlp-transformer": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-metrics": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
+    "@opentelemetry/otlp-transformer": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-metrics": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-http",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -95,11 +95,11 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/otlp-exporter-base": "0.46.0",
-    "@opentelemetry/otlp-transformer": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-metrics": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/otlp-exporter-base": "0.47.0",
+    "@opentelemetry/otlp-transformer": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-metrics": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-proto",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -75,13 +75,13 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.46.0",
-    "@opentelemetry/otlp-exporter-base": "0.46.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.46.0",
-    "@opentelemetry/otlp-transformer": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-metrics": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
+    "@opentelemetry/otlp-exporter-base": "0.47.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
+    "@opentelemetry/otlp-transformer": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-metrics": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.19.0",
+    "@opentelemetry/semantic-conventions": "1.20.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -61,9 +61,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-metrics": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-metrics": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-prometheus",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-fetch",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry fetch automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-zone": "1.19.0",
-    "@opentelemetry/propagator-b3": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
+    "@opentelemetry/context-zone": "1.20.0",
+    "@opentelemetry/propagator-b3": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -88,10 +88,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/instrumentation": "0.46.0",
-    "@opentelemetry/sdk-trace-web": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/instrumentation": "0.47.0",
+    "@opentelemetry/sdk-trace-web": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-grpc",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry grpc automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,10 +50,10 @@
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-async-hooks": "1.19.0",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
-    "@opentelemetry/sdk-trace-node": "1.19.0",
+    "@opentelemetry/context-async-hooks": "1.20.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/sdk-trace-node": "1.20.0",
     "@protobuf-ts/grpc-transport": "2.9.3",
     "@protobuf-ts/runtime": "2.9.3",
     "@protobuf-ts/runtime-rpc": "2.9.3",
@@ -75,8 +75,8 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "0.46.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/instrumentation": "0.47.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-http",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry http/https automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,10 +46,10 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-async-hooks": "1.19.0",
-    "@opentelemetry/sdk-metrics": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
-    "@opentelemetry/sdk-trace-node": "1.19.0",
+    "@opentelemetry/context-async-hooks": "1.20.0",
+    "@opentelemetry/sdk-metrics": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/sdk-trace-node": "1.20.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/request-promise-native": "1.0.21",
@@ -74,9 +74,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/instrumentation": "0.46.0",
-    "@opentelemetry/semantic-conventions": "1.19.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/instrumentation": "0.47.0",
+    "@opentelemetry/semantic-conventions": "1.20.0",
     "semver": "^7.5.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http",

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-xml-http-request",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry XMLHttpRequest automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,9 +56,9 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-zone": "1.19.0",
-    "@opentelemetry/propagator-b3": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
+    "@opentelemetry/context-zone": "1.20.0",
+    "@opentelemetry/propagator-b3": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -88,10 +88,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/instrumentation": "0.46.0",
-    "@opentelemetry/sdk-trace-web": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/instrumentation": "0.47.0",
+    "@opentelemetry/sdk-trace-web": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Base class for node which OpenTelemetry instrumentation modules extend",
   "author": "OpenTelemetry Authors",
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation",
@@ -83,7 +83,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/sdk-metrics": "1.19.0",
+    "@opentelemetry/sdk-metrics": "1.20.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.6",

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-node",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry SDK for Node.js",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,27 +44,27 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.46.0",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.46.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.46.0",
-    "@opentelemetry/exporter-zipkin": "1.19.0",
-    "@opentelemetry/instrumentation": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-logs": "0.46.0",
-    "@opentelemetry/sdk-metrics": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
-    "@opentelemetry/sdk-trace-node": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/api-logs": "0.47.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+    "@opentelemetry/exporter-zipkin": "1.20.0",
+    "@opentelemetry/instrumentation": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-logs": "0.47.0",
+    "@opentelemetry/sdk-metrics": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/sdk-trace-node": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.3.0 <1.8.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-async-hooks": "1.19.0",
-    "@opentelemetry/exporter-jaeger": "1.19.0",
+    "@opentelemetry/context-async-hooks": "1.20.0",
+    "@opentelemetry/exporter-jaeger": "1.20.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.6",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-exporter-base",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry OTLP Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0"
+    "@opentelemetry/core": "1.20.0"
   },
   "devDependencies": {
     "@babel/core": "7.23.6",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-grpc-exporter-base",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry OTLP-gRPC Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,9 +50,9 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/otlp-transformer": "0.46.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
+    "@opentelemetry/otlp-transformer": "0.47.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -73,8 +73,8 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/otlp-exporter-base": "0.46.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/otlp-exporter-base": "0.47.0",
     "protobufjs": "^7.2.3"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-grpc-exporter-base",

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-proto-exporter-base",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenTelemetry OTLP-HTTP-protobuf Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -79,8 +79,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/otlp-exporter-base": "0.46.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/otlp-exporter-base": "0.47.0",
     "protobufjs": "^7.2.3"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-proto-exporter-base",

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Transform OpenTelemetry SDK data into OTLP",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
@@ -79,12 +79,12 @@
     "webpack": "5.89.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.46.0",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-logs": "0.46.0",
-    "@opentelemetry/sdk-metrics": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0"
+    "@opentelemetry/api-logs": "0.47.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-logs": "0.47.0",
+    "@opentelemetry/sdk-metrics": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-transformer",
   "sideEffects": false

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-logs",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "publishConfig": {
     "access": "public"
   },
@@ -74,7 +74,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@opentelemetry/api": ">=1.4.0 <1.8.0",
-    "@opentelemetry/api-logs": "0.46.0",
+    "@opentelemetry/api-logs": "0.47.0",
     "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -100,7 +100,7 @@
     "webpack-merge": "5.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/resources": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/resources": "1.20.0"
   }
 }

--- a/experimental/packages/shim-opencensus/package.json
+++ b/experimental/packages/shim-opencensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opencensus",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "OpenCensus to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,8 +50,8 @@
   "devDependencies": {
     "@opencensus/core": "0.1.0",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-async-hooks": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
+    "@opentelemetry/context-async-hooks": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -69,9 +69,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-metrics": "1.19.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-metrics": "1.20.0",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2"
   },

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.19.0",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
+    "@opentelemetry/context-async-hooks": "1.20.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
     "axios": "1.5.1",
     "body-parser": "1.19.0",
     "express": "4.17.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
-        "api",
         "packages/*",
         "experimental/packages/*",
         "experimental/examples/*",
@@ -195,17 +194,17 @@
       }
     },
     "examples/esm-http-ts": {
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.46.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/instrumentation-http": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/instrumentation-http": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "engines": {
         "node": ">=14"
@@ -213,18 +212,18 @@
     },
     "examples/http": {
       "name": "http-example",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.19.0",
-        "@opentelemetry/exporter-zipkin": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/instrumentation-http": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/exporter-jaeger": "1.20.0",
+        "@opentelemetry/exporter-zipkin": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/instrumentation-http": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -235,18 +234,18 @@
     },
     "examples/https": {
       "name": "https-example",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.19.0",
-        "@opentelemetry/exporter-zipkin": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/instrumentation-http": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/exporter-jaeger": "1.20.0",
+        "@opentelemetry/exporter-zipkin": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/instrumentation-http": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -257,24 +256,24 @@
     },
     "examples/opentelemetry-web": {
       "name": "web-opentelemetry-example",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.46.0",
-        "@opentelemetry/exporter-zipkin": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/instrumentation-fetch": "0.46.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.46.0",
-        "@opentelemetry/propagator-b3": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-web": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/context-zone": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+        "@opentelemetry/exporter-zipkin": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/instrumentation-fetch": "0.47.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.47.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-web": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "^7.6.0",
@@ -608,21 +607,21 @@
     },
     "examples/otlp-exporter-node": {
       "name": "example-otlp-exporter-node",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.46.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.46.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.47.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "engines": {
         "node": ">=14"
@@ -630,11 +629,11 @@
     },
     "experimental/backwards-compatibility/node14": {
       "name": "backcompat-node14",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-node": "0.46.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0"
+        "@opentelemetry/sdk-node": "0.47.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
       },
       "devDependencies": {
         "@types/node": "14.18.25",
@@ -651,11 +650,11 @@
     },
     "experimental/backwards-compatibility/node16": {
       "name": "backcompat-node16",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-node": "0.46.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0"
+        "@opentelemetry/sdk-node": "0.47.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
       },
       "devDependencies": {
         "@types/node": "16.11.52",
@@ -672,11 +671,11 @@
     },
     "experimental/examples/logs": {
       "name": "logs-example",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/sdk-logs": "0.46.0"
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/sdk-logs": "0.47.0"
       },
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -742,20 +741,20 @@
       }
     },
     "experimental/examples/opencensus-shim": {
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opencensus/core": "0.1.0",
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/exporter-prometheus": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
-        "@opentelemetry/shim-opencensus": "0.46.0"
+        "@opentelemetry/exporter-prometheus": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/shim-opencensus": "0.47.0"
       },
       "engines": {
         "node": ">=14"
@@ -763,17 +762,17 @@
     },
     "experimental/examples/prometheus": {
       "name": "prometheus-example",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-prometheus": "0.46.0",
-        "@opentelemetry/sdk-metrics": "1.19.0"
+        "@opentelemetry/exporter-prometheus": "0.47.0",
+        "@opentelemetry/sdk-metrics": "1.20.0"
       }
     },
     "experimental/packages/api-events": {
       "name": "@opentelemetry/api-events",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
@@ -912,7 +911,7 @@
     },
     "experimental/packages/api-logs": {
       "name": "@opentelemetry/api-logs",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
@@ -1051,22 +1050,22 @@
     },
     "experimental/packages/exporter-logs-otlp-grpc": {
       "name": "@opentelemetry/exporter-logs-otlp-grpc",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/sdk-logs": "0.46.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/sdk-logs": "0.47.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1090,19 +1089,19 @@
     },
     "experimental/packages/exporter-logs-otlp-http": {
       "name": "@opentelemetry/exporter-logs-otlp-http",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/sdk-logs": "0.46.0"
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/sdk-logs": "0.47.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/resources": "1.19.0",
+        "@opentelemetry/resources": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1403,17 +1402,17 @@
     },
     "experimental/packages/exporter-logs-otlp-proto": {
       "name": "@opentelemetry/exporter-logs-otlp-proto",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-logs": "0.46.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0"
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-logs": "0.47.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -1716,21 +1715,21 @@
     },
     "experimental/packages/exporter-trace-otlp-grpc": {
       "name": "@opentelemetry/exporter-trace-otlp-grpc",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1754,14 +1753,14 @@
     },
     "experimental/packages/exporter-trace-otlp-http": {
       "name": "@opentelemetry/exporter-trace-otlp-http",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -2066,15 +2065,15 @@
     },
     "experimental/packages/exporter-trace-otlp-proto": {
       "name": "@opentelemetry/exporter-trace-otlp-proto",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -2377,11 +2376,11 @@
     },
     "experimental/packages/opentelemetry-browser-detector": {
       "name": "@opentelemetry/opentelemetry-browser-detector",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -2683,16 +2682,16 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc": {
       "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.46.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -2721,14 +2720,14 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-http": {
       "name": "@opentelemetry/exporter-metrics-otlp-http",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -3033,16 +3032,16 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-proto": {
       "name": "@opentelemetry/exporter-metrics-otlp-proto",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.46.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -3070,16 +3069,16 @@
     },
     "experimental/packages/opentelemetry-exporter-prometheus": {
       "name": "@opentelemetry/exporter-prometheus",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -3101,7 +3100,7 @@
     },
     "experimental/packages/opentelemetry-instrumentation": {
       "name": "@opentelemetry/instrumentation",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/shimmer": "^1.0.2",
@@ -3113,7 +3112,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -3150,20 +3149,20 @@
     },
     "experimental/packages/opentelemetry-instrumentation-fetch": {
       "name": "@opentelemetry/instrumentation-fetch",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/sdk-trace-web": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/sdk-trace-web": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone": "1.19.0",
-        "@opentelemetry/propagator-b3": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/context-zone": "1.20.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -3463,21 +3462,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-grpc": {
       "name": "@opentelemetry/instrumentation-grpc",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
         "@bufbuild/buf": "1.21.0-1",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
         "@protobuf-ts/grpc-transport": "2.9.3",
         "@protobuf-ts/runtime": "2.9.3",
         "@protobuf-ts/runtime-rpc": "2.9.3",
@@ -3504,20 +3503,20 @@
     },
     "experimental/packages/opentelemetry-instrumentation-http": {
       "name": "@opentelemetry/instrumentation-http",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
@@ -3557,20 +3556,20 @@
     },
     "experimental/packages/opentelemetry-instrumentation-xml-http-request": {
       "name": "@opentelemetry/instrumentation-xml-http-request",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/sdk-trace-web": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/sdk-trace-web": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone": "1.19.0",
-        "@opentelemetry/propagator-b3": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/context-zone": "1.20.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -4135,27 +4134,27 @@
     },
     "experimental/packages/opentelemetry-sdk-node": {
       "name": "@opentelemetry/sdk-node",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.46.0",
-        "@opentelemetry/exporter-zipkin": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-logs": "0.46.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+        "@opentelemetry/exporter-zipkin": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-logs": "0.47.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.19.0",
-        "@opentelemetry/exporter-jaeger": "1.19.0",
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/exporter-jaeger": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -4180,10 +4179,10 @@
     },
     "experimental/packages/otlp-exporter-base": {
       "name": "@opentelemetry/otlp-exporter-base",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0"
+        "@opentelemetry/core": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -4485,20 +4484,20 @@
     },
     "experimental/packages/otlp-grpc-exporter-base": {
       "name": "@opentelemetry/otlp-grpc-exporter-base",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
         "protobufjs": "^7.2.3"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -4523,11 +4522,11 @@
     },
     "experimental/packages/otlp-proto-exporter-base": {
       "name": "@opentelemetry/otlp-proto-exporter-base",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
         "protobufjs": "^7.2.3"
       },
       "devDependencies": {
@@ -4556,15 +4555,15 @@
     },
     "experimental/packages/otlp-transformer": {
       "name": "@opentelemetry/otlp-transformer",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-logs": "0.46.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0"
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-logs": "0.47.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
@@ -4703,16 +4702,16 @@
     },
     "experimental/packages/sdk-logs": {
       "name": "@opentelemetry/sdk-logs",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": ">=1.4.0 <1.8.0",
-        "@opentelemetry/api-logs": "0.46.0",
+        "@opentelemetry/api-logs": "0.47.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -5062,20 +5061,20 @@
     },
     "experimental/packages/shim-opencensus": {
       "name": "@opentelemetry/shim-opencensus",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opencensus/core": "0.1.0",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -5097,13 +5096,13 @@
       }
     },
     "integration-tests/propagation-validation-server": {
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "axios": "1.5.1",
         "body-parser": "1.19.0",
         "express": "4.17.3"
@@ -32940,7 +32939,7 @@
     },
     "packages/opentelemetry-context-async-hooks": {
       "name": "@opentelemetry/context-async-hooks",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -32963,10 +32962,10 @@
     },
     "packages/opentelemetry-context-zone": {
       "name": "@opentelemetry/context-zone",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.19.0",
+        "@opentelemetry/context-zone-peer-dep": "1.20.0",
         "zone.js": "^0.11.0"
       },
       "devDependencies": {
@@ -33000,7 +32999,7 @@
     },
     "packages/opentelemetry-context-zone-peer-dep": {
       "name": "@opentelemetry/context-zone-peer-dep",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -33579,10 +33578,10 @@
     },
     "packages/opentelemetry-core": {
       "name": "@opentelemetry/core",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -33724,17 +33723,17 @@
     },
     "packages/opentelemetry-exporter-jaeger": {
       "name": "@opentelemetry/exporter-jaeger",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "jaeger-client": "^3.15.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/resources": "1.19.0",
+        "@opentelemetry/resources": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -33757,13 +33756,13 @@
     },
     "packages/opentelemetry-exporter-zipkin": {
       "name": "@opentelemetry/exporter-zipkin",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -34068,10 +34067,10 @@
     },
     "packages/opentelemetry-propagator-b3": {
       "name": "@opentelemetry/propagator-b3",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0"
+        "@opentelemetry/core": "1.20.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -34095,10 +34094,10 @@
     },
     "packages/opentelemetry-propagator-jaeger": {
       "name": "@opentelemetry/propagator-jaeger",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0"
+        "@opentelemetry/core": "1.20.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -34240,11 +34239,11 @@
     },
     "packages/opentelemetry-resources": {
       "name": "@opentelemetry/resources",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -34585,12 +34584,12 @@
     },
     "packages/opentelemetry-sdk-trace-base": {
       "name": "@opentelemetry/sdk-trace-base",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -34733,20 +34732,20 @@
     },
     "packages/opentelemetry-sdk-trace-node": {
       "name": "@opentelemetry/sdk-trace-node",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/propagator-b3": "1.19.0",
-        "@opentelemetry/propagator-jaeger": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/propagator-jaeger": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -34769,19 +34768,19 @@
     },
     "packages/opentelemetry-sdk-trace-web": {
       "name": "@opentelemetry/sdk-trace-web",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/context-zone": "1.19.0",
-        "@opentelemetry/propagator-b3": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
+        "@opentelemetry/context-zone": "1.20.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
         "@types/jquery": "3.5.29",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -35084,7 +35083,7 @@
     },
     "packages/opentelemetry-semantic-conventions": {
       "name": "@opentelemetry/semantic-conventions",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/mocha": "10.0.6",
@@ -35106,18 +35105,18 @@
     },
     "packages/opentelemetry-shim-opentracing": {
       "name": "@opentelemetry/shim-opentracing",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "opentracing": "^0.14.4"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/propagator-b3": "1.19.0",
-        "@opentelemetry/propagator-jaeger": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/propagator-jaeger": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -35137,11 +35136,11 @@
     },
     "packages/sdk-metrics": {
       "name": "@opentelemetry/sdk-metrics",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
         "lodash.merge": "^4.6.2"
       },
       "devDependencies": {
@@ -35445,7 +35444,7 @@
     },
     "packages/template": {
       "name": "@opentelemetry/template",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -35459,19 +35458,19 @@
     },
     "selenium-tests": {
       "name": "@opentelemetry/selenium-tests",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
-        "@opentelemetry/exporter-zipkin": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/instrumentation-fetch": "0.46.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.46.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-web": "1.19.0",
+        "@opentelemetry/context-zone-peer-dep": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-zipkin": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/instrumentation-fetch": "0.47.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.47.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-web": "1.20.0",
         "zone.js": "0.11.4"
       },
       "devDependencies": {
@@ -39141,7 +39140,7 @@
       "version": "file:packages/opentelemetry-context-zone",
       "requires": {
         "@babel/core": "7.23.6",
-        "@opentelemetry/context-zone-peer-dep": "1.19.0",
+        "@opentelemetry/context-zone-peer-dep": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39480,7 +39479,7 @@
       "version": "file:packages/opentelemetry-core",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39567,10 +39566,10 @@
       "version": "file:packages/opentelemetry-exporter-jaeger",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39593,13 +39592,13 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-logs": "0.46.0",
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-logs": "0.47.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39620,12 +39619,12 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-logs": "0.46.0",
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-logs": "0.47.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39793,14 +39792,14 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-logs": "0.46.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-logs": "0.47.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39968,12 +39967,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.46.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39994,11 +39993,11 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40166,13 +40165,13 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.46.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40192,10 +40191,10 @@
       "version": "file:experimental/packages/opentelemetry-exporter-prometheus",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40216,12 +40215,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40242,11 +40241,11 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40414,12 +40413,12 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40585,10 +40584,10 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40756,7 +40755,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -40930,13 +40929,13 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/propagator-b3": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-web": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/context-zone": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-web": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41105,12 +41104,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@protobuf-ts/grpc-transport": "2.9.3",
         "@protobuf-ts/runtime": "2.9.3",
         "@protobuf-ts/runtime-rpc": "2.9.3",
@@ -41133,13 +41132,13 @@
       "version": "file:experimental/packages/opentelemetry-instrumentation-http",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
@@ -41178,13 +41177,13 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/propagator-b3": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-web": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/context-zone": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-web": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41351,8 +41350,8 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41517,7 +41516,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41683,11 +41682,11 @@
         "@babel/core": "7.23.6",
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
-        "@opentelemetry/otlp-transformer": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-transformer": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41710,8 +41709,8 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/otlp-exporter-base": "0.46.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/otlp-exporter-base": "0.47.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41732,12 +41731,12 @@
       "version": "file:experimental/packages/otlp-transformer",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-logs": "0.46.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-logs": "0.47.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/webpack-env": "1.16.3",
         "babel-plugin-istanbul": "6.1.1",
@@ -41821,7 +41820,7 @@
       "version": "file:packages/opentelemetry-propagator-b3",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -41838,7 +41837,7 @@
       "version": "file:packages/opentelemetry-propagator-jaeger",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41925,9 +41924,9 @@
       "version": "file:packages/opentelemetry-resources",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -42114,9 +42113,9 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": ">=1.4.0 <1.8.0",
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -42315,8 +42314,8 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": ">=1.3.0 <1.8.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
         "@types/lodash.merge": "4.6.9",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -42482,21 +42481,21 @@
       "version": "file:experimental/packages/opentelemetry-sdk-node",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/context-async-hooks": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/exporter-jaeger": "1.19.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.46.0",
-        "@opentelemetry/exporter-zipkin": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-logs": "0.46.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-jaeger": "1.20.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+        "@opentelemetry/exporter-zipkin": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-logs": "0.47.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -42517,9 +42516,9 @@
       "version": "file:packages/opentelemetry-sdk-trace-base",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -42607,13 +42606,13 @@
       "version": "file:packages/opentelemetry-sdk-trace-node",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/context-async-hooks": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/propagator-b3": "1.19.0",
-        "@opentelemetry/propagator-jaeger": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/propagator-jaeger": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -42634,12 +42633,12 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/context-zone": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/propagator-b3": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/context-zone": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/jquery": "3.5.29",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -42813,16 +42812,16 @@
         "@babel/plugin-transform-runtime": "7.22.15",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone-peer-dep": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
-        "@opentelemetry/exporter-zipkin": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/instrumentation-fetch": "0.46.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.46.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-web": "1.19.0",
+        "@opentelemetry/context-zone-peer-dep": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-zipkin": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/instrumentation-fetch": "0.47.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.47.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-web": "1.20.0",
         "babel-loader": "8.3.0",
         "babel-polyfill": "6.26.0",
         "browserstack-local": "1.4.8",
@@ -43154,11 +43153,11 @@
       "requires": {
         "@opencensus/core": "0.1.0",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -43178,11 +43177,11 @@
       "version": "file:packages/opentelemetry-shim-opentracing",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/propagator-b3": "1.19.0",
-        "@opentelemetry/propagator-jaeger": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/propagator-jaeger": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -45766,8 +45765,8 @@
     "backcompat-node14": {
       "version": "file:experimental/backwards-compatibility/node14",
       "requires": {
-        "@opentelemetry/sdk-node": "0.46.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/sdk-node": "0.47.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/node": "14.18.25",
         "typescript": "4.4.4"
       },
@@ -45781,8 +45780,8 @@
     "backcompat-node16": {
       "version": "file:experimental/backwards-compatibility/node16",
       "requires": {
-        "@opentelemetry/sdk-node": "0.46.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/sdk-node": "0.47.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "@types/node": "16.11.52",
         "typescript": "4.4.4"
       },
@@ -48281,13 +48280,13 @@
       "version": "file:examples/esm-http-ts",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.46.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/instrumentation-http": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/instrumentation-http": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       }
     },
     "espree": {
@@ -48391,17 +48390,17 @@
       "version": "file:examples/otlp-exporter-node",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.46.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.46.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0"
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.47.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0"
       }
     },
     "execa": {
@@ -49892,14 +49891,14 @@
       "version": "file:examples/http",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.19.0",
-        "@opentelemetry/exporter-zipkin": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/instrumentation-http": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/exporter-jaeger": "1.20.0",
+        "@opentelemetry/exporter-zipkin": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/instrumentation-http": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "cross-env": "^6.0.0"
       }
     },
@@ -49985,14 +49984,14 @@
       "version": "file:examples/https",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.19.0",
-        "@opentelemetry/exporter-zipkin": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/instrumentation-http": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/exporter-jaeger": "1.20.0",
+        "@opentelemetry/exporter-zipkin": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/instrumentation-http": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "cross-env": "^6.0.0"
       }
     },
@@ -51725,8 +51724,8 @@
       "version": "file:experimental/examples/logs",
       "requires": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-logs": "0.46.0",
-        "@opentelemetry/sdk-logs": "0.46.0",
+        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/sdk-logs": "0.47.0",
         "@types/node": "18.6.5",
         "ts-node": "^10.9.1"
       },
@@ -54129,13 +54128,13 @@
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/exporter-prometheus": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.46.0",
-        "@opentelemetry/resources": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-node": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
-        "@opentelemetry/shim-opencensus": "0.46.0"
+        "@opentelemetry/exporter-prometheus": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
+        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/shim-opencensus": "0.47.0"
       }
     },
     "opentracing": {
@@ -54868,8 +54867,8 @@
       "version": "file:experimental/examples/prometheus",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-prometheus": "0.46.0",
-        "@opentelemetry/sdk-metrics": "1.19.0"
+        "@opentelemetry/exporter-prometheus": "0.47.0",
+        "@opentelemetry/sdk-metrics": "1.20.0"
       }
     },
     "promise-all-reject-late": {
@@ -54907,9 +54906,9 @@
       "version": "file:integration-tests/propagation-validation-server",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
+        "@opentelemetry/context-async-hooks": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
         "axios": "1.5.1",
         "body-parser": "1.19.0",
         "express": "4.17.3",
@@ -58312,20 +58311,20 @@
       "requires": {
         "@babel/core": "^7.6.0",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.19.0",
-        "@opentelemetry/core": "1.19.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.46.0",
-        "@opentelemetry/exporter-zipkin": "1.19.0",
-        "@opentelemetry/instrumentation": "0.46.0",
-        "@opentelemetry/instrumentation-fetch": "0.46.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.46.0",
-        "@opentelemetry/propagator-b3": "1.19.0",
-        "@opentelemetry/sdk-metrics": "1.19.0",
-        "@opentelemetry/sdk-trace-base": "1.19.0",
-        "@opentelemetry/sdk-trace-web": "1.19.0",
-        "@opentelemetry/semantic-conventions": "1.19.0",
+        "@opentelemetry/context-zone": "1.20.0",
+        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
+        "@opentelemetry/exporter-zipkin": "1.20.0",
+        "@opentelemetry/instrumentation": "0.47.0",
+        "@opentelemetry/instrumentation-fetch": "0.47.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.47.0",
+        "@opentelemetry/propagator-b3": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-trace-web": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.20.0",
         "babel-loader": "^8.0.6",
         "ts-loader": "^9.2.6",
         "typescript": "^4.5.2",

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -75,7 +75,7 @@
     "webpack-merge": "5.10.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.19.0",
+    "@opentelemetry/context-zone-peer-dep": "1.20.0",
     "zone.js": "^0.11.0"
   },
   "sideEffects": true,

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,7 +91,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core",
   "sideEffects": false

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/resources": "1.19.0",
+    "@opentelemetry/resources": "1.20.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -63,9 +63,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0",
     "jaeger-client": "^3.15.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -92,10 +92,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin",
   "sideEffects": false

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0"
+    "@opentelemetry/core": "1.20.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.8.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -81,7 +81,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0"
+    "@opentelemetry/core": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger",
   "sideEffects": false

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,8 +91,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,9 +93,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.8.0",
-    "@opentelemetry/resources": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0",
+    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.6",
@@ -65,11 +65,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.19.0",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/propagator-b3": "1.19.0",
-    "@opentelemetry/propagator-jaeger": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
+    "@opentelemetry/context-async-hooks": "1.20.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/propagator-b3": "1.20.0",
+    "@opentelemetry/propagator-jaeger": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
     "semver": "^7.5.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,9 +57,9 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@opentelemetry/api": ">=1.0.0 <1.8.0",
-    "@opentelemetry/context-zone": "1.19.0",
-    "@opentelemetry/propagator-b3": "1.19.0",
-    "@opentelemetry/resources": "1.19.0",
+    "@opentelemetry/context-zone": "1.20.0",
+    "@opentelemetry/propagator-b3": "1.20.0",
+    "@opentelemetry/resources": "1.20.0",
     "@types/jquery": "3.5.29",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -92,9 +92,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0"
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web",
   "sideEffects": false

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -43,9 +43,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.8.0",
-    "@opentelemetry/propagator-b3": "1.19.0",
-    "@opentelemetry/propagator-jaeger": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
+    "@opentelemetry/propagator-b3": "1.20.0",
+    "@opentelemetry/propagator-jaeger": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
@@ -60,8 +60,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/semantic-conventions": "1.19.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.20.0",
     "opentracing": "^0.14.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing",

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -84,8 +84,8 @@
     "@opentelemetry/api": ">=1.3.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/resources": "1.19.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/resources": "1.20.0",
     "lodash.merge": "^4.6.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-metrics",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
@@ -56,16 +56,16 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.19.0",
-    "@opentelemetry/core": "1.19.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.46.0",
-    "@opentelemetry/exporter-zipkin": "1.19.0",
-    "@opentelemetry/instrumentation": "0.46.0",
-    "@opentelemetry/instrumentation-fetch": "0.46.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.46.0",
-    "@opentelemetry/sdk-metrics": "1.19.0",
-    "@opentelemetry/sdk-trace-base": "1.19.0",
-    "@opentelemetry/sdk-trace-web": "1.19.0",
+    "@opentelemetry/context-zone-peer-dep": "1.20.0",
+    "@opentelemetry/core": "1.20.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
+    "@opentelemetry/exporter-zipkin": "1.20.0",
+    "@opentelemetry/instrumentation": "0.47.0",
+    "@opentelemetry/instrumentation-fetch": "0.47.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.47.0",
+    "@opentelemetry/sdk-metrics": "1.20.0",
+    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/sdk-trace-web": "1.20.0",
     "zone.js": "0.11.4"
   }
 }


### PR DESCRIPTION
## 1.20.0

### :rocket: (Enhancement)

* perf(otlp-transformer): skip unnecessary base64 encode of span contexts [#4343](https://github.com/open-telemetry/opentelemetry-js/pull/4343) @seemk
* feat(sdk-trace-base): improve log messages when dropping span events [#4223](https://github.com/open-telemetry/opentelemetry-js/pull/4223) @mkubliniak

## 0.47.0

### :bug: (Bug Fix)

* fix(instrumentation): use caret range on import-in-the-middle [#4380](https://github.com/open-telemetry/opentelemetry-js/pull/4380) @pichlermarc
