### PR TITLE
refactor(core): drop unnecessary assignment of HOSTNAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 ### :bug: (Bug Fix)
 
 * fix(sdk-trace-base): ensure attribute value length limit is enforced on span creation [#4417](https://github.com/open-telemetry/opentelemetry-js/pull/4417) @pichlermarc
-* refactor(core): drop unnecessary assignment of HOSTNAME [#4421](https://github.com/open-telemetry/opentelemetry-js/pull/4421) @pichlermarc
 
 ### :books: (Refine Doc)
 
 ### :house: (Internal)
 
 * chore(opentelemetry-context-zone-peer-dep): support zone.js ^v0.13.0 [#4320](https://github.com/open-telemetry/opentelemetry-js/pull/4320)
+* refactor(core): drop unnecessary assignment of HOSTNAME [#4421](https://github.com/open-telemetry/opentelemetry-js/pull/4421) @pichlermarc
 
 ## 1.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 ### :bug: (Bug Fix)
 
 * fix(sdk-trace-base): ensure attribute value length limit is enforced on span creation [#4417](https://github.com/open-telemetry/opentelemetry-js/pull/4417) @pichlermarc
+* fix(core): drop unnecessary assignment of HOSTNAME [#4421](https://github.com/open-telemetry/opentelemetry-js/pull/4421) @pichlermarc
 
 ### :books: (Refine Doc)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 ### :bug: (Bug Fix)
 
 * fix(sdk-trace-base): ensure attribute value length limit is enforced on span creation [#4417](https://github.com/open-telemetry/opentelemetry-js/pull/4417) @pichlermarc
-* fix(core): drop unnecessary assignment of HOSTNAME [#4421](https://github.com/open-telemetry/opentelemetry-js/pull/4421) @pichlermarc
+* refactor(core): drop unnecessary assignment of HOSTNAME [#4421](https://github.com/open-telemetry/opentelemetry-js/pull/4421) @pichlermarc
 
 ### :books: (Refine Doc)
 

--- a/packages/opentelemetry-core/src/platform/node/environment.ts
+++ b/packages/opentelemetry-core/src/platform/node/environment.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as os from 'os';
 import {
   DEFAULT_ENVIRONMENT,
   ENVIRONMENT,
@@ -27,11 +26,5 @@ import {
  */
 export function getEnv(): Required<ENVIRONMENT> {
   const processEnv = parseEnvironment(process.env as RAW_ENVIRONMENT);
-  return Object.assign(
-    {
-      HOSTNAME: os.hostname(),
-    },
-    DEFAULT_ENVIRONMENT,
-    processEnv
-  );
+  return Object.assign({}, DEFAULT_ENVIRONMENT, processEnv);
 }


### PR DESCRIPTION
## Which problem is this PR solving?

We currently try to assign `os.hostname()` as the default, but we override it with the emtpy string from `DEFAULT_ENVIRONMENT`. This PR removes that assignment of `HOSTNAME` as it's not doing anything.

While we don't use `HOSTNAME` anywhere other than in tests, `getEnv()` may be used by consumers of the `@opentelemetry/core` library and they might depend on the default for that value being the empty string. Also since `getEnv()` indicates us getting environment variables, I think we should not fall back to anything that's not a static default (as is the case for all other variables).

Fixes #4405 

## Type of change

- [x] refactor

## How Has This Been Tested?

- [x] Existing tests