### PR TITLE
fix(exporters): use parseHeaders() to ensure header-values are not 'undefined'

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(exporter-*-otlp-*): use parseHeaders() to ensure header-values are not 'undefined' #4540
+  * Fixes a bug where passing `undefined` as a header value would crash the end-user app after the export timeout elapsed.
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/exporter-logs-otlp-http/src/platform/node/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-http/src/platform/node/OTLPLogExporter.ts
@@ -21,7 +21,10 @@ import type {
 import type { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
 import type { IExportLogsServiceRequest } from '@opentelemetry/otlp-transformer';
 import { getEnv, baggageUtils } from '@opentelemetry/core';
-import { OTLPExporterNodeBase } from '@opentelemetry/otlp-exporter-base';
+import {
+  OTLPExporterNodeBase,
+  parseHeaders,
+} from '@opentelemetry/otlp-exporter-base';
 import { createExportLogsServiceRequest } from '@opentelemetry/otlp-transformer';
 
 import { getDefaultUrl } from '../config';
@@ -50,7 +53,7 @@ export class OTLPLogExporter
       ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_LOGS_HEADERS
       ),
-      ...config.headers,
+      ...parseHeaders(config?.headers),
     };
   }
 

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
@@ -19,6 +19,7 @@ import {
   OTLPExporterConfigBase,
   appendResourcePathToUrl,
   appendRootPathToUrlIfNeeded,
+  parseHeaders,
 } from '@opentelemetry/otlp-exporter-base';
 import {
   OTLPProtoExporterNodeBase,
@@ -57,7 +58,7 @@ export class OTLPLogExporter
       ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_LOGS_HEADERS
       ),
-      ...config.headers,
+      ...parseHeaders(config?.headers),
     };
   }
   convert(logs: ReadableLogRecord[]): IExportLogsServiceRequest {

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/node/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/node/OTLPTraceExporter.ts
@@ -16,7 +16,10 @@
 
 import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { getEnv, baggageUtils } from '@opentelemetry/core';
-import { OTLPExporterNodeBase } from '@opentelemetry/otlp-exporter-base';
+import {
+  OTLPExporterNodeBase,
+  parseHeaders,
+} from '@opentelemetry/otlp-exporter-base';
 import {
   OTLPExporterNodeConfigBase,
   appendResourcePathToUrl,
@@ -49,7 +52,7 @@ export class OTLPTraceExporter
       ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_TRACES_HEADERS
       ),
-      ...config.headers,
+      ...parseHeaders(config?.headers),
     };
   }
 

--- a/experimental/packages/exporter-trace-otlp-proto/src/platform/node/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/src/platform/node/OTLPTraceExporter.ts
@@ -20,6 +20,7 @@ import {
   OTLPExporterNodeConfigBase,
   appendResourcePathToUrl,
   appendRootPathToUrlIfNeeded,
+  parseHeaders,
 } from '@opentelemetry/otlp-exporter-base';
 import {
   OTLPProtoExporterNodeBase,
@@ -52,7 +53,7 @@ export class OTLPTraceExporter
       ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_TRACES_HEADERS
       ),
-      ...config.headers,
+      ...parseHeaders(config?.headers),
     };
   }
 

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/OTLPMetricExporter.ts
@@ -33,6 +33,7 @@ import {
   IExportMetricsServiceResponse,
 } from '@opentelemetry/otlp-transformer';
 import { VERSION } from './version';
+import { parseHeaders } from '@opentelemetry/otlp-exporter-base';
 
 const USER_AGENT = {
   'User-Agent': `OTel-OTLP-Exporter-JavaScript/${VERSION}`,
@@ -49,7 +50,7 @@ class OTLPMetricExporterProxy extends OTLPGRPCExporterNodeBase<
       ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
       ),
-      ...config?.headers,
+      ...parseHeaders(config?.headers),
     };
     super(
       config,

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/OTLPMetricExporter.ts
@@ -23,6 +23,7 @@ import {
   OTLPExporterNodeConfigBase,
   appendResourcePathToUrl,
   appendRootPathToUrlIfNeeded,
+  parseHeaders,
 } from '@opentelemetry/otlp-exporter-base';
 import {
   createExportMetricsServiceRequest,
@@ -48,7 +49,7 @@ class OTLPExporterNodeProxy extends OTLPExporterNodeBase<
       ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
       ),
-      ...config?.headers,
+      ...parseHeaders(config?.headers),
     };
   }
 

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/OTLPMetricExporter.ts
@@ -26,6 +26,7 @@ import {
   OTLPExporterNodeConfigBase,
   appendResourcePathToUrl,
   appendRootPathToUrlIfNeeded,
+  parseHeaders,
 } from '@opentelemetry/otlp-exporter-base';
 import {
   createExportMetricsServiceRequest,
@@ -51,7 +52,7 @@ class OTLPMetricExporterNodeProxy extends OTLPProtoExporterNodeBase<
       ...baggageUtils.parseKeyPairsIntoRecord(
         getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
       ),
-      ...config?.headers,
+      ...parseHeaders(config?.headers),
     };
   }
 

--- a/experimental/packages/otlp-exporter-base/src/util.ts
+++ b/experimental/packages/otlp-exporter-base/src/util.ts
@@ -35,7 +35,9 @@ export function parseHeaders(
     if (typeof value !== 'undefined') {
       headers[key] = String(value);
     } else {
-      diag.warn(`Header "${key}" has wrong value and will be ignored`);
+      diag.warn(
+        `Header "${key}" has invalid value (${value}) and will be ignored`
+      );
     }
   });
   return headers;

--- a/experimental/packages/otlp-exporter-base/test/common/util.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/common/util.test.ts
@@ -46,7 +46,7 @@ describe('utils', () => {
       const args = spyWarn.args[0];
       assert.strictEqual(
         args[0],
-        'Header "foo1" has wrong value and will be ignored'
+        'Header "foo1" has invalid value (undefined) and will be ignored'
       );
     });
 


### PR DESCRIPTION
## Which problem is this PR solving?

When passing an options object like `{ headers: { foo: undefined } }` to the http/json and http/protobuf exporters, the headers will not be validated and that will cause 

https://github.com/open-telemetry/opentelemetry-js/blob/abfe059d72d2a50d993ee7fb5ea50a1c29851a31/experimental/packages/otlp-exporter-base/src/platform/node/util.ts#L89

to throw, as we're passing an `undefined` header value. While this alone will not cause an application crash, trying to access `req` at

https://github.com/open-telemetry/opentelemetry-js/blob/abfe059d72d2a50d993ee7fb5ea50a1c29851a31/experimental/packages/otlp-exporter-base/src/platform/node/util.ts#L62

will cause the end-user's application to crash within typically 10s after the first export (when using defaults).

This PR fixes this by sanitizing these headers first using `parseHeaders()`.

Fixes #4541 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
