### PR TITLE
fix: ConsoleMetricExporter Should Not Export Shallowly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
   * fixes a bug where `Meter.createHistogram()` with the advice `explicitBucketBoundaries: []` would throw
 * fix(context-zone-peer-dep, context-zone):  support zone.js 0.13.x, 0.14.x [#4469](https://github.com/open-telemetry/opentelemetry-js/pull/4469) @pichlermarc
   * fixes a bug where old versions of `zone.js` affected by <https://github.com/angular/angular/issues/53507> would be pulled in
+  * fix(sdk-metrics): increase the depth of the output to the console such that objects in the metric are printed fully to the console [#4522](https://github.com/open-telemetry/opentelemetry-js/pull/4522) @JacksonWeber
 
 ### :books: (Refine Doc)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+* fix(sdk-metrics): increase the depth of the output to the console such that objects in the metric are printed fully to the console [#4522](https://github.com/open-telemetry/opentelemetry-js/pull/4522) @JacksonWeber
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)
@@ -35,7 +37,6 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
   * fixes a bug where `Meter.createHistogram()` with the advice `explicitBucketBoundaries: []` would throw
 * fix(context-zone-peer-dep, context-zone):  support zone.js 0.13.x, 0.14.x [#4469](https://github.com/open-telemetry/opentelemetry-js/pull/4469) @pichlermarc
   * fixes a bug where old versions of `zone.js` affected by <https://github.com/angular/angular/issues/53507> would be pulled in
-  * fix(sdk-metrics): increase the depth of the output to the console such that objects in the metric are printed fully to the console [#4522](https://github.com/open-telemetry/opentelemetry-js/pull/4522) @JacksonWeber
 
 ### :books: (Refine Doc)
 

--- a/packages/sdk-metrics/src/export/ConsoleMetricExporter.ts
+++ b/packages/sdk-metrics/src/export/ConsoleMetricExporter.ts
@@ -71,11 +71,14 @@ export class ConsoleMetricExporter implements PushMetricExporter {
   ): void {
     for (const scopeMetrics of metrics.scopeMetrics) {
       for (const metric of scopeMetrics.metrics) {
-        console.dir({
-          descriptor: metric.descriptor,
-          dataPointType: metric.dataPointType,
-          dataPoints: metric.dataPoints,
-        });
+        console.dir(
+          {
+            descriptor: metric.descriptor,
+            dataPointType: metric.dataPointType,
+            dataPoints: metric.dataPoints,
+          },
+          { depth: null }
+        );
       }
     }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Changed the depth of which the ConsoleMetricExporter will log such that values on metrics like attributes, startTime, endTime, and value will be logged entirely.

Example:
![image](https://github.com/open-telemetry/opentelemetry-js/assets/47067795/8b6745e5-c55a-4c39-acb6-14f1383979f7)

Fixes #4061 

## Short description of the changes
Change the console.dir depth to `null` to ensure objects part of the output metrics are fully serialized in the console.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Create a sample application that logs metrics to the console using the `ConsoleMetricExporter`. Observe the output metrics for correctness.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
