### PR TITLE
Fix `NaN` and `Infinity` values in logs being coerced into `null` and causing exception in OTEL collector

### DIFF
--- a/experimental/packages/otlp-transformer/src/common/internal.ts
+++ b/experimental/packages/otlp-transformer/src/common/internal.ts
@@ -30,7 +30,7 @@ export function toKeyValue(key: string, value: unknown): IKeyValue {
 export function toAnyValue(value: unknown): IAnyValue {
   const t = typeof value;
   if (t === 'string') return { stringValue: value as string };
-  if (t === 'number' && Number.isFinite(t)) {
+  if (t === 'number' && Number.isFinite(value)) {
     if (!Number.isInteger(value)) return { doubleValue: value as number };
     return { intValue: value as number };
   }

--- a/experimental/packages/otlp-transformer/src/common/internal.ts
+++ b/experimental/packages/otlp-transformer/src/common/internal.ts
@@ -30,7 +30,7 @@ export function toKeyValue(key: string, value: unknown): IKeyValue {
 export function toAnyValue(value: unknown): IAnyValue {
   const t = typeof value;
   if (t === 'string') return { stringValue: value as string };
-  if (t === 'number') {
+  if (t === 'number' && Number.isFinite(t)) {
     if (!Number.isInteger(value)) return { doubleValue: value as number };
     return { intValue: value as number };
   }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

OpenTelemetry JS logging SDK had a bug where if the log had a `NaN`, `Infinity` or `-Infinity` value, it was treated as a number and returned

```js
{
  doubleValue: null;
}
```

to Collector, which caused an exception.

## Short description of the changes

This PR uses [`Number.isFinite`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite) method to check if the value is in fact a number, and won't be coerced into `null` by `JSON.stringify`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
