### PR TITLE
fix: add missing cloud.resource_id in SemanticResourceAttributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
   * fixes a bug where `Meter.createHistogram()` with the advice `explicitBucketBoundaries: []` would throw
 * fix(context-zone-peer-dep, context-zone):  support zone.js 0.13.x, 0.14.x [#4469](https://github.com/open-telemetry/opentelemetry-js/pull/4469) @pichlermarc
   * fixes a bug where old versions of `zone.js` affected by <https://github.com/angular/angular/issues/53507> would be pulled in
-* fix(semantic-conventions): add `cloud.resource_id` resource attribute [???]() @mmanciop
+* fix(semantic-conventions): add `cloud.resource_id` resource attribute [#4485](https://github.com/open-telemetry/opentelemetry-js/pull/4485) @mmanciop
 
 ### :books: (Refine Doc)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
   * fixes a bug where `Meter.createHistogram()` with the advice `explicitBucketBoundaries: []` would throw
 * fix(context-zone-peer-dep, context-zone):  support zone.js 0.13.x, 0.14.x [#4469](https://github.com/open-telemetry/opentelemetry-js/pull/4469) @pichlermarc
   * fixes a bug where old versions of `zone.js` affected by <https://github.com/angular/angular/issues/53507> would be pulled in
+* fix(semantic-conventions): add `cloud.resource_id` resource attribute [???]() @mmanciop
 
 ### :books: (Refine Doc)
 

--- a/packages/opentelemetry-semantic-conventions/src/resource/SemanticResourceAttributes.ts
+++ b/packages/opentelemetry-semantic-conventions/src/resource/SemanticResourceAttributes.ts
@@ -46,6 +46,11 @@ export const SemanticResourceAttributes = {
   CLOUD_PLATFORM: 'cloud.platform',
 
   /**
+   * Cloud provider-specific native identifier of the monitored cloud resource (e.g. an ARN on AWS, a fully qualified resource ID on Azure, a full resource name on GCP).
+   */
+  CLOUD_RESOURCE_ID: 'cloud.resource.id',
+
+  /**
    * The Amazon Resource Name (ARN) of an [ECS container instance](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html).
    */
   AWS_ECS_CONTAINER_ARN: 'aws.ecs.container.arn',


### PR DESCRIPTION
## Which problem is this PR solving?

Add missing [`cloud.resource_id`](https://opentelemetry.io/docs/specs/semconv/attributes-registry/cloud/) resource attribute key.

Fixes #4483 

## Short description of the changes

Add missing entry in `detectors/node/opentelemetry-resource-detector-aws/src/detectors/SemanticResourceAttributes.ts`.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- N/A, just adding entry to enum

## Checklist:

- [X] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
