### PR TITLE
chore: prepare release 1.21.0/0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :rocket: (Enhancement)
 
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 1.21.0
+
+### :rocket: (Enhancement)
+
 * feat(sdk-metrics): add constructor option to add metric readers [#4427](https://github.com/open-telemetry/opentelemetry-js/pull/4427) @pichlermarc
   * deprecates `MeterProvider.addMetricReader()` please use the constructor option `readers` instead.
 
@@ -18,8 +28,6 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 * fix(sdk-trace-base): ensure attribute value length limit is enforced on span creation [#4417](https://github.com/open-telemetry/opentelemetry-js/pull/4417) @pichlermarc
 * fix(sdk-trace-base): Export processed spans while exporter failed [#4287](https://github.com/open-telemetry/opentelemetry-js/pull/4287) @Zirak
-
-### :books: (Refine Doc)
 
 ### :house: (Internal)
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The below table describes which versions of each set of packages are expected to
 
 | Stable Packages                                                 | Experimental Packages |
 |-----------------------------------------------------------------|-----------------------|
+| 1.21.x                                                          | 0.48.x                |
 | 1.20.x                                                          | 0.47.x                |
 | 1.19.x                                                          | 0.46.x                |
 | 1.18.x                                                          | 0.45.x                |

--- a/examples/esm-http-ts/package.json
+++ b/examples/esm-http-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esm-http-ts",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Example of HTTP integration with OpenTelemetry using ESM and TypeScript",
   "main": "build/index.js",
   "type": "module",
@@ -31,12 +31,12 @@
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/",
   "dependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
-    "@opentelemetry/instrumentation": "0.47.0",
-    "@opentelemetry/instrumentation-http": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
-    "@opentelemetry/sdk-trace-node": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
+    "@opentelemetry/instrumentation": "0.48.0",
+    "@opentelemetry/instrumentation-http": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/sdk-trace-node": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   }
 }

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-example",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Example of HTTP integration with OpenTelemetry",
   "main": "index.js",
   "scripts": {
@@ -29,14 +29,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-jaeger": "1.20.0",
-    "@opentelemetry/exporter-zipkin": "1.20.0",
-    "@opentelemetry/instrumentation": "0.47.0",
-    "@opentelemetry/instrumentation-http": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
-    "@opentelemetry/sdk-trace-node": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/exporter-jaeger": "1.21.0",
+    "@opentelemetry/exporter-zipkin": "1.21.0",
+    "@opentelemetry/instrumentation": "0.48.0",
+    "@opentelemetry/instrumentation-http": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/sdk-trace-node": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/http",
   "devDependencies": {

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,7 +1,7 @@
 {
   "name": "https-example",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Example of HTTPs integration with OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -33,14 +33,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/exporter-jaeger": "1.20.0",
-    "@opentelemetry/exporter-zipkin": "1.20.0",
-    "@opentelemetry/instrumentation": "0.47.0",
-    "@opentelemetry/instrumentation-http": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
-    "@opentelemetry/sdk-trace-node": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/exporter-jaeger": "1.21.0",
+    "@opentelemetry/exporter-zipkin": "1.21.0",
+    "@opentelemetry/instrumentation": "0.48.0",
+    "@opentelemetry/instrumentation-http": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/sdk-trace-node": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-opentelemetry-example",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Example of using @opentelemetry/sdk-trace-web and @opentelemetry/sdk-metrics in browser",
   "main": "index.js",
   "scripts": {
@@ -44,20 +44,20 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/context-zone": "1.20.0",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
-    "@opentelemetry/exporter-zipkin": "1.20.0",
-    "@opentelemetry/instrumentation": "0.47.0",
-    "@opentelemetry/instrumentation-fetch": "0.47.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.47.0",
-    "@opentelemetry/propagator-b3": "1.20.0",
-    "@opentelemetry/sdk-metrics": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
-    "@opentelemetry/sdk-trace-web": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/context-zone": "1.21.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
+    "@opentelemetry/exporter-zipkin": "1.21.0",
+    "@opentelemetry/instrumentation": "0.48.0",
+    "@opentelemetry/instrumentation-fetch": "0.48.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.48.0",
+    "@opentelemetry/propagator-b3": "1.21.0",
+    "@opentelemetry/sdk-metrics": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/sdk-trace-web": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web"
 }

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-otlp-exporter-node",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
@@ -29,17 +29,17 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.47.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "0.47.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-metrics": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.48.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "0.48.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-metrics": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/otlp-exporter-node"
 }

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,13 +6,23 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+### :rocket: (Enhancement)
+
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 0.48.0
+
+### :boom: Breaking Change
+
 * fix(instrumentation)!: pin import-in-the-middle@1.7.1 [#4441](https://github.com/open-telemetry/opentelemetry-js/pull/4441)
   * Fixes a bug where, in some circumstances, ESM instrumentation packages would try to instrument CJS exports on ESM, causing the end-user application to crash.
   * This breaking change only affects users that are using the *experimental* `@opentelemetry/instrumentation/hook.mjs` loader hook AND Node.js 18.19 or later:
     * This reverts back to an older version of `import-in-the-middle` due to <https://github.com/DataDog/import-in-the-middle/issues/57>
     * This version does not support Node.js 18.19 or later
-
-### :rocket: (Enhancement)
 
 ### :bug: (Bug Fix)
 
@@ -21,8 +31,6 @@ All notable changes to experimental packages in this project will be documented 
 * fix(exporter-logs-otlp-http): set User-Agent header [#4398](https://github.com/open-telemetry/opentelemetry-js/pull/4398) @Vunovati
 * fix(exporter-logs-otlp-proto): set User-Agent header [#4398](https://github.com/open-telemetry/opentelemetry-js/pull/4398) @Vunovati
 * fix(instrumentation-fetch): compatibility with Map types for fetch headers
-
-### :books: (Refine Doc)
 
 ### :house: (Internal)
 

--- a/experimental/backwards-compatibility/node14/package.json
+++ b/experimental/backwards-compatibility/node14/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node14",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "private": true,
   "description": "Backwards compatibility app for node 14 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.47.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0"
+    "@opentelemetry/sdk-node": "0.48.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0"
   },
   "devDependencies": {
     "@types/node": "14.18.25",

--- a/experimental/backwards-compatibility/node16/package.json
+++ b/experimental/backwards-compatibility/node16/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node16",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "private": true,
   "description": "Backwards compatibility app for node 16 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.47.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0"
+    "@opentelemetry/sdk-node": "0.48.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0"
   },
   "devDependencies": {
     "@types/node": "16.11.52",

--- a/experimental/examples/logs/package.json
+++ b/experimental/examples/logs/package.json
@@ -1,14 +1,14 @@
 {
   "name": "logs-example",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "private": true,
   "scripts": {
     "start": "ts-node index.ts"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/api-logs": "0.47.0",
-    "@opentelemetry/sdk-logs": "0.47.0"
+    "@opentelemetry/api-logs": "0.48.0",
+    "@opentelemetry/sdk-logs": "0.48.0"
   },
   "devDependencies": {
     "@types/node": "18.6.5",

--- a/experimental/examples/opencensus-shim/package.json
+++ b/experimental/examples/opencensus-shim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencensus-shim",
   "private": true,
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Example of using @opentelemetry/shim-opencensus in Node.js",
   "main": "index.js",
   "scripts": {
@@ -31,13 +31,13 @@
     "@opencensus/instrumentation-http": "0.1.0",
     "@opencensus/nodejs-base": "0.1.0",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/exporter-prometheus": "0.47.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-metrics": "1.20.0",
-    "@opentelemetry/sdk-trace-node": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0",
-    "@opentelemetry/shim-opencensus": "0.47.0"
+    "@opentelemetry/exporter-prometheus": "0.48.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-metrics": "1.21.0",
+    "@opentelemetry/sdk-trace-node": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0",
+    "@opentelemetry/shim-opencensus": "0.48.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/examples/opencensus-shim"
 }

--- a/experimental/examples/prometheus/package.json
+++ b/experimental/examples/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prometheus-example",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "private": true,
   "description": "Example of using @opentelemetry/sdk-metrics and @opentelemetry/exporter-prometheus",
   "main": "index.js",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-prometheus": "0.47.0",
-    "@opentelemetry/sdk-metrics": "1.20.0"
+    "@opentelemetry/exporter-prometheus": "0.48.0",
+    "@opentelemetry/sdk-metrics": "1.21.0"
   }
 }

--- a/experimental/packages/api-events/package.json
+++ b/experimental/packages/api-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-events",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Public events API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/api-logs/package.json
+++ b/experimental/packages/api-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-logs",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Public logs API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-grpc",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected log records to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,9 +50,9 @@
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/api-logs": "0.47.0",
-    "@opentelemetry/otlp-exporter-base": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/api-logs": "0.48.0",
+    "@opentelemetry/otlp-exporter-base": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -72,10 +72,10 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
-    "@opentelemetry/otlp-transformer": "0.47.0",
-    "@opentelemetry/sdk-logs": "0.47.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
+    "@opentelemetry/otlp-transformer": "0.48.0",
+    "@opentelemetry/sdk-logs": "0.48.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-http",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "publishConfig": {
     "access": "public"
   },
@@ -74,7 +74,7 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/resources": "1.21.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -105,10 +105,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.47.0",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/otlp-exporter-base": "0.47.0",
-    "@opentelemetry/otlp-transformer": "0.47.0",
-    "@opentelemetry/sdk-logs": "0.47.0"
+    "@opentelemetry/api-logs": "0.48.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/otlp-exporter-base": "0.48.0",
+    "@opentelemetry/otlp-transformer": "0.48.0",
+    "@opentelemetry/sdk-logs": "0.48.0"
   }
 }

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-proto",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "An OTLP exporter to send logs using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,14 +94,14 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.47.0",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/otlp-exporter-base": "0.47.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
-    "@opentelemetry/otlp-transformer": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-logs": "0.47.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0"
+    "@opentelemetry/api-logs": "0.48.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/otlp-exporter-base": "0.48.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
+    "@opentelemetry/otlp-transformer": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-logs": "0.48.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-grpc",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/otlp-exporter-base": "0.47.0",
+    "@opentelemetry/otlp-exporter-base": "0.48.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -69,11 +69,11 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
-    "@opentelemetry/otlp-transformer": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
+    "@opentelemetry/otlp-transformer": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-http",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry Collector Trace Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -96,11 +96,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/otlp-exporter-base": "0.47.0",
-    "@opentelemetry/otlp-transformer": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/otlp-exporter-base": "0.48.0",
+    "@opentelemetry/otlp-transformer": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-proto",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,12 +93,12 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/otlp-exporter-base": "0.47.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
-    "@opentelemetry/otlp-transformer": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/otlp-exporter-base": "0.48.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
+    "@opentelemetry/otlp-transformer": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/opentelemetry-browser-detector",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry Resource Detector for Browser",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -83,8 +83,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/browser-detector"
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -68,12 +68,12 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
-    "@opentelemetry/otlp-transformer": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-metrics": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
+    "@opentelemetry/otlp-transformer": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-metrics": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-http",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -96,11 +96,11 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/otlp-exporter-base": "0.47.0",
-    "@opentelemetry/otlp-transformer": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-metrics": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/otlp-exporter-base": "0.48.0",
+    "@opentelemetry/otlp-transformer": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-metrics": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-proto",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -74,13 +74,13 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
-    "@opentelemetry/otlp-exporter-base": "0.47.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
-    "@opentelemetry/otlp-transformer": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-metrics": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
+    "@opentelemetry/otlp-exporter-base": "0.48.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
+    "@opentelemetry/otlp-transformer": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-metrics": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.20.0",
+    "@opentelemetry/semantic-conventions": "1.21.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -61,9 +61,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-metrics": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-metrics": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-prometheus",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-fetch",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry fetch automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,9 +57,9 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-zone": "1.20.0",
-    "@opentelemetry/propagator-b3": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/context-zone": "1.21.0",
+    "@opentelemetry/propagator-b3": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -89,10 +89,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/instrumentation": "0.47.0",
-    "@opentelemetry/sdk-trace-web": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/instrumentation": "0.48.0",
+    "@opentelemetry/sdk-trace-web": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-grpc",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry grpc automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,10 +50,10 @@
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-async-hooks": "1.20.0",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
-    "@opentelemetry/sdk-trace-node": "1.20.0",
+    "@opentelemetry/context-async-hooks": "1.21.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/sdk-trace-node": "1.21.0",
     "@protobuf-ts/grpc-transport": "2.9.3",
     "@protobuf-ts/runtime": "2.9.3",
     "@protobuf-ts/runtime-rpc": "2.9.3",
@@ -75,8 +75,8 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "0.47.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/instrumentation": "0.48.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-http",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry http/https automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,10 +46,10 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-async-hooks": "1.20.0",
-    "@opentelemetry/sdk-metrics": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
-    "@opentelemetry/sdk-trace-node": "1.20.0",
+    "@opentelemetry/context-async-hooks": "1.21.0",
+    "@opentelemetry/sdk-metrics": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/sdk-trace-node": "1.21.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/request-promise-native": "1.0.21",
@@ -74,9 +74,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/instrumentation": "0.47.0",
-    "@opentelemetry/semantic-conventions": "1.20.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/instrumentation": "0.48.0",
+    "@opentelemetry/semantic-conventions": "1.21.0",
     "semver": "^7.5.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http",

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-xml-http-request",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry XMLHttpRequest automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,9 +57,9 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-zone": "1.20.0",
-    "@opentelemetry/propagator-b3": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/context-zone": "1.21.0",
+    "@opentelemetry/propagator-b3": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -89,10 +89,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/instrumentation": "0.47.0",
-    "@opentelemetry/sdk-trace-web": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/instrumentation": "0.48.0",
+    "@opentelemetry/sdk-trace-web": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Base class for node which OpenTelemetry instrumentation modules extend",
   "author": "OpenTelemetry Authors",
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation",
@@ -84,7 +84,7 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/sdk-metrics": "1.20.0",
+    "@opentelemetry/sdk-metrics": "1.21.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.6",

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-node",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry SDK for Node.js",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,27 +44,27 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.47.0",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
-    "@opentelemetry/exporter-zipkin": "1.20.0",
-    "@opentelemetry/instrumentation": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-logs": "0.47.0",
-    "@opentelemetry/sdk-metrics": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
-    "@opentelemetry/sdk-trace-node": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/api-logs": "0.48.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
+    "@opentelemetry/exporter-zipkin": "1.21.0",
+    "@opentelemetry/instrumentation": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-logs": "0.48.0",
+    "@opentelemetry/sdk-metrics": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/sdk-trace-node": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.3.0 <1.8.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-async-hooks": "1.20.0",
-    "@opentelemetry/exporter-jaeger": "1.20.0",
+    "@opentelemetry/context-async-hooks": "1.21.0",
+    "@opentelemetry/exporter-jaeger": "1.21.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.6",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-exporter-base",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry OTLP Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0"
+    "@opentelemetry/core": "1.21.0"
   },
   "devDependencies": {
     "@babel/core": "7.23.6",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-grpc-exporter-base",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry OTLP-gRPC Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,9 +49,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/otlp-transformer": "0.47.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/otlp-transformer": "0.48.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -72,8 +72,8 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/otlp-exporter-base": "0.47.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/otlp-exporter-base": "0.48.0",
     "protobufjs": "^7.2.3"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-grpc-exporter-base",

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-proto-exporter-base",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenTelemetry OTLP-HTTP-protobuf Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -80,8 +80,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/otlp-exporter-base": "0.47.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/otlp-exporter-base": "0.48.0",
     "protobufjs": "^7.2.3"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-proto-exporter-base",

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Transform OpenTelemetry SDK data into OTLP",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
@@ -79,12 +79,12 @@
     "webpack": "5.89.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.47.0",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-logs": "0.47.0",
-    "@opentelemetry/sdk-metrics": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0"
+    "@opentelemetry/api-logs": "0.48.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-logs": "0.48.0",
+    "@opentelemetry/sdk-metrics": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-transformer",
   "sideEffects": false

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-logs",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "publishConfig": {
     "access": "public"
   },
@@ -75,7 +75,7 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": ">=1.4.0 <1.8.0",
-    "@opentelemetry/api-logs": "0.47.0",
+    "@opentelemetry/api-logs": "0.48.0",
     "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -101,7 +101,7 @@
     "webpack-merge": "5.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/resources": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/resources": "1.21.0"
   }
 }

--- a/experimental/packages/shim-opencensus/package.json
+++ b/experimental/packages/shim-opencensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opencensus",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "OpenCensus to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,8 +50,8 @@
   "devDependencies": {
     "@opencensus/core": "0.1.0",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-async-hooks": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/context-async-hooks": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -69,9 +69,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-metrics": "1.20.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-metrics": "1.21.0",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2"
   },

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.20.0",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/context-async-hooks": "1.21.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
     "axios": "1.5.1",
     "body-parser": "1.19.0",
     "express": "4.17.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
-        "api",
         "packages/*",
         "experimental/packages/*",
         "experimental/examples/*",
@@ -195,17 +194,17 @@
       }
     },
     "examples/esm-http-ts": {
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/instrumentation-http": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/instrumentation-http": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -213,18 +212,18 @@
     },
     "examples/http": {
       "name": "http-example",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.20.0",
-        "@opentelemetry/exporter-zipkin": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/instrumentation-http": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/exporter-jaeger": "1.21.0",
+        "@opentelemetry/exporter-zipkin": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/instrumentation-http": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -235,18 +234,18 @@
     },
     "examples/https": {
       "name": "https-example",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.20.0",
-        "@opentelemetry/exporter-zipkin": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/instrumentation-http": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/exporter-jaeger": "1.21.0",
+        "@opentelemetry/exporter-zipkin": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/instrumentation-http": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -257,24 +256,24 @@
     },
     "examples/opentelemetry-web": {
       "name": "web-opentelemetry-example",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
-        "@opentelemetry/exporter-zipkin": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/instrumentation-fetch": "0.47.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.47.0",
-        "@opentelemetry/propagator-b3": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-web": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/context-zone": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
+        "@opentelemetry/exporter-zipkin": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/instrumentation-fetch": "0.48.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.48.0",
+        "@opentelemetry/propagator-b3": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-web": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.6",
@@ -609,21 +608,21 @@
     },
     "examples/otlp-exporter-node": {
       "name": "example-otlp-exporter-node",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.47.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.48.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -631,11 +630,11 @@
     },
     "experimental/backwards-compatibility/node14": {
       "name": "backcompat-node14",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-node": "0.47.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0"
+        "@opentelemetry/sdk-node": "0.48.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
       },
       "devDependencies": {
         "@types/node": "14.18.25",
@@ -652,11 +651,11 @@
     },
     "experimental/backwards-compatibility/node16": {
       "name": "backcompat-node16",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-node": "0.47.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0"
+        "@opentelemetry/sdk-node": "0.48.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
       },
       "devDependencies": {
         "@types/node": "16.11.52",
@@ -673,11 +672,11 @@
     },
     "experimental/examples/logs": {
       "name": "logs-example",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/sdk-logs": "0.47.0"
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/sdk-logs": "0.48.0"
       },
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -743,20 +742,20 @@
       }
     },
     "experimental/examples/opencensus-shim": {
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opencensus/core": "0.1.0",
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/exporter-prometheus": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
-        "@opentelemetry/shim-opencensus": "0.47.0"
+        "@opentelemetry/exporter-prometheus": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/shim-opencensus": "0.48.0"
       },
       "engines": {
         "node": ">=14"
@@ -764,17 +763,17 @@
     },
     "experimental/examples/prometheus": {
       "name": "prometheus-example",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-prometheus": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.20.0"
+        "@opentelemetry/exporter-prometheus": "0.48.0",
+        "@opentelemetry/sdk-metrics": "1.21.0"
       }
     },
     "experimental/packages/api-events": {
       "name": "@opentelemetry/api-events",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
@@ -913,7 +912,7 @@
     },
     "experimental/packages/api-logs": {
       "name": "@opentelemetry/api-logs",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
@@ -1052,21 +1051,21 @@
     },
     "experimental/packages/exporter-logs-otlp-grpc": {
       "name": "@opentelemetry/exporter-logs-otlp-grpc",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/sdk-logs": "0.47.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/sdk-logs": "0.48.0"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1090,20 +1089,20 @@
     },
     "experimental/packages/exporter-logs-otlp-http": {
       "name": "@opentelemetry/exporter-logs-otlp-http",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/sdk-logs": "0.47.0"
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/sdk-logs": "0.48.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/resources": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1404,17 +1403,17 @@
     },
     "experimental/packages/exporter-logs-otlp-proto": {
       "name": "@opentelemetry/exporter-logs-otlp-proto",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-logs": "0.47.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0"
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-logs": "0.48.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -1718,20 +1717,20 @@
     },
     "experimental/packages/exporter-trace-otlp-grpc": {
       "name": "@opentelemetry/exporter-trace-otlp-grpc",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1755,14 +1754,14 @@
     },
     "experimental/packages/exporter-trace-otlp-http": {
       "name": "@opentelemetry/exporter-trace-otlp-http",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -2068,15 +2067,15 @@
     },
     "experimental/packages/exporter-trace-otlp-proto": {
       "name": "@opentelemetry/exporter-trace-otlp-proto",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -2380,11 +2379,11 @@
     },
     "experimental/packages/opentelemetry-browser-detector": {
       "name": "@opentelemetry/opentelemetry-browser-detector",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -2687,16 +2686,16 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc": {
       "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
@@ -2724,14 +2723,14 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-http": {
       "name": "@opentelemetry/exporter-metrics-otlp-http",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -3037,16 +3036,16 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-proto": {
       "name": "@opentelemetry/exporter-metrics-otlp-proto",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
@@ -3073,16 +3072,16 @@
     },
     "experimental/packages/opentelemetry-exporter-prometheus": {
       "name": "@opentelemetry/exporter-prometheus",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -3104,7 +3103,7 @@
     },
     "experimental/packages/opentelemetry-instrumentation": {
       "name": "@opentelemetry/instrumentation",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/shimmer": "^1.0.2",
@@ -3117,7 +3116,7 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -3154,21 +3153,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-fetch": {
       "name": "@opentelemetry/instrumentation-fetch",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/sdk-trace-web": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/sdk-trace-web": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone": "1.20.0",
-        "@opentelemetry/propagator-b3": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/context-zone": "1.21.0",
+        "@opentelemetry/propagator-b3": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -3468,21 +3467,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-grpc": {
       "name": "@opentelemetry/instrumentation-grpc",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "devDependencies": {
         "@bufbuild/buf": "1.21.0-1",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/context-async-hooks": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
         "@protobuf-ts/grpc-transport": "2.9.3",
         "@protobuf-ts/runtime": "2.9.3",
         "@protobuf-ts/runtime-rpc": "2.9.3",
@@ -3509,20 +3508,20 @@
     },
     "experimental/packages/opentelemetry-instrumentation-http": {
       "name": "@opentelemetry/instrumentation-http",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
+        "@opentelemetry/context-async-hooks": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
@@ -3562,21 +3561,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-xml-http-request": {
       "name": "@opentelemetry/instrumentation-xml-http-request",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/sdk-trace-web": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/sdk-trace-web": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone": "1.20.0",
-        "@opentelemetry/propagator-b3": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/context-zone": "1.21.0",
+        "@opentelemetry/propagator-b3": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -4152,27 +4151,27 @@
     },
     "experimental/packages/opentelemetry-sdk-node": {
       "name": "@opentelemetry/sdk-node",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
-        "@opentelemetry/exporter-zipkin": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-logs": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
+        "@opentelemetry/exporter-zipkin": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-logs": "0.48.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.20.0",
-        "@opentelemetry/exporter-jaeger": "1.20.0",
+        "@opentelemetry/context-async-hooks": "1.21.0",
+        "@opentelemetry/exporter-jaeger": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -4197,10 +4196,10 @@
     },
     "experimental/packages/otlp-exporter-base": {
       "name": "@opentelemetry/otlp-exporter-base",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0"
+        "@opentelemetry/core": "1.21.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -4503,19 +4502,19 @@
     },
     "experimental/packages/otlp-grpc-exporter-base": {
       "name": "@opentelemetry/otlp-grpc-exporter-base",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
         "protobufjs": "^7.2.3"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -4540,11 +4539,11 @@
     },
     "experimental/packages/otlp-proto-exporter-base": {
       "name": "@opentelemetry/otlp-proto-exporter-base",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
         "protobufjs": "^7.2.3"
       },
       "devDependencies": {
@@ -4574,15 +4573,15 @@
     },
     "experimental/packages/otlp-transformer": {
       "name": "@opentelemetry/otlp-transformer",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-logs": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0"
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-logs": "0.48.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
@@ -4721,17 +4720,17 @@
     },
     "experimental/packages/sdk-logs": {
       "name": "@opentelemetry/sdk-logs",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.4.0 <1.8.0",
-        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/api-logs": "0.48.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -5081,20 +5080,20 @@
     },
     "experimental/packages/shim-opencensus": {
       "name": "@opentelemetry/shim-opencensus",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opencensus/core": "0.1.0",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/context-async-hooks": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -5116,13 +5115,13 @@
       }
     },
     "integration-tests/propagation-validation-server": {
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/context-async-hooks": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "axios": "1.5.1",
         "body-parser": "1.19.0",
         "express": "4.17.3"
@@ -32949,7 +32948,7 @@
     },
     "packages/opentelemetry-context-async-hooks": {
       "name": "@opentelemetry/context-async-hooks",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -32972,10 +32971,10 @@
     },
     "packages/opentelemetry-context-zone": {
       "name": "@opentelemetry/context-zone",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.20.0",
+        "@opentelemetry/context-zone-peer-dep": "1.21.0",
         "zone.js": "^0.11.0"
       },
       "devDependencies": {
@@ -32989,7 +32988,7 @@
     },
     "packages/opentelemetry-context-zone-peer-dep": {
       "name": "@opentelemetry/context-zone-peer-dep",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -33305,10 +33304,10 @@
     },
     "packages/opentelemetry-core": {
       "name": "@opentelemetry/core",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -33450,17 +33449,17 @@
     },
     "packages/opentelemetry-exporter-jaeger": {
       "name": "@opentelemetry/exporter-jaeger",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "jaeger-client": "^3.15.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/resources": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -33483,13 +33482,13 @@
     },
     "packages/opentelemetry-exporter-zipkin": {
       "name": "@opentelemetry/exporter-zipkin",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -33795,10 +33794,10 @@
     },
     "packages/opentelemetry-propagator-b3": {
       "name": "@opentelemetry/propagator-b3",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0"
+        "@opentelemetry/core": "1.21.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -33822,10 +33821,10 @@
     },
     "packages/opentelemetry-propagator-jaeger": {
       "name": "@opentelemetry/propagator-jaeger",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0"
+        "@opentelemetry/core": "1.21.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -33967,11 +33966,11 @@
     },
     "packages/opentelemetry-resources": {
       "name": "@opentelemetry/resources",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -34312,12 +34311,12 @@
     },
     "packages/opentelemetry-sdk-trace-base": {
       "name": "@opentelemetry/sdk-trace-base",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -34460,20 +34459,20 @@
     },
     "packages/opentelemetry-sdk-trace-node": {
       "name": "@opentelemetry/sdk-trace-node",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/propagator-b3": "1.20.0",
-        "@opentelemetry/propagator-jaeger": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/context-async-hooks": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/propagator-b3": "1.21.0",
+        "@opentelemetry/propagator-jaeger": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -34496,20 +34495,20 @@
     },
     "packages/opentelemetry-sdk-trace-web": {
       "name": "@opentelemetry/sdk-trace-web",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/context-zone": "1.20.0",
-        "@opentelemetry/propagator-b3": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/context-zone": "1.21.0",
+        "@opentelemetry/propagator-b3": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
         "@types/jquery": "3.5.29",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -34812,7 +34811,7 @@
     },
     "packages/opentelemetry-semantic-conventions": {
       "name": "@opentelemetry/semantic-conventions",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/mocha": "10.0.6",
@@ -34834,18 +34833,18 @@
     },
     "packages/opentelemetry-shim-opentracing": {
       "name": "@opentelemetry/shim-opentracing",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "opentracing": "^0.14.4"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/propagator-b3": "1.20.0",
-        "@opentelemetry/propagator-jaeger": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/propagator-b3": "1.21.0",
+        "@opentelemetry/propagator-jaeger": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -34865,11 +34864,11 @@
     },
     "packages/sdk-metrics": {
       "name": "@opentelemetry/sdk-metrics",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
         "lodash.merge": "^4.6.2"
       },
       "devDependencies": {
@@ -35174,7 +35173,7 @@
     },
     "packages/template": {
       "name": "@opentelemetry/template",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -35188,19 +35187,19 @@
     },
     "selenium-tests": {
       "name": "@opentelemetry/selenium-tests",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
-        "@opentelemetry/exporter-zipkin": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/instrumentation-fetch": "0.47.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-web": "1.20.0",
+        "@opentelemetry/context-zone-peer-dep": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
+        "@opentelemetry/exporter-zipkin": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/instrumentation-fetch": "0.48.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.48.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-web": "1.21.0",
         "zone.js": "0.11.4"
       },
       "devDependencies": {
@@ -38869,7 +38868,7 @@
     "@opentelemetry/context-zone": {
       "version": "file:packages/opentelemetry-context-zone",
       "requires": {
-        "@opentelemetry/context-zone-peer-dep": "1.20.0",
+        "@opentelemetry/context-zone-peer-dep": "1.21.0",
         "cross-var": "1.1.0",
         "lerna": "6.6.2",
         "typescript": "4.4.4",
@@ -39057,7 +39056,7 @@
       "version": "file:packages/opentelemetry-core",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39144,10 +39143,10 @@
       "version": "file:packages/opentelemetry-exporter-jaeger",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39169,13 +39168,13 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-logs": "0.47.0",
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-logs": "0.48.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39197,12 +39196,12 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-logs": "0.47.0",
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-logs": "0.48.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39371,14 +39370,14 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-logs": "0.47.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-logs": "0.48.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39545,12 +39544,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39572,11 +39571,11 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39743,13 +39742,13 @@
       "version": "file:experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39769,10 +39768,10 @@
       "version": "file:experimental/packages/opentelemetry-exporter-prometheus",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39792,12 +39791,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39819,11 +39818,11 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39992,12 +39991,12 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40164,10 +40163,10 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40336,7 +40335,7 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -40522,13 +40521,13 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/propagator-b3": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-web": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/context-zone": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/propagator-b3": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-web": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40697,12 +40696,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/context-async-hooks": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@protobuf-ts/grpc-transport": "2.9.3",
         "@protobuf-ts/runtime": "2.9.3",
         "@protobuf-ts/runtime-rpc": "2.9.3",
@@ -40725,13 +40724,13 @@
       "version": "file:experimental/packages/opentelemetry-instrumentation-http",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/context-async-hooks": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
@@ -40771,13 +40770,13 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/propagator-b3": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-web": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/context-zone": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/propagator-b3": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-web": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40945,8 +40944,8 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41112,7 +41111,7 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41277,11 +41276,11 @@
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
-        "@opentelemetry/otlp-transformer": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-transformer": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41305,8 +41304,8 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/otlp-exporter-base": "0.47.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/otlp-exporter-base": "0.48.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41327,12 +41326,12 @@
       "version": "file:experimental/packages/otlp-transformer",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-logs": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-logs": "0.48.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/webpack-env": "1.16.3",
         "babel-plugin-istanbul": "6.1.1",
@@ -41416,7 +41415,7 @@
       "version": "file:packages/opentelemetry-propagator-b3",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -41433,7 +41432,7 @@
       "version": "file:packages/opentelemetry-propagator-jaeger",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41520,9 +41519,9 @@
       "version": "file:packages/opentelemetry-resources",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41710,9 +41709,9 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.4.0 <1.8.0",
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -41912,8 +41911,8 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.3.0 <1.8.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
         "@types/lodash.merge": "4.6.9",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -42079,21 +42078,21 @@
       "version": "file:experimental/packages/opentelemetry-sdk-node",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/context-async-hooks": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/exporter-jaeger": "1.20.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
-        "@opentelemetry/exporter-zipkin": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-logs": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/context-async-hooks": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/exporter-jaeger": "1.21.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
+        "@opentelemetry/exporter-zipkin": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-logs": "0.48.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -42114,9 +42113,9 @@
       "version": "file:packages/opentelemetry-sdk-trace-base",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -42204,13 +42203,13 @@
       "version": "file:packages/opentelemetry-sdk-trace-node",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/context-async-hooks": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/propagator-b3": "1.20.0",
-        "@opentelemetry/propagator-jaeger": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/context-async-hooks": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/propagator-b3": "1.21.0",
+        "@opentelemetry/propagator-jaeger": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -42232,12 +42231,12 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/context-zone": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/propagator-b3": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/context-zone": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/propagator-b3": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/jquery": "3.5.29",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -42411,16 +42410,16 @@
         "@babel/plugin-transform-runtime": "7.22.15",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone-peer-dep": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
-        "@opentelemetry/exporter-zipkin": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/instrumentation-fetch": "0.47.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-web": "1.20.0",
+        "@opentelemetry/context-zone-peer-dep": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
+        "@opentelemetry/exporter-zipkin": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/instrumentation-fetch": "0.48.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.48.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-web": "1.21.0",
         "babel-loader": "8.3.0",
         "babel-polyfill": "6.26.0",
         "browserstack-local": "1.4.8",
@@ -42752,11 +42751,11 @@
       "requires": {
         "@opencensus/core": "0.1.0",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/context-async-hooks": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -42776,11 +42775,11 @@
       "version": "file:packages/opentelemetry-shim-opentracing",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/propagator-b3": "1.20.0",
-        "@opentelemetry/propagator-jaeger": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/propagator-b3": "1.21.0",
+        "@opentelemetry/propagator-jaeger": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -45364,8 +45363,8 @@
     "backcompat-node14": {
       "version": "file:experimental/backwards-compatibility/node14",
       "requires": {
-        "@opentelemetry/sdk-node": "0.47.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-node": "0.48.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/node": "14.18.25",
         "typescript": "4.4.4"
       },
@@ -45379,8 +45378,8 @@
     "backcompat-node16": {
       "version": "file:experimental/backwards-compatibility/node16",
       "requires": {
-        "@opentelemetry/sdk-node": "0.47.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/sdk-node": "0.48.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "@types/node": "16.11.52",
         "typescript": "4.4.4"
       },
@@ -47879,13 +47878,13 @@
       "version": "file:examples/esm-http-ts",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/instrumentation-http": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/instrumentation-http": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       }
     },
     "espree": {
@@ -47989,17 +47988,17 @@
       "version": "file:examples/otlp-exporter-node",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.47.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.48.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       }
     },
     "execa": {
@@ -49492,14 +49491,14 @@
       "version": "file:examples/http",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.20.0",
-        "@opentelemetry/exporter-zipkin": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/instrumentation-http": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/exporter-jaeger": "1.21.0",
+        "@opentelemetry/exporter-zipkin": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/instrumentation-http": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "cross-env": "^6.0.0"
       }
     },
@@ -49585,14 +49584,14 @@
       "version": "file:examples/https",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.20.0",
-        "@opentelemetry/exporter-zipkin": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/instrumentation-http": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/exporter-jaeger": "1.21.0",
+        "@opentelemetry/exporter-zipkin": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/instrumentation-http": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "cross-env": "^6.0.0"
       }
     },
