### PR TITLE
perf(export): do not allocate arrays if resource has no pending async attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :rocket: (Enhancement)
 
-perf(sdk-trace-base): do not allocate arrays if resource has no pending async attributes
+* perf(sdk-trace-base): do not allocate arrays if resource has no pending async attributes
 
 ### :bug: (Bug Fix)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :rocket: (Enhancement)
 
+perf(sdk-trace-base): do not allocate arrays if resource has no pending async attributes
+
 ### :bug: (Bug Fix)
 
 * fix(sdk-metrics): increase the depth of the output to the console such that objects in the metric are printed fully to the console [#4522](https://github.com/open-telemetry/opentelemetry-js/pull/4522) @JacksonWeber

--- a/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
@@ -181,7 +181,13 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
         // Reset the finished spans buffer here because the next invocations of the _flush method
         // could pass the same finished spans to the exporter if the buffer is cleared
         // outside the execution of this callback.
-        const spans = this._finishedSpans.splice(0, this._maxExportBatchSize);
+        let spans: ReadableSpan[];
+        if (this._finishedSpans.length <= this._maxExportBatchSize) {
+          spans = this._finishedSpans;
+          this._finishedSpans = [];
+        } else {
+          spans = this._finishedSpans.splice(0, this._maxExportBatchSize);
+        }
 
         const doExport = () =>
           this._exporter.export(spans, result => {

--- a/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/BatchSpanProcessorBase.ts
@@ -195,19 +195,24 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
               );
             }
           });
-        const pendingResources = spans
-          .map(span => span.resource)
-          .filter(resource => resource.asyncAttributesPending);
+
+        let pendingResources: Array<Promise<void>> | null = null;
+        for (let i = 0, len = spans.length; i < len; i++) {
+          const span = spans[i];
+          if (
+            span.resource.asyncAttributesPending &&
+            span.resource.waitForAsyncAttributes
+          ) {
+            pendingResources ??= [];
+            pendingResources.push(span.resource.waitForAsyncAttributes());
+          }
+        }
 
         // Avoid scheduling a promise to make the behavior more predictable and easier to test
-        if (pendingResources.length === 0) {
+        if (pendingResources === null) {
           doExport();
         } else {
-          Promise.all(
-            pendingResources.map(
-              resource => resource.waitForAsyncAttributes?.()
-            )
-          ).then(doExport, err => {
+          Promise.all(pendingResources).then(doExport, err => {
             globalErrorHandler(err);
             reject(err);
           });


### PR DESCRIPTION
## Which problem is this PR solving?

OpenTelemetry is producing too much overhead for scenarios with significant load. One of the example is BatchSpanExporter, that is allocating array of batch size only to check is it has any pending attributes. 

Fixes # (issue)

## Short description of the changes

Replaced map & filter with a simple loop.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Benchmarks:

Before 
create spans (10 attributes) x 689,041 ops/sec ±1.54% (92 runs sampled)
BatchSpanProcessor process span x 660,065 ops/sec ±1.08% (95 runs sampled)

After:
create spans (10 attributes) x 688,731 ops/sec ±1.15% (94 runs sampled)
BatchSpanProcessor process span x 673,550 ops/sec ±1.01% (93 runs sampled)

- [ ] Test A

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
