### PR TITLE
feat(otlp-transformer): consolidate scope/resource creation in transformer

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to experimental packages in this project will be documented 
 * fix(events-api)!: renamed EventEmitter to EventLogger in the Events API [#4569](https://github.com/open-telemetry/opentelemetry-js/pull/4568)
 * feat(api-logs)!: changed LogRecord body data type to AnyValue [#4575](https://github.com/open-telemetry/opentelemetry-js/pull/4575)
 and AnyValueMap types [#4575](https://github.com/open-telemetry/opentelemetry-js/pull/4575)
+* feat(otlp-transformer): consolidate scope/resource creation in transformer [#4600](https://github.com/open-telemetry/opentelemetry-js/pull/4600)
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/otlp-transformer/src/common/internal.ts
+++ b/experimental/packages/otlp-transformer/src/common/internal.ts
@@ -15,15 +15,16 @@
  */
 import type { IAnyValue, IInstrumentationScope, IKeyValue } from './types';
 import { Attributes } from '@opentelemetry/api';
-import {InstrumentationScope} from "@opentelemetry/core";
+import { InstrumentationScope } from '@opentelemetry/core';
 
 export function createInstrumentationScope(
-  scope: InstrumentationScope): IInstrumentationScope {
-  return  {
+  scope: InstrumentationScope
+): IInstrumentationScope {
+  return {
     name: scope.name,
     version: scope.version,
     droppedAttributesCount: 0,
-  }
+  };
 }
 
 export function toAttributes(attributes: Attributes): IKeyValue[] {

--- a/experimental/packages/otlp-transformer/src/common/internal.ts
+++ b/experimental/packages/otlp-transformer/src/common/internal.ts
@@ -23,7 +23,6 @@ export function createInstrumentationScope(
   return {
     name: scope.name,
     version: scope.version,
-    droppedAttributesCount: 0,
   };
 }
 

--- a/experimental/packages/otlp-transformer/src/common/internal.ts
+++ b/experimental/packages/otlp-transformer/src/common/internal.ts
@@ -13,8 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { IAnyValue, IKeyValue } from './types';
+import type { IAnyValue, IInstrumentationScope, IKeyValue } from './types';
 import { Attributes } from '@opentelemetry/api';
+import {InstrumentationScope} from "@opentelemetry/core";
+
+export function createInstrumentationScope(
+  scope: InstrumentationScope): IInstrumentationScope {
+  return  {
+    name: scope.name,
+    version: scope.version,
+    droppedAttributesCount: 0,
+  }
+}
 
 export function toAttributes(attributes: Attributes): IKeyValue[] {
   return Object.keys(attributes).map(key => toKeyValue(key, attributes[key]));

--- a/experimental/packages/otlp-transformer/src/logs/index.ts
+++ b/experimental/packages/otlp-transformer/src/logs/index.ts
@@ -23,11 +23,15 @@ import {
 } from './types';
 import { IResource } from '@opentelemetry/resources';
 import { Encoder, getOtlpEncoder } from '../common';
-import { createInstrumentationScope, toAnyValue, toKeyValue } from '../common/internal';
+import {
+  createInstrumentationScope,
+  toAnyValue,
+  toKeyValue,
+} from '../common/internal';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { OtlpEncodingOptions, IKeyValue } from '../common/types';
 import { LogAttributes } from '@opentelemetry/api-logs';
-import { createResource } from "../resource/internal";
+import { createResource } from '../resource/internal';
 
 export function createExportLogsServiceRequest(
   logRecords: ReadableLogRecord[],

--- a/experimental/packages/otlp-transformer/src/logs/index.ts
+++ b/experimental/packages/otlp-transformer/src/logs/index.ts
@@ -23,10 +23,11 @@ import {
 } from './types';
 import { IResource } from '@opentelemetry/resources';
 import { Encoder, getOtlpEncoder } from '../common';
-import { toAnyValue, toAttributes, toKeyValue } from '../common/internal';
+import { createInstrumentationScope, toAnyValue, toKeyValue } from '../common/internal';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { OtlpEncodingOptions, IKeyValue } from '../common/types';
 import { LogAttributes } from '@opentelemetry/api-logs';
+import { createResource } from "../resource/internal";
 
 export function createExportLogsServiceRequest(
   logRecords: ReadableLogRecord[],
@@ -75,18 +76,12 @@ function logRecordsToResourceLogs(
 ): IResourceLogs[] {
   const resourceMap = createResourceMap(logRecords);
   return Array.from(resourceMap, ([resource, ismMap]) => ({
-    resource: {
-      attributes: toAttributes(resource.attributes),
-      droppedAttributesCount: 0,
-    },
+    resource: createResource(resource),
     scopeLogs: Array.from(ismMap, ([, scopeLogs]) => {
-      const {
-        instrumentationScope: { name, version, schemaUrl },
-      } = scopeLogs[0];
       return {
-        scope: { name, version },
+        scope: createInstrumentationScope(scopeLogs[0].instrumentationScope),
         logRecords: scopeLogs.map(log => toLogRecord(log, encoder)),
-        schemaUrl,
+        schemaUrl: scopeLogs[0].instrumentationScope.schemaUrl,
       };
     }),
     schemaUrl: undefined,

--- a/experimental/packages/otlp-transformer/src/metrics/internal.ts
+++ b/experimental/packages/otlp-transformer/src/metrics/internal.ts
@@ -25,7 +25,6 @@ import {
   ResourceMetrics,
   ScopeMetrics,
 } from '@opentelemetry/sdk-metrics';
-import { toAttributes } from '../common/internal';
 import {
   EAggregationTemporality,
   IExponentialHistogramDataPoint,
@@ -35,7 +34,9 @@ import {
   IResourceMetrics,
   IScopeMetrics,
 } from './types';
-import { Encoder, getOtlpEncoder } from '../common';
+import {Encoder, getOtlpEncoder} from '../common';
+import { createInstrumentationScope, toAttributes } from '../common/internal';
+import { createResource } from "../resource/internal";
 
 export function toResourceMetrics(
   resourceMetrics: ResourceMetrics,
@@ -43,10 +44,7 @@ export function toResourceMetrics(
 ): IResourceMetrics {
   const encoder = getOtlpEncoder(options);
   return {
-    resource: {
-      attributes: toAttributes(resourceMetrics.resource.attributes),
-      droppedAttributesCount: 0,
-    },
+    resource: createResource(resourceMetrics.resource),
     schemaUrl: undefined,
     scopeMetrics: toScopeMetrics(resourceMetrics.scopeMetrics, encoder),
   };
@@ -58,10 +56,7 @@ export function toScopeMetrics(
 ): IScopeMetrics[] {
   return Array.from(
     scopeMetrics.map(metrics => ({
-      scope: {
-        name: metrics.scope.name,
-        version: metrics.scope.version,
-      },
+      scope: createInstrumentationScope(metrics.scope),
       metrics: metrics.metrics.map(metricData => toMetric(metricData, encoder)),
       schemaUrl: metrics.scope.schemaUrl,
     }))

--- a/experimental/packages/otlp-transformer/src/metrics/internal.ts
+++ b/experimental/packages/otlp-transformer/src/metrics/internal.ts
@@ -34,9 +34,9 @@ import {
   IResourceMetrics,
   IScopeMetrics,
 } from './types';
-import {Encoder, getOtlpEncoder} from '../common';
+import { Encoder, getOtlpEncoder } from '../common';
 import { createInstrumentationScope, toAttributes } from '../common/internal';
-import { createResource } from "../resource/internal";
+import { createResource } from '../resource/internal';
 
 export function toResourceMetrics(
   resourceMetrics: ResourceMetrics,

--- a/experimental/packages/otlp-transformer/src/resource/internal.ts
+++ b/experimental/packages/otlp-transformer/src/resource/internal.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { IResource as ISdkResource } from '@opentelemetry/resources';
+import { toAttributes } from "../common/internal";
+import { IResource } from "./types";
+
+export function createResource(
+  resource: ISdkResource): IResource {
+  return {
+    attributes: toAttributes(resource.attributes),
+    droppedAttributesCount: 0,
+  }
+}

--- a/experimental/packages/otlp-transformer/src/resource/internal.ts
+++ b/experimental/packages/otlp-transformer/src/resource/internal.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 import { IResource as ISdkResource } from '@opentelemetry/resources';
-import { toAttributes } from "../common/internal";
-import { IResource } from "./types";
+import { toAttributes } from '../common/internal';
+import { IResource } from './types';
 
-export function createResource(
-  resource: ISdkResource): IResource {
+export function createResource(resource: ISdkResource): IResource {
   return {
     attributes: toAttributes(resource.attributes),
     droppedAttributesCount: 0,
-  }
+  };
 }

--- a/experimental/packages/otlp-transformer/src/trace/index.ts
+++ b/experimental/packages/otlp-transformer/src/trace/index.ts
@@ -16,14 +16,15 @@
 import type { IResource } from '@opentelemetry/resources';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import type { OtlpEncodingOptions } from '../common/types';
-import { toAttributes } from '../common/internal';
 import { sdkSpanToOtlpSpan } from './internal';
 import {
   IExportTraceServiceRequest,
   IResourceSpans,
   IScopeSpans,
 } from './types';
-import { Encoder, getOtlpEncoder } from '../common';
+import { Encoder, getOtlpEncoder} from '../common';
+import { createInstrumentationScope } from '../common/internal';
+import { createResource } from "../resource/internal";
 
 export function createExportTraceServiceRequest(
   spans: ReadableSpan[],
@@ -79,26 +80,21 @@ function spanRecordsToResourceSpans(
     while (!ilmEntry.done) {
       const scopeSpans = ilmEntry.value;
       if (scopeSpans.length > 0) {
-        const { name, version, schemaUrl } =
-          scopeSpans[0].instrumentationLibrary;
         const spans = scopeSpans.map(readableSpan =>
           sdkSpanToOtlpSpan(readableSpan, encoder)
         );
 
         scopeResourceSpans.push({
-          scope: { name, version },
+          scope: createInstrumentationScope(scopeSpans[0].instrumentationLibrary),
           spans: spans,
-          schemaUrl: schemaUrl,
+          schemaUrl: scopeSpans[0].instrumentationLibrary.schemaUrl,
         });
       }
       ilmEntry = ilmIterator.next();
     }
     // TODO SDK types don't provide resource schema URL at this time
     const transformedSpans: IResourceSpans = {
-      resource: {
-        attributes: toAttributes(resource.attributes),
-        droppedAttributesCount: 0,
-      },
+      resource: createResource(resource),
       scopeSpans: scopeResourceSpans,
       schemaUrl: undefined,
     };

--- a/experimental/packages/otlp-transformer/src/trace/index.ts
+++ b/experimental/packages/otlp-transformer/src/trace/index.ts
@@ -22,9 +22,9 @@ import {
   IResourceSpans,
   IScopeSpans,
 } from './types';
-import { Encoder, getOtlpEncoder} from '../common';
+import { Encoder, getOtlpEncoder } from '../common';
 import { createInstrumentationScope } from '../common/internal';
-import { createResource } from "../resource/internal";
+import { createResource } from '../resource/internal';
 
 export function createExportTraceServiceRequest(
   spans: ReadableSpan[],
@@ -85,7 +85,9 @@ function spanRecordsToResourceSpans(
         );
 
         scopeResourceSpans.push({
-          scope: createInstrumentationScope(scopeSpans[0].instrumentationLibrary),
+          scope: createInstrumentationScope(
+            scopeSpans[0].instrumentationLibrary
+          ),
           spans: spans,
           schemaUrl: scopeSpans[0].instrumentationLibrary.schemaUrl,
         });

--- a/experimental/packages/otlp-transformer/test/logs.test.ts
+++ b/experimental/packages/otlp-transformer/test/logs.test.ts
@@ -46,7 +46,11 @@ function createExpectedLogJson(useHex: boolean): IExportLogsServiceRequest {
         schemaUrl: undefined,
         scopeLogs: [
           {
-            scope: { name: 'scope_name_1', version: '0.1.0' },
+            scope: {
+              name: 'scope_name_1',
+              version: '0.1.0',
+              droppedAttributesCount: 0,
+            },
             logRecords: [
               {
                 timeUnixNano: { low: 4132445859, high: 391214506 },

--- a/experimental/packages/otlp-transformer/test/logs.test.ts
+++ b/experimental/packages/otlp-transformer/test/logs.test.ts
@@ -49,7 +49,6 @@ function createExpectedLogJson(useHex: boolean): IExportLogsServiceRequest {
             scope: {
               name: 'scope_name_1',
               version: '0.1.0',
-              droppedAttributesCount: 0,
             },
             logRecords: [
               {

--- a/experimental/packages/otlp-transformer/test/metrics.test.ts
+++ b/experimental/packages/otlp-transformer/test/metrics.test.ts
@@ -55,7 +55,6 @@ describe('Metrics', () => {
     const expectedScope = {
       name: 'mylib',
       version: '0.1.0',
-      droppedAttributesCount: 0,
     };
 
     const expectedSchemaUrl = 'http://url.to.schema';

--- a/experimental/packages/otlp-transformer/test/metrics.test.ts
+++ b/experimental/packages/otlp-transformer/test/metrics.test.ts
@@ -55,6 +55,7 @@ describe('Metrics', () => {
     const expectedScope = {
       name: 'mylib',
       version: '0.1.0',
+      droppedAttributesCount: 0,
     };
 
     const expectedSchemaUrl = 'http://url.to.schema';

--- a/experimental/packages/otlp-transformer/test/trace.test.ts
+++ b/experimental/packages/otlp-transformer/test/trace.test.ts
@@ -71,7 +71,6 @@ function createExpectedSpanJson(options: OtlpEncodingOptions) {
             scope: {
               name: 'myLib',
               version: '0.1.0',
-              droppedAttributesCount: 0,
             },
             spans: [
               {

--- a/experimental/packages/otlp-transformer/test/trace.test.ts
+++ b/experimental/packages/otlp-transformer/test/trace.test.ts
@@ -68,7 +68,11 @@ function createExpectedSpanJson(options: OtlpEncodingOptions) {
         schemaUrl: undefined,
         scopeSpans: [
           {
-            scope: { name: 'myLib', version: '0.1.0' },
+            scope: {
+              name: 'myLib',
+              version: '0.1.0',
+              droppedAttributesCount: 0,
+            },
             spans: [
               {
                 traceId: traceId,


### PR DESCRIPTION
## Which problem is this PR solving?

Resources and scopes creation are currently duplicated across all signals even though they're the same. This PR pulls them out into shared functions for all signals. 

Replaces #4429