@@ -51314,8 +51313,8 @@
       "version": "file:experimental/examples/logs",
       "requires": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/sdk-logs": "0.47.0",
+        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/sdk-logs": "0.48.0",
         "@types/node": "18.6.5",
         "ts-node": "^10.9.1"
       },
@@ -53718,13 +53717,13 @@
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/exporter-prometheus": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.47.0",
-        "@opentelemetry/resources": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-node": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
-        "@opentelemetry/shim-opencensus": "0.47.0"
+        "@opentelemetry/exporter-prometheus": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
+        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/shim-opencensus": "0.48.0"
       }
     },
     "opentracing": {
@@ -54457,8 +54456,8 @@
       "version": "file:experimental/examples/prometheus",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-prometheus": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.20.0"
+        "@opentelemetry/exporter-prometheus": "0.48.0",
+        "@opentelemetry/sdk-metrics": "1.21.0"
       }
     },
     "promise-all-reject-late": {
@@ -54496,9 +54495,9 @@
       "version": "file:integration-tests/propagation-validation-server",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
+        "@opentelemetry/context-async-hooks": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
         "axios": "1.5.1",
         "body-parser": "1.19.0",
         "express": "4.17.3",
@@ -57902,20 +57901,20 @@
         "@babel/core": "^7.23.6",
         "@babel/preset-env": "^7.22.20",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.20.0",
-        "@opentelemetry/core": "1.20.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.47.0",
-        "@opentelemetry/exporter-zipkin": "1.20.0",
-        "@opentelemetry/instrumentation": "0.47.0",
-        "@opentelemetry/instrumentation-fetch": "0.47.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.47.0",
-        "@opentelemetry/propagator-b3": "1.20.0",
-        "@opentelemetry/sdk-metrics": "1.20.0",
-        "@opentelemetry/sdk-trace-base": "1.20.0",
-        "@opentelemetry/sdk-trace-web": "1.20.0",
-        "@opentelemetry/semantic-conventions": "1.20.0",
+        "@opentelemetry/context-zone": "1.21.0",
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
+        "@opentelemetry/exporter-zipkin": "1.21.0",
+        "@opentelemetry/instrumentation": "0.48.0",
+        "@opentelemetry/instrumentation-fetch": "0.48.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.48.0",
+        "@opentelemetry/propagator-b3": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-trace-web": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0",
         "babel-loader": "^8.0.6",
         "ts-loader": "^9.2.6",
         "typescript": "^4.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
+        "api",
         "packages/*",
         "experimental/packages/*",
         "experimental/examples/*",

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -55,7 +55,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.20.0",
+    "@opentelemetry/context-zone-peer-dep": "1.21.0",
     "zone.js": "^0.11.0"
   },
   "sideEffects": true,

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,7 +91,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core",
   "sideEffects": false

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/resources": "1.21.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -63,9 +63,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0",
     "jaeger-client": "^3.15.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,10 +93,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin",
   "sideEffects": false

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0"
+    "@opentelemetry/core": "1.21.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.8.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -81,7 +81,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0"
+    "@opentelemetry/core": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger",
   "sideEffects": false

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,8 +91,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,9 +93,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.8.0",
-    "@opentelemetry/resources": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0",
+    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.6",
@@ -65,11 +65,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.20.0",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/propagator-b3": "1.20.0",
-    "@opentelemetry/propagator-jaeger": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/context-async-hooks": "1.21.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/propagator-b3": "1.21.0",
+    "@opentelemetry/propagator-jaeger": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
     "semver": "^7.5.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -58,9 +58,9 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": ">=1.0.0 <1.8.0",
