### PR TITLE
fix(instrumentation): do not import 'path' in browser runtimes

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,8 +10,9 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
-fix(instrumentation): use caret range on import-in-the-middle [#4380](https://github.com/open-telemetry/opentelemetry-js/pull/4380) @pichlermarc
-
+* fix(instrumentation): use caret range on import-in-the-middle [#4380](https://github.com/open-telemetry/opentelemetry-js/pull/4380) @pichlermarc
+* fix(instrumentation): do not import 'path' in browser runtimes [#4378](https://github.com/open-telemetry/opentelemetry-js/pull/4378) @pichlermarc
+  * Fixes a bug where bundling for web would fail due to `InstrumentationNodeModuleDefinition` importing `path`
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to experimental packages in this project will be documented 
 * fix(instrumentation): use caret range on import-in-the-middle [#4380](https://github.com/open-telemetry/opentelemetry-js/pull/4380) @pichlermarc
 * fix(instrumentation): do not import 'path' in browser runtimes [#4378](https://github.com/open-telemetry/opentelemetry-js/pull/4378) @pichlermarc
   * Fixes a bug where bundling for web would fail due to `InstrumentationNodeModuleDefinition` importing `path`
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-instrumentation/src/instrumentationNodeModuleFile.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/instrumentationNodeModuleFile.ts
@@ -15,7 +15,7 @@
  */
 
 import { InstrumentationModuleFile } from './types';
-import { normalize } from 'path';
+import { normalize } from './platform/index';
 
 export class InstrumentationNodeModuleFile<T>
   implements InstrumentationModuleFile<T>

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/browser/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/browser/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { InstrumentationBase } from './instrumentation';
+export { normalize } from './throwing-normalize';

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/browser/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/browser/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { InstrumentationBase } from './instrumentation';
-export { normalize } from './throwing-normalize';
+export { normalize } from './noop-normalize';

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/browser/noop-normalize.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/browser/noop-normalize.ts
@@ -14,16 +14,22 @@
  * limitations under the License.
  */
 
+import { diag } from '@opentelemetry/api';
+
 /**
  * Placeholder normalize function to replace the node variant in browser runtimes,
- * this should never be called and will throw if it is called.
+ * this should never be called and will perform a no-op and warn if it is called regardless.
  *
  * This is a workaround to fix https://github.com/open-telemetry/opentelemetry-js/issues/4373 until the instrumentation
  * package can be made node-only.
  *
- * @param _path unused input path
+ * @param path input path
+ * @return unmodified path
  * @internal
  */
-export function normalize(_path: string): string {
-  throw new Error('Not implemented');
+export function normalize(path: string): string {
+  diag.warn(
+    'Path normalization is not implemented for this platform. To silence this warning, ensure no node-specific instrumentations are loaded, and node-specific types (e.g. InstrumentationNodeModuleFile), are not used in a browser context)'
+  );
+  return path;
 }

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/browser/throwing-normalize.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/browser/throwing-normalize.ts
@@ -13,5 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { InstrumentationBase } from './instrumentation';
-export { normalize } from './normalize';
+
+/**
+ * Placeholder normalize function to replace the node variant in browser runtimes,
+ * this should never be called and will throw if it is called.
+ *
+ * This is a workaround to fix https://github.com/open-telemetry/opentelemetry-js/issues/4373 until the instrumentation
+ * package can be made node-only.
+ *
+ * @param _path unused input path
+ * @internal
+ */
+export function normalize(_path: string): string {
+  throw new Error('Not implemented');
+}

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { InstrumentationBase } from './node';
+export { InstrumentationBase, normalize } from './node';

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/normalize.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/normalize.ts
@@ -1,0 +1,1 @@
+export { normalize } from 'path';

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/normalize.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/normalize.ts
@@ -1,1 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { normalize } from 'path';

--- a/experimental/packages/opentelemetry-instrumentation/test/browser/noop-normalize.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation/test/browser/noop-normalize.test.ts
@@ -17,8 +17,8 @@
 import * as assert from 'assert';
 import { normalize } from '../../src/platform/browser';
 
-describe('throwing-normalize', () => {
-  assert.throws(() => {
-    normalize('foo');
+describe('noop-normalize', function () {
+  it('should not normalize input', function () {
+    assert.strictEqual(normalize('/tmp/foo/../bar'), '/tmp/foo/../bar');
   });
 });

--- a/experimental/packages/opentelemetry-instrumentation/test/browser/throwing-normalize.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation/test/browser/throwing-normalize.test.ts
@@ -13,5 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { InstrumentationBase } from './instrumentation';
-export { normalize } from './normalize';
+
+import * as assert from 'assert';
+import { normalize } from '../../src/platform/browser';
+
+describe('throwing-normalize', () => {
+  assert.throws(() => {
+    normalize('foo');
+  });
+});


### PR DESCRIPTION
## Which problem is this PR solving?

Since we now export `InstrumentationNodeModuleDefinition` even if  `@opentelemetry/instrumentation` is used in a browser context. This PR changes it so that it does not import `'path'` anymore which is part of the nodejs core library. As only the `normalize` function is used, I replaced it with a function that throws on runtime should someone use `InstrumentationNodeModuleDefinition` in the browser for some reason.

Fixes #4373 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `npm pack`ed `@opentelemetry/instrumentation` locally, installed it in a local reproducer and packaged it with `webpack`. 
