### PR TITLE
perf(tracer): reduce overhead of attribute sanitization

### DIFF
--- a/packages/opentelemetry-core/src/common/attributes.ts
+++ b/packages/opentelemetry-core/src/common/attributes.ts
@@ -25,6 +25,9 @@ export function sanitizeAttributes(
   }
 
   for (const key in attributes) {
+    if (!Object.prototype.propertyIsEnumerable.call(attributes, key)) {
+      continue;
+    }
     if (!isAttributeKey(key)) {
       diag.warn(`Invalid attribute key: ${key}`);
       continue;
@@ -35,7 +38,7 @@ export function sanitizeAttributes(
       continue;
     }
     if (Array.isArray(val)) {
-      out[key] = out[key] == val ? val : val.slice();
+      out[key] = out[key] === val ? val : val.slice();
     } else {
       out[key] = val;
     }

--- a/packages/opentelemetry-core/src/common/attributes.ts
+++ b/packages/opentelemetry-core/src/common/attributes.ts
@@ -16,24 +16,26 @@
 
 import { diag, SpanAttributeValue, SpanAttributes } from '@opentelemetry/api';
 
-export function sanitizeAttributes(attributes: unknown): SpanAttributes {
-  const out: SpanAttributes = {};
-
+export function sanitizeAttributes(
+  attributes: unknown,
+  out: SpanAttributes = {}
+): SpanAttributes {
   if (typeof attributes !== 'object' || attributes == null) {
     return out;
   }
 
-  for (const [key, val] of Object.entries(attributes)) {
+  for (const key in attributes) {
     if (!isAttributeKey(key)) {
       diag.warn(`Invalid attribute key: ${key}`);
       continue;
     }
+    const val = attributes[key as keyof typeof attributes] as unknown;
     if (!isAttributeValue(val)) {
       diag.warn(`Invalid attribute value set for key: ${key}`);
       continue;
     }
     if (Array.isArray(val)) {
-      out[key] = val.slice();
+      out[key] = out[key] == val ? val : val.slice();
     } else {
       out[key] = val;
     }

--- a/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
@@ -134,9 +134,8 @@ export class Tracer implements api.Tracer {
 
     // Set initial span attributes. The attributes object may have been mutated
     // by the sampler, so we sanitize the merged attributes before setting them.
-    const initAttributes = sanitizeAttributes(
-      Object.assign(attributes, samplingResult.attributes)
-    );
+    Object.assign(attributes, samplingResult.attributes);
+    const initAttributes = sanitizeAttributes(attributes, attributes);
 
     const span = new Span(
       this,

--- a/packages/opentelemetry-sdk-trace-base/test/performance/benchmark/span.js
+++ b/packages/opentelemetry-sdk-trace-base/test/performance/benchmark/span.js
@@ -18,7 +18,7 @@ const Benchmark = require('benchmark');
 const { BasicTracerProvider } = require('../../../build/src');
 
 const tracerProvider = new BasicTracerProvider();
-const tracer = tracerProvider.getTracer('test')
+const tracer = tracerProvider.getTracer('test');
 
 const suite = new Benchmark.Suite();
 
@@ -26,7 +26,7 @@ suite.on('cycle', event => {
   console.log(String(event.target));
 });
 
-suite.add('create spans (10 attributes)', function() {
+suite.add('create spans (10 attributes)', function () {
   const span = tracer.startSpan('span');
   span.setAttribute('aaaaaaaaaaaaaaaaaaaa', 'aaaaaaaaaaaaaaaaaaaa');
   span.setAttribute('bbbbbbbbbbbbbbbbbbbb', 'aaaaaaaaaaaaaaaaaaaa');
@@ -39,6 +39,23 @@ suite.add('create spans (10 attributes)', function() {
   span.setAttribute('iiiiiiiiiiiiiiiiiiii', 'aaaaaaaaaaaaaaaaaaaa');
   span.setAttribute('jjjjjjjjjjjjjjjjjjjj', 'aaaaaaaaaaaaaaaaaaaa');
   span.end();
+});
+
+suite.add('create spans (10 attributes) passed as options', function () {
+  const span = tracer.startSpan('span', {
+    attributes: {
+      aaaaaaaaaaaaaaaaaaaa: 'aaaaaaaaaaaaaaaaaaaa',
+      bbbbbbbbbbbbbbbbbbbb: 'aaaaaaaaaaaaaaaaaaaa',
+      cccccccccccccccccccc: 'aaaaaaaaaaaaaaaaaaaa',
+      dddddddddddddddddddd: 'aaaaaaaaaaaaaaaaaaaa',
+      eeeeeeeeeeeeeeeeeeee: 'aaaaaaaaaaaaaaaaaaaa',
+      ffffffffffffffffffff: 'aaaaaaaaaaaaaaaaaaaa',
+      gggggggggggggggggggg: 'aaaaaaaaaaaaaaaaaaaa',
+      hhhhhhhhhhhhhhhhhhhh: 'aaaaaaaaaaaaaaaaaaaa',
+      iiiiiiiiiiiiiiiiiiii: 'aaaaaaaaaaaaaaaaaaaa',
+      jjjjjjjjjjjjjjjjjjjj: 'aaaaaaaaaaaaaaaaaaaa',
+    },
+  });
 });
 
 suite.run();


### PR DESCRIPTION
## Which problem is this PR solving?

OTEL is producing too much allocations

Fixes # (issue)

## Short description of the changes

Added possibility for sanitizeAttributes to operate in place on provided object. Remove Object.entries and do prevent copying already allocated copies of arrays

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

After:

create spans (10 attributes) x 702,092 ops/sec ±1.32% (88 runs sampled)
create spans (10 attributes) passed as options x 603,744 ops/sec ±0.57% (97 runs sampled)
BatchSpanProcessor process span x 652,096 ops/sec ±0.97% (93 runs sampled)

Before:

create spans (10 attributes) x 691,170 ops/sec ±1.13% (94 runs sampled)
create spans (10 attributes) passed as options x 291,230 ops/sec ±0.54% (99 runs sampled)
BatchSpanProcessor process span x 645,159 ops/sec ±0.97% (95 runs sampled)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
