### PR TITLE
fix(opentelemetry-js): remove deprecated lerna parameter

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
   "version": "independent",
-  "npmClient": "npm",
-  "useWorkspaces": true
+  "npmClient": "npm"
 }


### PR DESCRIPTION
## Which problem is this PR solving?

The parameter `useWorkspaces` was removed on [lerna](https://github.com/lerna/lerna/pull/3695), and trying to compile (`npm run compile`) or test (`npm test`) fails with the error:

```
lerna ERR! ECONFIGWORKSPACES The "useWorkspaces" option has been removed. By default lerna will resolve 
your packages using your package manager's workspaces configuration. Alternatively, you can manually provide 
a list of package globs to be used instead via the "packages" option in lerna.json.
```

Fixes #4556

## Short description of the changes

Once the attribute is removed, the commands work as expected.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually testing compile and test commands.

Before
<img width="779" alt="Screenshot 2024-03-19 at 4 59 48 PM" src="https://github.com/open-telemetry/opentelemetry-js/assets/1017486/3718a674-e16e-44b5-ba2d-366a2b9bf442">


After
<img width="772" alt="Screenshot 2024-03-19 at 5 00 02 PM" src="https://github.com/open-telemetry/opentelemetry-js/assets/1017486/3a5b9ce1-4a2c-4335-b0e1-a86516847e4a">


## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
