### PR TITLE
fix(otlp-transformer): only use BigInt inside hrTimeToNanos()

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to experimental packages in this project will be documented 
 * fix(sdk-node): allow using samplers when the exporter is defined in the environment [#4394](https://github.com/open-telemetry/opentelemetry-js/pull/4394) @JacksonWeber
 * fix(instrumentation): normalize paths for internal files in scoped packages [#4467](https://github.com/open-telemetry/opentelemetry-js/pull/4467) @pichlermarc
   * Fixes a bug where, on Windows, internal files on scoped packages would not be instrumented.
+* fix(otlp-transformer): only use BigInt inside hrTimeToNanos() [#4484](https://github.com/open-telemetry/opentelemetry-js/pull/4484) @pichlermarc
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/otlp-transformer/src/common/index.ts
+++ b/experimental/packages/otlp-transformer/src/common/index.ts
@@ -18,9 +18,8 @@ import type { OtlpEncodingOptions, Fixed64, LongBits } from './types';
 import { HrTime } from '@opentelemetry/api';
 import { hexToBinary, hrTimeToNanoseconds } from '@opentelemetry/core';
 
-const NANOSECONDS = BigInt(1_000_000_000);
-
 export function hrTimeToNanos(hrTime: HrTime): bigint {
+  const NANOSECONDS = BigInt(1_000_000_000);
   return BigInt(hrTime[0]) * NANOSECONDS + BigInt(hrTime[1]);
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

On older, *unsupported* browser runtimes the use of `BigInt` is causing some issues. (#4482, #4350)
We guard against the use of `BigInt` in the same file by falling back to to encoding the timestamp as a string if it is not defined, so this PR attempts to follow this pattern.

Fixes #4350

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Existing tests

