### PR TITLE
 chore: prepare release API 1.8.0/Core 1.21.0/Experimental 0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :rocket: (Enhancement)
 
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 1.22.0
+
+### :rocket: (Enhancement)
+
 * feat(sdk-metrics): allow single bucket histograms [#4456](https://github.com/open-telemetry/opentelemetry-js/pull/4456) @pichlermarc
 * feat(instrumentation): Make `init()` method public [#4418](https://github.com/open-telemetry/opentelemetry-js/pull/4418)
 * feat(context-zone-peer-dep, context-zone): support zone.js 0.13.x, 0.14.x [#4469](https://github.com/open-telemetry/opentelemetry-js/pull/4469) @pichlermarc
@@ -29,8 +39,6 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 ### :books: (Refine Doc)
 
 * docs: shorten readme sections [#4460](https://github.com/open-telemetry/opentelemetry-js/pull/4460) @legendecas
-
-### :house: (Internal)
 
 ## 1.21.0
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -4,7 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### :boom: Breaking Change
+
+### :rocket: (Enhancement)
+
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 1.8.0
+
+### :rocket: (Enhancement)
+
 * feat(api): add SugaredTracer for functions not defined in the spec
+
+### :bug: (Bug Fix)
+
 * fix(api): fix unreachable @opentelemetry/api/experimental entry [#4446](https://github.com/open-telemetry/opentelemetry-js/pull/4446) @legendecas
 
 ## 1.7.0

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Public API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/examples/esm-http-ts/package.json
+++ b/examples/esm-http-ts/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/",
   "dependencies": {
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
     "@opentelemetry/instrumentation": "0.49.0",
     "@opentelemetry/instrumentation-http": "0.49.0",

--- a/examples/esm-http-ts/package.json
+++ b/examples/esm-http-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esm-http-ts",
   "private": true,
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Example of HTTP integration with OpenTelemetry using ESM and TypeScript",
   "main": "build/index.js",
   "type": "module",
@@ -31,12 +31,12 @@
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/",
   "dependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-    "@opentelemetry/instrumentation": "0.48.0",
-    "@opentelemetry/instrumentation-http": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
-    "@opentelemetry/sdk-trace-node": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
+    "@opentelemetry/instrumentation": "0.49.0",
+    "@opentelemetry/instrumentation-http": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/sdk-trace-node": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   }
 }

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-example",
   "private": true,
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Example of HTTP integration with OpenTelemetry",
   "main": "index.js",
   "scripts": {
@@ -29,14 +29,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-jaeger": "1.21.0",
-    "@opentelemetry/exporter-zipkin": "1.21.0",
-    "@opentelemetry/instrumentation": "0.48.0",
-    "@opentelemetry/instrumentation-http": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
-    "@opentelemetry/sdk-trace-node": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/exporter-jaeger": "1.22.0",
+    "@opentelemetry/exporter-zipkin": "1.22.0",
+    "@opentelemetry/instrumentation": "0.49.0",
+    "@opentelemetry/instrumentation-http": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/sdk-trace-node": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/http",
   "devDependencies": {

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,7 +1,7 @@
 {
   "name": "https-example",
   "private": true,
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Example of HTTPs integration with OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -33,14 +33,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/exporter-jaeger": "1.21.0",
-    "@opentelemetry/exporter-zipkin": "1.21.0",
-    "@opentelemetry/instrumentation": "0.48.0",
-    "@opentelemetry/instrumentation-http": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
-    "@opentelemetry/sdk-trace-node": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/exporter-jaeger": "1.22.0",
+    "@opentelemetry/exporter-zipkin": "1.22.0",
+    "@opentelemetry/instrumentation": "0.49.0",
+    "@opentelemetry/instrumentation-http": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/sdk-trace-node": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-opentelemetry-example",
   "private": true,
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Example of using @opentelemetry/sdk-trace-web and @opentelemetry/sdk-metrics in browser",
   "main": "index.js",
   "scripts": {
@@ -44,20 +44,20 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/context-zone": "1.21.0",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-    "@opentelemetry/exporter-zipkin": "1.21.0",
-    "@opentelemetry/instrumentation": "0.48.0",
-    "@opentelemetry/instrumentation-fetch": "0.48.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.48.0",
-    "@opentelemetry/propagator-b3": "1.21.0",
-    "@opentelemetry/sdk-metrics": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
-    "@opentelemetry/sdk-trace-web": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/context-zone": "1.22.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.49.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
+    "@opentelemetry/exporter-zipkin": "1.22.0",
+    "@opentelemetry/instrumentation": "0.49.0",
+    "@opentelemetry/instrumentation-fetch": "0.49.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.49.0",
+    "@opentelemetry/propagator-b3": "1.22.0",
+    "@opentelemetry/sdk-metrics": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/sdk-trace-web": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web"
 }

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-otlp-exporter-node",
   "private": true,
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
@@ -29,17 +29,17 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.48.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "0.48.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-metrics": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.49.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "0.49.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.49.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.49.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-metrics": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/otlp-exporter-node"
 }

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+### :rocket: (Enhancement)
+
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 0.49.0
+
+### :boom: Breaking Change
+
 * fix(otlp-exporter-base)!: remove unload event from OTLPExporterBrowserBase [#4438](https://github.com/open-telemetry/opentelemetry-js/pull/4438) @eldavojohn
   * Reason: The 'unload' event prevents sites from taking advantage of Google's [backward/forward cache](https://web.dev/articles/bfcache#never_use_the_unload_event) and will be [deprecated](https://developer.chrome.com/articles/deprecating-unload/).  It is now up to the consuming site to implement these shutdown events.
   * This breaking change affects users under this scenario:
@@ -27,8 +39,6 @@ All notable changes to experimental packages in this project will be documented 
   * Fixes a bug where, on Windows, internal files on scoped packages would not be instrumented.
 * fix(otlp-transformer): only use BigInt inside hrTimeToNanos() [#4484](https://github.com/open-telemetry/opentelemetry-js/pull/4484) @pichlermarc
 * fix(instrumentation-fetch): do not enable in Node.js; clarify in docs this instr is for web fetch only [#4498](https://github.com/open-telemetry/opentelemetry-js/pull/4498) @trentm
-
-### :books: (Refine Doc)
 
 ### :house: (Internal)
 

--- a/experimental/backwards-compatibility/node14/package.json
+++ b/experimental/backwards-compatibility/node14/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node14",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "private": true,
   "description": "Backwards compatibility app for node 14 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.48.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0"
+    "@opentelemetry/sdk-node": "0.49.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0"
   },
   "devDependencies": {
     "@types/node": "14.18.25",

--- a/experimental/backwards-compatibility/node16/package.json
+++ b/experimental/backwards-compatibility/node16/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node16",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "private": true,
   "description": "Backwards compatibility app for node 16 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.48.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0"
+    "@opentelemetry/sdk-node": "0.49.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0"
   },
   "devDependencies": {
     "@types/node": "16.11.52",

--- a/experimental/examples/logs/package.json
+++ b/experimental/examples/logs/package.json
@@ -1,14 +1,14 @@
 {
   "name": "logs-example",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "private": true,
   "scripts": {
     "start": "ts-node index.ts"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/api-logs": "0.48.0",
-    "@opentelemetry/sdk-logs": "0.48.0"
+    "@opentelemetry/api-logs": "0.49.0",
+    "@opentelemetry/sdk-logs": "0.49.0"
   },
   "devDependencies": {
     "@types/node": "18.6.5",

--- a/experimental/examples/opencensus-shim/package.json
+++ b/experimental/examples/opencensus-shim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencensus-shim",
   "private": true,
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Example of using @opentelemetry/shim-opencensus in Node.js",
   "main": "index.js",
   "scripts": {
@@ -31,13 +31,13 @@
     "@opencensus/instrumentation-http": "0.1.0",
     "@opencensus/nodejs-base": "0.1.0",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/exporter-prometheus": "0.48.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-metrics": "1.21.0",
-    "@opentelemetry/sdk-trace-node": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0",
-    "@opentelemetry/shim-opencensus": "0.48.0"
+    "@opentelemetry/exporter-prometheus": "0.49.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-metrics": "1.22.0",
+    "@opentelemetry/sdk-trace-node": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0",
+    "@opentelemetry/shim-opencensus": "0.49.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/examples/opencensus-shim"
 }

--- a/experimental/examples/opencensus-shim/package.json
+++ b/experimental/examples/opencensus-shim/package.json
@@ -30,7 +30,7 @@
     "@opencensus/core": "0.1.0",
     "@opencensus/instrumentation-http": "0.1.0",
     "@opencensus/nodejs-base": "0.1.0",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/exporter-prometheus": "0.49.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.49.0",
     "@opentelemetry/resources": "1.22.0",

--- a/experimental/examples/prometheus/package.json
+++ b/experimental/examples/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prometheus-example",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "private": true,
   "description": "Example of using @opentelemetry/sdk-metrics and @opentelemetry/exporter-prometheus",
   "main": "index.js",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-prometheus": "0.48.0",
-    "@opentelemetry/sdk-metrics": "1.21.0"
+    "@opentelemetry/exporter-prometheus": "0.49.0",
+    "@opentelemetry/sdk-metrics": "1.22.0"
   }
 }

--- a/experimental/packages/api-events/package.json
+++ b/experimental/packages/api-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-events",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Public events API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/api-logs/package.json
+++ b/experimental/packages/api-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-logs",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Public logs API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/api-logs": "0.49.0",
     "@opentelemetry/otlp-exporter-base": "0.49.0",
     "@opentelemetry/resources": "1.22.0",

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-grpc",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected log records to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,9 +50,9 @@
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/api-logs": "0.48.0",
-    "@opentelemetry/otlp-exporter-base": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/api-logs": "0.49.0",
+    "@opentelemetry/otlp-exporter-base": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -72,10 +72,10 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
-    "@opentelemetry/otlp-transformer": "0.48.0",
-    "@opentelemetry/sdk-logs": "0.48.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.49.0",
+    "@opentelemetry/otlp-transformer": "0.49.0",
+    "@opentelemetry/sdk-logs": "0.49.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-http",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "publishConfig": {
     "access": "public"
   },
@@ -74,7 +74,7 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/resources": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -105,10 +105,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.48.0",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/otlp-exporter-base": "0.48.0",
-    "@opentelemetry/otlp-transformer": "0.48.0",
-    "@opentelemetry/sdk-logs": "0.48.0"
+    "@opentelemetry/api-logs": "0.49.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/otlp-exporter-base": "0.49.0",
+    "@opentelemetry/otlp-transformer": "0.49.0",
+    "@opentelemetry/sdk-logs": "0.49.0"
   }
 }

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -73,7 +73,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/resources": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-proto",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "An OTLP exporter to send logs using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,14 +94,14 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.48.0",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/otlp-exporter-base": "0.48.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-    "@opentelemetry/otlp-transformer": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-logs": "0.48.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0"
+    "@opentelemetry/api-logs": "0.49.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/otlp-exporter-base": "0.49.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.49.0",
+    "@opentelemetry/otlp-transformer": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-logs": "0.49.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-grpc",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/otlp-exporter-base": "0.48.0",
+    "@opentelemetry/otlp-exporter-base": "0.49.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -69,11 +69,11 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
-    "@opentelemetry/otlp-transformer": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.49.0",
+    "@opentelemetry/otlp-transformer": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/otlp-exporter-base": "0.49.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-http",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry Collector Trace Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -96,11 +96,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/otlp-exporter-base": "0.48.0",
-    "@opentelemetry/otlp-transformer": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/otlp-exporter-base": "0.49.0",
+    "@opentelemetry/otlp-transformer": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-proto",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,12 +93,12 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/otlp-exporter-base": "0.48.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-    "@opentelemetry/otlp-transformer": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/otlp-exporter-base": "0.49.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.49.0",
+    "@opentelemetry/otlp-transformer": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/opentelemetry-browser-detector",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry Resource Detector for Browser",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -83,8 +83,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/browser-detector"
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -68,12 +68,12 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
-    "@opentelemetry/otlp-transformer": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-metrics": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.49.0",
+    "@opentelemetry/otlp-transformer": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-metrics": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-http",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -96,11 +96,11 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/otlp-exporter-base": "0.48.0",
-    "@opentelemetry/otlp-transformer": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-metrics": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/otlp-exporter-base": "0.49.0",
+    "@opentelemetry/otlp-transformer": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-metrics": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-proto",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -74,13 +74,13 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-    "@opentelemetry/otlp-exporter-base": "0.48.0",
-    "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-    "@opentelemetry/otlp-transformer": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-metrics": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
+    "@opentelemetry/otlp-exporter-base": "0.49.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.49.0",
+    "@opentelemetry/otlp-transformer": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-metrics": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -55,7 +55,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/semantic-conventions": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/semantic-conventions": "1.21.0",
+    "@opentelemetry/semantic-conventions": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -61,9 +61,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-metrics": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-metrics": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-prometheus",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/context-zone": "1.22.0",
     "@opentelemetry/propagator-b3": "1.22.0",
     "@opentelemetry/sdk-trace-base": "1.22.0",

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-fetch",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry fetch automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,9 +57,9 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-zone": "1.21.0",
-    "@opentelemetry/propagator-b3": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/context-zone": "1.22.0",
+    "@opentelemetry/propagator-b3": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -89,10 +89,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/instrumentation": "0.48.0",
-    "@opentelemetry/sdk-trace-web": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/instrumentation": "0.49.0",
+    "@opentelemetry/sdk-trace-web": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -49,7 +49,7 @@
     "@bufbuild/buf": "1.21.0-1",
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.10",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/context-async-hooks": "1.22.0",
     "@opentelemetry/core": "1.22.0",
     "@opentelemetry/sdk-trace-base": "1.22.0",

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-grpc",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry grpc automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,10 +50,10 @@
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-async-hooks": "1.21.0",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
-    "@opentelemetry/sdk-trace-node": "1.21.0",
+    "@opentelemetry/context-async-hooks": "1.22.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/sdk-trace-node": "1.22.0",
     "@protobuf-ts/grpc-transport": "2.9.3",
     "@protobuf-ts/runtime": "2.9.3",
     "@protobuf-ts/runtime-rpc": "2.9.3",
@@ -75,8 +75,8 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "0.48.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/instrumentation": "0.49.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/context-async-hooks": "1.22.0",
     "@opentelemetry/sdk-metrics": "1.22.0",
     "@opentelemetry/sdk-trace-base": "1.22.0",

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-http",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry http/https automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,10 +46,10 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-async-hooks": "1.21.0",
-    "@opentelemetry/sdk-metrics": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
-    "@opentelemetry/sdk-trace-node": "1.21.0",
+    "@opentelemetry/context-async-hooks": "1.22.0",
+    "@opentelemetry/sdk-metrics": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/sdk-trace-node": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/request-promise-native": "1.0.21",
@@ -74,9 +74,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/instrumentation": "0.48.0",
-    "@opentelemetry/semantic-conventions": "1.21.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/instrumentation": "0.49.0",
+    "@opentelemetry/semantic-conventions": "1.22.0",
     "semver": "^7.5.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http",

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/context-zone": "1.22.0",
     "@opentelemetry/propagator-b3": "1.22.0",
     "@opentelemetry/sdk-trace-base": "1.22.0",

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-xml-http-request",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry XMLHttpRequest automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,9 +57,9 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-zone": "1.21.0",
-    "@opentelemetry/propagator-b3": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/context-zone": "1.22.0",
+    "@opentelemetry/propagator-b3": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -89,10 +89,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/instrumentation": "0.48.0",
-    "@opentelemetry/sdk-trace-web": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/instrumentation": "0.49.0",
+    "@opentelemetry/sdk-trace-web": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Base class for node which OpenTelemetry instrumentation modules extend",
   "author": "OpenTelemetry Authors",
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation",
@@ -86,7 +86,7 @@
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.7.0",
     "@opentelemetry/api-logs": "0.47.0",
-    "@opentelemetry/sdk-metrics": "1.21.0",
+    "@opentelemetry/sdk-metrics": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.6",

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -84,7 +84,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/api-logs": "0.47.0",
     "@opentelemetry/sdk-metrics": "1.22.0",
     "@types/mocha": "10.0.6",

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-node",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry SDK for Node.js",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,27 +44,27 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.48.0",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-    "@opentelemetry/exporter-zipkin": "1.21.0",
-    "@opentelemetry/instrumentation": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-logs": "0.48.0",
-    "@opentelemetry/sdk-metrics": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
-    "@opentelemetry/sdk-trace-node": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/api-logs": "0.49.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.49.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.49.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
+    "@opentelemetry/exporter-zipkin": "1.22.0",
+    "@opentelemetry/instrumentation": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-logs": "0.49.0",
+    "@opentelemetry/sdk-metrics": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/sdk-trace-node": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.3.0 <1.8.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-async-hooks": "1.21.0",
-    "@opentelemetry/exporter-jaeger": "1.21.0",
+    "@opentelemetry/context-async-hooks": "1.22.0",
+    "@opentelemetry/exporter-jaeger": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.6",

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -59,10 +59,10 @@
     "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.3.0 <1.8.0"
+    "@opentelemetry/api": ">=1.3.0 <1.9.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/context-async-hooks": "1.22.0",
     "@opentelemetry/exporter-jaeger": "1.22.0",
     "@types/mocha": "10.0.6",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-exporter-base",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry OTLP Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0"
+    "@opentelemetry/core": "1.22.0"
   },
   "devDependencies": {
     "@babel/core": "7.23.6",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -48,7 +48,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/otlp-transformer": "0.49.0",
     "@opentelemetry/resources": "1.22.0",
     "@opentelemetry/sdk-trace-base": "1.22.0",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-grpc-exporter-base",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry OTLP-gRPC Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,9 +49,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/otlp-transformer": "0.48.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/otlp-transformer": "0.49.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -72,8 +72,8 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/otlp-exporter-base": "0.48.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/otlp-exporter-base": "0.49.0",
     "protobufjs": "^7.2.3"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-grpc-exporter-base",

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-proto-exporter-base",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenTelemetry OTLP-HTTP-protobuf Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -80,8 +80,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/otlp-exporter-base": "0.48.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/otlp-exporter-base": "0.49.0",
     "protobufjs": "^7.2.3"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-proto-exporter-base",

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -55,10 +55,10 @@
     "README.md"
   ],
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.3.0 <1.8.0"
+    "@opentelemetry/api": ">=1.3.0 <1.9.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@types/mocha": "10.0.6",
     "@types/webpack-env": "1.16.3",
     "babel-plugin-istanbul": "6.1.1",

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Transform OpenTelemetry SDK data into OTLP",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
@@ -79,12 +79,12 @@
     "webpack": "5.89.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.48.0",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-logs": "0.48.0",
-    "@opentelemetry/sdk-metrics": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0"
+    "@opentelemetry/api-logs": "0.49.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-logs": "0.49.0",
+    "@opentelemetry/sdk-metrics": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-transformer",
   "sideEffects": false

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -68,13 +68,13 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.4.0 <1.8.0",
+    "@opentelemetry/api": ">=1.4.0 <1.9.0",
     "@opentelemetry/api-logs": ">=0.39.1"
   },
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": ">=1.4.0 <1.8.0",
+    "@opentelemetry/api": ">=1.4.0 <1.9.0",
     "@opentelemetry/api-logs": "0.49.0",
     "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
     "@types/mocha": "10.0.6",

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-logs",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "publishConfig": {
     "access": "public"
   },
@@ -75,7 +75,7 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": ">=1.4.0 <1.8.0",
-    "@opentelemetry/api-logs": "0.48.0",
+    "@opentelemetry/api-logs": "0.49.0",
     "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -101,7 +101,7 @@
     "webpack-merge": "5.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/resources": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/resources": "1.22.0"
   }
 }

--- a/experimental/packages/shim-opencensus/package.json
+++ b/experimental/packages/shim-opencensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opencensus",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "OpenCensus to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,8 +50,8 @@
   "devDependencies": {
     "@opencensus/core": "0.1.0",
     "@opentelemetry/api": "1.7.0",
-    "@opentelemetry/context-async-hooks": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/context-async-hooks": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -69,9 +69,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-metrics": "1.21.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-metrics": "1.22.0",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2"
   },

--- a/experimental/packages/shim-opencensus/package.json
+++ b/experimental/packages/shim-opencensus/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@opencensus/core": "0.1.0",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "@opentelemetry/context-async-hooks": "1.22.0",
     "@opentelemetry/sdk-trace-base": "1.22.0",
     "@types/mocha": "10.0.6",

--- a/integration-tests/api/package.json
+++ b/integration-tests/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/integration-tests-api",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.21.0",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/context-async-hooks": "1.22.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
     "axios": "1.5.1",
     "body-parser": "1.19.0",
     "express": "4.17.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -195,17 +195,17 @@
       }
     },
     "examples/esm-http-ts": {
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/instrumentation-http": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/instrumentation-http": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -213,18 +213,18 @@
     },
     "examples/http": {
       "name": "http-example",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.21.0",
-        "@opentelemetry/exporter-zipkin": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/instrumentation-http": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/exporter-jaeger": "1.22.0",
+        "@opentelemetry/exporter-zipkin": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/instrumentation-http": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -235,18 +235,18 @@
     },
     "examples/https": {
       "name": "https-example",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.21.0",
-        "@opentelemetry/exporter-zipkin": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/instrumentation-http": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/exporter-jaeger": "1.22.0",
+        "@opentelemetry/exporter-zipkin": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/instrumentation-http": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -257,24 +257,24 @@
     },
     "examples/opentelemetry-web": {
       "name": "web-opentelemetry-example",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-        "@opentelemetry/exporter-zipkin": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/instrumentation-fetch": "0.48.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.48.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-web": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/context-zone": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
+        "@opentelemetry/exporter-zipkin": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/instrumentation-fetch": "0.49.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.49.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-web": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.6",
@@ -609,21 +609,21 @@
     },
     "examples/otlp-exporter-node": {
       "name": "example-otlp-exporter-node",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.48.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.49.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "engines": {
         "node": ">=14"
@@ -631,11 +631,11 @@
     },
     "experimental/backwards-compatibility/node14": {
       "name": "backcompat-node14",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-node": "0.48.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/sdk-node": "0.49.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "devDependencies": {
         "@types/node": "14.18.25",
@@ -652,11 +652,11 @@
     },
     "experimental/backwards-compatibility/node16": {
       "name": "backcompat-node16",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-node": "0.48.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/sdk-node": "0.49.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "devDependencies": {
         "@types/node": "16.11.52",
@@ -673,11 +673,11 @@
     },
     "experimental/examples/logs": {
       "name": "logs-example",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/sdk-logs": "0.48.0"
+        "@opentelemetry/api-logs": "0.49.0",
+        "@opentelemetry/sdk-logs": "0.49.0"
       },
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -743,20 +743,20 @@
       }
     },
     "experimental/examples/opencensus-shim": {
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opencensus/core": "0.1.0",
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/exporter-prometheus": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
-        "@opentelemetry/shim-opencensus": "0.48.0"
+        "@opentelemetry/exporter-prometheus": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/shim-opencensus": "0.49.0"
       },
       "engines": {
         "node": ">=14"
@@ -764,17 +764,17 @@
     },
     "experimental/examples/prometheus": {
       "name": "prometheus-example",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-prometheus": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0"
+        "@opentelemetry/exporter-prometheus": "0.49.0",
+        "@opentelemetry/sdk-metrics": "1.22.0"
       }
     },
     "experimental/packages/api-events": {
       "name": "@opentelemetry/api-events",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
@@ -913,7 +913,7 @@
     },
     "experimental/packages/api-logs": {
       "name": "@opentelemetry/api-logs",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
@@ -1052,21 +1052,21 @@
     },
     "experimental/packages/exporter-logs-otlp-grpc": {
       "name": "@opentelemetry/exporter-logs-otlp-grpc",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/sdk-logs": "0.48.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/sdk-logs": "0.49.0"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/api-logs": "0.49.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1090,20 +1090,20 @@
     },
     "experimental/packages/exporter-logs-otlp-http": {
       "name": "@opentelemetry/exporter-logs-otlp-http",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/sdk-logs": "0.48.0"
+        "@opentelemetry/api-logs": "0.49.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/sdk-logs": "0.49.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/resources": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1404,17 +1404,17 @@
     },
     "experimental/packages/exporter-logs-otlp-proto": {
       "name": "@opentelemetry/exporter-logs-otlp-proto",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/api-logs": "0.49.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -1718,20 +1718,20 @@
     },
     "experimental/packages/exporter-trace-otlp-grpc": {
       "name": "@opentelemetry/exporter-trace-otlp-grpc",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1755,14 +1755,14 @@
     },
     "experimental/packages/exporter-trace-otlp-http": {
       "name": "@opentelemetry/exporter-trace-otlp-http",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -2068,15 +2068,15 @@
     },
     "experimental/packages/exporter-trace-otlp-proto": {
       "name": "@opentelemetry/exporter-trace-otlp-proto",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -2380,11 +2380,11 @@
     },
     "experimental/packages/opentelemetry-browser-detector": {
       "name": "@opentelemetry/opentelemetry-browser-detector",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -2687,16 +2687,16 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc": {
       "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
@@ -2724,14 +2724,14 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-http": {
       "name": "@opentelemetry/exporter-metrics-otlp-http",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -3037,16 +3037,16 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-proto": {
       "name": "@opentelemetry/exporter-metrics-otlp-proto",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
@@ -3073,16 +3073,16 @@
     },
     "experimental/packages/opentelemetry-exporter-prometheus": {
       "name": "@opentelemetry/exporter-prometheus",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -3104,7 +3104,7 @@
     },
     "experimental/packages/opentelemetry-instrumentation": {
       "name": "@opentelemetry/instrumentation",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/shimmer": "^1.0.2",
@@ -3118,7 +3118,7 @@
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -3156,21 +3156,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-fetch": {
       "name": "@opentelemetry/instrumentation-fetch",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/sdk-trace-web": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/sdk-trace-web": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone": "1.21.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/context-zone": "1.22.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -3470,21 +3470,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-grpc": {
       "name": "@opentelemetry/instrumentation-grpc",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
         "@bufbuild/buf": "1.21.0-1",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
         "@protobuf-ts/grpc-transport": "2.9.3",
         "@protobuf-ts/runtime": "2.9.3",
         "@protobuf-ts/runtime-rpc": "2.9.3",
@@ -3511,20 +3511,20 @@
     },
     "experimental/packages/opentelemetry-instrumentation-http": {
       "name": "@opentelemetry/instrumentation-http",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
@@ -3564,21 +3564,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-xml-http-request": {
       "name": "@opentelemetry/instrumentation-xml-http-request",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/sdk-trace-web": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/sdk-trace-web": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone": "1.21.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/context-zone": "1.22.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -4166,27 +4166,27 @@
     },
     "experimental/packages/opentelemetry-sdk-node": {
       "name": "@opentelemetry/sdk-node",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-        "@opentelemetry/exporter-zipkin": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/api-logs": "0.49.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
+        "@opentelemetry/exporter-zipkin": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/exporter-jaeger": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/exporter-jaeger": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -4211,10 +4211,10 @@
     },
     "experimental/packages/otlp-exporter-base": {
       "name": "@opentelemetry/otlp-exporter-base",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0"
+        "@opentelemetry/core": "1.22.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -4517,19 +4517,19 @@
     },
     "experimental/packages/otlp-grpc-exporter-base": {
       "name": "@opentelemetry/otlp-grpc-exporter-base",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
         "protobufjs": "^7.2.3"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -4554,11 +4554,11 @@
     },
     "experimental/packages/otlp-proto-exporter-base": {
       "name": "@opentelemetry/otlp-proto-exporter-base",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
         "protobufjs": "^7.2.3"
       },
       "devDependencies": {
@@ -4588,15 +4588,15 @@
     },
     "experimental/packages/otlp-transformer": {
       "name": "@opentelemetry/otlp-transformer",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0"
+        "@opentelemetry/api-logs": "0.49.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.7.0",
@@ -4735,17 +4735,17 @@
     },
     "experimental/packages/sdk-logs": {
       "name": "@opentelemetry/sdk-logs",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.4.0 <1.8.0",
-        "@opentelemetry/api-logs": "0.48.0",
+        "@opentelemetry/api-logs": "0.49.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -5095,20 +5095,20 @@
     },
     "experimental/packages/shim-opencensus": {
       "name": "@opentelemetry/shim-opencensus",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opencensus/core": "0.1.0",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -5131,7 +5131,7 @@
     },
     "integration-tests/api": {
       "name": "@opentelemetry/integration-tests-api",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
@@ -5458,13 +5458,13 @@
       }
     },
     "integration-tests/propagation-validation-server": {
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "axios": "1.5.1",
         "body-parser": "1.19.0",
         "express": "4.17.3"
@@ -34260,7 +34260,7 @@
     },
     "packages/opentelemetry-context-async-hooks": {
       "name": "@opentelemetry/context-async-hooks",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -34283,10 +34283,10 @@
     },
     "packages/opentelemetry-context-zone": {
       "name": "@opentelemetry/context-zone",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.21.0",
+        "@opentelemetry/context-zone-peer-dep": "1.22.0",
         "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
       },
       "devDependencies": {
@@ -34300,7 +34300,7 @@
     },
     "packages/opentelemetry-context-zone-peer-dep": {
       "name": "@opentelemetry/context-zone-peer-dep",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -34616,10 +34616,10 @@
     },
     "packages/opentelemetry-core": {
       "name": "@opentelemetry/core",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -34761,17 +34761,17 @@
     },
     "packages/opentelemetry-exporter-jaeger": {
       "name": "@opentelemetry/exporter-jaeger",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "jaeger-client": "^3.15.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/resources": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -34794,13 +34794,13 @@
     },
     "packages/opentelemetry-exporter-zipkin": {
       "name": "@opentelemetry/exporter-zipkin",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -35106,10 +35106,10 @@
     },
     "packages/opentelemetry-propagator-b3": {
       "name": "@opentelemetry/propagator-b3",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0"
+        "@opentelemetry/core": "1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -35133,10 +35133,10 @@
     },
     "packages/opentelemetry-propagator-jaeger": {
       "name": "@opentelemetry/propagator-jaeger",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0"
+        "@opentelemetry/core": "1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -35278,11 +35278,11 @@
     },
     "packages/opentelemetry-resources": {
       "name": "@opentelemetry/resources",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -35623,12 +35623,12 @@
     },
     "packages/opentelemetry-sdk-trace-base": {
       "name": "@opentelemetry/sdk-trace-base",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
@@ -35771,20 +35771,20 @@
     },
     "packages/opentelemetry-sdk-trace-node": {
       "name": "@opentelemetry/sdk-trace-node",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/propagator-jaeger": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/propagator-jaeger": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -35807,20 +35807,20 @@
     },
     "packages/opentelemetry-sdk-trace-web": {
       "name": "@opentelemetry/sdk-trace-web",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/context-zone": "1.21.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/context-zone": "1.22.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
         "@types/jquery": "3.5.29",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -36123,7 +36123,7 @@
     },
     "packages/opentelemetry-semantic-conventions": {
       "name": "@opentelemetry/semantic-conventions",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@size-limit/file": "^11.0.1",
@@ -36211,18 +36211,18 @@
     },
     "packages/opentelemetry-shim-opentracing": {
       "name": "@opentelemetry/shim-opentracing",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "opentracing": "^0.14.4"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/propagator-jaeger": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/propagator-jaeger": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -36242,11 +36242,11 @@
     },
     "packages/sdk-metrics": {
       "name": "@opentelemetry/sdk-metrics",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
         "lodash.merge": "^4.6.2"
       },
       "devDependencies": {
@@ -36551,7 +36551,7 @@
     },
     "packages/template": {
       "name": "@opentelemetry/template",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -36565,19 +36565,19 @@
     },
     "selenium-tests": {
       "name": "@opentelemetry/selenium-tests",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-zipkin": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/instrumentation-fetch": "0.48.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-web": "1.21.0",
+        "@opentelemetry/context-zone-peer-dep": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.49.0",
+        "@opentelemetry/exporter-zipkin": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/instrumentation-fetch": "0.49.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.49.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-web": "1.22.0",
         "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
       },
       "devDependencies": {
@@ -40239,7 +40239,7 @@
     "@opentelemetry/context-zone": {
       "version": "file:packages/opentelemetry-context-zone",
       "requires": {
-        "@opentelemetry/context-zone-peer-dep": "1.21.0",
+        "@opentelemetry/context-zone-peer-dep": "1.22.0",
         "cross-var": "1.1.0",
         "lerna": "6.6.2",
         "typescript": "4.4.4",
@@ -40427,7 +40427,7 @@
       "version": "file:packages/opentelemetry-core",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40514,10 +40514,10 @@
       "version": "file:packages/opentelemetry-exporter-jaeger",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40539,13 +40539,13 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
+        "@opentelemetry/api-logs": "0.49.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40567,12 +40567,12 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
+        "@opentelemetry/api-logs": "0.49.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40741,14 +40741,14 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/api-logs": "0.49.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40915,12 +40915,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40942,11 +40942,11 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41113,13 +41113,13 @@
       "version": "file:experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41139,10 +41139,10 @@
       "version": "file:experimental/packages/opentelemetry-exporter-prometheus",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41162,12 +41162,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41189,11 +41189,11 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41362,12 +41362,12 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41534,10 +41534,10 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41707,7 +41707,7 @@
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
         "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -41902,13 +41902,13 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-web": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/context-zone": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-web": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -42077,12 +42077,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@protobuf-ts/grpc-transport": "2.9.3",
         "@protobuf-ts/runtime": "2.9.3",
         "@protobuf-ts/runtime-rpc": "2.9.3",
@@ -42105,13 +42105,13 @@
       "version": "file:experimental/packages/opentelemetry-instrumentation-http",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
@@ -42151,13 +42151,13 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-web": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/context-zone": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-web": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -42563,8 +42563,8 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -42730,7 +42730,7 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -42895,11 +42895,11 @@
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
-        "@opentelemetry/otlp-transformer": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
+        "@opentelemetry/otlp-transformer": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -42923,8 +42923,8 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/otlp-exporter-base": "0.48.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/otlp-exporter-base": "0.49.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -42945,12 +42945,12 @@
       "version": "file:experimental/packages/otlp-transformer",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/api-logs": "0.49.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/webpack-env": "1.16.3",
         "babel-plugin-istanbul": "6.1.1",
@@ -43034,7 +43034,7 @@
       "version": "file:packages/opentelemetry-propagator-b3",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -43051,7 +43051,7 @@
       "version": "file:packages/opentelemetry-propagator-jaeger",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -43138,9 +43138,9 @@
       "version": "file:packages/opentelemetry-resources",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -43328,9 +43328,9 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.4.0 <1.8.0",
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/api-logs": "0.49.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -43530,8 +43530,8 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.3.0 <1.8.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
         "@types/lodash.merge": "4.6.9",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -43697,21 +43697,21 @@
       "version": "file:experimental/packages/opentelemetry-sdk-node",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-jaeger": "1.21.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-        "@opentelemetry/exporter-zipkin": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/api-logs": "0.49.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-jaeger": "1.22.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
+        "@opentelemetry/exporter-zipkin": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-logs": "0.49.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -43732,9 +43732,9 @@
       "version": "file:packages/opentelemetry-sdk-trace-base",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -43822,13 +43822,13 @@
       "version": "file:packages/opentelemetry-sdk-trace-node",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/propagator-jaeger": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/propagator-jaeger": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -43850,12 +43850,12 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/context-zone": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/context-zone": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/jquery": "3.5.29",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -44029,16 +44029,16 @@
         "@babel/plugin-transform-runtime": "7.22.15",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-zone-peer-dep": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-zipkin": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/instrumentation-fetch": "0.48.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-web": "1.21.0",
+        "@opentelemetry/context-zone-peer-dep": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.49.0",
+        "@opentelemetry/exporter-zipkin": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/instrumentation-fetch": "0.49.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.49.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-web": "1.22.0",
         "babel-loader": "8.3.0",
         "babel-polyfill": "6.26.0",
         "browserstack-local": "1.4.8",
@@ -44404,11 +44404,11 @@
       "requires": {
         "@opencensus/core": "0.1.0",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -44428,11 +44428,11 @@
       "version": "file:packages/opentelemetry-shim-opentracing",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/propagator-jaeger": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/propagator-jaeger": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -47170,8 +47170,8 @@
     "backcompat-node14": {
       "version": "file:experimental/backwards-compatibility/node14",
       "requires": {
-        "@opentelemetry/sdk-node": "0.48.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-node": "0.49.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/node": "14.18.25",
         "typescript": "4.4.4"
       },
@@ -47185,8 +47185,8 @@
     "backcompat-node16": {
       "version": "file:experimental/backwards-compatibility/node16",
       "requires": {
-        "@opentelemetry/sdk-node": "0.48.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/sdk-node": "0.49.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/node": "16.11.52",
         "typescript": "4.4.4"
       },
@@ -49766,13 +49766,13 @@
       "version": "file:examples/esm-http-ts",
       "requires": {
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/instrumentation-http": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/instrumentation-http": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       }
     },
     "espree": {
@@ -49903,17 +49903,17 @@
       "version": "file:examples/otlp-exporter-node",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.48.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0"
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.49.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0"
       }
     },
     "execa": {
@@ -51463,14 +51463,14 @@
       "version": "file:examples/http",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.21.0",
-        "@opentelemetry/exporter-zipkin": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/instrumentation-http": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/exporter-jaeger": "1.22.0",
+        "@opentelemetry/exporter-zipkin": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/instrumentation-http": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "cross-env": "^6.0.0"
       }
     },
@@ -51556,14 +51556,14 @@
       "version": "file:examples/https",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.21.0",
-        "@opentelemetry/exporter-zipkin": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/instrumentation-http": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/exporter-jaeger": "1.22.0",
+        "@opentelemetry/exporter-zipkin": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/instrumentation-http": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "cross-env": "^6.0.0"
       }
     },
@@ -53291,8 +53291,8 @@
       "version": "file:experimental/examples/logs",
       "requires": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-logs": "0.48.0",
-        "@opentelemetry/sdk-logs": "0.48.0",
+        "@opentelemetry/api-logs": "0.49.0",
+        "@opentelemetry/sdk-logs": "0.49.0",
         "@types/node": "18.6.5",
         "ts-node": "^10.9.1"
       },
