### PR TITLE
test: transpile zone.js products in test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 ### :house: (Internal)
 
 * chore(opentelemetry-context-zone-peer-dep): support zone.js ^v0.13.0 [#4320](https://github.com/open-telemetry/opentelemetry-js/pull/4320)
+* test(opentelemetry-context-zone-peer-dep): transpile zone.js in tests [#4423](https://github.com/open-telemetry/opentelemetry-js/pull/4423) @legendecas
 
 ## 1.20.0
 

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -32,7 +32,8 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "devDependencies": {
-    "@babel/core": "^7.6.0",
+    "@babel/core": "^7.23.6",
+    "@babel/preset-env": "^7.22.20",
     "babel-loader": "^8.0.6",
     "ts-loader": "^9.2.6",
     "typescript": "^4.5.2",

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -48,7 +48,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@babel/core": "7.23.6",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.7.0",
     "@opentelemetry/api-logs": "0.47.0",

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -72,6 +72,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
     "@opentelemetry/resources": "1.20.0",
     "@types/mocha": "10.0.6",

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -47,7 +47,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@babel/core": "7.23.6",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.7.0",
     "@opentelemetry/otlp-exporter-base": "0.47.0",

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -47,7 +47,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@babel/core": "7.23.6",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.7.0",
     "@types/mocha": "10.0.6",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -55,7 +55,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@babel/core": "7.23.6",
     "@opentelemetry/api": "1.7.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
     "@opentelemetry/context-zone": "1.20.0",
     "@opentelemetry/propagator-b3": "1.20.0",

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
     "@opentelemetry/context-zone": "1.20.0",
     "@opentelemetry/propagator-b3": "1.20.0",

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -82,6 +82,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
     "@opentelemetry/sdk-metrics": "1.20.0",
     "@types/mocha": "10.0.6",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -48,7 +48,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@babel/core": "7.23.6",
     "@opentelemetry/api": "1.7.0",
     "@opentelemetry/otlp-transformer": "0.47.0",
     "@opentelemetry/resources": "1.20.0",

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -73,6 +73,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": ">=1.4.0 <1.8.0",
     "@opentelemetry/api-logs": "0.47.0",
     "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",

--- a/karma.webpack.js
+++ b/karma.webpack.js
@@ -27,6 +27,22 @@ module.exports = {
     rules: [
       { test: /\.ts$/, use: 'ts-loader' },
       {
+        test: /\.js$/,
+        exclude: {
+          and: [/node_modules/], // Exclude libraries in node_modules ...
+          not: [
+            // Except for a few of them that needs to be transpiled because they use modern syntax
+            /zone.js/,
+          ],
+        },
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env'],
+          }
+        },
+      },
+      {
         enforce: 'post',
         exclude: /(node_modules|\.test\.[tj]sx?$)/,
         test: /\.ts$/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
+        "api",
         "packages/*",
         "experimental/packages/*",
         "experimental/examples/*",
@@ -276,7 +277,8 @@
         "@opentelemetry/semantic-conventions": "1.20.0"
       },
       "devDependencies": {
-        "@babel/core": "^7.6.0",
+        "@babel/core": "^7.23.6",
+        "@babel/preset-env": "^7.22.20",
         "babel-loader": "^8.0.6",
         "ts-loader": "^9.2.6",
         "typescript": "^4.5.2",
@@ -1060,7 +1062,6 @@
         "@opentelemetry/sdk-logs": "0.47.0"
       },
       "devDependencies": {
-        "@babel/core": "7.23.6",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/api-logs": "0.47.0",
@@ -1100,6 +1101,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/resources": "1.20.0",
         "@types/mocha": "10.0.6",
@@ -1416,6 +1418,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -1726,7 +1729,6 @@
         "@opentelemetry/sdk-trace-base": "1.20.0"
       },
       "devDependencies": {
-        "@babel/core": "7.23.6",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/otlp-exporter-base": "0.47.0",
@@ -1764,6 +1766,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -2077,6 +2080,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -2384,6 +2388,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -2694,7 +2699,6 @@
         "@opentelemetry/sdk-metrics": "1.20.0"
       },
       "devDependencies": {
-        "@babel/core": "7.23.6",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
         "@types/mocha": "10.0.6",
@@ -2731,6 +2735,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -3044,7 +3049,6 @@
         "@opentelemetry/sdk-metrics": "1.20.0"
       },
       "devDependencies": {
-        "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -3111,6 +3115,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/sdk-metrics": "1.20.0",
         "@types/mocha": "10.0.6",
@@ -3159,6 +3164,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/context-zone": "1.20.0",
         "@opentelemetry/propagator-b3": "1.20.0",
@@ -3566,6 +3572,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/context-zone": "1.20.0",
         "@opentelemetry/propagator-b3": "1.20.0",
@@ -4186,6 +4193,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -4493,7 +4501,6 @@
         "protobufjs": "^7.2.3"
       },
       "devDependencies": {
-        "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/otlp-transformer": "0.47.0",
         "@opentelemetry/resources": "1.20.0",
@@ -4531,6 +4538,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -4710,6 +4718,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.4.0 <1.8.0",
         "@opentelemetry/api-logs": "0.47.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
@@ -32970,29 +32979,9 @@
         "zone.js": "^0.11.0"
       },
       "devDependencies": {
-        "@babel/core": "7.23.6",
-        "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
-        "@types/sinon": "10.0.20",
-        "@types/webpack-env": "1.16.3",
-        "babel-loader": "8.3.0",
-        "codecov": "3.8.3",
         "cross-var": "1.1.0",
-        "karma": "6.4.2",
-        "karma-chrome-launcher": "3.1.0",
-        "karma-mocha": "2.0.1",
-        "karma-spec-reporter": "0.0.36",
-        "karma-webpack": "4.0.2",
         "lerna": "6.6.2",
-        "mocha": "10.2.0",
-        "nyc": "15.1.0",
-        "sinon": "15.1.2",
-        "ts-loader": "8.4.0",
-        "ts-mocha": "10.0.0",
-        "typescript": "4.4.4",
-        "webpack": "5.89.0",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "typescript": "4.4.4"
       },
       "engines": {
         "node": ">=14"
@@ -33004,6 +32993,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -33313,271 +33303,6 @@
         "tslib": "^2.3.0"
       }
     },
-    "packages/opentelemetry-context-zone/node_modules/@webpack-cli/configtest": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "peerDependencies": {
-        "webpack": "5.x.x",
-        "webpack-cli": "5.x.x"
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/@webpack-cli/info": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "peerDependencies": {
-        "webpack": "5.x.x",
-        "webpack-cli": "5.x.x"
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/@webpack-cli/serve": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "peerDependencies": {
-        "webpack": "5.x.x",
-        "webpack-cli": "5.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/commander": {
-      "version": "10.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/enhanced-resolve": {
-      "version": "5.15.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/interpret": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/rechoir": {
-      "version": "0.8.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve": "^1.20.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/tapable": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/terser-webpack-plugin": {
-      "version": "5.3.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.17",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.1",
-        "terser": "^5.16.8"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/webpack": {
-      "version": "5.89.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/webpack-cli": {
-      "version": "5.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@discoveryjs/json-ext": "^0.5.0",
-        "@webpack-cli/configtest": "^2.1.1",
-        "@webpack-cli/info": "^2.0.2",
-        "@webpack-cli/serve": "^2.0.5",
-        "colorette": "^2.0.14",
-        "commander": "^10.0.1",
-        "cross-spawn": "^7.0.3",
-        "envinfo": "^7.7.3",
-        "fastest-levenshtein": "^1.0.12",
-        "import-local": "^3.0.2",
-        "interpret": "^3.1.1",
-        "rechoir": "^0.8.0",
-        "webpack-merge": "^5.7.3"
-      },
-      "bin": {
-        "webpack-cli": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "5.x.x"
-      },
-      "peerDependenciesMeta": {
-        "@webpack-cli/generators": {
-          "optional": true
-        },
-        "webpack-bundle-analyzer": {
-          "optional": true
-        },
-        "webpack-dev-server": {
-          "optional": true
-        }
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/webpack-sources": {
-      "version": "3.2.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "packages/opentelemetry-context-zone/node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "packages/opentelemetry-core": {
       "name": "@opentelemetry/core",
       "version": "1.20.0",
@@ -33768,6 +33493,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "^1.0.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -34779,6 +34505,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
         "@opentelemetry/context-zone": "1.20.0",
         "@opentelemetry/propagator-b3": "1.20.0",
@@ -35147,6 +34874,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.3.0 <1.8.0",
         "@types/lodash.merge": "4.6.9",
         "@types/mocha": "10.0.6",
@@ -39141,172 +38869,18 @@
     "@opentelemetry/context-zone": {
       "version": "file:packages/opentelemetry-context-zone",
       "requires": {
-        "@babel/core": "7.23.6",
         "@opentelemetry/context-zone-peer-dep": "1.20.0",
-        "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
-        "@types/sinon": "10.0.20",
-        "@types/webpack-env": "1.16.3",
-        "babel-loader": "8.3.0",
-        "codecov": "3.8.3",
         "cross-var": "1.1.0",
-        "karma": "6.4.2",
-        "karma-chrome-launcher": "3.1.0",
-        "karma-mocha": "2.0.1",
-        "karma-spec-reporter": "0.0.36",
-        "karma-webpack": "4.0.2",
         "lerna": "6.6.2",
-        "mocha": "10.2.0",
-        "nyc": "15.1.0",
-        "sinon": "15.1.2",
-        "ts-loader": "8.4.0",
-        "ts-mocha": "10.0.0",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0",
         "zone.js": "^0.11.0"
-      },
-      "dependencies": {
-        "@webpack-cli/configtest": {
-          "version": "2.1.1",
-          "dev": true,
-          "requires": {}
-        },
-        "@webpack-cli/info": {
-          "version": "2.0.2",
-          "dev": true,
-          "requires": {}
-        },
-        "@webpack-cli/serve": {
-          "version": "2.0.5",
-          "dev": true,
-          "requires": {}
-        },
-        "commander": {
-          "version": "10.0.1",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "7.0.3",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "enhanced-resolve": {
-          "version": "5.15.0",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.4",
-            "tapable": "^2.2.0"
-          }
-        },
-        "interpret": {
-          "version": "3.1.1",
-          "dev": true
-        },
-        "rechoir": {
-          "version": "0.8.0",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.20.0"
-          }
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "tapable": {
-          "version": "2.2.1",
-          "dev": true
-        },
-        "terser-webpack-plugin": {
-          "version": "5.3.9",
-          "dev": true,
-          "requires": {
-            "@jridgewell/trace-mapping": "^0.3.17",
-            "jest-worker": "^27.4.5",
-            "schema-utils": "^3.1.1",
-            "serialize-javascript": "^6.0.1",
-            "terser": "^5.16.8"
-          }
-        },
-        "webpack": {
-          "version": "5.89.0",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        },
-        "webpack-cli": {
-          "version": "5.1.4",
-          "dev": true,
-          "requires": {
-            "@discoveryjs/json-ext": "^0.5.0",
-            "@webpack-cli/configtest": "^2.1.1",
-            "@webpack-cli/info": "^2.0.2",
-            "@webpack-cli/serve": "^2.0.5",
-            "colorette": "^2.0.14",
-            "commander": "^10.0.1",
-            "cross-spawn": "^7.0.3",
-            "envinfo": "^7.7.3",
-            "fastest-levenshtein": "^1.0.12",
-            "import-local": "^3.0.2",
-            "interpret": "^3.1.1",
-            "rechoir": "^0.8.0",
-            "webpack-merge": "^5.7.3"
-          }
-        },
-        "webpack-sources": {
-          "version": "3.2.3",
-          "dev": true
-        },
-        "which": {
-          "version": "2.0.2",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
       }
     },
     "@opentelemetry/context-zone-peer-dep": {
       "version": "file:packages/opentelemetry-context-zone-peer-dep",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -39592,7 +39166,6 @@
     "@opentelemetry/exporter-logs-otlp-grpc": {
       "version": "file:experimental/packages/exporter-logs-otlp-grpc",
       "requires": {
-        "@babel/core": "7.23.6",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
@@ -39622,6 +39195,7 @@
       "version": "file:experimental/packages/exporter-logs-otlp-http",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/api-logs": "0.47.0",
         "@opentelemetry/core": "1.20.0",
@@ -39795,6 +39369,7 @@
       "version": "file:experimental/packages/exporter-logs-otlp-proto",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/api-logs": "0.47.0",
         "@opentelemetry/core": "1.20.0",
@@ -39967,7 +39542,6 @@
     "@opentelemetry/exporter-metrics-otlp-grpc": {
       "version": "file:experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
       "requires": {
-        "@babel/core": "7.23.6",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
@@ -39996,6 +39570,7 @@
       "version": "file:experimental/packages/opentelemetry-exporter-metrics-otlp-http",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/core": "1.20.0",
         "@opentelemetry/otlp-exporter-base": "0.47.0",
@@ -40167,7 +39742,6 @@
     "@opentelemetry/exporter-metrics-otlp-proto": {
       "version": "file:experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
       "requires": {
-        "@babel/core": "7.23.6",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/core": "1.20.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
@@ -40215,7 +39789,6 @@
     "@opentelemetry/exporter-trace-otlp-grpc": {
       "version": "file:experimental/packages/exporter-trace-otlp-grpc",
       "requires": {
-        "@babel/core": "7.23.6",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
@@ -40244,6 +39817,7 @@
       "version": "file:experimental/packages/exporter-trace-otlp-http",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/core": "1.20.0",
         "@opentelemetry/otlp-exporter-base": "0.47.0",
@@ -40416,6 +39990,7 @@
       "version": "file:experimental/packages/exporter-trace-otlp-proto",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/core": "1.20.0",
         "@opentelemetry/otlp-exporter-base": "0.47.0",
@@ -40587,6 +40162,7 @@
       "version": "file:packages/opentelemetry-exporter-zipkin",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/core": "1.20.0",
         "@opentelemetry/resources": "1.20.0",
@@ -40758,6 +40334,7 @@
       "version": "file:experimental/packages/opentelemetry-instrumentation",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/sdk-metrics": "1.20.0",
         "@types/mocha": "10.0.6",
@@ -40932,6 +40509,7 @@
       "version": "file:experimental/packages/opentelemetry-instrumentation-fetch",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/context-zone": "1.20.0",
         "@opentelemetry/core": "1.20.0",
@@ -41180,6 +40758,7 @@
       "version": "file:experimental/packages/opentelemetry-instrumentation-xml-http-request",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/context-zone": "1.20.0",
         "@opentelemetry/core": "1.20.0",
@@ -41353,6 +40932,7 @@
       "version": "file:experimental/packages/opentelemetry-browser-detector",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/resources": "1.20.0",
         "@opentelemetry/semantic-conventions": "1.20.0",
@@ -41519,6 +41099,7 @@
       "version": "file:experimental/packages/otlp-exporter-base",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/core": "1.20.0",
         "@types/mocha": "10.0.6",
@@ -41683,7 +41264,6 @@
     "@opentelemetry/otlp-grpc-exporter-base": {
       "version": "file:experimental/packages/otlp-grpc-exporter-base",
       "requires": {
-        "@babel/core": "7.23.6",
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/core": "1.20.0",
@@ -41712,6 +41292,7 @@
       "version": "file:experimental/packages/otlp-proto-exporter-base",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/core": "1.20.0",
         "@opentelemetry/otlp-exporter-base": "0.47.0",
@@ -42116,6 +41697,7 @@
       "version": "file:experimental/packages/sdk-logs",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.4.0 <1.8.0",
         "@opentelemetry/api-logs": "0.47.0",
         "@opentelemetry/core": "1.20.0",
@@ -42317,6 +41899,7 @@
       "version": "file:packages/sdk-metrics",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.3.0 <1.8.0",
         "@opentelemetry/core": "1.20.0",
         "@opentelemetry/resources": "1.20.0",
@@ -42636,6 +42219,7 @@
       "version": "file:packages/opentelemetry-sdk-trace-web",
       "requires": {
         "@babel/core": "7.23.6",
+        "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
         "@opentelemetry/context-zone": "1.20.0",
         "@opentelemetry/core": "1.20.0",
@@ -58315,7 +57899,8 @@
     "web-opentelemetry-example": {
       "version": "file:examples/opentelemetry-web",
       "requires": {
-        "@babel/core": "^7.6.0",
+        "@babel/core": "^7.23.6",
+        "@babel/preset-env": "^7.22.20",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-zone": "1.20.0",
         "@opentelemetry/core": "1.20.0",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": ">=1.0.0 <1.8.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/packages/opentelemetry-context-zone-peer-dep/test/ZoneContextManager.test.ts
+++ b/packages/opentelemetry-context-zone-peer-dep/test/ZoneContextManager.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import 'zone.js/dist/zone';
+import 'zone.js';
 import * as sinon from 'sinon';
 import * as assert from 'assert';
 import { ZoneContextManager } from '../src';

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -50,29 +50,9 @@
     "access": "public"
   },
   "devDependencies": {
-    "@babel/core": "7.23.6",
-    "@types/mocha": "10.0.6",
-    "@types/node": "18.6.5",
-    "@types/sinon": "10.0.20",
-    "@types/webpack-env": "1.16.3",
-    "babel-loader": "8.3.0",
-    "codecov": "3.8.3",
     "cross-var": "1.1.0",
-    "karma": "6.4.2",
-    "karma-chrome-launcher": "3.1.0",
-    "karma-mocha": "2.0.1",
-    "karma-spec-reporter": "0.0.36",
-    "karma-webpack": "4.0.2",
     "lerna": "6.6.2",
-    "mocha": "10.2.0",
-    "nyc": "15.1.0",
-    "sinon": "15.1.2",
-    "ts-loader": "8.4.0",
-    "ts-mocha": "10.0.0",
-    "typescript": "4.4.4",
-    "webpack": "5.89.0",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "typescript": "4.4.4"
   },
   "dependencies": {
     "@opentelemetry/context-zone-peer-dep": "1.20.0",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "^1.0.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": ">=1.0.0 <1.8.0",
     "@opentelemetry/context-zone": "1.20.0",
     "@opentelemetry/propagator-b3": "1.20.0",

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
+    "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": ">=1.3.0 <1.8.0",
     "@types/lodash.merge": "4.6.9",
     "@types/mocha": "10.0.6",


### PR DESCRIPTION
## Which problem is this PR solving?

Test with zone.js' default export entry rather than specifying `'zone.js/dist/index'`

## Short description of the changes

Zone.js' default export entry that is picked by the bundler contains new syntax that needs to be transpiled.

## Type of change

- [x] Test

## Checklist:

- [x] Followed the style guidelines of this project
