### PR TITLE
fix(sdk-logs): ensure default resource attributes are used as fallbacks when a resource is passed to LoggerProvider

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to experimental packages in this project will be documented 
 
 * fix(exporter-*-otlp-*): use parseHeaders() to ensure header-values are not 'undefined' #4540
   * Fixes a bug where passing `undefined` as a header value would crash the end-user app after the export timeout elapsed.
+* fix(sdk-logs): ensure default resource attributes are used as fallbacks when a resource is passed to LoggerProvider.
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/sdk-logs/README.md
+++ b/experimental/packages/sdk-logs/README.md
@@ -46,7 +46,7 @@ const logger = logsAPI.logs.getLogger('default');
 
 // emit a log record
 logger.emit({
-  severityNumber: SeverityNumber.INFO,
+  severityNumber: logsAPI.SeverityNumber.INFO,
   severityText: 'INFO',
   body: 'this is a log record body',
   attributes: { 'log.type': 'LogRecord' },

--- a/experimental/packages/sdk-logs/src/LoggerProvider.ts
+++ b/experimental/packages/sdk-logs/src/LoggerProvider.ts
@@ -33,15 +33,14 @@ export class LoggerProvider implements logsAPI.LoggerProvider {
   private readonly _sharedState: LoggerProviderSharedState;
 
   constructor(config: LoggerProviderConfig = {}) {
-    const {
-      resource = Resource.default(),
-      logRecordLimits,
-      forceFlushTimeoutMillis,
-    } = merge({}, loadDefaultConfig(), config);
+    const mergedConfig = merge({}, loadDefaultConfig(), config);
+    const resource = Resource.default().merge(
+      mergedConfig.resource ?? Resource.empty()
+    );
     this._sharedState = new LoggerProviderSharedState(
       resource,
-      forceFlushTimeoutMillis,
-      reconfigureLimits(logRecordLimits)
+      mergedConfig.forceFlushTimeoutMillis,
+      reconfigureLimits(mergedConfig.logRecordLimits)
     );
     this._shutdownOnce = new BindOnceFuture(this._shutdown, this);
   }

--- a/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
@@ -63,6 +63,16 @@ describe('LoggerProvider', () => {
         assert.deepStrictEqual(resource, Resource.default());
       });
 
+      it('should fallback to default resource attrs', () => {
+        const passedInResource = new Resource({ foo: 'bar' });
+        const provider = new LoggerProvider({ resource: passedInResource });
+        const { resource } = provider['_sharedState'];
+        assert.deepStrictEqual(
+          resource,
+          Resource.default().merge(passedInResource)
+        );
+      });
+
       it('should have default forceFlushTimeoutMillis if not pass', () => {
         const provider = new LoggerProvider();
         const sharedState = provider['_sharedState'];


### PR DESCRIPTION
Before this, Resource.default() attributes would only be used if *no*
resource was given to LoggerProvider. That would mean that
'service.name' and others could be missing, e.g. when called from
NodeSDK.

* * *

Here is where, for example, NodeSDK passes in a resource to LoggerProvider:
https://github.com/open-telemetry/opentelemetry-js/blob/aabd1a9b001ae9c8190bf2ddc1f3c8fe3a94a74d/experimental/packages/opentelemetry-sdk-node/src/sdk.ts#L360-L362
