### PR TITLE
refactor(instr-http): use exported strings for semconv

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :rocket: (Enhancement)
 
+* refactor(instr-http): use exported strings for semconv. [#4573](https://github.com/open-telemetry/opentelemetry-js/pull/4573/) @JamieDanielson
+
 ### :bug: (Bug Fix)
 
 * fix(exporter-*-otlp-*): use parseHeaders() to ensure header-values are not 'undefined' #4540

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -58,7 +58,7 @@ import {
 } from '@opentelemetry/instrumentation';
 import { RPCMetadata, RPCType, setRPCMetadata } from '@opentelemetry/core';
 import { errorMonitor } from 'events';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 
 /**
  * Http instrumentation instrumentation for Opentelemetry
@@ -746,7 +746,7 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       code: utils.parseResponseStatus(SpanKind.SERVER, response.statusCode),
     });
 
-    const route = attributes[SemanticAttributes.HTTP_ROUTE];
+    const route = attributes[SEMATTRS_HTTP_ROUTE];
     if (route) {
       span.updateName(`${request.method || 'GET'} ${route}`);
     }

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -22,8 +22,30 @@ import {
   SpanKind,
 } from '@opentelemetry/api';
 import {
-  NetTransportValues,
-  SemanticAttributes,
+  NETTRANSPORTVALUES_IP_TCP,
+  NETTRANSPORTVALUES_IP_UDP,
+  SEMATTRS_HTTP_CLIENT_IP,
+  SEMATTRS_HTTP_FLAVOR,
+  SEMATTRS_HTTP_HOST,
+  SEMATTRS_HTTP_METHOD,
+  SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH,
+  SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
+  SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH,
+  SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
+  SEMATTRS_HTTP_ROUTE,
+  SEMATTRS_HTTP_SCHEME,
+  SEMATTRS_HTTP_SERVER_NAME,
+  SEMATTRS_HTTP_STATUS_CODE,
+  SEMATTRS_HTTP_TARGET,
+  SEMATTRS_HTTP_URL,
+  SEMATTRS_HTTP_USER_AGENT,
+  SEMATTRS_NET_HOST_IP,
+  SEMATTRS_NET_HOST_NAME,
+  SEMATTRS_NET_HOST_PORT,
+  SEMATTRS_NET_PEER_IP,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
+  SEMATTRS_NET_TRANSPORT,
 } from '@opentelemetry/semantic-conventions';
 import {
   IncomingHttpHeaders,
@@ -167,10 +189,9 @@ export const setRequestContentLengthAttribute = (
   if (length === null) return;
 
   if (isCompressed(request.headers)) {
-    attributes[SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH] = length;
+    attributes[SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH] = length;
   } else {
-    attributes[SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED] =
-      length;
+    attributes[SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED] = length;
   }
 };
 
@@ -187,10 +208,9 @@ export const setResponseContentLengthAttribute = (
   if (length === null) return;
 
   if (isCompressed(response.headers)) {
-    attributes[SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH] = length;
+    attributes[SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH] = length;
   } else {
-    attributes[SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED] =
-      length;
+    attributes[SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED] = length;
   }
 };
 
@@ -343,20 +363,19 @@ export const getOutgoingRequestAttributes = (
   const headers = requestOptions.headers || {};
   const userAgent = headers['user-agent'];
   const attributes: SpanAttributes = {
-    [SemanticAttributes.HTTP_URL]: getAbsoluteUrl(
+    [SEMATTRS_HTTP_URL]: getAbsoluteUrl(
       requestOptions,
       headers,
       `${options.component}:`
     ),
-    [SemanticAttributes.HTTP_METHOD]: method,
-    [SemanticAttributes.HTTP_TARGET]: requestOptions.path || '/',
-    [SemanticAttributes.NET_PEER_NAME]: hostname,
-    [SemanticAttributes.HTTP_HOST]:
-      requestOptions.headers?.host ?? `${hostname}:${port}`,
+    [SEMATTRS_HTTP_METHOD]: method,
+    [SEMATTRS_HTTP_TARGET]: requestOptions.path || '/',
+    [SEMATTRS_NET_PEER_NAME]: hostname,
+    [SEMATTRS_HTTP_HOST]: requestOptions.headers?.host ?? `${hostname}:${port}`,
   };
 
   if (userAgent !== undefined) {
-    attributes[SemanticAttributes.HTTP_USER_AGENT] = userAgent;
+    attributes[SEMATTRS_HTTP_USER_AGENT] = userAgent;
   }
   return Object.assign(attributes, options.hookAttributes);
 };
@@ -369,10 +388,9 @@ export const getOutgoingRequestMetricAttributes = (
   spanAttributes: SpanAttributes
 ): MetricAttributes => {
   const metricAttributes: MetricAttributes = {};
-  metricAttributes[SemanticAttributes.HTTP_METHOD] =
-    spanAttributes[SemanticAttributes.HTTP_METHOD];
-  metricAttributes[SemanticAttributes.NET_PEER_NAME] =
-    spanAttributes[SemanticAttributes.NET_PEER_NAME];
+  metricAttributes[SEMATTRS_HTTP_METHOD] = spanAttributes[SEMATTRS_HTTP_METHOD];
+  metricAttributes[SEMATTRS_NET_PEER_NAME] =
+    spanAttributes[SEMATTRS_NET_PEER_NAME];
   //TODO: http.url attribute, it should substitute any parameters to avoid high cardinality.
   return metricAttributes;
 };
@@ -384,11 +402,11 @@ export const getOutgoingRequestMetricAttributes = (
 export const getAttributesFromHttpKind = (kind?: string): SpanAttributes => {
   const attributes: SpanAttributes = {};
   if (kind) {
-    attributes[SemanticAttributes.HTTP_FLAVOR] = kind;
+    attributes[SEMATTRS_HTTP_FLAVOR] = kind;
     if (kind.toUpperCase() !== 'QUIC') {
-      attributes[SemanticAttributes.NET_TRANSPORT] = NetTransportValues.IP_TCP;
+      attributes[SEMATTRS_NET_TRANSPORT] = NETTRANSPORTVALUES_IP_TCP;
     } else {
-      attributes[SemanticAttributes.NET_TRANSPORT] = NetTransportValues.IP_UDP;
+      attributes[SEMATTRS_NET_TRANSPORT] = NETTRANSPORTVALUES_IP_UDP;
     }
   }
   return attributes;
@@ -406,13 +424,13 @@ export const getOutgoingRequestAttributesOnResponse = (
   const attributes: SpanAttributes = {};
   if (socket) {
     const { remoteAddress, remotePort } = socket;
-    attributes[SemanticAttributes.NET_PEER_IP] = remoteAddress;
-    attributes[SemanticAttributes.NET_PEER_PORT] = remotePort;
+    attributes[SEMATTRS_NET_PEER_IP] = remoteAddress;
+    attributes[SEMATTRS_NET_PEER_PORT] = remotePort;
   }
   setResponseContentLengthAttribute(response, attributes);
 
   if (statusCode) {
-    attributes[SemanticAttributes.HTTP_STATUS_CODE] = statusCode;
+    attributes[SEMATTRS_HTTP_STATUS_CODE] = statusCode;
     attributes[AttributeNames.HTTP_STATUS_TEXT] = (
       statusMessage || ''
     ).toUpperCase();
@@ -430,12 +448,11 @@ export const getOutgoingRequestMetricAttributesOnResponse = (
   spanAttributes: SpanAttributes
 ): MetricAttributes => {
   const metricAttributes: MetricAttributes = {};
-  metricAttributes[SemanticAttributes.NET_PEER_PORT] =
-    spanAttributes[SemanticAttributes.NET_PEER_PORT];
-  metricAttributes[SemanticAttributes.HTTP_STATUS_CODE] =
-    spanAttributes[SemanticAttributes.HTTP_STATUS_CODE];
-  metricAttributes[SemanticAttributes.HTTP_FLAVOR] =
-    spanAttributes[SemanticAttributes.HTTP_FLAVOR];
+  metricAttributes[SEMATTRS_NET_PEER_PORT] =
+    spanAttributes[SEMATTRS_NET_PEER_PORT];
+  metricAttributes[SEMATTRS_HTTP_STATUS_CODE] =
+    spanAttributes[SEMATTRS_HTTP_STATUS_CODE];
+  metricAttributes[SEMATTRS_HTTP_FLAVOR] = spanAttributes[SEMATTRS_HTTP_FLAVOR];
   return metricAttributes;
 };
 
@@ -465,31 +482,31 @@ export const getIncomingRequestAttributes = (
     'localhost';
   const serverName = options.serverName;
   const attributes: SpanAttributes = {
-    [SemanticAttributes.HTTP_URL]: getAbsoluteUrl(
+    [SEMATTRS_HTTP_URL]: getAbsoluteUrl(
       requestUrl,
       headers,
       `${options.component}:`
     ),
-    [SemanticAttributes.HTTP_HOST]: host,
-    [SemanticAttributes.NET_HOST_NAME]: hostname,
-    [SemanticAttributes.HTTP_METHOD]: method,
-    [SemanticAttributes.HTTP_SCHEME]: options.component,
+    [SEMATTRS_HTTP_HOST]: host,
+    [SEMATTRS_NET_HOST_NAME]: hostname,
+    [SEMATTRS_HTTP_METHOD]: method,
+    [SEMATTRS_HTTP_SCHEME]: options.component,
   };
 
   if (typeof ips === 'string') {
-    attributes[SemanticAttributes.HTTP_CLIENT_IP] = ips.split(',')[0];
+    attributes[SEMATTRS_HTTP_CLIENT_IP] = ips.split(',')[0];
   }
 
   if (typeof serverName === 'string') {
-    attributes[SemanticAttributes.HTTP_SERVER_NAME] = serverName;
+    attributes[SEMATTRS_HTTP_SERVER_NAME] = serverName;
   }
 
   if (requestUrl) {
-    attributes[SemanticAttributes.HTTP_TARGET] = requestUrl.path || '/';
+    attributes[SEMATTRS_HTTP_TARGET] = requestUrl.path || '/';
   }
 
   if (userAgent !== undefined) {
-    attributes[SemanticAttributes.HTTP_USER_AGENT] = userAgent;
+    attributes[SEMATTRS_HTTP_USER_AGENT] = userAgent;
   }
   setRequestContentLengthAttribute(request, attributes);
 
@@ -506,14 +523,11 @@ export const getIncomingRequestMetricAttributes = (
   spanAttributes: SpanAttributes
 ): MetricAttributes => {
   const metricAttributes: MetricAttributes = {};
-  metricAttributes[SemanticAttributes.HTTP_SCHEME] =
-    spanAttributes[SemanticAttributes.HTTP_SCHEME];
-  metricAttributes[SemanticAttributes.HTTP_METHOD] =
-    spanAttributes[SemanticAttributes.HTTP_METHOD];
-  metricAttributes[SemanticAttributes.NET_HOST_NAME] =
-    spanAttributes[SemanticAttributes.NET_HOST_NAME];
-  metricAttributes[SemanticAttributes.HTTP_FLAVOR] =
-    spanAttributes[SemanticAttributes.HTTP_FLAVOR];
+  metricAttributes[SEMATTRS_HTTP_SCHEME] = spanAttributes[SEMATTRS_HTTP_SCHEME];
+  metricAttributes[SEMATTRS_HTTP_METHOD] = spanAttributes[SEMATTRS_HTTP_METHOD];
+  metricAttributes[SEMATTRS_NET_HOST_NAME] =
+    spanAttributes[SEMATTRS_NET_HOST_NAME];
+  metricAttributes[SEMATTRS_HTTP_FLAVOR] = spanAttributes[SEMATTRS_HTTP_FLAVOR];
   //TODO: http.target attribute, it should substitute any parameters to avoid high cardinality.
   return metricAttributes;
 };
@@ -535,18 +549,18 @@ export const getIncomingRequestAttributesOnResponse = (
   const attributes: SpanAttributes = {};
   if (socket) {
     const { localAddress, localPort, remoteAddress, remotePort } = socket;
-    attributes[SemanticAttributes.NET_HOST_IP] = localAddress;
-    attributes[SemanticAttributes.NET_HOST_PORT] = localPort;
-    attributes[SemanticAttributes.NET_PEER_IP] = remoteAddress;
-    attributes[SemanticAttributes.NET_PEER_PORT] = remotePort;
+    attributes[SEMATTRS_NET_HOST_IP] = localAddress;
+    attributes[SEMATTRS_NET_HOST_PORT] = localPort;
+    attributes[SEMATTRS_NET_PEER_IP] = remoteAddress;
+    attributes[SEMATTRS_NET_PEER_PORT] = remotePort;
   }
-  attributes[SemanticAttributes.HTTP_STATUS_CODE] = statusCode;
+  attributes[SEMATTRS_HTTP_STATUS_CODE] = statusCode;
   attributes[AttributeNames.HTTP_STATUS_TEXT] = (
     statusMessage || ''
   ).toUpperCase();
 
   if (rpcMetadata?.type === RPCType.HTTP && rpcMetadata.route !== undefined) {
-    attributes[SemanticAttributes.HTTP_ROUTE] = rpcMetadata.route;
+    attributes[SEMATTRS_HTTP_ROUTE] = rpcMetadata.route;
   }
   return attributes;
 };
@@ -559,13 +573,12 @@ export const getIncomingRequestMetricAttributesOnResponse = (
   spanAttributes: SpanAttributes
 ): MetricAttributes => {
   const metricAttributes: MetricAttributes = {};
-  metricAttributes[SemanticAttributes.HTTP_STATUS_CODE] =
-    spanAttributes[SemanticAttributes.HTTP_STATUS_CODE];
-  metricAttributes[SemanticAttributes.NET_HOST_PORT] =
-    spanAttributes[SemanticAttributes.NET_HOST_PORT];
-  if (spanAttributes[SemanticAttributes.HTTP_ROUTE] !== undefined) {
-    metricAttributes[SemanticAttributes.HTTP_ROUTE] =
-      spanAttributes[SemanticAttributes.HTTP_ROUTE];
+  metricAttributes[SEMATTRS_HTTP_STATUS_CODE] =
+    spanAttributes[SEMATTRS_HTTP_STATUS_CODE];
+  metricAttributes[SEMATTRS_NET_HOST_PORT] =
+    spanAttributes[SEMATTRS_NET_HOST_PORT];
+  if (spanAttributes[SEMATTRS_HTTP_ROUTE] !== undefined) {
+    metricAttributes[SEMATTRS_HTTP_ROUTE] = spanAttributes[SEMATTRS_HTTP_ROUTE];
   }
   return metricAttributes;
 };

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
@@ -30,8 +30,14 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import {
-  NetTransportValues,
-  SemanticAttributes,
+  NETTRANSPORTVALUES_IP_TCP,
+  SEMATTRS_HTTP_CLIENT_IP,
+  SEMATTRS_HTTP_FLAVOR,
+  SEMATTRS_HTTP_ROUTE,
+  SEMATTRS_HTTP_STATUS_CODE,
+  SEMATTRS_NET_HOST_PORT,
+  SEMATTRS_NET_PEER_PORT,
+  SEMATTRS_NET_TRANSPORT,
 } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import * as nock from 'nock';
@@ -211,11 +217,11 @@ describe('HttpInstrumentation', () => {
         assertSpan(incomingSpan, SpanKind.SERVER, validations);
         assertSpan(outgoingSpan, SpanKind.CLIENT, validations);
         assert.strictEqual(
-          incomingSpan.attributes[SemanticAttributes.NET_HOST_PORT],
+          incomingSpan.attributes[SEMATTRS_NET_HOST_PORT],
           serverPort
         );
         assert.strictEqual(
-          outgoingSpan.attributes[SemanticAttributes.NET_PEER_PORT],
+          outgoingSpan.attributes[SEMATTRS_NET_PEER_PORT],
           serverPort
         );
       });
@@ -329,28 +335,25 @@ describe('HttpInstrumentation', () => {
 
         assert.strictEqual(spans.length, 2);
         assert.strictEqual(
-          incomingSpan.attributes[SemanticAttributes.HTTP_CLIENT_IP],
+          incomingSpan.attributes[SEMATTRS_HTTP_CLIENT_IP],
           '<client>'
         );
         assert.strictEqual(
-          incomingSpan.attributes[SemanticAttributes.NET_HOST_PORT],
+          incomingSpan.attributes[SEMATTRS_NET_HOST_PORT],
           serverPort
         );
         assert.strictEqual(
-          outgoingSpan.attributes[SemanticAttributes.NET_PEER_PORT],
+          outgoingSpan.attributes[SEMATTRS_NET_PEER_PORT],
           serverPort
         );
         [
           { span: incomingSpan, kind: SpanKind.SERVER },
           { span: outgoingSpan, kind: SpanKind.CLIENT },
         ].forEach(({ span, kind }) => {
+          assert.strictEqual(span.attributes[SEMATTRS_HTTP_FLAVOR], '1.1');
           assert.strictEqual(
-            span.attributes[SemanticAttributes.HTTP_FLAVOR],
-            '1.1'
-          );
-          assert.strictEqual(
-            span.attributes[SemanticAttributes.NET_TRANSPORT],
-            NetTransportValues.IP_TCP
+            span.attributes[SEMATTRS_NET_TRANSPORT],
+            NETTRANSPORTVALUES_IP_TCP
           );
           assertSpan(span, kind, validations);
         });
@@ -363,10 +366,7 @@ describe('HttpInstrumentation', () => {
         const span = memoryExporter.getFinishedSpans()[0];
 
         assert.strictEqual(span.kind, SpanKind.SERVER);
-        assert.strictEqual(
-          span.attributes[SemanticAttributes.HTTP_ROUTE],
-          'TheRoute'
-        );
+        assert.strictEqual(span.attributes[SEMATTRS_HTTP_ROUTE], 'TheRoute');
         assert.strictEqual(span.name, 'GET TheRoute');
       });
 
@@ -796,10 +796,7 @@ describe('HttpInstrumentation', () => {
             const [span] = spans;
             assert.strictEqual(spans.length, 1);
             assert.ok(Object.keys(span.attributes).length > 6);
-            assert.strictEqual(
-              span.attributes[SemanticAttributes.HTTP_STATUS_CODE],
-              404
-            );
+            assert.strictEqual(span.attributes[SEMATTRS_HTTP_STATUS_CODE], 404);
             assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
             done();
           });

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
@@ -20,7 +20,16 @@ import {
   MeterProvider,
 } from '@opentelemetry/sdk-metrics';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_HTTP_FLAVOR,
+  SEMATTRS_HTTP_METHOD,
+  SEMATTRS_HTTP_SCHEME,
+  SEMATTRS_HTTP_STATUS_CODE,
+  SEMATTRS_NET_HOST_NAME,
+  SEMATTRS_NET_HOST_PORT,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
+} from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import { HttpInstrumentation } from '../../src/http';
 import { httpRequest } from '../utils/httpRequest';
@@ -91,27 +100,27 @@ describe('metrics', () => {
       requestCount
     );
     assert.strictEqual(
-      metrics[0].dataPoints[0].attributes[SemanticAttributes.HTTP_SCHEME],
+      metrics[0].dataPoints[0].attributes[SEMATTRS_HTTP_SCHEME],
       'http'
     );
     assert.strictEqual(
-      metrics[0].dataPoints[0].attributes[SemanticAttributes.HTTP_METHOD],
+      metrics[0].dataPoints[0].attributes[SEMATTRS_HTTP_METHOD],
       'GET'
     );
     assert.strictEqual(
-      metrics[0].dataPoints[0].attributes[SemanticAttributes.HTTP_FLAVOR],
+      metrics[0].dataPoints[0].attributes[SEMATTRS_HTTP_FLAVOR],
       '1.1'
     );
     assert.strictEqual(
-      metrics[0].dataPoints[0].attributes[SemanticAttributes.NET_HOST_NAME],
+      metrics[0].dataPoints[0].attributes[SEMATTRS_NET_HOST_NAME],
       'localhost'
     );
     assert.strictEqual(
-      metrics[0].dataPoints[0].attributes[SemanticAttributes.HTTP_STATUS_CODE],
+      metrics[0].dataPoints[0].attributes[SEMATTRS_HTTP_STATUS_CODE],
       200
     );
     assert.strictEqual(
-      metrics[0].dataPoints[0].attributes[SemanticAttributes.NET_HOST_PORT],
+      metrics[0].dataPoints[0].attributes[SEMATTRS_NET_HOST_PORT],
       22346
     );
 
@@ -128,23 +137,23 @@ describe('metrics', () => {
       requestCount
     );
     assert.strictEqual(
-      metrics[1].dataPoints[0].attributes[SemanticAttributes.HTTP_METHOD],
+      metrics[1].dataPoints[0].attributes[SEMATTRS_HTTP_METHOD],
       'GET'
     );
     assert.strictEqual(
-      metrics[1].dataPoints[0].attributes[SemanticAttributes.NET_PEER_NAME],
+      metrics[1].dataPoints[0].attributes[SEMATTRS_NET_PEER_NAME],
       'localhost'
     );
     assert.strictEqual(
-      metrics[1].dataPoints[0].attributes[SemanticAttributes.NET_PEER_PORT],
+      metrics[1].dataPoints[0].attributes[SEMATTRS_NET_PEER_PORT],
       22346
     );
     assert.strictEqual(
-      metrics[1].dataPoints[0].attributes[SemanticAttributes.HTTP_STATUS_CODE],
+      metrics[1].dataPoints[0].attributes[SEMATTRS_HTTP_STATUS_CODE],
       200
     );
     assert.strictEqual(
-      metrics[1].dataPoints[0].attributes[SemanticAttributes.HTTP_FLAVOR],
+      metrics[1].dataPoints[0].attributes[SEMATTRS_HTTP_FLAVOR],
       '1.1'
     );
   });

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
@@ -30,8 +30,13 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import {
-  NetTransportValues,
-  SemanticAttributes,
+  NETTRANSPORTVALUES_IP_TCP,
+  SEMATTRS_HTTP_CLIENT_IP,
+  SEMATTRS_HTTP_FLAVOR,
+  SEMATTRS_HTTP_STATUS_CODE,
+  SEMATTRS_NET_HOST_PORT,
+  SEMATTRS_NET_PEER_PORT,
+  SEMATTRS_NET_TRANSPORT,
 } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import * as fs from 'fs';
@@ -170,11 +175,11 @@ describe('HttpsInstrumentation', () => {
         assertSpan(incomingSpan, SpanKind.SERVER, validations);
         assertSpan(outgoingSpan, SpanKind.CLIENT, validations);
         assert.strictEqual(
-          incomingSpan.attributes[SemanticAttributes.NET_HOST_PORT],
+          incomingSpan.attributes[SEMATTRS_NET_HOST_PORT],
           serverPort
         );
         assert.strictEqual(
-          outgoingSpan.attributes[SemanticAttributes.NET_PEER_PORT],
+          outgoingSpan.attributes[SEMATTRS_NET_PEER_PORT],
           serverPort
         );
       });
@@ -264,15 +269,15 @@ describe('HttpsInstrumentation', () => {
 
         assert.strictEqual(spans.length, 2);
         assert.strictEqual(
-          incomingSpan.attributes[SemanticAttributes.HTTP_CLIENT_IP],
+          incomingSpan.attributes[SEMATTRS_HTTP_CLIENT_IP],
           '<client>'
         );
         assert.strictEqual(
-          incomingSpan.attributes[SemanticAttributes.NET_HOST_PORT],
+          incomingSpan.attributes[SEMATTRS_NET_HOST_PORT],
           serverPort
         );
         assert.strictEqual(
-          outgoingSpan.attributes[SemanticAttributes.NET_PEER_PORT],
+          outgoingSpan.attributes[SEMATTRS_NET_PEER_PORT],
           serverPort
         );
 
@@ -280,13 +285,10 @@ describe('HttpsInstrumentation', () => {
           { span: incomingSpan, kind: SpanKind.SERVER },
           { span: outgoingSpan, kind: SpanKind.CLIENT },
         ].forEach(({ span, kind }) => {
+          assert.strictEqual(span.attributes[SEMATTRS_HTTP_FLAVOR], '1.1');
           assert.strictEqual(
-            span.attributes[SemanticAttributes.HTTP_FLAVOR],
-            '1.1'
-          );
-          assert.strictEqual(
-            span.attributes[SemanticAttributes.NET_TRANSPORT],
-            NetTransportValues.IP_TCP
+            span.attributes[SEMATTRS_NET_TRANSPORT],
+            NETTRANSPORTVALUES_IP_TCP
           );
           assertSpan(span, kind, validations);
         });
@@ -694,10 +696,7 @@ describe('HttpsInstrumentation', () => {
             const [span] = spans;
             assert.strictEqual(spans.length, 1);
             assert.ok(Object.keys(span.attributes).length > 6);
-            assert.strictEqual(
-              span.attributes[SemanticAttributes.HTTP_STATUS_CODE],
-              404
-            );
+            assert.strictEqual(span.attributes[SEMATTRS_HTTP_STATUS_CODE], 404);
             assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
             done();
           });

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -23,7 +23,14 @@ import {
   Attributes,
 } from '@opentelemetry/api';
 import { BasicTracerProvider, Span } from '@opentelemetry/sdk-trace-base';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH,
+  SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
+  SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH,
+  SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
+  SEMATTRS_HTTP_ROUTE,
+  SEMATTRS_HTTP_TARGET,
+} from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import { IncomingMessage, ServerResponse } from 'http';
 import { Socket } from 'net';
@@ -301,10 +308,7 @@ describe('Utility', () => {
             request,
             {} as ServerResponse
           );
-          assert.deepStrictEqual(
-            attributes[SemanticAttributes.HTTP_ROUTE],
-            '/user/:id'
-          );
+          assert.deepStrictEqual(attributes[SEMATTRS_HTTP_ROUTE], '/user/:id');
           context.disable();
           return done();
         }
@@ -318,20 +322,20 @@ describe('Utility', () => {
       const attributes = utils.getIncomingRequestAttributesOnResponse(request, {
         socket: {},
       } as ServerResponse & { socket: Socket });
-      assert.deepEqual(attributes[SemanticAttributes.HTTP_ROUTE], undefined);
+      assert.deepEqual(attributes[SEMATTRS_HTTP_ROUTE], undefined);
     });
   });
 
   describe('getIncomingRequestMetricAttributesOnResponse()', () => {
     it('should correctly add http_route if span has it', () => {
       const spanAttributes: Attributes = {
-        [SemanticAttributes.HTTP_ROUTE]: '/user/:id',
+        [SEMATTRS_HTTP_ROUTE]: '/user/:id',
       };
       const metricAttributes =
         utils.getIncomingRequestMetricAttributesOnResponse(spanAttributes);
 
       assert.deepStrictEqual(
-        metricAttributes[SemanticAttributes.HTTP_ROUTE],
+        metricAttributes[SEMATTRS_HTTP_ROUTE],
         '/user/:id'
       );
     });
@@ -340,10 +344,7 @@ describe('Utility', () => {
       const spanAttributes: Attributes = {};
       const metricAttributes =
         utils.getIncomingRequestMetricAttributesOnResponse(spanAttributes);
-      assert.deepEqual(
-        metricAttributes[SemanticAttributes.HTTP_ROUTE],
-        undefined
-      );
+      assert.deepEqual(metricAttributes[SEMATTRS_HTTP_ROUTE], undefined);
     });
   });
   // Verify the key in the given attributes is set to the given value,
@@ -354,10 +355,10 @@ describe('Utility', () => {
     value: number
   ) {
     const SemanticAttributess = [
-      SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
-      SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH,
-      SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
-      SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH,
+      SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
+      SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH,
+      SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
+      SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH,
     ];
 
     for (const attr of SemanticAttributess) {
@@ -381,7 +382,7 @@ describe('Utility', () => {
 
       verifyValueInAttributes(
         attributes,
-        SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
+        SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
         1200
       );
     });
@@ -397,7 +398,7 @@ describe('Utility', () => {
 
       verifyValueInAttributes(
         attributes,
-        SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
+        SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
         1200
       );
     });
@@ -413,7 +414,7 @@ describe('Utility', () => {
 
       verifyValueInAttributes(
         attributes,
-        SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH,
+        SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH,
         1200
       );
     });
@@ -432,7 +433,7 @@ describe('Utility', () => {
 
       verifyValueInAttributes(
         attributes,
-        SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
+        SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
         1200
       );
     });
@@ -451,7 +452,7 @@ describe('Utility', () => {
 
       verifyValueInAttributes(
         attributes,
-        SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
+        SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
         1200
       );
     });
@@ -470,7 +471,7 @@ describe('Utility', () => {
 
       verifyValueInAttributes(
         attributes,
-        SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH,
+        SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH,
         1200
       );
     });
@@ -501,7 +502,7 @@ describe('Utility', () => {
       const attributes = utils.getIncomingRequestAttributes(request, {
         component: 'http',
       });
-      assert.strictEqual(attributes[SemanticAttributes.HTTP_ROUTE], undefined);
+      assert.strictEqual(attributes[SEMATTRS_HTTP_ROUTE], undefined);
     });
 
     it('should set http.target as path in http span attributes', () => {
@@ -515,10 +516,7 @@ describe('Utility', () => {
       const attributes = utils.getIncomingRequestAttributes(request, {
         component: 'http',
       });
-      assert.strictEqual(
-        attributes[SemanticAttributes.HTTP_TARGET],
-        '/user/?q=val'
-      );
+      assert.strictEqual(attributes[SEMATTRS_HTTP_TARGET], '/user/?q=val');
     });
   });
 

--- a/experimental/packages/opentelemetry-instrumentation-http/test/integrations/http-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/integrations/http-enable.test.ts
@@ -16,9 +16,11 @@
 
 import { SpanKind, Span, context, propagation } from '@opentelemetry/api';
 import {
-  HttpFlavorValues,
-  NetTransportValues,
-  SemanticAttributes,
+  HTTPFLAVORVALUES_HTTP_1_1,
+  NETTRANSPORTVALUES_IP_TCP,
+  SEMATTRS_HTTP_FLAVOR,
+  SEMATTRS_HTTP_HOST,
+  SEMATTRS_NET_TRANSPORT,
 } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import * as url from 'url';
@@ -236,12 +238,12 @@ describe('HttpInstrumentation Integration tests', () => {
       assert.strictEqual(span.name, 'GET');
       assert.strictEqual(result.reqHeaders['x-foo'], 'foo');
       assert.strictEqual(
-        span.attributes[SemanticAttributes.HTTP_FLAVOR],
-        HttpFlavorValues.HTTP_1_1
+        span.attributes[SEMATTRS_HTTP_FLAVOR],
+        HTTPFLAVORVALUES_HTTP_1_1
       );
       assert.strictEqual(
-        span.attributes[SemanticAttributes.NET_TRANSPORT],
-        NetTransportValues.IP_TCP
+        span.attributes[SEMATTRS_NET_TRANSPORT],
+        NETTRANSPORTVALUES_IP_TCP
       );
       assertSpan(span, SpanKind.CLIENT, validations);
     });
@@ -397,7 +399,7 @@ describe('HttpInstrumentation Integration tests', () => {
       assert.ok(span);
       assert.strictEqual(span.name, 'GET');
       assert.strictEqual(
-        span.attributes[SemanticAttributes.HTTP_HOST],
+        span.attributes[SEMATTRS_HTTP_HOST],
         `localhost:${mockServerPort}`
       );
     });

--- a/experimental/packages/opentelemetry-instrumentation-http/test/integrations/https-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/integrations/https-enable.test.ts
@@ -16,9 +16,10 @@
 
 import { SpanKind, Span, context, propagation } from '@opentelemetry/api';
 import {
-  HttpFlavorValues,
-  NetTransportValues,
-  SemanticAttributes,
+  HTTPFLAVORVALUES_HTTP_1_1,
+  NETTRANSPORTVALUES_IP_TCP,
+  SEMATTRS_HTTP_FLAVOR,
+  SEMATTRS_NET_TRANSPORT,
 } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import * as http from 'http';
@@ -240,12 +241,12 @@ describe('HttpsInstrumentation Integration tests', () => {
       assert.strictEqual(span.name, 'GET');
       assert.strictEqual(result.reqHeaders['x-foo'], 'foo');
       assert.strictEqual(
-        span.attributes[SemanticAttributes.HTTP_FLAVOR],
-        HttpFlavorValues.HTTP_1_1
+        span.attributes[SEMATTRS_HTTP_FLAVOR],
+        HTTPFLAVORVALUES_HTTP_1_1
       );
       assert.strictEqual(
-        span.attributes[SemanticAttributes.NET_TRANSPORT],
-        NetTransportValues.IP_TCP
+        span.attributes[SEMATTRS_NET_TRANSPORT],
+        NETTRANSPORTVALUES_IP_TCP
       );
       assertSpan(span, SpanKind.CLIENT, validations);
     });

--- a/experimental/packages/opentelemetry-instrumentation-http/test/utils/assertSpan.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/utils/assertSpan.ts
@@ -21,7 +21,24 @@ import {
 } from '@opentelemetry/api';
 import { hrTimeToNanoseconds } from '@opentelemetry/core';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_HTTP_METHOD,
+  SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH,
+  SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
+  SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH,
+  SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
+  SEMATTRS_HTTP_SCHEME,
+  SEMATTRS_HTTP_SERVER_NAME,
+  SEMATTRS_HTTP_STATUS_CODE,
+  SEMATTRS_HTTP_TARGET,
+  SEMATTRS_HTTP_URL,
+  SEMATTRS_HTTP_USER_AGENT,
+  SEMATTRS_NET_HOST_IP,
+  SEMATTRS_NET_HOST_PORT,
+  SEMATTRS_NET_PEER_IP,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
+} from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import * as http from 'http';
 import * as utils from '../../src/utils';
@@ -55,15 +72,15 @@ export const assertSpan = (
     span.status.message
   );
   assert.strictEqual(
-    span.attributes[SemanticAttributes.HTTP_METHOD],
+    span.attributes[SEMATTRS_HTTP_METHOD],
     validations.httpMethod
   );
   assert.strictEqual(
-    span.attributes[SemanticAttributes.HTTP_TARGET],
+    span.attributes[SEMATTRS_HTTP_TARGET],
     validations.path || validations.pathname
   );
   assert.strictEqual(
-    span.attributes[SemanticAttributes.HTTP_STATUS_CODE],
+    span.attributes[SEMATTRS_HTTP_STATUS_CODE],
     validations.httpStatusCode
   );
 
@@ -97,10 +114,7 @@ export const assertSpan = (
   if (validations.reqHeaders) {
     const userAgent = validations.reqHeaders['user-agent'];
     if (userAgent) {
-      assert.strictEqual(
-        span.attributes[SemanticAttributes.HTTP_USER_AGENT],
-        userAgent
-      );
+      assert.strictEqual(span.attributes[SEMATTRS_HTTP_USER_AGENT], userAgent);
     }
   }
   if (span.kind === SpanKind.CLIENT) {
@@ -112,36 +126,28 @@ export const assertSpan = (
         validations.resHeaders['content-encoding'] !== 'identity'
       ) {
         assert.strictEqual(
-          span.attributes[SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH],
+          span.attributes[SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH],
           contentLength
         );
       } else {
         assert.strictEqual(
-          span.attributes[
-            SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED
-          ],
+          span.attributes[SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED],
           contentLength
         );
       }
     }
     assert.strictEqual(
-      span.attributes[SemanticAttributes.NET_PEER_NAME],
+      span.attributes[SEMATTRS_NET_PEER_NAME],
       validations.hostname,
       'must be consistent (PEER_NAME and hostname)'
     );
     if (!validations.noNetPeer) {
-      assert.ok(
-        span.attributes[SemanticAttributes.NET_PEER_IP],
-        'must have PEER_IP'
-      );
-      assert.ok(
-        span.attributes[SemanticAttributes.NET_PEER_PORT],
-        'must have PEER_PORT'
-      );
+      assert.ok(span.attributes[SEMATTRS_NET_PEER_IP], 'must have PEER_IP');
+      assert.ok(span.attributes[SEMATTRS_NET_PEER_PORT], 'must have PEER_PORT');
     }
     assert.ok(
-      (span.attributes[SemanticAttributes.HTTP_URL] as string).indexOf(
-        span.attributes[SemanticAttributes.NET_PEER_NAME] as string
+      (span.attributes[SEMATTRS_HTTP_URL] as string).indexOf(
+        span.attributes[SEMATTRS_NET_PEER_NAME] as string
       ) > -1,
       'must be consistent'
     );
@@ -155,35 +161,27 @@ export const assertSpan = (
         validations.reqHeaders['content-encoding'] !== 'identity'
       ) {
         assert.strictEqual(
-          span.attributes[SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH],
+          span.attributes[SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH],
           contentLength
         );
       } else {
         assert.strictEqual(
-          span.attributes[
-            SemanticAttributes.HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED
-          ],
+          span.attributes[SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED],
           contentLength
         );
       }
     }
     if (validations.serverName) {
       assert.strictEqual(
-        span.attributes[SemanticAttributes.HTTP_SERVER_NAME],
+        span.attributes[SEMATTRS_HTTP_SERVER_NAME],
         validations.serverName,
         ' must have serverName attribute'
       );
-      assert.ok(
-        span.attributes[SemanticAttributes.NET_HOST_PORT],
-        'must have HOST_PORT'
-      );
-      assert.ok(
-        span.attributes[SemanticAttributes.NET_HOST_IP],
-        'must have HOST_IP'
-      );
+      assert.ok(span.attributes[SEMATTRS_NET_HOST_PORT], 'must have HOST_PORT');
+      assert.ok(span.attributes[SEMATTRS_NET_HOST_IP], 'must have HOST_IP');
     }
     assert.strictEqual(
-      span.attributes[SemanticAttributes.HTTP_SCHEME],
+      span.attributes[SEMATTRS_HTTP_SCHEME],
       validations.component,
       ' must have http.scheme attribute'
     );


### PR DESCRIPTION
## Which problem is this PR solving?

Updates #4567 

## Short description of the changes

- Replace `SemanticAttributes.*`, `NetTransportValues.*`, and `HttpFlavorValues.*` with specific exported strings for http instrumentation package.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

Not quite sure; chore to replace deprecated fields but feature to improve minification?

## How Has This Been Tested?

- [x] unit tests

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
