### PR TITLE
chore(otel-resources): replace deprecated spanAttributes

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -2,6 +2,7 @@
 
 ### :boom: Breaking Change
 
+* chore(otel-resources): replace deprecated SpanAttributes [#4428](https://github.com/open-telemetry/opentelemetry-js/pull/4428) @JamieDanielson
 * chore(otel-core): replace deprecated SpanAttributes [#4408](https://github.com/open-telemetry/opentelemetry-js/pull/4408) @JamieDanielson
 
 ### :rocket: (Enhancement)

--- a/package-lock.json
+++ b/package-lock.json
@@ -31307,7 +31307,7 @@
         "@opentelemetry/semantic-conventions": "1.18.1"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.1.0 <1.8.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -37075,7 +37075,7 @@
     "@opentelemetry/resources": {
       "version": "file:packages/opentelemetry-resources",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.1.0 <1.8.0",
         "@opentelemetry/core": "1.18.1",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@opentelemetry/semantic-conventions": "1.18.1",

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0",
+    "@opentelemetry/api": ">=1.1.0 <1.8.0",
     "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -119,7 +119,7 @@ export class Resource implements IResource {
   merge(other: IResource | null): IResource {
     if (!other) return this;
 
-    // SpanAttributes from other resource overwrite attributes from this resource.
+    // Attributes from other resource overwrite attributes from this resource.
     const mergedSyncAttributes = {
       ...this._syncAttributes,
       //Support for old resource implementation where _syncAttributes is not defined

--- a/packages/opentelemetry-resources/src/types.ts
+++ b/packages/opentelemetry-resources/src/types.ts
@@ -15,15 +15,13 @@
  */
 
 import { ResourceDetectionConfig } from './config';
-import { SpanAttributes } from '@opentelemetry/api';
+import { Attributes } from '@opentelemetry/api';
 import { IResource } from './IResource';
 
 /**
  * Interface for Resource attributes.
- * General `Attributes` interface is added in api v1.1.0.
- * To backward support older api (1.0.x), the deprecated `SpanAttributes` is used here.
  */
-export type ResourceAttributes = SpanAttributes;
+export type ResourceAttributes = Attributes;
 
 /**
  * @deprecated please use {@link DetectorSync}

--- a/packages/opentelemetry-resources/src/types.ts
+++ b/packages/opentelemetry-resources/src/types.ts
@@ -21,6 +21,7 @@ import { IResource } from './IResource';
 /**
  * Interface for Resource attributes.
  */
+// TODO: replace ResourceAttributes with Attributes
 export type ResourceAttributes = Attributes;
 
 /**


### PR DESCRIPTION
## Which problem is this PR solving?

- Updates #4175 

## Short description of the changes

- Update minimum API version to 1.1.0 in opentelemetry-resources
- Replace deprecated `SpanAttributes` with `Attributes`

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Unit tests pass

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been updated
