### PR TITLE
Generate SBOM on release

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,34 @@
+name: SBOM
+on:
+  release:
+    types: [published]
+          
+permissions: read-all
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_UNSAFE_PERM: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - run: npm install -g npm@latest
+
+      - name: Bootstrap
+        run: npm ci
+
+      - uses: advanced-security/sbom-generator-action@v0.0.1
+        id: sbom
+        env: 
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - uses: actions/upload-artifact@v3.1.0
+        with: 
+          path: ${{steps.sbom.outputs.fileName }}
+          name: "SBOM"


### PR DESCRIPTION
## Which problem is this PR solving?

This adds a Github workflow that generates an SBOM file using the Github dependency graph. SBOMs are useful for users to detect vulnerabilities in packages including their dependencies. 

An example SBOM file generated by this workflow is available [here](https://github.com/martinkuba/opentelemetry-js/actions/runs/7892467878).
