### PR TITLE
fix(instr-fetch): do not enable in Node.js; clarify in docs this instr is for web fetch only

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to experimental packages in this project will be documented 
 * fix(instrumentation): normalize paths for internal files in scoped packages [#4467](https://github.com/open-telemetry/opentelemetry-js/pull/4467) @pichlermarc
   * Fixes a bug where, on Windows, internal files on scoped packages would not be instrumented.
 * fix(otlp-transformer): only use BigInt inside hrTimeToNanos() [#4484](https://github.com/open-telemetry/opentelemetry-js/pull/4484) @pichlermarc
+* fix(instrumentation-fetch): do not enable in Node.js; clarify in docs this instr is for web fetch only [#4498](https://github.com/open-telemetry/opentelemetry-js/pull/4498) @trentm
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/README.md
@@ -5,7 +5,8 @@
 
 **Note: This is an experimental package under active development. New releases may include breaking changes.**
 
-This module provides auto instrumentation for web using fetch.
+This module provides auto instrumentation for web using [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch).
+(Note: This instrumentation does **not** instrument [Node.js' fetch](https://nodejs.org/api/globals.html#fetch). See [this issue](https://github.com/open-telemetry/opentelemetry-js/issues/4333).)
 
 ## Installation
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -470,6 +470,7 @@ export class FetchInstrumentation extends InstrumentationBase<
     if (isNode) {
       // Node.js v18+ *does* have a global `fetch()`, but this package does not
       // support instrumenting it.
+      this._diag.warn('this instrumentation is intended for web usage only, it does not instrument Node.js\'s fetch()')
       return;
     }
     if (isWrapped(fetch)) {

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -470,7 +470,9 @@ export class FetchInstrumentation extends InstrumentationBase<
     if (isNode) {
       // Node.js v18+ *does* have a global `fetch()`, but this package does not
       // support instrumenting it.
-      this._diag.warn('this instrumentation is intended for web usage only, it does not instrument Node.js\'s fetch()')
+      this._diag.warn(
+        "this instrumentation is intended for web usage only, it does not instrument Node.js's fetch()"
+      );
       return;
     }
     if (isWrapped(fetch)) {

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -35,6 +35,8 @@ import { _globalThis } from '@opentelemetry/core';
 // safe enough
 const OBSERVER_WAIT_TIME_MS = 300;
 
+const isNode = typeof process === 'object' && process.release?.name === 'node';
+
 export interface FetchCustomAttributeFunction {
   (
     span: api.Span,
@@ -465,6 +467,11 @@ export class FetchInstrumentation extends InstrumentationBase<
    * implements enable function
    */
   override enable(): void {
+    if (isNode) {
+      // Node.js v18+ *does* have a global `fetch()`, but this package does not
+      // support instrumenting it.
+      return;
+    }
     if (isWrapped(fetch)) {
       this._unwrap(_globalThis, 'fetch');
       this._diag.debug('removing previous patch for constructor');
@@ -476,6 +483,9 @@ export class FetchInstrumentation extends InstrumentationBase<
    * implements unpatch function
    */
   override disable(): void {
+    if (isNode) {
+      return;
+    }
     this._unwrap(_globalThis, 'fetch');
     this._usedResources = new WeakSet<PerformanceResourceTiming>();
   }


### PR DESCRIPTION
A side issue from https://github.com/open-telemetry/opentelemetry-js/issues/4496 was the mistaken use of instrumentation-fetch for *Node.js's* `fetch()`. instrumentation-fetch does not intend to handle Node.js's fetch. 

This change makes it so instrumentation-fetch will noop when used in Node.js.

Refs: https://github.com/open-telemetry/opentelemetry-js/issues/4496

* * *

Theoretically I think instrumentation-fetch *should* be able instrument Node.js fetch, but currently it is written with dependencies on a web otel package and its tests assume web/browser. See https://github.com/open-telemetry/opentelemetry-js/issues/4333 for discussion on instrumenting Node.js' `fetch()`.
