### PR TITLE
feat(sdk-node): add `HostDetector` as default resource detector

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :rocket: (Enhancement)
 
+* feat(node-sdk): add `HostDetector` as default resource detector
+
 ### :bug: (Bug Fix)
 
 * fix(exporter-*-otlp-*): use parseHeaders() to ensure header-values are not 'undefined' #4540

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -26,7 +26,6 @@ All notable changes to experimental packages in this project will be documented 
 * refactor(instr-http): use exported strings for semconv. [#4573](https://github.com/open-telemetry/opentelemetry-js/pull/4573/) @JamieDanielson
 * feat(sdk-node): add `HostDetector` as default resource detector
 
-
 ### :bug: (Bug Fix)
 
 * fix(exporter-*-otlp-*): use parseHeaders() to ensure header-values are not 'undefined' #4540

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :rocket: (Enhancement)
 
-* feat(node-sdk): add `HostDetector` as default resource detector
+* feat(sdk-node): add `HostDetector` as default resource detector
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -31,6 +31,7 @@ import {
   DetectorSync,
   detectResourcesSync,
   envDetector,
+  hostDetector,
   IResource,
   processDetector,
   Resource,
@@ -46,7 +47,7 @@ import {
   NodeTracerConfig,
   NodeTracerProvider,
 } from '@opentelemetry/sdk-trace-node';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { NodeSDKConfiguration } from './types';
 import { TracerProviderWithEnvExporters } from './TracerProviderWithEnvExporter';
 import { getEnv, getEnvWithoutDefaults } from '@opentelemetry/core';
@@ -123,6 +124,7 @@ export class NodeSDK {
     this._resourceDetectors = configuration.resourceDetectors ?? [
       envDetector,
       processDetector,
+      hostDetector,
     ];
 
     this._serviceName = configuration.serviceName;
@@ -328,7 +330,7 @@ export class NodeSDK {
         ? this._resource
         : this._resource.merge(
             new Resource({
-              [SemanticResourceAttributes.SERVICE_NAME]: this._serviceName,
+              [SEMRESATTRS_SERVICE_NAME]: this._serviceName,
             })
           );
 


### PR DESCRIPTION
## Which problem is this PR solving?

Host resources were not being set by default when initializing node SDK with `NodeSDK`.

Fixes #4282

## Short description of the changes

- Add `HostDetector` to the list of default resource detectors
- Add test to make sure host and process values are being set by default
- Update from deprecated `sdk.detectResources()` to `sdk.start()` on tests
- Update from deprecated `SemanticResourceAttributes.SERVICE_NAME` to `SEMRESATTRS_SERVICE_NAME` on SDK file

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

- [x] Tested manually
- [x] New test added to `sdk.test.ts`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
