### PR TITLE
Rename EventEmitter to EventLogger in the Events API

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to experimental packages in this project will be documented 
       * was used internally to keep track of the service client used by the exporter, as a side effect it allowed end-users to modify the gRPC service client that was used
     * `compression`
       * was used internally to keep track of the compression to use but was unintentionally exposed to the users. It allowed to read and write the value, writing, however, would have no effect.
+* fix(events-api)!: renamed EventEmitter to EventLogger in the Events API [#4569](https://github.com/open-telemetry/opentelemetry-js/pull/4568)
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/api-events/README.md
+++ b/experimental/packages/api-events/README.md
@@ -28,18 +28,18 @@ If you are writing an instrumentation library, or prefer to call the API methods
 ```javascript
 const api = require("@opentelemetry/api-events");
 
-/* A specific implementation of EventEmitterProvider comes from an SDK */
-const eventEmitterProvider = createEventEmitterProvider();
+/* A specific implementation of EventLoggerProvider comes from an SDK */
+const eventLoggerProvider = createEventLoggerProvider();
 
-/* Initialize EventEmitterProvider */
-api.events.setGlobalEventEmitterProvider(eventEmitterProvider);
-/* returns eventEmitterProvider (no-op if a working provider has not been initialized) */
-api.events.getEventEmitterProvider();
+/* Initialize EventLoggerProvider */
+api.events.setGlobalEventLoggerProvider(eventLoggerProvider);
+/* returns eventLoggerProvider (no-op if a working provider has not been initialized) */
+api.events.getEventLoggerProvider();
 /* returns an event emitter from the registered global event emitter provider (no-op if a working provider has not been initialized) */
-const eventEmitter = api.events.getEventEmitter(name, version);
+const eventLogger = api.events.getEventLogger(name, version);
 
 // logging an event in an instrumentation library
-eventEmitter.emit({ name: 'event-name', domain: 'event-domain' });
+eventLogger.emit({ name: 'event-name', domain: 'event-domain' });
 ```
 
 ## Useful links

--- a/experimental/packages/api-events/README.md
+++ b/experimental/packages/api-events/README.md
@@ -35,7 +35,7 @@ const eventLoggerProvider = createEventLoggerProvider();
 api.events.setGlobalEventLoggerProvider(eventLoggerProvider);
 /* returns eventLoggerProvider (no-op if a working provider has not been initialized) */
 api.events.getEventLoggerProvider();
-/* returns an event emitter from the registered global event emitter provider (no-op if a working provider has not been initialized) */
+/* returns an event logger from the registered global event logger provider (no-op if a working provider has not been initialized) */
 const eventLogger = api.events.getEventLogger(name, version);
 
 // logging an event in an instrumentation library

--- a/experimental/packages/api-events/src/NoopEventLogger.ts
+++ b/experimental/packages/api-events/src/NoopEventLogger.ts
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-import { Event } from './Event';
+import { EventLogger } from './types/EventLogger';
+import { Event } from './types/Event';
 
-export interface EventEmitter {
-  /**
-   * Emit an event. This method should only be used by instrumentations emitting events.
-   *
-   * @param event
-   */
-  emit(event: Event): void;
+export class NoopEventLogger implements EventLogger {
+  emit(_event: Event): void {}
 }

--- a/experimental/packages/api-events/src/NoopEventLoggerProvider.ts
+++ b/experimental/packages/api-events/src/NoopEventLoggerProvider.ts
@@ -30,4 +30,4 @@ export class NoopEventLoggerProvider implements EventLoggerProvider {
   }
 }
 
-export const NOOP_EVENT_EMITTER_PROVIDER = new NoopEventLoggerProvider();
+export const NOOP_EVENT_LOGGER_PROVIDER = new NoopEventLoggerProvider();

--- a/experimental/packages/api-events/src/NoopEventLoggerProvider.ts
+++ b/experimental/packages/api-events/src/NoopEventLoggerProvider.ts
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-import { EventEmitterProvider } from './types/EventEmitterProvider';
-import { EventEmitter } from './types/EventEmitter';
-import { EventEmitterOptions } from './types/EventEmitterOptions';
-import { NoopEventEmitter } from './NoopEventEmitter';
+import { EventLoggerProvider } from './types/EventLoggerProvider';
+import { EventLogger } from './types/EventLogger';
+import { EventLoggerOptions } from './types/EventLoggerOptions';
+import { NoopEventLogger } from './NoopEventLogger';
 
-export class NoopEventEmitterProvider implements EventEmitterProvider {
-  getEventEmitter(
+export class NoopEventLoggerProvider implements EventLoggerProvider {
+  getEventLogger(
     _name: string,
     _domain: string,
     _version?: string | undefined,
-    _options?: EventEmitterOptions | undefined
-  ): EventEmitter {
-    return new NoopEventEmitter();
+    _options?: EventLoggerOptions | undefined
+  ): EventLogger {
+    return new NoopEventLogger();
   }
 }
 
-export const NOOP_EVENT_EMITTER_PROVIDER = new NoopEventEmitterProvider();
+export const NOOP_EVENT_EMITTER_PROVIDER = new NoopEventLoggerProvider();

--- a/experimental/packages/api-events/src/api/events.ts
+++ b/experimental/packages/api-events/src/api/events.ts
@@ -20,10 +20,10 @@ import {
   _global,
   makeGetter,
 } from '../internal/global-utils';
-import { EventEmitterProvider } from '../types/EventEmitterProvider';
-import { NOOP_EVENT_EMITTER_PROVIDER } from '../NoopEventEmitterProvider';
-import { EventEmitter } from '../types/EventEmitter';
-import { EventEmitterOptions } from '../types/EventEmitterOptions';
+import { EventLoggerProvider } from '../types/EventLoggerProvider';
+import { NOOP_EVENT_EMITTER_PROVIDER } from '../NoopEventLoggerProvider';
+import { EventLogger } from '../types/EventLogger';
+import { EventLoggerOptions } from '../types/EventLoggerOptions';
 
 export class EventsAPI {
   private static _instance?: EventsAPI;
@@ -38,14 +38,14 @@ export class EventsAPI {
     return this._instance;
   }
 
-  public setGlobalEventEmitterProvider(
-    provider: EventEmitterProvider
-  ): EventEmitterProvider {
+  public setGlobalEventLoggerProvider(
+    provider: EventLoggerProvider
+  ): EventLoggerProvider {
     if (_global[GLOBAL_EVENTS_API_KEY]) {
-      return this.getEventEmitterProvider();
+      return this.getEventLoggerProvider();
     }
 
-    _global[GLOBAL_EVENTS_API_KEY] = makeGetter<EventEmitterProvider>(
+    _global[GLOBAL_EVENTS_API_KEY] = makeGetter<EventLoggerProvider>(
       API_BACKWARDS_COMPATIBILITY_VERSION,
       provider,
       NOOP_EVENT_EMITTER_PROVIDER
@@ -57,9 +57,9 @@ export class EventsAPI {
   /**
    * Returns the global event emitter provider.
    *
-   * @returns EventEmitterProvider
+   * @returns EventLoggerProvider
    */
-  public getEventEmitterProvider(): EventEmitterProvider {
+  public getEventLoggerProvider(): EventLoggerProvider {
     return (
       _global[GLOBAL_EVENTS_API_KEY]?.(API_BACKWARDS_COMPATIBILITY_VERSION) ??
       NOOP_EVENT_EMITTER_PROVIDER
@@ -69,15 +69,15 @@ export class EventsAPI {
   /**
    * Returns a event emitter from the global event emitter provider.
    *
-   * @returns EventEmitter
+   * @returns EventLogger
    */
-  public getEventEmitter(
+  public getEventLogger(
     name: string,
     domain: string,
     version?: string,
-    options?: EventEmitterOptions
-  ): EventEmitter {
-    return this.getEventEmitterProvider().getEventEmitter(
+    options?: EventLoggerOptions
+  ): EventLogger {
+    return this.getEventLoggerProvider().getEventLogger(
       name,
       domain,
       version,

--- a/experimental/packages/api-events/src/api/events.ts
+++ b/experimental/packages/api-events/src/api/events.ts
@@ -21,7 +21,7 @@ import {
   makeGetter,
 } from '../internal/global-utils';
 import { EventLoggerProvider } from '../types/EventLoggerProvider';
-import { NOOP_EVENT_EMITTER_PROVIDER } from '../NoopEventLoggerProvider';
+import { NOOP_EVENT_LOGGER_PROVIDER } from '../NoopEventLoggerProvider';
 import { EventLogger } from '../types/EventLogger';
 import { EventLoggerOptions } from '../types/EventLoggerOptions';
 
@@ -48,26 +48,26 @@ export class EventsAPI {
     _global[GLOBAL_EVENTS_API_KEY] = makeGetter<EventLoggerProvider>(
       API_BACKWARDS_COMPATIBILITY_VERSION,
       provider,
-      NOOP_EVENT_EMITTER_PROVIDER
+      NOOP_EVENT_LOGGER_PROVIDER
     );
 
     return provider;
   }
 
   /**
-   * Returns the global event emitter provider.
+   * Returns the global event logger provider.
    *
    * @returns EventLoggerProvider
    */
   public getEventLoggerProvider(): EventLoggerProvider {
     return (
       _global[GLOBAL_EVENTS_API_KEY]?.(API_BACKWARDS_COMPATIBILITY_VERSION) ??
-      NOOP_EVENT_EMITTER_PROVIDER
+      NOOP_EVENT_LOGGER_PROVIDER
     );
   }
 
   /**
-   * Returns a event emitter from the global event emitter provider.
+   * Returns a event logger from the global event logger provider.
    *
    * @returns EventLogger
    */
@@ -85,7 +85,7 @@ export class EventsAPI {
     );
   }
 
-  /** Remove the global event emitter provider */
+  /** Remove the global event logger provider */
   public disable(): void {
     delete _global[GLOBAL_EVENTS_API_KEY];
   }

--- a/experimental/packages/api-events/src/api/events.ts
+++ b/experimental/packages/api-events/src/api/events.ts
@@ -76,11 +76,7 @@ export class EventsAPI {
     version?: string,
     options?: EventLoggerOptions
   ): EventLogger {
-    return this.getEventLoggerProvider().getEventLogger(
-      name,
-      version,
-      options
-    );
+    return this.getEventLoggerProvider().getEventLogger(name, version, options);
   }
 
   /** Remove the global event logger provider */

--- a/experimental/packages/api-events/src/index.ts
+++ b/experimental/packages/api-events/src/index.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-export * from './types/EventEmitter';
-export * from './types/EventEmitterProvider';
+export * from './types/EventLogger';
+export * from './types/EventLoggerProvider';
 export * from './types/Event';
-export * from './types/EventEmitterOptions';
+export * from './types/EventLoggerOptions';
 
 import { EventsAPI } from './api/events';
 export const events = EventsAPI.getInstance();

--- a/experimental/packages/api-events/src/internal/global-utils.ts
+++ b/experimental/packages/api-events/src/internal/global-utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { EventEmitterProvider } from '../types/EventEmitterProvider';
+import { EventLoggerProvider } from '../types/EventLoggerProvider';
 import { _globalThis } from '../platform';
 
 export const GLOBAL_EVENTS_API_KEY = Symbol.for(
@@ -23,7 +23,7 @@ export const GLOBAL_EVENTS_API_KEY = Symbol.for(
 
 type Get<T> = (version: number) => T;
 type OtelGlobal = Partial<{
-  [GLOBAL_EVENTS_API_KEY]: Get<EventEmitterProvider>;
+  [GLOBAL_EVENTS_API_KEY]: Get<EventLoggerProvider>;
 }>;
 
 export const _global = _globalThis as OtelGlobal;

--- a/experimental/packages/api-events/src/types/EventLogger.ts
+++ b/experimental/packages/api-events/src/types/EventLogger.ts
@@ -14,17 +14,13 @@
  * limitations under the License.
  */
 
-import { Attributes } from '@opentelemetry/api';
+import { Event } from './Event';
 
-export interface EventEmitterOptions {
+export interface EventLogger {
   /**
-   * The schemaUrl of the tracer or instrumentation library
-   * @default ''
+   * Emit an event. This method should only be used by instrumentations emitting events.
+   *
+   * @param event
    */
-  schemaUrl?: string;
-
-  /**
-   * The instrumentation scope attributes to associate with emitted telemetry
-   */
-  scopeAttributes?: Attributes;
+  emit(event: Event): void;
 }

--- a/experimental/packages/api-events/src/types/EventLoggerOptions.ts
+++ b/experimental/packages/api-events/src/types/EventLoggerOptions.ts
@@ -14,9 +14,17 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from './types/EventEmitter';
-import { Event } from './types/Event';
+import { Attributes } from '@opentelemetry/api';
 
-export class NoopEventEmitter implements EventEmitter {
-  emit(_event: Event): void {}
+export interface EventLoggerOptions {
+  /**
+   * The schemaUrl of the tracer or instrumentation library
+   * @default ''
+   */
+  schemaUrl?: string;
+
+  /**
+   * The instrumentation scope attributes to associate with emitted telemetry
+   */
+  scopeAttributes?: Attributes;
 }

--- a/experimental/packages/api-events/src/types/EventLoggerProvider.ts
+++ b/experimental/packages/api-events/src/types/EventLoggerProvider.ts
@@ -25,11 +25,11 @@ export interface EventLoggerProvider {
    * Returns an EventLogger, creating one if one with the given name, version, and
    * schemaUrl pair is not already created.
    *
-   * @param name The name of the event emitter or instrumentation library.
-   * @param domain The domain for events created by the event emitter.
-   * @param version The version of the event emitter or instrumentation library.
-   * @param options The options of the event emitter or instrumentation library.
-   * @returns EventLogger An event emitter with the given name and version.
+   * @param name The name of the event logger or instrumentation library.
+   * @param domain The domain for events created by the event logger.
+   * @param version The version of the event logger or instrumentation library.
+   * @param options The options of the event logger or instrumentation library.
+   * @returns EventLogger An event logger with the given name and version.
    */
   getEventLogger(
     name: string,

--- a/experimental/packages/api-events/src/types/EventLoggerProvider.ts
+++ b/experimental/packages/api-events/src/types/EventLoggerProvider.ts
@@ -14,27 +14,27 @@
  * limitations under the License.
  */
 
-import { EventEmitter } from './EventEmitter';
-import { EventEmitterOptions } from './EventEmitterOptions';
+import { EventLogger } from './EventLogger';
+import { EventLoggerOptions } from './EventLoggerOptions';
 
 /**
- * A registry for creating named {@link EventEmitter}s.
+ * A registry for creating named {@link EventLogger}s.
  */
-export interface EventEmitterProvider {
+export interface EventLoggerProvider {
   /**
-   * Returns an EventEmitter, creating one if one with the given name, version, and
+   * Returns an EventLogger, creating one if one with the given name, version, and
    * schemaUrl pair is not already created.
    *
    * @param name The name of the event emitter or instrumentation library.
    * @param domain The domain for events created by the event emitter.
    * @param version The version of the event emitter or instrumentation library.
    * @param options The options of the event emitter or instrumentation library.
-   * @returns EventEmitter An event emitter with the given name and version.
+   * @returns EventLogger An event emitter with the given name and version.
    */
-  getEventEmitter(
+  getEventLogger(
     name: string,
     domain: string,
     version?: string,
-    options?: EventEmitterOptions
-  ): EventEmitter;
+    options?: EventLoggerOptions
+  ): EventLogger;
 }

--- a/experimental/packages/api-events/test/api/api.test.ts
+++ b/experimental/packages/api-events/test/api/api.test.ts
@@ -15,57 +15,57 @@
  */
 
 import * as assert from 'assert';
-import { EventEmitter, events } from '../../src';
-import { NoopEventEmitter } from '../../src/NoopEventEmitter';
-import { NoopEventEmitterProvider } from '../../src/NoopEventEmitterProvider';
+import { EventLogger, events } from '../../src';
+import { NoopEventLogger } from '../../src/NoopEventLogger';
+import { NoopEventLoggerProvider } from '../../src/NoopEventLoggerProvider';
 
 describe('API', () => {
-  const dummyEventEmitter = new NoopEventEmitter();
+  const dummyEventLogger = new NoopEventLogger();
 
-  it('should expose a event emitter provider via getEventEmitterProvider', () => {
-    const provider = events.getEventEmitterProvider();
+  it('should expose a event emitter provider via getEventLoggerProvider', () => {
+    const provider = events.getEventLoggerProvider();
     assert.ok(provider);
     assert.strictEqual(typeof provider, 'object');
   });
 
-  describe('GlobalEventEmitterProvider', () => {
+  describe('GlobalEventLoggerProvider', () => {
     beforeEach(() => {
       events.disable();
     });
 
     it('should use the global event emitter provider', () => {
-      events.setGlobalEventEmitterProvider(new TestEventEmitterProvider());
-      const eventEmitter = events
-        .getEventEmitterProvider()
-        .getEventEmitter('name', 'domain');
-      assert.deepStrictEqual(eventEmitter, dummyEventEmitter);
+      events.setGlobalEventLoggerProvider(new TestEventLoggerProvider());
+      const eventLogger = events
+        .getEventLoggerProvider()
+        .getEventLogger('name', 'domain');
+      assert.deepStrictEqual(eventLogger, dummyEventLogger);
     });
 
     it('should not allow overriding global provider if already set', () => {
-      const provider1 = new TestEventEmitterProvider();
-      const provider2 = new TestEventEmitterProvider();
-      events.setGlobalEventEmitterProvider(provider1);
-      assert.equal(events.getEventEmitterProvider(), provider1);
-      events.setGlobalEventEmitterProvider(provider2);
-      assert.equal(events.getEventEmitterProvider(), provider1);
+      const provider1 = new TestEventLoggerProvider();
+      const provider2 = new TestEventLoggerProvider();
+      events.setGlobalEventLoggerProvider(provider1);
+      assert.equal(events.getEventLoggerProvider(), provider1);
+      events.setGlobalEventLoggerProvider(provider2);
+      assert.equal(events.getEventLoggerProvider(), provider1);
     });
   });
 
-  describe('getEventEmitter', () => {
+  describe('getEventLogger', () => {
     beforeEach(() => {
       events.disable();
     });
 
     it('should return a event emitter instance from global provider', () => {
-      events.setGlobalEventEmitterProvider(new TestEventEmitterProvider());
-      const eventEmitter = events.getEventEmitter('myEventEmitter', 'domain');
-      assert.deepStrictEqual(eventEmitter, dummyEventEmitter);
+      events.setGlobalEventLoggerProvider(new TestEventLoggerProvider());
+      const eventLogger = events.getEventLogger('myEventLogger', 'domain');
+      assert.deepStrictEqual(eventLogger, dummyEventLogger);
     });
   });
 
-  class TestEventEmitterProvider extends NoopEventEmitterProvider {
-    override getEventEmitter(): EventEmitter {
-      return dummyEventEmitter;
+  class TestEventLoggerProvider extends NoopEventLoggerProvider {
+    override getEventLogger(): EventLogger {
+      return dummyEventLogger;
     }
   }
 });

--- a/experimental/packages/api-events/test/api/api.test.ts
+++ b/experimental/packages/api-events/test/api/api.test.ts
@@ -22,7 +22,7 @@ import { NoopEventLoggerProvider } from '../../src/NoopEventLoggerProvider';
 describe('API', () => {
   const dummyEventLogger = new NoopEventLogger();
 
-  it('should expose a event emitter provider via getEventLoggerProvider', () => {
+  it('should expose a event logger provider via getEventLoggerProvider', () => {
     const provider = events.getEventLoggerProvider();
     assert.ok(provider);
     assert.strictEqual(typeof provider, 'object');
@@ -33,7 +33,7 @@ describe('API', () => {
       events.disable();
     });
 
-    it('should use the global event emitter provider', () => {
+    it('should use the global event logger provider', () => {
       events.setGlobalEventLoggerProvider(new TestEventLoggerProvider());
       const eventLogger = events
         .getEventLoggerProvider()
@@ -56,7 +56,7 @@ describe('API', () => {
       events.disable();
     });
 
-    it('should return a event emitter instance from global provider', () => {
+    it('should return a event logger instance from global provider', () => {
       events.setGlobalEventLoggerProvider(new TestEventLoggerProvider());
       const eventLogger = events.getEventLogger('myEventLogger', 'domain');
       assert.deepStrictEqual(eventLogger, dummyEventLogger);

--- a/experimental/packages/api-events/test/internal/global.test.ts
+++ b/experimental/packages/api-events/test/internal/global.test.ts
@@ -19,7 +19,7 @@ import {
   _global,
   GLOBAL_EVENTS_API_KEY,
 } from '../../src/internal/global-utils';
-import { NoopEventEmitterProvider } from '../../src/NoopEventEmitterProvider';
+import { NoopEventLoggerProvider } from '../../src/NoopEventLoggerProvider';
 
 const api1 = require('../../src') as typeof import('../../src');
 
@@ -34,8 +34,8 @@ describe('Global Utils', () => {
   assert.notStrictEqual(api1, api2);
   // that return separate noop instances to start
   assert.notStrictEqual(
-    api1.events.getEventEmitterProvider(),
-    api2.events.getEventEmitterProvider()
+    api1.events.getEventLoggerProvider(),
+    api2.events.getEventLoggerProvider()
   );
 
   beforeEach(() => {
@@ -44,37 +44,37 @@ describe('Global Utils', () => {
   });
 
   it('should change the global event emitter provider', () => {
-    const original = api1.events.getEventEmitterProvider();
-    const newEventEmitterProvider = new NoopEventEmitterProvider();
-    api1.events.setGlobalEventEmitterProvider(newEventEmitterProvider);
-    assert.notStrictEqual(api1.events.getEventEmitterProvider(), original);
+    const original = api1.events.getEventLoggerProvider();
+    const newEventLoggerProvider = new NoopEventLoggerProvider();
+    api1.events.setGlobalEventLoggerProvider(newEventLoggerProvider);
+    assert.notStrictEqual(api1.events.getEventLoggerProvider(), original);
     assert.strictEqual(
-      api1.events.getEventEmitterProvider(),
-      newEventEmitterProvider
+      api1.events.getEventLoggerProvider(),
+      newEventLoggerProvider
     );
   });
 
   it('should load an instance from one which was set in the other', () => {
-    api1.events.setGlobalEventEmitterProvider(new NoopEventEmitterProvider());
+    api1.events.setGlobalEventLoggerProvider(new NoopEventLoggerProvider());
     assert.strictEqual(
-      api1.events.getEventEmitterProvider(),
-      api2.events.getEventEmitterProvider()
+      api1.events.getEventLoggerProvider(),
+      api2.events.getEventLoggerProvider()
     );
   });
 
   it('should disable both if one is disabled', () => {
-    const original = api1.events.getEventEmitterProvider();
+    const original = api1.events.getEventLoggerProvider();
 
-    api1.events.setGlobalEventEmitterProvider(new NoopEventEmitterProvider());
+    api1.events.setGlobalEventLoggerProvider(new NoopEventLoggerProvider());
 
-    assert.notStrictEqual(original, api1.events.getEventEmitterProvider());
+    assert.notStrictEqual(original, api1.events.getEventLoggerProvider());
     api2.events.disable();
-    assert.strictEqual(original, api1.events.getEventEmitterProvider());
+    assert.strictEqual(original, api1.events.getEventLoggerProvider());
   });
 
   it('should return the module NoOp implementation if the version is a mismatch', () => {
-    const original = api1.events.getEventEmitterProvider();
-    api1.events.setGlobalEventEmitterProvider(new NoopEventEmitterProvider());
+    const original = api1.events.getEventLoggerProvider();
+    api1.events.setGlobalEventLoggerProvider(new NoopEventLoggerProvider());
     const afterSet = _global[GLOBAL_EVENTS_API_KEY]!(-1);
 
     assert.strictEqual(original, afterSet);

--- a/experimental/packages/api-events/test/internal/global.test.ts
+++ b/experimental/packages/api-events/test/internal/global.test.ts
@@ -43,7 +43,7 @@ describe('Global Utils', () => {
     api2.events.disable();
   });
 
-  it('should change the global event emitter provider', () => {
+  it('should change the global event logger provider', () => {
     const original = api1.events.getEventLoggerProvider();
     const newEventLoggerProvider = new NoopEventLoggerProvider();
     api1.events.setGlobalEventLoggerProvider(newEventLoggerProvider);

--- a/experimental/packages/api-events/test/noop-implementations/noop-event-logger-provider.test.ts
+++ b/experimental/packages/api-events/test/noop-implementations/noop-event-logger-provider.test.ts
@@ -15,28 +15,28 @@
  */
 
 import * as assert from 'assert';
-import { NoopEventEmitter } from '../../src/NoopEventEmitter';
-import { NoopEventEmitterProvider } from '../../src/NoopEventEmitterProvider';
+import { NoopEventLogger } from '../../src/NoopEventLogger';
+import { NoopEventLoggerProvider } from '../../src/NoopEventLoggerProvider';
 
 describe('NoopLoggerProvider', () => {
   it('should not crash', () => {
-    const eventEmitterProvider = new NoopEventEmitterProvider();
+    const eventLoggerProvider = new NoopEventLoggerProvider();
 
     assert.ok(
-      eventEmitterProvider.getEventEmitter('emitter-name', 'domain') instanceof
-        NoopEventEmitter
+      eventLoggerProvider.getEventLogger('emitter-name', 'domain') instanceof
+        NoopEventLogger
     );
     assert.ok(
-      eventEmitterProvider.getEventEmitter(
+      eventLoggerProvider.getEventLogger(
         'emitter-name',
         'domain',
         'v1'
-      ) instanceof NoopEventEmitter
+      ) instanceof NoopEventLogger
     );
     assert.ok(
-      eventEmitterProvider.getEventEmitter('emitter-name', 'domain', 'v1', {
+      eventLoggerProvider.getEventLogger('emitter-name', 'domain', 'v1', {
         schemaUrl: 'https://opentelemetry.io/schemas/1.7.0',
-      }) instanceof NoopEventEmitter
+      }) instanceof NoopEventLogger
     );
   });
 });

--- a/experimental/packages/api-events/test/noop-implementations/noop-event-logger-provider.test.ts
+++ b/experimental/packages/api-events/test/noop-implementations/noop-event-logger-provider.test.ts
@@ -23,18 +23,18 @@ describe('NoopLoggerProvider', () => {
     const eventLoggerProvider = new NoopEventLoggerProvider();
 
     assert.ok(
-      eventLoggerProvider.getEventLogger('emitter-name', 'domain') instanceof
+      eventLoggerProvider.getEventLogger('logger-name', 'domain') instanceof
         NoopEventLogger
     );
     assert.ok(
       eventLoggerProvider.getEventLogger(
-        'emitter-name',
+        'logger-name',
         'domain',
         'v1'
       ) instanceof NoopEventLogger
     );
     assert.ok(
-      eventLoggerProvider.getEventLogger('emitter-name', 'domain', 'v1', {
+      eventLoggerProvider.getEventLogger('logger-name', 'domain', 'v1', {
         schemaUrl: 'https://opentelemetry.io/schemas/1.7.0',
       }) instanceof NoopEventLogger
     );

--- a/experimental/packages/api-events/test/noop-implementations/noop-event-logger-provider.test.ts
+++ b/experimental/packages/api-events/test/noop-implementations/noop-event-logger-provider.test.ts
@@ -27,10 +27,8 @@ describe('NoopLoggerProvider', () => {
         NoopEventLogger
     );
     assert.ok(
-      eventLoggerProvider.getEventLogger(
-        'logger-name',
-        'v1'
-      ) instanceof NoopEventLogger
+      eventLoggerProvider.getEventLogger('logger-name', 'v1') instanceof
+        NoopEventLogger
     );
     assert.ok(
       eventLoggerProvider.getEventLogger('logger-name', 'v1', {

--- a/experimental/packages/api-events/test/noop-implementations/noop-event-logger.test.ts
+++ b/experimental/packages/api-events/test/noop-implementations/noop-event-logger.test.ts
@@ -15,20 +15,20 @@
  */
 
 import * as assert from 'assert';
-import { NoopEventEmitter } from '../../src/NoopEventEmitter';
-import { NoopEventEmitterProvider } from '../../src/NoopEventEmitterProvider';
+import { NoopEventLogger } from '../../src/NoopEventLogger';
+import { NoopEventLoggerProvider } from '../../src/NoopEventLoggerProvider';
 
-describe('NoopEventEmitter', () => {
+describe('NoopEventLogger', () => {
   it('constructor should not crash', () => {
-    const logger = new NoopEventEmitterProvider().getEventEmitter(
+    const logger = new NoopEventLoggerProvider().getEventLogger(
       'test-noop',
       'test-domain'
     );
-    assert(logger instanceof NoopEventEmitter);
+    assert(logger instanceof NoopEventLogger);
   });
 
   it('calling emit should not crash', () => {
-    const emitter = new NoopEventEmitterProvider().getEventEmitter(
+    const emitter = new NoopEventLoggerProvider().getEventLogger(
       'test-noop',
       'test-domain'
     );

--- a/experimental/packages/api-events/test/noop-implementations/noop-event-logger.test.ts
+++ b/experimental/packages/api-events/test/noop-implementations/noop-event-logger.test.ts
@@ -20,16 +20,12 @@ import { NoopEventLoggerProvider } from '../../src/NoopEventLoggerProvider';
 
 describe('NoopEventLogger', () => {
   it('constructor should not crash', () => {
-    const logger = new NoopEventLoggerProvider().getEventLogger(
-      'test-noop',
-    );
+    const logger = new NoopEventLoggerProvider().getEventLogger('test-noop');
     assert(logger instanceof NoopEventLogger);
   });
 
   it('calling emit should not crash', () => {
-    const logger = new NoopEventLoggerProvider().getEventLogger(
-      'test-noop',
-    );
+    const logger = new NoopEventLoggerProvider().getEventLogger('test-noop');
     logger.emit({
       name: 'event name',
     });

--- a/experimental/packages/api-events/test/noop-implementations/noop-event-logger.test.ts
+++ b/experimental/packages/api-events/test/noop-implementations/noop-event-logger.test.ts
@@ -28,11 +28,11 @@ describe('NoopEventLogger', () => {
   });
 
   it('calling emit should not crash', () => {
-    const emitter = new NoopEventLoggerProvider().getEventLogger(
+    const logger = new NoopEventLoggerProvider().getEventLogger(
       'test-noop',
       'test-domain'
     );
-    emitter.emit({
+    logger.emit({
       name: 'event name',
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

As discussed in https://github.com/open-telemetry/opentelemetry-specification/pull/3869, the decision has been made in the Specification SIG meeting on 3/2/24 to rename EventEmitter to EventLogger in the API.

Technically this is a breaking change. But the API is in very early experimental stage without a default SDK implementation.  

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
