### PR TITLE
Remove domain from the Events API

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to experimental packages in this project will be documented 
       * was used internally to keep track of the service client used by the exporter, as a side effect it allowed end-users to modify the gRPC service client that was used
     * `compression`
       * was used internally to keep track of the compression to use but was unintentionally exposed to the users. It allowed to read and write the value, writing, however, would have no effect.
+* feat(api-events)!: removed domain from the Events API [#4569](https://github.com/open-telemetry/opentelemetry-js/pull/4569)
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/api-events/README.md
+++ b/experimental/packages/api-events/README.md
@@ -39,7 +39,7 @@ api.events.getEventEmitterProvider();
 const eventEmitter = api.events.getEventEmitter(name, version);
 
 // logging an event in an instrumentation library
-eventEmitter.emit({ name: 'event-name', domain: 'event-domain' });
+eventEmitter.emit({ name: 'event-name' });
 ```
 
 ## Useful links

--- a/experimental/packages/api-events/src/NoopEventEmitterProvider.ts
+++ b/experimental/packages/api-events/src/NoopEventEmitterProvider.ts
@@ -22,7 +22,6 @@ import { NoopEventEmitter } from './NoopEventEmitter';
 export class NoopEventEmitterProvider implements EventEmitterProvider {
   getEventEmitter(
     _name: string,
-    _domain: string,
     _version?: string | undefined,
     _options?: EventEmitterOptions | undefined
   ): EventEmitter {

--- a/experimental/packages/api-events/src/api/events.ts
+++ b/experimental/packages/api-events/src/api/events.ts
@@ -73,13 +73,11 @@ export class EventsAPI {
    */
   public getEventEmitter(
     name: string,
-    domain: string,
     version?: string,
     options?: EventEmitterOptions
   ): EventEmitter {
     return this.getEventEmitterProvider().getEventEmitter(
       name,
-      domain,
       version,
       options
     );

--- a/experimental/packages/api-events/src/types/EventEmitterProvider.ts
+++ b/experimental/packages/api-events/src/types/EventEmitterProvider.ts
@@ -26,14 +26,12 @@ export interface EventEmitterProvider {
    * schemaUrl pair is not already created.
    *
    * @param name The name of the event emitter or instrumentation library.
-   * @param domain The domain for events created by the event emitter.
    * @param version The version of the event emitter or instrumentation library.
    * @param options The options of the event emitter or instrumentation library.
    * @returns EventEmitter An event emitter with the given name and version.
    */
   getEventEmitter(
     name: string,
-    domain: string,
     version?: string,
     options?: EventEmitterOptions
   ): EventEmitter;

--- a/experimental/packages/api-events/test/api/api.test.ts
+++ b/experimental/packages/api-events/test/api/api.test.ts
@@ -37,7 +37,7 @@ describe('API', () => {
       events.setGlobalEventEmitterProvider(new TestEventEmitterProvider());
       const eventEmitter = events
         .getEventEmitterProvider()
-        .getEventEmitter('name', 'domain');
+        .getEventEmitter('name');
       assert.deepStrictEqual(eventEmitter, dummyEventEmitter);
     });
 
@@ -58,7 +58,7 @@ describe('API', () => {
 
     it('should return a event emitter instance from global provider', () => {
       events.setGlobalEventEmitterProvider(new TestEventEmitterProvider());
-      const eventEmitter = events.getEventEmitter('myEventEmitter', 'domain');
+      const eventEmitter = events.getEventEmitter('myEventEmitter');
       assert.deepStrictEqual(eventEmitter, dummyEventEmitter);
     });
   });

--- a/experimental/packages/api-events/test/noop-implementations/noop-event-emitter-provider.test.ts
+++ b/experimental/packages/api-events/test/noop-implementations/noop-event-emitter-provider.test.ts
@@ -27,10 +27,8 @@ describe('NoopLoggerProvider', () => {
         NoopEventEmitter
     );
     assert.ok(
-      eventEmitterProvider.getEventEmitter(
-        'emitter-name',
-        'v1'
-      ) instanceof NoopEventEmitter
+      eventEmitterProvider.getEventEmitter('emitter-name', 'v1') instanceof
+        NoopEventEmitter
     );
     assert.ok(
       eventEmitterProvider.getEventEmitter('emitter-name', 'v1', {

--- a/experimental/packages/api-events/test/noop-implementations/noop-event-emitter-provider.test.ts
+++ b/experimental/packages/api-events/test/noop-implementations/noop-event-emitter-provider.test.ts
@@ -23,18 +23,17 @@ describe('NoopLoggerProvider', () => {
     const eventEmitterProvider = new NoopEventEmitterProvider();
 
     assert.ok(
-      eventEmitterProvider.getEventEmitter('emitter-name', 'domain') instanceof
+      eventEmitterProvider.getEventEmitter('emitter-name') instanceof
         NoopEventEmitter
     );
     assert.ok(
       eventEmitterProvider.getEventEmitter(
         'emitter-name',
-        'domain',
         'v1'
       ) instanceof NoopEventEmitter
     );
     assert.ok(
-      eventEmitterProvider.getEventEmitter('emitter-name', 'domain', 'v1', {
+      eventEmitterProvider.getEventEmitter('emitter-name', 'v1', {
         schemaUrl: 'https://opentelemetry.io/schemas/1.7.0',
       }) instanceof NoopEventEmitter
     );

--- a/experimental/packages/api-events/test/noop-implementations/noop-event-emitter.test.ts
+++ b/experimental/packages/api-events/test/noop-implementations/noop-event-emitter.test.ts
@@ -22,7 +22,6 @@ describe('NoopEventEmitter', () => {
   it('constructor should not crash', () => {
     const logger = new NoopEventEmitterProvider().getEventEmitter(
       'test-noop',
-      'test-domain'
     );
     assert(logger instanceof NoopEventEmitter);
   });
@@ -30,7 +29,6 @@ describe('NoopEventEmitter', () => {
   it('calling emit should not crash', () => {
     const emitter = new NoopEventEmitterProvider().getEventEmitter(
       'test-noop',
-      'test-domain'
     );
     emitter.emit({
       name: 'event name',

--- a/experimental/packages/api-events/test/noop-implementations/noop-event-emitter.test.ts
+++ b/experimental/packages/api-events/test/noop-implementations/noop-event-emitter.test.ts
@@ -20,16 +20,12 @@ import { NoopEventEmitterProvider } from '../../src/NoopEventEmitterProvider';
 
 describe('NoopEventEmitter', () => {
   it('constructor should not crash', () => {
-    const logger = new NoopEventEmitterProvider().getEventEmitter(
-      'test-noop',
-    );
+    const logger = new NoopEventEmitterProvider().getEventEmitter('test-noop');
     assert(logger instanceof NoopEventEmitter);
   });
 
   it('calling emit should not crash', () => {
-    const emitter = new NoopEventEmitterProvider().getEventEmitter(
-      'test-noop',
-    );
+    const emitter = new NoopEventEmitterProvider().getEventEmitter('test-noop');
     emitter.emit({
       name: 'event name',
     });


### PR DESCRIPTION
## Which problem is this PR solving?

`event domain` was removed from the specification in this PR https://github.com/open-telemetry/opentelemetry-specification/pull/3749.

Fixes # https://github.com/open-telemetry/opentelemetry-specification/issues/2994

## Short description of the changes

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)