### PR TITLE
fix(exporter-logs-otlp-*): set User-Agent header

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -18,6 +18,9 @@ All notable changes to experimental packages in this project will be documented 
 * fix(instrumentation): use caret range on import-in-the-middle [#4380](https://github.com/open-telemetry/opentelemetry-js/pull/4380) @pichlermarc
 * fix(instrumentation): do not import 'path' in browser runtimes [#4378](https://github.com/open-telemetry/opentelemetry-js/pull/4378) @pichlermarc
   * Fixes a bug where bundling for web would fail due to `InstrumentationNodeModuleDefinition` importing `path`
+* fix(exporter-logs-otlp-grpc): set User-Agent header [#4398](https://github.com/open-telemetry/opentelemetry-js/pull/4398) @Vunovati
+* fix(exporter-logs-otlp-http): set User-Agent header [#4398](https://github.com/open-telemetry/opentelemetry-js/pull/4398) @Vunovati
+* fix(exporter-logs-otlp-proto): set User-Agent header [#4398](https://github.com/open-telemetry/opentelemetry-js/pull/4398) @Vunovati
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/exporter-logs-otlp-grpc/src/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/src/OTLPLogExporter.ts
@@ -28,6 +28,11 @@ import {
   createExportLogsServiceRequest,
   IExportLogsServiceRequest,
 } from '@opentelemetry/otlp-transformer';
+import { VERSION } from './version';
+
+const USER_AGENT = {
+  'User-Agent': `OTel-OTLP-Exporter-JavaScript/${VERSION}`,
+};
 
 /**
  * OTLP Logs Exporter for Node
@@ -38,9 +43,12 @@ export class OTLPLogExporter
 {
   constructor(config: OTLPGRPCExporterConfigNode = {}) {
     super(config);
-    const headers = baggageUtils.parseKeyPairsIntoRecord(
-      getEnv().OTEL_EXPORTER_OTLP_LOGS_HEADERS
-    );
+    const headers = {
+      ...USER_AGENT,
+      ...baggageUtils.parseKeyPairsIntoRecord(
+        getEnv().OTEL_EXPORTER_OTLP_LOGS_HEADERS
+      ),
+    };
     this.metadata ||= new Metadata();
     for (const [k, v] of Object.entries(headers)) {
       this.metadata.set(k, v);

--- a/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
@@ -37,6 +37,7 @@ import {
   IExportLogsServiceRequest,
   IResourceLogs,
 } from '@opentelemetry/otlp-transformer';
+import { VERSION } from '../src/version';
 
 const logsServiceProtoPath =
   'opentelemetry/proto/collector/logs/v1/logs_service.proto';
@@ -332,6 +333,12 @@ describe('when configuring via environment', () => {
     assert.strictEqual(collectorExporter.url, 'foo.logs');
     envSource.OTEL_EXPORTER_OTLP_ENDPOINT = '';
     envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = '';
+  });
+  it('should include user-agent header by default', () => {
+    const collectorExporter = new OTLPLogExporter();
+    assert.deepStrictEqual(collectorExporter.metadata?.get('User-Agent'), [
+      `OTel-OTLP-Exporter-JavaScript/${VERSION}`,
+    ]);
   });
   it('should use headers defined via env', () => {
     envSource.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar';

--- a/experimental/packages/exporter-logs-otlp-http/src/platform/node/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-http/src/platform/node/OTLPLogExporter.ts
@@ -25,6 +25,11 @@ import { OTLPExporterNodeBase } from '@opentelemetry/otlp-exporter-base';
 import { createExportLogsServiceRequest } from '@opentelemetry/otlp-transformer';
 
 import { getDefaultUrl } from '../config';
+import { VERSION } from '../../version';
+
+const USER_AGENT = {
+  'User-Agent': `OTel-OTLP-Exporter-JavaScript/${VERSION}`,
+};
 
 /**
  * Collector Logs Exporter for Node
@@ -39,13 +44,14 @@ export class OTLPLogExporter
       timeoutMillis: getEnv().OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
       ...config,
     });
-    this.headers = Object.assign(
-      this.headers,
-      baggageUtils.parseKeyPairsIntoRecord(
+    this.headers = {
+      ...this.headers,
+      ...USER_AGENT,
+      ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_LOGS_HEADERS
       ),
-      config.headers
-    );
+      ...config.headers,
+    };
   }
 
   convert(logRecords: ReadableLogRecord[]): IExportLogsServiceRequest {

--- a/experimental/packages/exporter-logs-otlp-http/test/node/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-http/test/node/OTLPLogExporter.test.ts
@@ -31,6 +31,7 @@ import {
 import { PassThrough, Stream } from 'stream';
 import { IExportLogsServiceRequest } from '@opentelemetry/otlp-transformer';
 import { ExportResultCode } from '@opentelemetry/core';
+import { VERSION } from '../../src/version';
 
 let fakeRequest: PassThrough;
 
@@ -77,6 +78,14 @@ describe('OTLPLogExporter', () => {
     it('should create an instance', () => {
       const exporter = new OTLPLogExporter();
       assert.ok(exporter instanceof OTLPLogExporter);
+    });
+
+    it('should include user-agent header by default', () => {
+      const exporter = new OTLPLogExporter();
+      assert.strictEqual(
+        exporter.headers['User-Agent'],
+        `OTel-OTLP-Exporter-JavaScript/${VERSION}`
+      );
     });
 
     it('should use headers defined via env', () => {

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
@@ -30,6 +30,11 @@ import {
 } from '@opentelemetry/otlp-transformer';
 
 import { ReadableLogRecord, LogRecordExporter } from '@opentelemetry/sdk-logs';
+import { VERSION } from '../../version';
+
+const USER_AGENT = {
+  'User-Agent': `OTel-OTLP-Exporter-JavaScript/${VERSION}`,
+};
 
 const DEFAULT_COLLECTOR_RESOURCE_PATH = 'v1/logs';
 const DEFAULT_COLLECTOR_URL = `http://localhost:4318/${DEFAULT_COLLECTOR_RESOURCE_PATH}`;
@@ -46,13 +51,14 @@ export class OTLPLogExporter
 {
   constructor(config: OTLPExporterConfigBase = {}) {
     super(config);
-    this.headers = Object.assign(
-      this.headers,
-      baggageUtils.parseKeyPairsIntoRecord(
+    this.headers = {
+      ...this.headers,
+      ...USER_AGENT,
+      ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_LOGS_HEADERS
       ),
-      config.headers
-    );
+      ...config.headers,
+    };
   }
   convert(logs: ReadableLogRecord[]): IExportLogsServiceRequest {
     return createExportLogsServiceRequest(logs);

--- a/experimental/packages/exporter-logs-otlp-proto/test/node/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/test/node/OTLPLogExporter.test.ts
@@ -39,6 +39,7 @@ import {
 } from '@opentelemetry/otlp-proto-exporter-base';
 import { IExportLogsServiceRequest } from '@opentelemetry/otlp-transformer';
 import { ReadableLogRecord } from '@opentelemetry/sdk-logs';
+import { VERSION } from '../../src/version';
 
 let fakeRequest: PassThrough;
 
@@ -136,6 +137,13 @@ describe('OTLPLogExporter - node with proto over http', () => {
         `${envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT}`
       );
       envSource.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = '';
+    });
+    it('should include user-agent header by default', () => {
+      const exporter = new OTLPLogExporter();
+      assert.strictEqual(
+        exporter.headers['User-Agent'],
+        `OTel-OTLP-Exporter-JavaScript/${VERSION}`
+      );
     });
     it('should use headers defined via env', () => {
       envSource.OTEL_EXPORTER_OTLP_LOGS_HEADERS = 'foo=bar';


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The User-Agent header is set for all log exporters by default 
Fixes #4397

Adds the header to node exporters for:
* exporter-logs-otlp-proto
* exporter-logs-otlp-http
* exporter-logs-otlp-grpc

## Short description of the changes
The headers have been updated. The headers are overridden by using the spread operator instead of `Object.assign` to achieve consistency with exporters of other signals.
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] added unit test in exporter-logs-otlp-proto
- [x] added unit test in exporter-logs-otlp-http
- [x] added unit test in exporter-logs-otlp-grpc

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
