### PR TITLE
fix(instrumentation)!: pin import-in-the-middle@1.7.1

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
- * fix(instrumentation)!: pin import-in-the-middle@1.7.1 [#4441](https://github.com/open-telemetry/opentelemetry-js/pull/4441)
+* fix(instrumentation)!: pin import-in-the-middle@1.7.1 [#4441](https://github.com/open-telemetry/opentelemetry-js/pull/4441)
   * Only affects users that are using the experimental `@opentelemetry/instrumentation/hook.mjs` loder hook AND Node.js 18.19 or later:
-    * This reverts back to an older version of import-in-the-middle due to https://github.com/DataDog/import-in-the-middle/issues/57
+    * This reverts back to an older version of import-in-the-middle due to <https://github.com/DataDog/import-in-the-middle/issues/57>
 
 ### :rocket: (Enhancement)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to experimental packages in this project will be documented 
 * fix(instrumentation)!: pin import-in-the-middle@1.7.1 [#4441](https://github.com/open-telemetry/opentelemetry-js/pull/4441)
   * Fixes a bug where, in some circumstances, ESM instrumentation packages would try to instrument CJS exports on ESM, causing the end-user application to crash.
   * This breaking change only affects users that are using the *experimental* `@opentelemetry/instrumentation/hook.mjs` loader hook AND Node.js 18.19 or later:
-    * This reverts back to an older version of `import-in-the-middle` due to https://github.com/DataDog/import-in-the-middle/issues/57
+    * This reverts back to an older version of `import-in-the-middle` due to <https://github.com/DataDog/import-in-the-middle/issues/57>
     * This version does not support Node.js 18.19 or later
 
 ### :rocket: (Enhancement)

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
-* fix(instrumentation)!: pin import-in-the-middle@1.7.1 [#4441](https://github.com/open-telemetry/opentelemetry-js/pull/4441)
-  * Only affects users that are using the experimental `@opentelemetry/instrumentation/hook.mjs` loder hook AND Node.js 18.19 or later:
-    * This reverts back to an older version of import-in-the-middle due to <https://github.com/DataDog/import-in-the-middle/issues/57>
+ * fix(instrumentation)!: pin import-in-the-middle@1.7.1 [#4441](https://github.com/open-telemetry/opentelemetry-js/pull/4441)
+  * Fixes a bug where, in some circumstances, ESM instrumentation packages would try to instrument CJS exports on ESM, causing the end-user application to crash.
+  * This breaking change only affects users that are using the *experimental* `@opentelemetry/instrumentation/hook.mjs` loader hook AND Node.js 18.19 or later:
+    * This reverts back to an older version of `import-in-the-middle` due to https://github.com/DataDog/import-in-the-middle/issues/57
+    * This version does not support Node.js 18.19 or later.
 
 ### :rocket: (Enhancement)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+ * fix(instrumentation)!: pin import-in-the-middle@1.7.1 [#4441](https://github.com/open-telemetry/opentelemetry-js/pull/4441)
+  * Only affects users that are using the experimental `@opentelemetry/instrumentation/hook.mjs` loder hook AND Node.js 18.19 or later:
+    * This reverts back to an older version of import-in-the-middle due to https://github.com/DataDog/import-in-the-middle/issues/57
+
 ### :rocket: (Enhancement)
 
 ### :bug: (Bug Fix)

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
- * fix(instrumentation)!: pin import-in-the-middle@1.7.1 [#4441](https://github.com/open-telemetry/opentelemetry-js/pull/4441)
+* fix(instrumentation)!: pin import-in-the-middle@1.7.1 [#4441](https://github.com/open-telemetry/opentelemetry-js/pull/4441)
   * Fixes a bug where, in some circumstances, ESM instrumentation packages would try to instrument CJS exports on ESM, causing the end-user application to crash.
   * This breaking change only affects users that are using the *experimental* `@opentelemetry/instrumentation/hook.mjs` loader hook AND Node.js 18.19 or later:
     * This reverts back to an older version of `import-in-the-middle` due to https://github.com/DataDog/import-in-the-middle/issues/57
-    * This version does not support Node.js 18.19 or later.
+    * This version does not support Node.js 18.19 or later
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@types/shimmer": "^1.0.2",
-    "import-in-the-middle": "^1.7.2",
+    "import-in-the-middle": "1.7.1",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2",
     "shimmer": "^1.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3108,7 +3108,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "^1.7.2",
+        "import-in-the-middle": "1.7.1",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -3946,6 +3946,17 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "experimental/packages/opentelemetry-instrumentation/node_modules/import-in-the-middle": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
+      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
       }
     },
     "experimental/packages/opentelemetry-instrumentation/node_modules/interpret": {
@@ -19484,17 +19495,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/import-in-the-middle": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.2.tgz",
-      "integrity": "sha512-coz7AjRnPyKW36J6JX5Bjz1mcX7MX1H2XsEGseVcnXMdzsAbbAu0HBZhiAem+3SAmuZdi+p8OwoB2qUpTRgjOQ==",
-      "dependencies": {
-        "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
-        "cjs-module-lexer": "^1.2.2",
-        "module-details-from-path": "^1.0.3"
       }
     },
     "node_modules/import-local": {
@@ -40348,7 +40348,7 @@
         "codecov": "3.8.3",
         "cpx": "1.5.0",
         "cross-var": "1.1.0",
-        "import-in-the-middle": "^1.7.2",
+        "import-in-the-middle": "1.7.1",
         "karma": "6.4.2",
         "karma-chrome-launcher": "3.1.0",
         "karma-coverage": "2.2.1",
@@ -40404,6 +40404,17 @@
           "requires": {
             "graceful-fs": "^4.2.4",
             "tapable": "^2.2.0"
+          }
+        },
+        "import-in-the-middle": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
+          "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+          "requires": {
+            "acorn": "^8.8.2",
+            "acorn-import-assertions": "^1.9.0",
+            "cjs-module-lexer": "^1.2.2",
+            "module-details-from-path": "^1.0.3"
           }
         },
         "interpret": {
@@ -49646,17 +49657,6 @@
           "version": "4.0.0",
           "dev": true
         }
-      }
-    },
-    "import-in-the-middle": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.2.tgz",
-      "integrity": "sha512-coz7AjRnPyKW36J6JX5Bjz1mcX7MX1H2XsEGseVcnXMdzsAbbAu0HBZhiAem+3SAmuZdi+p8OwoB2qUpTRgjOQ==",
-      "requires": {
-        "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
-        "cjs-module-lexer": "^1.2.2",
-        "module-details-from-path": "^1.0.3"
       }
     },
     "import-local": {


### PR DESCRIPTION
## Which problem is this PR solving?

import-in-the-middle@1.7.2 and later includes a bug (https://github.com/DataDog/import-in-the-middle/issues/57) where a property we use to distinguish ESM from CJS modules is not present, causing instrumentation to crash end-user apps.

This drops support for ESM instrumentation again for Node.js 18.19 and later.

## Short description of the changes

pin import-in-the-middle@1.7.1

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)