### PR TITLE
add logic to collect span attributes representing request body size a…

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -382,32 +382,32 @@ describe('fetch', () => {
         `attributes ${SemanticAttributes.HTTP_URL} is wrong`
       );
       assert.strictEqual(
-        attributes[keys[3]],
+        attributes[keys[4]],
         200,
         `attributes ${SemanticAttributes.HTTP_STATUS_CODE} is wrong`
       );
       assert.ok(
-        attributes[keys[4]] === 'OK' || attributes[keys[4]] === '',
+        attributes[keys[5]] === 'OK' || attributes[keys[5]] === '',
         `attributes ${AttributeNames.HTTP_STATUS_TEXT} is wrong`
       );
       assert.ok(
-        (attributes[keys[5]] as string).indexOf('localhost') === 0,
+        (attributes[keys[6]] as string).indexOf('localhost') === 0,
         `attributes ${SemanticAttributes.HTTP_HOST} is wrong`
       );
       assert.ok(
-        attributes[keys[6]] === 'http' || attributes[keys[6]] === 'https',
+        attributes[keys[7]] === 'http' || attributes[keys[6]] === 'https',
         `attributes ${SemanticAttributes.HTTP_SCHEME} is wrong`
       );
       assert.ok(
-        attributes[keys[7]] !== '',
+        attributes[keys[8]] !== '',
         `attributes ${SemanticAttributes.HTTP_USER_AGENT} is not defined`
       );
       assert.ok(
-        (attributes[keys[8]] as number) > 0,
+        (attributes[keys[9]] as number) > 0,
         `attributes ${SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH} is <= 0`
       );
 
-      assert.strictEqual(keys.length, 9, 'number of attributes is wrong');
+      assert.strictEqual(keys.length, 11, 'number of attributes is wrong');
     });
 
     it('span should have correct events', () => {
@@ -932,7 +932,7 @@ describe('fetch', () => {
 
       // should still have basic attributes
       assert.strictEqual(
-        attributes[keys[3]],
+        attributes[keys[4]],
         200,
         `Missing basic attribute ${SemanticAttributes.HTTP_STATUS_CODE}`
       );

--- a/packages/opentelemetry-sdk-trace-web/src/enums/PerformanceTimingNames.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/enums/PerformanceTimingNames.ts
@@ -35,6 +35,7 @@ export enum PerformanceTimingNames {
   RESPONSE_END = 'responseEnd',
   RESPONSE_START = 'responseStart',
   SECURE_CONNECTION_START = 'secureConnectionStart',
+  TRANSFER_SIZE = 'transferSize',
   UNLOAD_EVENT_END = 'unloadEventEnd',
   UNLOAD_EVENT_START = 'unloadEventStart',
 }

--- a/packages/opentelemetry-sdk-trace-web/src/types.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/types.ts
@@ -35,6 +35,7 @@ export type PerformanceEntries = {
   [PerformanceTimingNames.RESPONSE_END]?: number;
   [PerformanceTimingNames.RESPONSE_START]?: number;
   [PerformanceTimingNames.SECURE_CONNECTION_START]?: number;
+  [PerformanceTimingNames.TRANSFER_SIZE]?: number;
   [PerformanceTimingNames.UNLOAD_EVENT_END]?: number;
   [PerformanceTimingNames.UNLOAD_EVENT_START]?: number;
 };

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -110,6 +110,10 @@ export function addSpanNetworkEvents(
       decodedLength
     );
   }
+  const transferSize = resource[PTN.TRANSFER_SIZE];
+  if (transferSize !== undefined) {
+    span.setAttribute('http.response_transfer_size', transferSize);
+  }
 }
 
 /**


### PR DESCRIPTION
…nd transfer size

## Which problem is this PR solving?

I'm working on a project to collect telemetry about the network utilization of a frontend application. This PR adds two pieces of information that I can't currently capture:

1. "transfer size" to indicate whether a response came from the remote or a browser cache
2. outgoing request body size

Let me know if you would be receptive to adding these, and if so I'll polish things up and add some tests. Thanks!

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
