### PR TITLE
fix(instrumentation): remove peer-dependency on @opentelemetry/api-logs

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(instrumentation): don't add `@opentelemetry/api-logs` as a `peerDependency`
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -75,11 +75,11 @@
     "import-in-the-middle": "1.7.1",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2",
-    "shimmer": "^1.2.1"
+    "shimmer": "^1.2.1",
+    "@opentelemetry/api-logs": "^0.49.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/api-logs": "^0.46.0"
+    "@opentelemetry/api": "^1.3.0"
   },
   "devDependencies": {
     "@babel/core": "7.23.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3107,6 +3107,7 @@
       "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/api-logs": "^0.49.0",
         "@types/shimmer": "^1.0.2",
         "import-in-the-middle": "1.7.1",
         "require-in-the-middle": "^7.1.1",
@@ -3150,8 +3151,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/api-logs": "^0.46.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "experimental/packages/opentelemetry-instrumentation-fetch": {


### PR DESCRIPTION
we added `@opentelemetry/api-logs` as a `peerDependency` when it should've been a `dependency`, requiring everyone using the package to install an old `@opentelemetry/api-logs` package.

fixes #4516 