### PR TITLE
fix(sdk-trace-base): ensure attribute value length limit is enforced on span creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+* fix(sdk-trace-base): ensure attribute value length limit is enforced on span creation [#4417](https://github.com/open-telemetry/opentelemetry-js/pull/4417) @pichlermarc
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -120,6 +120,8 @@ export class Span implements APISpan, ReadableSpan {
     this.resource = parentTracer.resource;
     this.instrumentationLibrary = parentTracer.instrumentationLibrary;
     this._spanLimits = parentTracer.getSpanLimits();
+    this._attributeValueLengthLimit =
+      this._spanLimits.attributeValueLengthLimit || 0;
 
     if (attributes != null) {
       this.setAttributes(attributes);
@@ -127,8 +129,6 @@ export class Span implements APISpan, ReadableSpan {
 
     this._spanProcessor = parentTracer.getActiveSpanProcessor();
     this._spanProcessor.onStart(this, context);
-    this._attributeValueLengthLimit =
-      this._spanLimits.attributeValueLengthLimit || 0;
   }
 
   spanContext(): SpanContext {

--- a/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
@@ -369,6 +369,22 @@ describe('Span', () => {
           span.setAttribute('attr-non-string', true);
           assert.strictEqual(span.attributes['attr-non-string'], true);
         });
+
+        it('should truncate value when attributes are passed to the constructor', () => {
+          const span = new Span(
+            tracer,
+            ROOT_CONTEXT,
+            name,
+            spanContext,
+            SpanKind.CLIENT,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { 'attr-with-more-length': 'abcdefgh' }
+          );
+          assert.strictEqual(span.attributes['attr-with-more-length'], 'abcde');
+        });
       });
 
       describe('when "attributeValueLengthLimit" option is invalid', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

The attribute value length limit was not enforced when a span was created with attributes

Fixes #4416 

## Short description of the changes

Set the length limit before setting the attributes.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added unit test