### PR TITLE
feat(instrumentation): add `getModuleDefinitions()` instead of making `init()` public

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
@@ -109,6 +109,23 @@ export abstract class InstrumentationAbstract<T = any>
   }
 
   /**
+   * @experimental
+   *
+   * Get module definitions defined by {@link init}.
+   * This can be used for experimental compile-time instrumentation.
+   *
+   * @returns an array of {@link InstrumentationModuleDefinition}
+   */
+  public getModuleDefinitions(): InstrumentationModuleDefinition<T>[] {
+    const initResult = this.init() ?? [];
+    if (!Array.isArray(initResult)) {
+      return [initResult];
+    }
+
+    return initResult;
+  }
+
+  /**
    * Sets the new metric instruments with the current Meter.
    */
   protected _updateMetricInstruments(): void {
@@ -153,11 +170,8 @@ export abstract class InstrumentationAbstract<T = any>
   /**
    * Init method in which plugin should define _modules and patches for
    * methods.
-   * Use `enable()` if you are trying to turn on this plugin. This method
-   * will return objects to patch specific modules with the appropriate
-   * instrumentation (or not return anything).
    */
-  abstract init():
+  protected abstract init():
     | InstrumentationModuleDefinition<T>
     | InstrumentationModuleDefinition<T>[]
     | void;

--- a/experimental/packages/opentelemetry-instrumentation/test/common/Instrumentation.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation/test/common/Instrumentation.test.ts
@@ -19,6 +19,7 @@ import {
   Instrumentation,
   InstrumentationBase,
   InstrumentationConfig,
+  InstrumentationModuleDefinition,
 } from '../../src';
 
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
@@ -130,6 +131,56 @@ describe('BaseInstrumentation', () => {
       const configuration =
         instrumentation.getConfig() as TestInstrumentationConfig;
       assert.strictEqual(configuration.isActive, true);
+    });
+  });
+
+  describe('getModuleDefinitions', () => {
+    const moduleDefinition: InstrumentationModuleDefinition<unknown> = {
+      name: 'foo',
+      patch: moduleExports => {},
+      unpatch: moduleExports => {},
+      moduleExports: {},
+      files: [],
+      supportedVersions: ['*'],
+    };
+
+    it('should return single module definition from init() as array ', () => {
+      class TestInstrumentation2 extends TestInstrumentation {
+        override init() {
+          return moduleDefinition;
+        }
+      }
+      const instrumentation = new TestInstrumentation2();
+
+      assert.deepStrictEqual(instrumentation.getModuleDefinitions(), [
+        moduleDefinition,
+      ]);
+    });
+
+    it('should return multiple module definitions from init() as array ', () => {
+      class TestInstrumentation2 extends TestInstrumentation {
+        override init() {
+          return [moduleDefinition, moduleDefinition, moduleDefinition];
+        }
+      }
+      const instrumentation = new TestInstrumentation2();
+
+      assert.deepStrictEqual(instrumentation.getModuleDefinitions(), [
+        moduleDefinition,
+        moduleDefinition,
+        moduleDefinition,
+      ]);
+    });
+
+    it('should return void from init() as empty array ', () => {
+      class TestInstrumentation2 extends TestInstrumentation {
+        override init() {
+          return;
+        }
+      }
+      const instrumentation = new TestInstrumentation2();
+
+      assert.deepStrictEqual(instrumentation.getModuleDefinitions(), []);
     });
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

Reviewing all changes for the next release, I've just realized that the changes from #4418 would be breaking for implementations that add the `protected` keyword to `init()`, which turns out to be a lot of them in contrib. This is my proposal, adding a new method that *should* have the same effect, but won't require changes to instrumentations. 

cc @drewcorlin1, I think this would also work, right?
cc @dyladan since you also reviewed #4418 

Relates to #4418 

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Exisitng unit tests
- [x] Added unit tests