-    "@opentelemetry/context-zone": "1.20.0",
-    "@opentelemetry/propagator-b3": "1.20.0",
-    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/context-zone": "1.21.0",
+    "@opentelemetry/propagator-b3": "1.21.0",
+    "@opentelemetry/resources": "1.21.0",
     "@types/jquery": "3.5.29",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -93,9 +93,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0"
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web",
   "sideEffects": false

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -43,9 +43,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.8.0",
-    "@opentelemetry/propagator-b3": "1.20.0",
-    "@opentelemetry/propagator-jaeger": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
+    "@opentelemetry/propagator-b3": "1.21.0",
+    "@opentelemetry/propagator-jaeger": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
@@ -60,8 +60,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/semantic-conventions": "1.20.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.21.0",
     "opentracing": "^0.14.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing",

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -85,8 +85,8 @@
     "@opentelemetry/api": ">=1.3.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/resources": "1.20.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/resources": "1.21.0",
     "lodash.merge": "^4.6.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-metrics",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
@@ -56,16 +56,16 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.20.0",
-    "@opentelemetry/core": "1.20.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.47.0",
-    "@opentelemetry/exporter-zipkin": "1.20.0",
-    "@opentelemetry/instrumentation": "0.47.0",
-    "@opentelemetry/instrumentation-fetch": "0.47.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.47.0",
-    "@opentelemetry/sdk-metrics": "1.20.0",
-    "@opentelemetry/sdk-trace-base": "1.20.0",
-    "@opentelemetry/sdk-trace-web": "1.20.0",
+    "@opentelemetry/context-zone-peer-dep": "1.21.0",
+    "@opentelemetry/core": "1.21.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
+    "@opentelemetry/exporter-zipkin": "1.21.0",
+    "@opentelemetry/instrumentation": "0.48.0",
+    "@opentelemetry/instrumentation-fetch": "0.48.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.48.0",
+    "@opentelemetry/sdk-metrics": "1.21.0",
+    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/sdk-trace-web": "1.21.0",
     "zone.js": "0.11.4"
   }
 }