@@ -55722,13 +55722,13 @@
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
         "@opentelemetry/api": "1.7.0",
-        "@opentelemetry/exporter-prometheus": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.48.0",
-        "@opentelemetry/resources": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-node": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
-        "@opentelemetry/shim-opencensus": "0.48.0"
+        "@opentelemetry/exporter-prometheus": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.0",
+        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/shim-opencensus": "0.49.0"
       }
     },
     "opentracing": {
@@ -56544,8 +56544,8 @@
       "version": "file:experimental/examples/prometheus",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-prometheus": "0.48.0",
-        "@opentelemetry/sdk-metrics": "1.21.0"
+        "@opentelemetry/exporter-prometheus": "0.49.0",
+        "@opentelemetry/sdk-metrics": "1.22.0"
       }
     },
     "promise-all-reject-late": {
@@ -56583,9 +56583,9 @@
       "version": "file:integration-tests/propagation-validation-server",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
+        "@opentelemetry/context-async-hooks": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
         "axios": "1.5.1",
         "body-parser": "1.19.0",
         "express": "4.17.3",
@@ -60264,20 +60264,20 @@
         "@babel/core": "^7.23.6",
         "@babel/preset-env": "^7.22.20",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.21.0",
-        "@opentelemetry/core": "1.21.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.48.0",
-        "@opentelemetry/exporter-zipkin": "1.21.0",
-        "@opentelemetry/instrumentation": "0.48.0",
-        "@opentelemetry/instrumentation-fetch": "0.48.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.48.0",
-        "@opentelemetry/propagator-b3": "1.21.0",
-        "@opentelemetry/sdk-metrics": "1.21.0",
-        "@opentelemetry/sdk-trace-base": "1.21.0",
-        "@opentelemetry/sdk-trace-web": "1.21.0",
-        "@opentelemetry/semantic-conventions": "1.21.0",
+        "@opentelemetry/context-zone": "1.22.0",
+        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.49.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
+        "@opentelemetry/exporter-zipkin": "1.22.0",
+        "@opentelemetry/instrumentation": "0.49.0",
+        "@opentelemetry/instrumentation-fetch": "0.49.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.49.0",
+        "@opentelemetry/propagator-b3": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-trace-web": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.22.0",
         "babel-loader": "^8.0.6",
         "ts-loader": "^9.2.6",
         "typescript": "^4.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
     },
     "api": {
       "name": "@opentelemetry/api",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/mocha": "10.0.6",
@@ -198,7 +198,7 @@
       "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
         "@opentelemetry/instrumentation": "0.49.0",
         "@opentelemetry/instrumentation-http": "0.49.0",
@@ -749,7 +749,7 @@
         "@opencensus/core": "0.1.0",
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/exporter-prometheus": "0.49.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.49.0",
         "@opentelemetry/resources": "1.22.0",
@@ -1063,7 +1063,7 @@
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/api-logs": "0.49.0",
         "@opentelemetry/otlp-exporter-base": "0.49.0",
         "@opentelemetry/resources": "1.22.0",
@@ -1102,7 +1102,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/resources": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -1419,7 +1419,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1730,7 +1730,7 @@
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/otlp-exporter-base": "0.49.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -1767,7 +1767,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -2081,7 +2081,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -2389,7 +2389,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -2700,7 +2700,7 @@
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -2736,7 +2736,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -3049,7 +3049,7 @@
         "@opentelemetry/sdk-metrics": "1.22.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -3081,7 +3081,7 @@
         "@opentelemetry/sdk-metrics": "1.22.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -3116,7 +3116,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/api-logs": "0.47.0",
         "@opentelemetry/sdk-metrics": "1.22.0",
         "@types/mocha": "10.0.6",
@@ -3167,7 +3167,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/context-zone": "1.22.0",
         "@opentelemetry/propagator-b3": "1.22.0",
         "@opentelemetry/sdk-trace-base": "1.22.0",
@@ -3480,7 +3480,7 @@
         "@bufbuild/buf": "1.21.0-1",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/context-async-hooks": "1.22.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/sdk-trace-base": "1.22.0",
@@ -3520,7 +3520,7 @@
         "semver": "^7.5.2"
       },
       "devDependencies": {
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/context-async-hooks": "1.22.0",
         "@opentelemetry/sdk-metrics": "1.22.0",
         "@opentelemetry/sdk-trace-base": "1.22.0",
@@ -3575,7 +3575,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/context-zone": "1.22.0",
         "@opentelemetry/propagator-b3": "1.22.0",
         "@opentelemetry/sdk-trace-base": "1.22.0",
@@ -4184,7 +4184,7 @@
         "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/context-async-hooks": "1.22.0",
         "@opentelemetry/exporter-jaeger": "1.22.0",
         "@types/mocha": "10.0.6",
@@ -4206,7 +4206,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
     "experimental/packages/otlp-exporter-base": {
@@ -4219,7 +4219,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -4526,7 +4526,7 @@
         "protobufjs": "^7.2.3"
       },
       "devDependencies": {
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/otlp-transformer": "0.49.0",
         "@opentelemetry/resources": "1.22.0",
         "@opentelemetry/sdk-trace-base": "1.22.0",
@@ -4564,7 +4564,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -4599,7 +4599,7 @@
         "@opentelemetry/sdk-trace-base": "1.22.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@types/mocha": "10.0.6",
         "@types/webpack-env": "1.16.3",
         "babel-plugin-istanbul": "6.1.1",
@@ -4623,7 +4623,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
     "experimental/packages/otlp-transformer/node_modules/enhanced-resolve": {
@@ -4744,7 +4744,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": ">=1.4.0 <1.8.0",
+        "@opentelemetry/api": ">=1.4.0 <1.9.0",
         "@opentelemetry/api-logs": "0.49.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
@@ -4774,7 +4774,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.8.0",
+        "@opentelemetry/api": ">=1.4.0 <1.9.0",
         "@opentelemetry/api-logs": ">=0.39.1"
       }
     },
@@ -5106,7 +5106,7 @@
       },
       "devDependencies": {
         "@opencensus/core": "0.1.0",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/context-async-hooks": "1.22.0",
         "@opentelemetry/sdk-trace-base": "1.22.0",
         "@types/mocha": "10.0.6",
@@ -34263,7 +34263,7 @@
       "version": "1.22.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -34278,7 +34278,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "packages/opentelemetry-context-zone": {
@@ -34305,7 +34305,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -34336,7 +34336,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "zone.js": "^0.10.2 || ^0.11.0 || ^0.13.0 || ^0.14.0"
       }
     },
