### PR TITLE
feat(opentelemetry-instrumentation-xhr): optionally ignore network events

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :rocket: (Enhancement)
 
+* feat(opentelemetry-instrumentation-xhr): optionally ignore network events [#4571](https://github.com/open-telemetry/opentelemetry-js/pull/4571/) @mustafahaddara
 * refactor(instr-http): use exported strings for semconv. [#4573](https://github.com/open-telemetry/opentelemetry-js/pull/4573/) @JamieDanielson
 * feat(sdk-node): add `HostDetector` as default resource detector
 

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/README.md
@@ -64,6 +64,15 @@ req.send();
 
 ```
 
+### XHR Instrumentation options
+
+XHR instrumentation plugin has few options available to choose from. You can set the following:
+
+| Options                                                                                                                                                                           | Type                         | Description                                                                             |
+|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------|-----------------------------------------------------------------------------------------|
+| [`applyCustomAttributesOnSpan`](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts#L76) | `XHRCustomAttributeFunction` | Function for adding custom attributes                                                   |
+| [`ignoreNetworkEvents`](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts#L78)         | `boolean`                    | Disable network events being added as span events (network events are added by default) |
+
 ## Example Screenshots
 
 ![Screenshot of the running example](images/main.jpg)

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -74,6 +74,8 @@ export interface XMLHttpRequestInstrumentationConfig
   ignoreUrls?: Array<string | RegExp>;
   /** Function for adding custom attributes on the span */
   applyCustomAttributesOnSpan?: XHRCustomAttributeFunction;
+  /** Ignore adding network events as span events */
+  ignoreNetworkEvents?: boolean;
 }
 
 /**
@@ -140,7 +142,9 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
       const childSpan = this.tracer.startSpan('CORS Preflight', {
         startTime: corsPreFlightRequest[PTN.FETCH_START],
       });
-      addSpanNetworkEvents(childSpan, corsPreFlightRequest);
+      if (!this._getConfig().ignoreNetworkEvents) {
+        addSpanNetworkEvents(childSpan, corsPreFlightRequest);
+      }
       childSpan.end(corsPreFlightRequest[PTN.RESPONSE_END]);
     });
   }
@@ -292,7 +296,9 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
         this._addChildSpan(span, corsPreFlightRequest);
         this._markResourceAsUsed(corsPreFlightRequest);
       }
-      addSpanNetworkEvents(span, mainRequest);
+      if (!this._getConfig().ignoreNetworkEvents) {
+        addSpanNetworkEvents(span, mainRequest);
+      }
     }
   }
 

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -783,6 +783,20 @@ describe('xhr', () => {
             );
           });
         });
+
+        describe('when network events are ignored', () => {
+          beforeEach(done => {
+            clearData();
+            prepareData(done, url, {
+              ignoreNetworkEvents: true,
+            });
+          });
+          it('should NOT add network events', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const events = span.events;
+            assert.strictEqual(events.length, 3, 'number of events is wrong');
+          });
+        });
       });
 
       describe('when request is NOT successful', () => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

PR https://github.com/open-telemetry/opentelemetry-js/pull/3028 added a `ignoreNetworkEvents` boolean to the `experimental/opentelemetry-instrumentation-fetch` package. This PR adds the same behaviour + flag to the `experimental/opentelemetry-instrumentation-xml-http-request` package. 

Quoting from that PR

> Summary: This PR allows to optionally disable adding network events as span events to control the total volume of telemetry data produced.
> 
> Some of the modern vendors treat spans and span events (annotations) equally – both are counted towards the overall retained events volume. Similarly, vendors that charge for the overall size of data retained will count span annotations as part of the data. Typically, span produced by the @opentelemetry-instrumentation-fetch includes 9 network events – 10 event items along with the span itself. It would be great to have ability to optionally disable network events being added as span annotations to reduce the overall volume of data/events generated and eventually retained.

## Short description of the changes
This PR adds an optional boolean flag `ignoreNetworkEvents` to the XMLHttpRequest instrumentation. When set to true network events are not added to the span.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Running npm run test:browser will run the newly added test as part of the suite:

    ...
    when network events are ignored
      ✓ should NOT add network events


## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206873139078450