### PR TITLE
feat: make custom attributes function async

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-fetch/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/README.md
@@ -68,7 +68,7 @@ Fetch instrumentation plugin has few options available to choose from. You can s
 
 | Options                                                                                                                                                                  | Type                          | Description                                                                             |
 |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|-----------------------------------------------------------------------------------------|
-| [`applyCustomAttributesOnSpan`](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts#L64) | `HttpCustomAttributeFunction` | Function for adding custom attributes                                                   |
+| [`applyCustomAttributesOnSpan`](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts#L64) | `FetchCustomAttributeFunction` | Function for adding custom attributes                                                   |
 | [`ignoreNetworkEvents`](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts#L67)                      | `boolean`                     | Disable network events being added as span events (network events are added by default) |
 
 ## Useful links

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -345,7 +345,7 @@ export class FetchInstrumentation extends InstrumentationBase<
         ) {
           await plugin._applyAttributesAfterFetch(span, options, response);
           if (response.status >= 200 && response.status < 400) {
-            plugin._endSpan(span, spanData, response);
+            plugin._endSpan(span, spanData, response, endTime);
           } else {
             plugin._endSpan(
               span,

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -674,6 +674,23 @@ describe('fetch', () => {
       assert.ok(attributes[CUSTOM_ATTRIBUTE_KEY] === 'custom value');
     });
 
+    it('applies custom attributes when the function is async', async () => {
+      await prepare(badUrl, async span => {
+        const p = () =>
+          new Promise(resolve => {
+            setTimeout(() => {
+              resolve(true);
+            }, 1000);
+          });
+        await p();
+        span.setAttribute(CUSTOM_ATTRIBUTE_KEY, 'custom value');
+      });
+      const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+      const attributes = span.attributes;
+
+      assert.ok(attributes[CUSTOM_ATTRIBUTE_KEY] === 'custom value');
+    });
+
     it('has request and response objects in callback arguments', async () => {
       let request: any;
       let response: any;


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

In the `applyCustomAttributes` function, we are provided the request and response objects which each have async functions that can be used to read the response body and request body and use those to add different attributes to the spans. The problem is that this function call is not awaited in the fetch instrumentation, so there are times where the span is ended before the attributes can be added and are therefore missed.

This change will properly await the custom attributes function and will not affect synchronous usages of the function. I have also moved up the calculation of the span end time to make it more accurate to the length of time that the request took and not include the time that it took to run the custom attributes function

Fixes # (issue)

## Short description of the changes

- Typing `applyCustomAttributes` to accept an async function
- Awaiting `applyCustomAttributes` so that it can apply attributes without worry of the span being ended
- Moving calculation of end time up further in callstack to make it more accurate to the request length of time

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

1. I set up a `applyCustomAttributes` function that includes a 10 second timeout before returning
2. I ran the fetch instrumentation without these changes and got the `Can not execute the operation on ended Span` error in the console
3. I added my changes and used `yalc` to add the package to my setup
4. I ran the application again and saw the attributes being added after my ten second timeout without error

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