### PR DESCRIPTION
## 1.21.0

### :rocket: (Enhancement)

* feat(sdk-metrics): add constructor option to add metric readers [#4427](https://github.com/open-telemetry/opentelemetry-js/pull/4427) @pichlermarc
  * deprecates `MeterProvider.addMetricReader()` please use the constructor option `readers` instead.

### :bug: (Bug Fix)

* fix(sdk-trace-base): ensure attribute value length limit is enforced on span creation [#4417](https://github.com/open-telemetry/opentelemetry-js/pull/4417) @pichlermarc
* fix(sdk-trace-base): Export processed spans while exporter failed [#4287](https://github.com/open-telemetry/opentelemetry-js/pull/4287) @Zirak

### :house: (Internal)

* chore(opentelemetry-context-zone-peer-dep): support zone.js ^v0.13.0 [#4320](https://github.com/open-telemetry/opentelemetry-js/pull/4320)
* refactor(core): drop unnecessary assignment of HOSTNAME [#4421](https://github.com/open-telemetry/opentelemetry-js/pull/4421) @pichlermarc
* test(opentelemetry-context-zone-peer-dep): transpile zone.js in tests [#4423](https://github.com/open-telemetry/opentelemetry-js/pull/4423) @legendecas

## Experimental 0.48.0

### :boom: Breaking Change

* fix(instrumentation)!: pin import-in-the-middle@1.7.1 [#4441](https://github.com/open-telemetry/opentelemetry-js/pull/4441)
  * Fixes a bug where, in some circumstances, ESM instrumentation packages would try to instrument CJS exports on ESM, causing the end-user application to crash.
  * This breaking change only affects users that are using the *experimental* `@opentelemetry/instrumentation/hook.mjs` loader hook AND Node.js 18.19 or later:
    * This reverts back to an older version of `import-in-the-middle` due to <https://github.com/DataDog/import-in-the-middle/issues/57>
    * This version does not support Node.js 18.19 or later

### :bug: (Bug Fix)

* fix(exporter-prometheus): avoid invoking callback synchronously [#4431](https://github.com/open-telemetry/opentelemetry-js/pull/4431) @legendecas
* fix(exporter-logs-otlp-grpc): set User-Agent header [#4398](https://github.com/open-telemetry/opentelemetry-js/pull/4398) @Vunovati
* fix(exporter-logs-otlp-http): set User-Agent header [#4398](https://github.com/open-telemetry/opentelemetry-js/pull/4398) @Vunovati
* fix(exporter-logs-otlp-proto): set User-Agent header [#4398](https://github.com/open-telemetry/opentelemetry-js/pull/4398) @Vunovati
* fix(instrumentation-fetch): compatibility with Map types for fetch headers

### :house: (Internal)

* refactor(exporter-prometheus): promisify prometheus tests [#4431](https://github.com/open-telemetry/opentelemetry-js/pull/4431) @legendecas
