### PR TITLE
feat(context-zone*): support zone.js 0.13.x, 0.14.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32941,8 +32941,9 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.11.8",
-      "license": "MIT",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.3.tgz",
+      "integrity": "sha512-jYoNqF046Q+JfcZSItRSt+oXFcpXL88yq7XAZjb/NKTS7w2hHpKjRJ3VlFD1k75wMaRRXNUt5vrZVlygiMyHbA==",
       "dependencies": {
         "tslib": "^2.3.0"
       }
@@ -32976,7 +32977,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/context-zone-peer-dep": "1.21.0",
-        "zone.js": "^0.11.0"
+        "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
       },
       "devDependencies": {
         "cross-var": "1.1.0",
@@ -33026,7 +33027,7 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "zone.js": "^0.10.2 || ^0.11.0 || ^0.13.0"
+        "zone.js": "^0.10.2 || ^0.11.0 || ^0.13.0 || ^0.14.0"
       }
     },
     "packages/opentelemetry-context-zone-peer-dep/node_modules/@webpack-cli/configtest": {
@@ -35201,7 +35202,7 @@
         "@opentelemetry/sdk-metrics": "1.21.0",
         "@opentelemetry/sdk-trace-base": "1.21.0",
         "@opentelemetry/sdk-trace-web": "1.21.0",
-        "zone.js": "0.11.4"
+        "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -35748,13 +35749,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "selenium-tests/node_modules/zone.js": {
-      "version": "0.11.4",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
       }
     }
   },
@@ -38873,7 +38867,7 @@
         "cross-var": "1.1.0",
         "lerna": "6.6.2",
         "typescript": "4.4.4",
-        "zone.js": "^0.11.0"
+        "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
       }
     },
     "@opentelemetry/context-zone-peer-dep": {
@@ -42435,7 +42429,7 @@
         "webpack-cli": "5.1.4",
         "webpack-dev-server": "4.5.0",
         "webpack-merge": "5.10.0",
-        "zone.js": "0.11.4"
+        "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
       },
       "dependencies": {
         "@webpack-cli/configtest": {
@@ -42720,12 +42714,6 @@
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
-          }
-        },
-        "zone.js": {
-          "version": "0.11.4",
-          "requires": {
-            "tslib": "^2.0.0"
           }
         }
       }
@@ -58881,7 +58869,9 @@
       }
     },
     "zone.js": {
-      "version": "0.11.8",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.3.tgz",
+      "integrity": "sha512-jYoNqF046Q+JfcZSItRSt+oXFcpXL88yq7XAZjb/NKTS7w2hHpKjRJ3VlFD1k75wMaRRXNUt5vrZVlygiMyHbA==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -84,7 +84,7 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.8.0",
-    "zone.js": "^0.10.2 || ^0.11.0 || ^0.13.0"
+    "zone.js": "^0.10.2 || ^0.11.0 || ^0.13.0 || ^0.14.0"
   },
   "sideEffects": false,
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-context-zone-peer-dep"

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@opentelemetry/context-zone-peer-dep": "1.21.0",
-    "zone.js": "^0.11.0"
+    "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
   },
   "sideEffects": true,
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-context-zone"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -66,6 +66,6 @@
     "@opentelemetry/sdk-metrics": "1.21.0",
     "@opentelemetry/sdk-trace-base": "1.21.0",
     "@opentelemetry/sdk-trace-web": "1.21.0",
-    "zone.js": "0.11.4"
+    "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
   }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

We've been behind on supporting recent `zone.js` versions, this PR adds support for 0.13.x and 0.14.x (used by Angular 17)

Fixes #4445 
Fixes #4354 

## Short description of the changes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
 - addresses #4354 
- [x] New feature (non-breaking change which adds functionality)
 - addresses #4445 

## How Has This Been Tested?

- [x] Existing tests