@@ -34622,7 +34622,7 @@
         "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -34649,7 +34649,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "packages/opentelemetry-core/node_modules/enhanced-resolve": {
@@ -35112,7 +35112,7 @@
         "@opentelemetry/core": "1.22.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -35128,7 +35128,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "packages/opentelemetry-propagator-jaeger": {
@@ -35139,7 +35139,7 @@
         "@opentelemetry/core": "1.22.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -35166,7 +35166,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "packages/opentelemetry-propagator-jaeger/node_modules/enhanced-resolve": {
@@ -35285,7 +35285,7 @@
         "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -35315,7 +35315,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "packages/opentelemetry-resources/node_modules/@opentelemetry/resources_1.9.0": {
@@ -35631,7 +35631,7 @@
         "@opentelemetry/semantic-conventions": "1.22.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -35659,7 +35659,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "packages/opentelemetry-sdk-trace-base/node_modules/enhanced-resolve": {
@@ -35782,7 +35782,7 @@
         "semver": "^7.5.2"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@opentelemetry/resources": "1.22.0",
         "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
@@ -35802,7 +35802,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "packages/opentelemetry-sdk-trace-web": {
@@ -35817,7 +35817,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@opentelemetry/context-zone": "1.22.0",
         "@opentelemetry/propagator-b3": "1.22.0",
         "@opentelemetry/resources": "1.22.0",
@@ -35853,7 +35853,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "packages/opentelemetry-sdk-trace-web/node_modules/@webpack-cli/configtest": {
@@ -36219,7 +36219,7 @@
         "opentracing": "^0.14.4"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@opentelemetry/propagator-b3": "1.22.0",
         "@opentelemetry/propagator-jaeger": "1.22.0",
         "@opentelemetry/sdk-trace-base": "1.22.0",
@@ -36237,7 +36237,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "packages/sdk-metrics": {
@@ -36252,7 +36252,7 @@
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": ">=1.3.0 <1.8.0",
+        "@opentelemetry/api": ">=1.3.0 <1.9.0",
         "@types/lodash.merge": "4.6.9",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -36281,7 +36281,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.8.0"
+        "@opentelemetry/api": ">=1.3.0 <1.9.0"
       }
     },
     "packages/sdk-metrics/node_modules/@webpack-cli/configtest": {
@@ -36586,7 +36586,7 @@
         "@babel/plugin-proposal-decorators": "7.22.15",
         "@babel/plugin-transform-runtime": "7.22.15",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "babel-loader": "8.3.0",
         "babel-polyfill": "6.26.0",
         "browserstack-local": "1.4.8",
@@ -40224,7 +40224,7 @@
     "@opentelemetry/context-async-hooks": {
       "version": "file:packages/opentelemetry-context-async-hooks",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -40251,7 +40251,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40426,7 +40426,7 @@
     "@opentelemetry/core": {
       "version": "file:packages/opentelemetry-core",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -40538,7 +40538,7 @@
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/api-logs": "0.49.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/otlp-exporter-base": "0.49.0",
@@ -40566,7 +40566,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/api-logs": "0.49.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/otlp-exporter-base": "0.49.0",
@@ -40740,7 +40740,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/api-logs": "0.49.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/otlp-exporter-base": "0.49.0",
@@ -40914,7 +40914,7 @@
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.49.0",
@@ -40941,7 +40941,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/otlp-exporter-base": "0.49.0",
         "@opentelemetry/otlp-transformer": "0.49.0",
@@ -41112,7 +41112,7 @@
     "@opentelemetry/exporter-metrics-otlp-proto": {
       "version": "file:experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
       "requires": {
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.49.0",
         "@opentelemetry/otlp-exporter-base": "0.49.0",
@@ -41138,7 +41138,7 @@
     "@opentelemetry/exporter-prometheus": {
       "version": "file:experimental/packages/opentelemetry-exporter-prometheus",
       "requires": {
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/resources": "1.22.0",
         "@opentelemetry/sdk-metrics": "1.22.0",
@@ -41161,7 +41161,7 @@
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/otlp-exporter-base": "0.49.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.49.0",
@@ -41188,7 +41188,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/otlp-exporter-base": "0.49.0",
         "@opentelemetry/otlp-transformer": "0.49.0",
@@ -41361,7 +41361,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/otlp-exporter-base": "0.49.0",
         "@opentelemetry/otlp-proto-exporter-base": "0.49.0",
@@ -41705,7 +41705,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/api-logs": "0.47.0",
         "@opentelemetry/sdk-metrics": "1.22.0",
         "@types/mocha": "10.0.6",
@@ -41901,7 +41901,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/context-zone": "1.22.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/instrumentation": "0.49.0",
@@ -42076,7 +42076,7 @@
         "@bufbuild/buf": "1.21.0-1",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/context-async-hooks": "1.22.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/instrumentation": "0.49.0",
@@ -42104,7 +42104,7 @@
     "@opentelemetry/instrumentation-http": {
       "version": "file:experimental/packages/opentelemetry-instrumentation-http",
       "requires": {
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/context-async-hooks": "1.22.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/instrumentation": "0.49.0",
@@ -42150,7 +42150,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/context-zone": "1.22.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/instrumentation": "0.49.0",
@@ -42562,7 +42562,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/resources": "1.22.0",
         "@opentelemetry/semantic-conventions": "1.22.0",
         "@types/mocha": "10.0.6",
@@ -42729,7 +42729,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/core": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -42894,7 +42894,7 @@
       "version": "file:experimental/packages/otlp-grpc-exporter-base",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/otlp-exporter-base": "0.49.0",
         "@opentelemetry/otlp-transformer": "0.49.0",
@@ -42922,7 +42922,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/otlp-exporter-base": "0.49.0",
         "@types/mocha": "10.0.6",
@@ -42944,7 +42944,7 @@
     "@opentelemetry/otlp-transformer": {
       "version": "file:experimental/packages/otlp-transformer",
       "requires": {
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/api-logs": "0.49.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/resources": "1.22.0",
@@ -43033,7 +43033,7 @@
     "@opentelemetry/propagator-b3": {
       "version": "file:packages/opentelemetry-propagator-b3",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@opentelemetry/core": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -43050,7 +43050,7 @@
     "@opentelemetry/propagator-jaeger": {
       "version": "file:packages/opentelemetry-propagator-jaeger",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@opentelemetry/core": "1.22.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -43137,7 +43137,7 @@
     "@opentelemetry/resources": {
       "version": "file:packages/opentelemetry-resources",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@opentelemetry/semantic-conventions": "1.22.0",
@@ -43327,7 +43327,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": ">=1.4.0 <1.8.0",
+        "@opentelemetry/api": ">=1.4.0 <1.9.0",
         "@opentelemetry/api-logs": "0.49.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/resources": "1.22.0",
@@ -43529,7 +43529,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": ">=1.3.0 <1.8.0",
+        "@opentelemetry/api": ">=1.3.0 <1.9.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/resources": "1.22.0",
         "@types/lodash.merge": "4.6.9",
@@ -43696,7 +43696,7 @@
     "@opentelemetry/sdk-node": {
       "version": "file:experimental/packages/opentelemetry-sdk-node",
       "requires": {
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/api-logs": "0.49.0",
         "@opentelemetry/context-async-hooks": "1.22.0",
         "@opentelemetry/core": "1.22.0",
@@ -43731,7 +43731,7 @@
     "@opentelemetry/sdk-trace-base": {
       "version": "file:packages/opentelemetry-sdk-trace-base",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/resources": "1.22.0",
         "@opentelemetry/semantic-conventions": "1.22.0",
@@ -43821,7 +43821,7 @@
     "@opentelemetry/sdk-trace-node": {
       "version": "file:packages/opentelemetry-sdk-trace-node",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@opentelemetry/context-async-hooks": "1.22.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/propagator-b3": "1.22.0",
@@ -43849,7 +43849,7 @@
       "requires": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@opentelemetry/context-zone": "1.22.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/propagator-b3": "1.22.0",
@@ -44028,7 +44028,7 @@
         "@babel/plugin-proposal-decorators": "7.22.15",
         "@babel/plugin-transform-runtime": "7.22.15",
         "@babel/preset-env": "7.22.20",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/context-zone-peer-dep": "1.22.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/exporter-trace-otlp-http": "0.49.0",
@@ -44403,7 +44403,7 @@
       "version": "file:experimental/packages/shim-opencensus",
       "requires": {
         "@opencensus/core": "0.1.0",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/context-async-hooks": "1.22.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/resources": "1.22.0",
@@ -44427,7 +44427,7 @@
     "@opentelemetry/shim-opentracing": {
       "version": "file:packages/opentelemetry-shim-opentracing",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.8.0",
+        "@opentelemetry/api": ">=1.0.0 <1.9.0",
         "@opentelemetry/core": "1.22.0",
         "@opentelemetry/propagator-b3": "1.22.0",
         "@opentelemetry/propagator-jaeger": "1.22.0",
@@ -49765,7 +49765,7 @@
     "esm-http-ts": {
       "version": "file:examples/esm-http-ts",
       "requires": {
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/exporter-trace-otlp-proto": "0.49.0",
         "@opentelemetry/instrumentation": "0.49.0",
         "@opentelemetry/instrumentation-http": "0.49.0",
@@ -55721,7 +55721,7 @@
         "@opencensus/core": "0.1.0",
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
-        "@opentelemetry/api": "1.7.0",
+        "@opentelemetry/api": "1.8.0",
         "@opentelemetry/exporter-prometheus": "0.49.0",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.49.0",
         "@opentelemetry/resources": "1.22.0",

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0",
+    "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0"
+    "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-context-async-hooks",
   "sideEffects": false

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": ">=1.0.0 <1.8.0",
+    "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -83,7 +83,7 @@
     "zone.js": "0.13.3"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0",
+    "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "zone.js": "^0.10.2 || ^0.11.0 || ^0.13.0 || ^0.14.0"
   },
   "sideEffects": false,

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -55,7 +55,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.21.0",
+    "@opentelemetry/context-zone-peer-dep": "1.22.0",
     "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
   },
   "sideEffects": true,

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,7 +91,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core",
   "sideEffects": false

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -64,7 +64,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0",
+    "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -88,7 +88,7 @@
     "webpack": "5.89.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0"
+    "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
     "@opentelemetry/semantic-conventions": "1.22.0"

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/resources": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -63,9 +63,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0",
     "jaeger-client": "^3.15.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,10 +93,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin",
   "sideEffects": false

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -54,10 +54,10 @@
     "@opentelemetry/core": "1.22.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0"
+    "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0",
+    "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0"
+    "@opentelemetry/core": "1.22.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.8.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -81,7 +81,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0"
+    "@opentelemetry/core": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger",
   "sideEffects": false

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -54,7 +54,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0",
+    "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -78,7 +78,7 @@
     "webpack": "5.89.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0"
+    "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
     "@opentelemetry/core": "1.22.0"

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,8 +91,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources",
   "sideEffects": false

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0",
+    "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -88,7 +88,7 @@
     "webpack-merge": "5.10.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0"
+    "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
     "@opentelemetry/core": "1.22.0",

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0",
+    "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -90,7 +90,7 @@
     "webpack": "5.89.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0"
+    "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
     "@opentelemetry/core": "1.22.0",

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,9 +93,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.8.0",
-    "@opentelemetry/resources": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0",
+    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.6",
@@ -65,11 +65,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.21.0",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/propagator-b3": "1.21.0",
-    "@opentelemetry/propagator-jaeger": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/context-async-hooks": "1.22.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/propagator-b3": "1.22.0",
+    "@opentelemetry/propagator-jaeger": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
     "semver": "^7.5.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0",
+    "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@opentelemetry/resources": "1.22.0",
     "@opentelemetry/semantic-conventions": "1.22.0",
     "@types/mocha": "10.0.6",
@@ -62,7 +62,7 @@
     "typescript": "4.4.4"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0"
+    "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
     "@opentelemetry/context-async-hooks": "1.22.0",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": ">=1.0.0 <1.8.0",
+    "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@opentelemetry/context-zone": "1.22.0",
     "@opentelemetry/propagator-b3": "1.22.0",
     "@opentelemetry/resources": "1.22.0",
@@ -90,7 +90,7 @@
     "webpack-merge": "5.10.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0"
+    "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
     "@opentelemetry/core": "1.22.0",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -58,9 +58,9 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": ">=1.0.0 <1.8.0",
-    "@opentelemetry/context-zone": "1.21.0",
-    "@opentelemetry/propagator-b3": "1.21.0",
-    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/context-zone": "1.22.0",
+    "@opentelemetry/propagator-b3": "1.22.0",
+    "@opentelemetry/resources": "1.22.0",
     "@types/jquery": "3.5.29",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -93,9 +93,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0"
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web",
   "sideEffects": false

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -50,12 +50,12 @@
     "access": "public"
   },
   "devDependencies": {
-    "@types/mocha": "10.0.6",
-    "@types/node": "18.6.5",
-    "@types/sinon": "10.0.20",
     "@size-limit/file": "^11.0.1",
     "@size-limit/time": "^11.0.1",
     "@size-limit/webpack": "^11.0.1",
+    "@types/mocha": "10.0.6",
+    "@types/node": "18.6.5",
+    "@types/sinon": "10.0.20",
     "codecov": "3.8.3",
     "cross-var": "1.1.0",
     "lerna": "6.6.2",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -43,9 +43,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.8.0",
-    "@opentelemetry/propagator-b3": "1.21.0",
-    "@opentelemetry/propagator-jaeger": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
+    "@opentelemetry/propagator-b3": "1.22.0",
+    "@opentelemetry/propagator-jaeger": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
@@ -60,8 +60,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/semantic-conventions": "1.21.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.22.0",
     "opentracing": "^0.14.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0",
+    "@opentelemetry/api": ">=1.0.0 <1.9.0",
     "@opentelemetry/propagator-b3": "1.22.0",
     "@opentelemetry/propagator-jaeger": "1.22.0",
     "@opentelemetry/sdk-trace-base": "1.22.0",
@@ -57,7 +57,7 @@
     "typescript": "4.4.4"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.8.0"
+    "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
     "@opentelemetry/core": "1.22.0",

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": ">=1.3.0 <1.8.0",
+    "@opentelemetry/api": ">=1.3.0 <1.9.0",
     "@types/lodash.merge": "4.6.9",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -82,7 +82,7 @@
     "webpack-merge": "5.10.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.3.0 <1.8.0"
+    "@opentelemetry/api": ">=1.3.0 <1.9.0"
   },
   "dependencies": {
     "@opentelemetry/core": "1.22.0",

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -85,8 +85,8 @@
     "@opentelemetry/api": ">=1.3.0 <1.8.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/resources": "1.21.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/resources": "1.22.0",
     "lodash.merge": "^4.6.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-metrics",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
@@ -56,16 +56,16 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.21.0",
-    "@opentelemetry/core": "1.21.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.48.0",
-    "@opentelemetry/exporter-zipkin": "1.21.0",
-    "@opentelemetry/instrumentation": "0.48.0",
-    "@opentelemetry/instrumentation-fetch": "0.48.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.48.0",
-    "@opentelemetry/sdk-metrics": "1.21.0",
-    "@opentelemetry/sdk-trace-base": "1.21.0",
-    "@opentelemetry/sdk-trace-web": "1.21.0",
+    "@opentelemetry/context-zone-peer-dep": "1.22.0",
+    "@opentelemetry/core": "1.22.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.49.0",
+    "@opentelemetry/exporter-zipkin": "1.22.0",
+    "@opentelemetry/instrumentation": "0.49.0",
+    "@opentelemetry/instrumentation-fetch": "0.49.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.49.0",
+    "@opentelemetry/sdk-metrics": "1.22.0",
+    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/sdk-trace-web": "1.22.0",
     "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
   }
 }

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -36,7 +36,7 @@
     "@babel/plugin-proposal-decorators": "7.22.15",
     "@babel/plugin-transform-runtime": "7.22.15",
     "@babel/preset-env": "7.22.20",
-    "@opentelemetry/api": "1.7.0",
+    "@opentelemetry/api": "1.8.0",
     "babel-loader": "8.3.0",
     "babel-polyfill": "6.26.0",
     "browserstack-local": "1.4.8",


### PR DESCRIPTION
## API 1.8.0

### :rocket: (Enhancement)

* feat(api): add SugaredTracer for functions not defined in the spec [#3317](https://github.com/open-telemetry/opentelemetry-js/pull/3317) @secustor

### :bug: (Bug Fix)

* fix(api): fix unreachable @opentelemetry/api/experimental entry [#4446](https://github.com/open-telemetry/opentelemetry-js/pull/4446) @legendecas

## Core 1.22.0

### :rocket: (Enhancement)

* feat(sdk-metrics): allow single bucket histograms [#4456](https://github.com/open-telemetry/opentelemetry-js/pull/4456) @pichlermarc
* feat(context-zone-peer-dep, context-zone): support zone.js 0.13.x, 0.14.x [#4469](https://github.com/open-telemetry/opentelemetry-js/pull/4469) @pichlermarc
* chore: Semantic Conventions export individual strings [4185](https://github.com/open-telemetry/opentelemetry-js/issues/4185) @MSNev 

### :bug: (Bug Fix)

* fix(sdk-metrics): handle zero bucket counts in exponential histogram merge [#4459](https://github.com/open-telemetry/opentelemetry-js/pull/4459) @mwear
* fix(sdk-metrics): ignore `NaN` value recordings in Histograms [#4455](https://github.com/open-telemetry/opentelemetry-js/pull/4455) @pichlermarc
  * fixes a bug where recording `NaN` on a histogram would result in the sum of bucket count values not matching the overall count
* fix(sdk-metrics): allow single bucket histograms [#4456](https://github.com/open-telemetry/opentelemetry-js/pull/4456) @pichlermarc
  * fixes a bug where `Meter.createHistogram()` with the advice `explicitBucketBoundaries: []` would throw
* fix(context-zone-peer-dep, context-zone):  support zone.js 0.13.x, 0.14.x [#4469](https://github.com/open-telemetry/opentelemetry-js/pull/4469) @pichlermarc
  * fixes a bug where old versions of `zone.js` affected by <https://github.com/angular/angular/issues/53507> would be pulled in

### :books: (Refine Doc)

* docs: shorten readme sections [#4460](https://github.com/open-telemetry/opentelemetry-js/pull/4460) @legendecas

## Experimental 0.49.0

### :boom: Breaking Change

* fix(otlp-exporter-base)!: remove unload event from OTLPExporterBrowserBase [#4438](https://github.com/open-telemetry/opentelemetry-js/pull/4438) @eldavojohn
  * Reason: The 'unload' event prevents sites from taking advantage of Google's [backward/forward cache](https://web.dev/articles/bfcache#never_use_the_unload_event) and will be [deprecated](https://developer.chrome.com/articles/deprecating-unload/).  It is now up to the consuming site to implement these shutdown events.
  * This breaking change affects users under this scenario:
    1. A user extends the exporter and overrides the shutdown function, and does something which is usually called by the unload listener
    2. We remove the unload event listener
    3. That user's overridden shutdown function no longer gets called

### :rocket: (Enhancement)

* feat(instrumentation): allow LoggerProvider to be specified in Instrumentations [#4314](https://github.com/open-telemetry/opentelemetry-js/pull/4314) @hectorhdzg
* feat(instrumentation): add getModuleDefinitions() to InstrumentationBase [#4475](https://github.com/open-telemetry/opentelemetry-js/pull/4475) @pichlermarc
* feat(exporter-metrics-otlp-http): add option to set the exporter aggregation preference  [#4409](https://github.com/open-telemetry/opentelemetry-js/pull/4409) @AkselAllas
* feat(node-sdk): add spanProcessors option [#4454](https://github.com/open-telemetry/opentelemetry-js/pull/4454) @naseemkullah

### :bug: (Bug Fix)

* fix(sdk-node): allow using samplers when the exporter is defined in the environment [#4394](https://github.com/open-telemetry/opentelemetry-js/pull/4394) @JacksonWeber
* fix(instrumentation): normalize paths for internal files in scoped packages [#4467](https://github.com/open-telemetry/opentelemetry-js/pull/4467) @pichlermarc
  * Fixes a bug where, on Windows, internal files on scoped packages would not be instrumented.
* fix(otlp-transformer): only use BigInt inside hrTimeToNanos() [#4484](https://github.com/open-telemetry/opentelemetry-js/pull/4484) @pichlermarc
* fix(instrumentation-fetch): do not enable in Node.js; clarify in docs this instr is for web fetch only [#4498](https://github.com/open-telemetry/opentelemetry-js/pull/4498) @trentm

