### PR TITLE
chore: prepare release 1.23.0/0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,23 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :rocket: (Enhancement)
 
-* perf(sdk-trace-base): do not allocate arrays if resource has no pending async attributes
-
 ### :bug: (Bug Fix)
-
-* fix(sdk-metrics): increase the depth of the output to the console such that objects in the metric are printed fully to the console [#4522](https://github.com/open-telemetry/opentelemetry-js/pull/4522) @JacksonWeber
 
 ### :books: (Refine Doc)
 
 ### :house: (Internal)
+
+## 1.23.0
+
+### :rocket: (Enhancement)
+
+* perf(sdk-trace-base): do not allocate arrays if resource has no pending async attributes [#4576](https://github.com/open-telemetry/opentelemetry-js/pull/4576) @Samuron
+* feat(sdk-metrics): added experimental synchronous gauge to SDK [#4565](https://github.com/open-telemetry/opentelemetry-js/pull/4565) @clintonb
+  * this change will become user-facing in an upcoming release
+
+### :bug: (Bug Fix)
+
+* fix(sdk-metrics): increase the depth of the output to the console such that objects in the metric are printed fully to the console [#4522](https://github.com/open-telemetry/opentelemetry-js/pull/4522) @JacksonWeber
 
 ## 1.22.0
 

--- a/examples/esm-http-ts/package.json
+++ b/examples/esm-http-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esm-http-ts",
   "private": true,
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "Example of HTTP integration with OpenTelemetry using ESM and TypeScript",
   "main": "build/index.js",
   "type": "module",
@@ -31,12 +31,12 @@
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/",
   "dependencies": {
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-    "@opentelemetry/instrumentation": "0.49.1",
-    "@opentelemetry/instrumentation-http": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
-    "@opentelemetry/sdk-trace-node": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+    "@opentelemetry/instrumentation": "0.50.0",
+    "@opentelemetry/instrumentation-http": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
+    "@opentelemetry/sdk-trace-node": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   }
 }

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-example",
   "private": true,
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "Example of HTTP integration with OpenTelemetry",
   "main": "index.js",
   "scripts": {
@@ -29,14 +29,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-jaeger": "1.22.0",
-    "@opentelemetry/exporter-zipkin": "1.22.0",
-    "@opentelemetry/instrumentation": "0.49.1",
-    "@opentelemetry/instrumentation-http": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
-    "@opentelemetry/sdk-trace-node": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/exporter-jaeger": "1.23.0",
+    "@opentelemetry/exporter-zipkin": "1.23.0",
+    "@opentelemetry/instrumentation": "0.50.0",
+    "@opentelemetry/instrumentation-http": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
+    "@opentelemetry/sdk-trace-node": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/http",
   "devDependencies": {

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,7 +1,7 @@
 {
   "name": "https-example",
   "private": true,
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "Example of HTTPs integration with OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -33,14 +33,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/exporter-jaeger": "1.22.0",
-    "@opentelemetry/exporter-zipkin": "1.22.0",
-    "@opentelemetry/instrumentation": "0.49.1",
-    "@opentelemetry/instrumentation-http": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
-    "@opentelemetry/sdk-trace-node": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/exporter-jaeger": "1.23.0",
+    "@opentelemetry/exporter-zipkin": "1.23.0",
+    "@opentelemetry/instrumentation": "0.50.0",
+    "@opentelemetry/instrumentation-http": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
+    "@opentelemetry/sdk-trace-node": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-opentelemetry-example",
   "private": true,
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "Example of using @opentelemetry/sdk-trace-web and @opentelemetry/sdk-metrics in browser",
   "main": "index.js",
   "scripts": {
@@ -44,20 +44,20 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/context-zone": "1.22.0",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-    "@opentelemetry/exporter-zipkin": "1.22.0",
-    "@opentelemetry/instrumentation": "0.49.1",
-    "@opentelemetry/instrumentation-fetch": "0.49.1",
-    "@opentelemetry/instrumentation-xml-http-request": "0.49.1",
-    "@opentelemetry/propagator-b3": "1.22.0",
-    "@opentelemetry/sdk-metrics": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
-    "@opentelemetry/sdk-trace-web": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/context-zone": "1.23.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.50.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+    "@opentelemetry/exporter-zipkin": "1.23.0",
+    "@opentelemetry/instrumentation": "0.50.0",
+    "@opentelemetry/instrumentation-fetch": "0.50.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.50.0",
+    "@opentelemetry/propagator-b3": "1.23.0",
+    "@opentelemetry/sdk-metrics": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
+    "@opentelemetry/sdk-trace-web": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web"
 }

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-otlp-exporter-node",
   "private": true,
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
@@ -29,17 +29,17 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.49.1",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
-    "@opentelemetry/exporter-metrics-otlp-proto": "0.49.1",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-metrics": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.50.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.50.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "0.50.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.50.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-metrics": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/otlp-exporter-node"
 }

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+### :rocket: (Enhancement)
+
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 0.50.0
+
+### :boom: Breaking Change
+
 * fix(exporter-*-otlp-grpc)!: lazy load gRPC to improve compatibility with `@opentelemetry/instrumenation-grpc` [#4432](https://github.com/open-telemetry/opentelemetry-js/pull/4432) @pichlermarc
   * Fixes a bug where requiring up the gRPC exporter before enabling the instrumentation from `@opentelemetry/instrumentation-grpc` would lead to missing telemetry
   * Breaking changes, removes several functions and properties that were used internally and were not intended for end-users
@@ -19,19 +31,17 @@ All notable changes to experimental packages in this project will be documented 
       * was used internally to keep track of the service client used by the exporter, as a side effect it allowed end-users to modify the gRPC service client that was used
     * `compression`
       * was used internally to keep track of the compression to use but was unintentionally exposed to the users. It allowed to read and write the value, writing, however, would have no effect.
-* feat(api-events)!: removed domain from the Events API [#4569](https://github.com/open-telemetry/opentelemetry-js/pull/4569)
-* fix(events-api)!: renamed EventEmitter to EventLogger in the Events API [#4569](https://github.com/open-telemetry/opentelemetry-js/pull/4568)
-* feat(api-logs)!: changed LogRecord body data type to AnyValue [#4575](https://github.com/open-telemetry/opentelemetry-js/pull/4575)
-and AnyValueMap types [#4575](https://github.com/open-telemetry/opentelemetry-js/pull/4575)
+* feat(api-events)!: removed domain from the Events API [#4569](https://github.com/open-telemetry/opentelemetry-js/pull/4569) @martinkuba
+* fix(api-events)!: renamed EventEmitter to EventLogger in the Events API [#4569](https://github.com/open-telemetry/opentelemetry-js/pull/4568) @martinkuba
+* feat(api-logs)!: changed LogRecord body data type to AnyValue and AnyValueMap types [#4575](https://github.com/open-telemetry/opentelemetry-js/pull/4575) @martinkuba
 
 ### :rocket: (Enhancement)
 
-* feat(metrics): added synchronous gauge to SDK [#4565](https://github.com/open-telemetry/opentelemetry-js/pull/4565) @clintonb
-* feat(opentelemetry-instrumentation-xhr): optionally ignore network events [#4571](https://github.com/open-telemetry/opentelemetry-js/pull/4571/) @mustafahaddara
-* refactor(instr-http): use exported strings for semconv. [#4573](https://github.com/open-telemetry/opentelemetry-js/pull/4573/) @JamieDanielson
+* feat(instrumentation-xhr): optionally ignore network events [#4571](https://github.com/open-telemetry/opentelemetry-js/pull/4571/) @mustafahaddara
+* refactor(instrumentation-http): use exported strings for semconv [#4573](https://github.com/open-telemetry/opentelemetry-js/pull/4573/) @JamieDanielson
 * perf(instrumentation-http): remove obvious temp allocations [#4576](https://github.com/open-telemetry/opentelemetry-js/pull/4576) @Samuron
-* feat(sdk-node): add `HostDetector` as default resource detector
-* feat(api-events): added data field to the Event interface [4575](https://github.com/open-telemetry/opentelemetry-js/pull/4575)
+* feat(sdk-node): add `HostDetector` as default resource detector [#4566](https://github.com/open-telemetry/opentelemetry-js/pull/4566) @maryliag
+* feat(api-events): added data field to the Event interface [#4575](https://github.com/open-telemetry/opentelemetry-js/pull/4575) @martinkuba
 
 ### :bug: (Bug Fix)
 
@@ -41,9 +51,7 @@ and AnyValueMap types [#4575](https://github.com/open-telemetry/opentelemetry-js
 
 ### :books: (Refine Doc)
 
-* docs(instr-http): document semantic conventions and attributes in use. [#4587](https://github.com/open-telemetry/opentelemetry-js/pull/4587/) @JamieDanielson
-
-### :house: (Internal)
+* docs(instrumentation-http): document semantic conventions and attributes in use. [#4587](https://github.com/open-telemetry/opentelemetry-js/pull/4587/) @JamieDanielson
 
 ## 0.49.1
 

--- a/experimental/backwards-compatibility/node14/package.json
+++ b/experimental/backwards-compatibility/node14/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node14",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "private": true,
   "description": "Backwards compatibility app for node 14 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.49.1",
-    "@opentelemetry/sdk-trace-base": "1.22.0"
+    "@opentelemetry/sdk-node": "0.50.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0"
   },
   "devDependencies": {
     "@types/node": "14.18.25",

--- a/experimental/backwards-compatibility/node16/package.json
+++ b/experimental/backwards-compatibility/node16/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node16",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "private": true,
   "description": "Backwards compatibility app for node 16 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -9,8 +9,8 @@
     "peer-api-check": "node ../../../scripts/peer-api-check.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.49.1",
-    "@opentelemetry/sdk-trace-base": "1.22.0"
+    "@opentelemetry/sdk-node": "0.50.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0"
   },
   "devDependencies": {
     "@types/node": "16.11.52",

--- a/experimental/examples/logs/package.json
+++ b/experimental/examples/logs/package.json
@@ -1,14 +1,14 @@
 {
   "name": "logs-example",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "private": true,
   "scripts": {
     "start": "ts-node index.ts"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/api-logs": "0.49.1",
-    "@opentelemetry/sdk-logs": "0.49.1"
+    "@opentelemetry/api-logs": "0.50.0",
+    "@opentelemetry/sdk-logs": "0.50.0"
   },
   "devDependencies": {
     "@types/node": "18.6.5",

--- a/experimental/examples/opencensus-shim/package.json
+++ b/experimental/examples/opencensus-shim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencensus-shim",
   "private": true,
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "Example of using @opentelemetry/shim-opencensus in Node.js",
   "main": "index.js",
   "scripts": {
@@ -31,13 +31,13 @@
     "@opencensus/instrumentation-http": "0.1.0",
     "@opencensus/nodejs-base": "0.1.0",
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/exporter-prometheus": "0.49.1",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-metrics": "1.22.0",
-    "@opentelemetry/sdk-trace-node": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0",
-    "@opentelemetry/shim-opencensus": "0.49.1"
+    "@opentelemetry/exporter-prometheus": "0.50.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-metrics": "1.23.0",
+    "@opentelemetry/sdk-trace-node": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0",
+    "@opentelemetry/shim-opencensus": "0.50.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/examples/opencensus-shim"
 }

--- a/experimental/examples/prometheus/package.json
+++ b/experimental/examples/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prometheus-example",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "private": true,
   "description": "Example of using @opentelemetry/sdk-metrics and @opentelemetry/exporter-prometheus",
   "main": "index.js",
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-prometheus": "0.49.1",
-    "@opentelemetry/sdk-metrics": "1.22.0"
+    "@opentelemetry/exporter-prometheus": "0.50.0",
+    "@opentelemetry/sdk-metrics": "1.23.0"
   }
 }

--- a/experimental/packages/api-events/package.json
+++ b/experimental/packages/api-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-events",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "Public events API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/api-logs": "0.49.1"
+    "@opentelemetry/api-logs": "0.50.0"
   },
   "devDependencies": {
     "@types/mocha": "10.0.6",

--- a/experimental/packages/api-logs/package.json
+++ b/experimental/packages/api-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-logs",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "Public logs API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-grpc",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected log records to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,9 +50,9 @@
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/api-logs": "0.49.1",
-    "@opentelemetry/otlp-exporter-base": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/api-logs": "0.50.0",
+    "@opentelemetry/otlp-exporter-base": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -72,10 +72,10 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
-    "@opentelemetry/otlp-transformer": "0.49.1",
-    "@opentelemetry/sdk-logs": "0.49.1"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.50.0",
+    "@opentelemetry/otlp-transformer": "0.50.0",
+    "@opentelemetry/sdk-logs": "0.50.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-http",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "publishConfig": {
     "access": "public"
   },
@@ -74,7 +74,7 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/resources": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -105,10 +105,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.49.1",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/otlp-exporter-base": "0.49.1",
-    "@opentelemetry/otlp-transformer": "0.49.1",
-    "@opentelemetry/sdk-logs": "0.49.1"
+    "@opentelemetry/api-logs": "0.50.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/otlp-exporter-base": "0.50.0",
+    "@opentelemetry/otlp-transformer": "0.50.0",
+    "@opentelemetry/sdk-logs": "0.50.0"
   }
 }

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-proto",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "An OTLP exporter to send logs using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,14 +94,14 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.49.1",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/otlp-exporter-base": "0.49.1",
-    "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
-    "@opentelemetry/otlp-transformer": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-logs": "0.49.1",
-    "@opentelemetry/sdk-trace-base": "1.22.0"
+    "@opentelemetry/api-logs": "0.50.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/otlp-exporter-base": "0.50.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.50.0",
+    "@opentelemetry/otlp-transformer": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-logs": "0.50.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-grpc",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/otlp-exporter-base": "0.49.1",
+    "@opentelemetry/otlp-exporter-base": "0.50.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -69,11 +69,11 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
-    "@opentelemetry/otlp-transformer": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.50.0",
+    "@opentelemetry/otlp-transformer": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-http",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry Collector Trace Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -96,11 +96,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/otlp-exporter-base": "0.49.1",
-    "@opentelemetry/otlp-transformer": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/otlp-exporter-base": "0.50.0",
+    "@opentelemetry/otlp-transformer": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-proto",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,12 +93,12 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/otlp-exporter-base": "0.49.1",
-    "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
-    "@opentelemetry/otlp-transformer": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/otlp-exporter-base": "0.50.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.50.0",
+    "@opentelemetry/otlp-transformer": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/opentelemetry-browser-detector",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry Resource Detector for Browser",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -83,8 +83,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/browser-detector"
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -68,12 +68,12 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
-    "@opentelemetry/otlp-transformer": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-metrics": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.50.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.50.0",
+    "@opentelemetry/otlp-transformer": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-metrics": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-http",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -96,11 +96,11 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/otlp-exporter-base": "0.49.1",
-    "@opentelemetry/otlp-transformer": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-metrics": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/otlp-exporter-base": "0.50.0",
+    "@opentelemetry/otlp-transformer": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-metrics": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-proto",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -74,13 +74,13 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
-    "@opentelemetry/otlp-exporter-base": "0.49.1",
-    "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
-    "@opentelemetry/otlp-transformer": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-metrics": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.50.0",
+    "@opentelemetry/otlp-exporter-base": "0.50.0",
+    "@opentelemetry/otlp-proto-exporter-base": "0.50.0",
+    "@opentelemetry/otlp-transformer": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-metrics": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/semantic-conventions": "1.22.0",
+    "@opentelemetry/semantic-conventions": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -61,9 +61,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-metrics": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-metrics": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-prometheus",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-fetch",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry fetch automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,9 +57,9 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/context-zone": "1.22.0",
-    "@opentelemetry/propagator-b3": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/context-zone": "1.23.0",
+    "@opentelemetry/propagator-b3": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -89,10 +89,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/instrumentation": "0.49.1",
-    "@opentelemetry/sdk-trace-web": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/instrumentation": "0.50.0",
+    "@opentelemetry/sdk-trace-web": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-grpc",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry grpc automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,10 +50,10 @@
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/context-async-hooks": "1.22.0",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
-    "@opentelemetry/sdk-trace-node": "1.22.0",
+    "@opentelemetry/context-async-hooks": "1.23.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
+    "@opentelemetry/sdk-trace-node": "1.23.0",
     "@protobuf-ts/grpc-transport": "2.9.3",
     "@protobuf-ts/runtime": "2.9.3",
     "@protobuf-ts/runtime-rpc": "2.9.3",
@@ -75,8 +75,8 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "0.49.1",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/instrumentation": "0.50.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-http",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry http/https automatic instrumentation package.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,10 +46,10 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/context-async-hooks": "1.22.0",
-    "@opentelemetry/sdk-metrics": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
-    "@opentelemetry/sdk-trace-node": "1.22.0",
+    "@opentelemetry/context-async-hooks": "1.23.0",
+    "@opentelemetry/sdk-metrics": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
+    "@opentelemetry/sdk-trace-node": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/request-promise-native": "1.0.21",
@@ -74,9 +74,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/instrumentation": "0.49.1",
-    "@opentelemetry/semantic-conventions": "1.22.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/instrumentation": "0.50.0",
+    "@opentelemetry/semantic-conventions": "1.23.0",
     "semver": "^7.5.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http",

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-xml-http-request",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry XMLHttpRequest automatic instrumentation package.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,9 +57,9 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/context-zone": "1.22.0",
-    "@opentelemetry/propagator-b3": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/context-zone": "1.23.0",
+    "@opentelemetry/propagator-b3": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -89,10 +89,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/instrumentation": "0.49.1",
-    "@opentelemetry/sdk-trace-web": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/instrumentation": "0.50.0",
+    "@opentelemetry/sdk-trace-web": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "Base class for node which OpenTelemetry instrumentation modules extend",
   "author": "OpenTelemetry Authors",
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation",
@@ -71,7 +71,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.49.1",
+    "@opentelemetry/api-logs": "0.50.0",
     "@types/shimmer": "^1.0.2",
     "import-in-the-middle": "1.7.1",
     "require-in-the-middle": "^7.1.1",
@@ -86,7 +86,7 @@
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.8.0",
     "@opentelemetry/api-logs": "0.47.0",
-    "@opentelemetry/sdk-metrics": "1.22.0",
+    "@opentelemetry/sdk-metrics": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.6",

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-node",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry SDK for Node.js",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,27 +44,27 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.49.1",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-    "@opentelemetry/exporter-zipkin": "1.22.0",
-    "@opentelemetry/instrumentation": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-logs": "0.49.1",
-    "@opentelemetry/sdk-metrics": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
-    "@opentelemetry/sdk-trace-node": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/api-logs": "0.50.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.50.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+    "@opentelemetry/exporter-zipkin": "1.23.0",
+    "@opentelemetry/instrumentation": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-logs": "0.50.0",
+    "@opentelemetry/sdk-metrics": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
+    "@opentelemetry/sdk-trace-node": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.3.0 <1.9.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/context-async-hooks": "1.22.0",
-    "@opentelemetry/exporter-jaeger": "1.22.0",
+    "@opentelemetry/context-async-hooks": "1.23.0",
+    "@opentelemetry/exporter-jaeger": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.6",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-exporter-base",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry OTLP Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -61,7 +61,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0"
+    "@opentelemetry/core": "1.23.0"
   },
   "devDependencies": {
     "@babel/core": "7.23.6",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-grpc-exporter-base",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry OTLP-gRPC Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,9 +49,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/otlp-transformer": "0.49.1",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/otlp-transformer": "0.50.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -72,8 +72,8 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/otlp-exporter-base": "0.49.1",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/otlp-exporter-base": "0.50.0",
     "protobufjs": "^7.2.3"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-grpc-exporter-base",

--- a/experimental/packages/otlp-proto-exporter-base/package.json
+++ b/experimental/packages/otlp-proto-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-proto-exporter-base",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenTelemetry OTLP-HTTP-protobuf Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -80,8 +80,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/otlp-exporter-base": "0.49.1",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/otlp-exporter-base": "0.50.0",
     "protobufjs": "^7.2.3"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-proto-exporter-base",

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "Transform OpenTelemetry SDK data into OTLP",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
@@ -79,12 +79,12 @@
     "webpack": "5.89.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.49.1",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-logs": "0.49.1",
-    "@opentelemetry/sdk-metrics": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0"
+    "@opentelemetry/api-logs": "0.50.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-logs": "0.50.0",
+    "@opentelemetry/sdk-metrics": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-transformer",
   "sideEffects": false

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-logs",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "publishConfig": {
     "access": "public"
   },
@@ -75,7 +75,7 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": ">=1.4.0 <1.9.0",
-    "@opentelemetry/api-logs": "0.49.1",
+    "@opentelemetry/api-logs": "0.50.0",
     "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -101,7 +101,7 @@
     "webpack-merge": "5.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/resources": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/resources": "1.23.0"
   }
 }

--- a/experimental/packages/shim-opencensus/package.json
+++ b/experimental/packages/shim-opencensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opencensus",
-  "version": "0.49.1",
+  "version": "0.50.0",
   "description": "OpenCensus to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,8 +50,8 @@
   "devDependencies": {
     "@opencensus/core": "0.1.0",
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/context-async-hooks": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/context-async-hooks": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -69,9 +69,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-metrics": "1.22.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-metrics": "1.23.0",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2"
   },

--- a/integration-tests/api/package.json
+++ b/integration-tests/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/integration-tests-api",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.22.0",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/context-async-hooks": "1.23.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
     "axios": "1.5.1",
     "body-parser": "1.19.0",
     "express": "4.19.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
-        "api",
         "packages/*",
         "experimental/packages/*",
         "experimental/examples/*",
@@ -195,17 +194,17 @@
       }
     },
     "examples/esm-http-ts": {
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/instrumentation-http": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/instrumentation-http": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -213,18 +212,18 @@
     },
     "examples/http": {
       "name": "http-example",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.22.0",
-        "@opentelemetry/exporter-zipkin": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/instrumentation-http": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/exporter-jaeger": "1.23.0",
+        "@opentelemetry/exporter-zipkin": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/instrumentation-http": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -235,18 +234,18 @@
     },
     "examples/https": {
       "name": "https-example",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.22.0",
-        "@opentelemetry/exporter-zipkin": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/instrumentation-http": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/exporter-jaeger": "1.23.0",
+        "@opentelemetry/exporter-zipkin": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/instrumentation-http": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -257,24 +256,24 @@
     },
     "examples/opentelemetry-web": {
       "name": "web-opentelemetry-example",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-        "@opentelemetry/exporter-zipkin": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/instrumentation-fetch": "0.49.1",
-        "@opentelemetry/instrumentation-xml-http-request": "0.49.1",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-web": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/context-zone": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+        "@opentelemetry/exporter-zipkin": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/instrumentation-fetch": "0.50.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.50.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-web": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.6",
@@ -609,21 +608,21 @@
     },
     "examples/otlp-exporter-node": {
       "name": "example-otlp-exporter-node",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.49.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.50.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -631,11 +630,11 @@
     },
     "experimental/backwards-compatibility/node14": {
       "name": "backcompat-node14",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-node": "0.49.1",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/sdk-node": "0.50.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "devDependencies": {
         "@types/node": "14.18.25",
@@ -652,11 +651,11 @@
     },
     "experimental/backwards-compatibility/node16": {
       "name": "backcompat-node16",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-node": "0.49.1",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/sdk-node": "0.50.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "devDependencies": {
         "@types/node": "16.11.52",
@@ -673,11 +672,11 @@
     },
     "experimental/examples/logs": {
       "name": "logs-example",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/sdk-logs": "0.49.1"
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/sdk-logs": "0.50.0"
       },
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -743,20 +742,20 @@
       }
     },
     "experimental/examples/opencensus-shim": {
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opencensus/core": "0.1.0",
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/exporter-prometheus": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
-        "@opentelemetry/shim-opencensus": "0.49.1"
+        "@opentelemetry/exporter-prometheus": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
+        "@opentelemetry/shim-opencensus": "0.50.0"
       },
       "engines": {
         "node": ">=14"
@@ -764,20 +763,21 @@
     },
     "experimental/examples/prometheus": {
       "name": "prometheus-example",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-prometheus": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0"
+        "@opentelemetry/exporter-prometheus": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0"
       }
     },
     "experimental/packages/api-events": {
       "name": "@opentelemetry/api-events",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/api-logs": "0.50.0"
       },
       "devDependencies": {
         "@types/mocha": "10.0.6",
@@ -913,7 +913,7 @@
     },
     "experimental/packages/api-logs": {
       "name": "@opentelemetry/api-logs",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
@@ -1052,21 +1052,21 @@
     },
     "experimental/packages/exporter-logs-otlp-grpc": {
       "name": "@opentelemetry/exporter-logs-otlp-grpc",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/sdk-logs": "0.49.1"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/sdk-logs": "0.50.0"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1090,20 +1090,20 @@
     },
     "experimental/packages/exporter-logs-otlp-http": {
       "name": "@opentelemetry/exporter-logs-otlp-http",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/sdk-logs": "0.49.1"
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/sdk-logs": "0.50.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/resources": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1404,17 +1404,17 @@
     },
     "experimental/packages/exporter-logs-otlp-proto": {
       "name": "@opentelemetry/exporter-logs-otlp-proto",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -1718,20 +1718,20 @@
     },
     "experimental/packages/exporter-trace-otlp-grpc": {
       "name": "@opentelemetry/exporter-trace-otlp-grpc",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1755,14 +1755,14 @@
     },
     "experimental/packages/exporter-trace-otlp-http": {
       "name": "@opentelemetry/exporter-trace-otlp-http",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -2068,15 +2068,15 @@
     },
     "experimental/packages/exporter-trace-otlp-proto": {
       "name": "@opentelemetry/exporter-trace-otlp-proto",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -2380,11 +2380,11 @@
     },
     "experimental/packages/opentelemetry-browser-detector": {
       "name": "@opentelemetry/opentelemetry-browser-detector",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -2687,16 +2687,16 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc": {
       "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.50.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
@@ -2724,14 +2724,14 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-http": {
       "name": "@opentelemetry/exporter-metrics-otlp-http",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -3037,16 +3037,16 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-proto": {
       "name": "@opentelemetry/exporter-metrics-otlp-proto",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.50.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.8.0",
@@ -3073,16 +3073,16 @@
     },
     "experimental/packages/opentelemetry-exporter-prometheus": {
       "name": "@opentelemetry/exporter-prometheus",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -3104,10 +3104,10 @@
     },
     "experimental/packages/opentelemetry-instrumentation": {
       "name": "@opentelemetry/instrumentation",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/api-logs": "0.50.0",
         "@types/shimmer": "^1.0.2",
         "import-in-the-middle": "1.7.1",
         "require-in-the-middle": "^7.1.1",
@@ -3119,7 +3119,7 @@
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
         "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -3156,21 +3156,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-fetch": {
       "name": "@opentelemetry/instrumentation-fetch",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/sdk-trace-web": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/sdk-trace-web": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-zone": "1.22.0",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/context-zone": "1.23.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -3470,21 +3470,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-grpc": {
       "name": "@opentelemetry/instrumentation-grpc",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "devDependencies": {
         "@bufbuild/buf": "1.21.0-1",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
         "@protobuf-ts/grpc-transport": "2.9.3",
         "@protobuf-ts/runtime": "2.9.3",
         "@protobuf-ts/runtime-rpc": "2.9.3",
@@ -3511,20 +3511,20 @@
     },
     "experimental/packages/opentelemetry-instrumentation-http": {
       "name": "@opentelemetry/instrumentation-http",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
@@ -3564,21 +3564,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-xml-http-request": {
       "name": "@opentelemetry/instrumentation-xml-http-request",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/sdk-trace-web": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/sdk-trace-web": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-zone": "1.22.0",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/context-zone": "1.23.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -4166,27 +4166,27 @@
     },
     "experimental/packages/opentelemetry-sdk-node": {
       "name": "@opentelemetry/sdk-node",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-        "@opentelemetry/exporter-zipkin": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+        "@opentelemetry/exporter-zipkin": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/exporter-jaeger": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/exporter-jaeger": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -4211,10 +4211,10 @@
     },
     "experimental/packages/otlp-exporter-base": {
       "name": "@opentelemetry/otlp-exporter-base",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0"
+        "@opentelemetry/core": "1.23.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -4517,19 +4517,19 @@
     },
     "experimental/packages/otlp-grpc-exporter-base": {
       "name": "@opentelemetry/otlp-grpc-exporter-base",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
         "protobufjs": "^7.2.3"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -4554,11 +4554,11 @@
     },
     "experimental/packages/otlp-proto-exporter-base": {
       "name": "@opentelemetry/otlp-proto-exporter-base",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
         "protobufjs": "^7.2.3"
       },
       "devDependencies": {
@@ -4588,15 +4588,15 @@
     },
     "experimental/packages/otlp-transformer": {
       "name": "@opentelemetry/otlp-transformer",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.8.0",
@@ -4735,17 +4735,17 @@
     },
     "experimental/packages/sdk-logs": {
       "name": "@opentelemetry/sdk-logs",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.4.0 <1.9.0",
-        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/api-logs": "0.50.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -5095,20 +5095,20 @@
     },
     "experimental/packages/shim-opencensus": {
       "name": "@opentelemetry/shim-opencensus",
-      "version": "0.49.1",
+      "version": "0.50.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opencensus/core": "0.1.0",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -5131,7 +5131,7 @@
     },
     "integration-tests/api": {
       "name": "@opentelemetry/integration-tests-api",
-      "version": "1.22.1",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
@@ -5458,13 +5458,13 @@
       }
     },
     "integration-tests/propagation-validation-server": {
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "axios": "1.5.1",
         "body-parser": "1.19.0",
         "express": "4.19.2"
@@ -34423,7 +34423,7 @@
     },
     "packages/opentelemetry-context-async-hooks": {
       "name": "@opentelemetry/context-async-hooks",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
@@ -34446,10 +34446,10 @@
     },
     "packages/opentelemetry-context-zone": {
       "name": "@opentelemetry/context-zone",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.22.0",
+        "@opentelemetry/context-zone-peer-dep": "1.23.0",
         "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
       },
       "devDependencies": {
@@ -34463,7 +34463,7 @@
     },
     "packages/opentelemetry-context-zone-peer-dep": {
       "name": "@opentelemetry/context-zone-peer-dep",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -34779,10 +34779,10 @@
     },
     "packages/opentelemetry-core": {
       "name": "@opentelemetry/core",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
@@ -34924,17 +34924,17 @@
     },
     "packages/opentelemetry-exporter-jaeger": {
       "name": "@opentelemetry/exporter-jaeger",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "jaeger-client": "^3.15.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/resources": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -34957,13 +34957,13 @@
     },
     "packages/opentelemetry-exporter-zipkin": {
       "name": "@opentelemetry/exporter-zipkin",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
@@ -35269,10 +35269,10 @@
     },
     "packages/opentelemetry-propagator-b3": {
       "name": "@opentelemetry/propagator-b3",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0"
+        "@opentelemetry/core": "1.23.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
@@ -35296,10 +35296,10 @@
     },
     "packages/opentelemetry-propagator-jaeger": {
       "name": "@opentelemetry/propagator-jaeger",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0"
+        "@opentelemetry/core": "1.23.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
@@ -35441,11 +35441,11 @@
     },
     "packages/opentelemetry-resources": {
       "name": "@opentelemetry/resources",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
@@ -35786,12 +35786,12 @@
     },
     "packages/opentelemetry-sdk-trace-base": {
       "name": "@opentelemetry/sdk-trace-base",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
@@ -35934,20 +35934,20 @@
     },
     "packages/opentelemetry-sdk-trace-node": {
       "name": "@opentelemetry/sdk-trace-node",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/propagator-jaeger": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/propagator-jaeger": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -35970,20 +35970,20 @@
     },
     "packages/opentelemetry-sdk-trace-web": {
       "name": "@opentelemetry/sdk-trace-web",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "devDependencies": {
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/context-zone": "1.22.0",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/context-zone": "1.23.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
         "@types/jquery": "3.5.29",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -36286,7 +36286,7 @@
     },
     "packages/opentelemetry-semantic-conventions": {
       "name": "@opentelemetry/semantic-conventions",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@size-limit/file": "^11.0.1",
@@ -36374,18 +36374,18 @@
     },
     "packages/opentelemetry-shim-opentracing": {
       "name": "@opentelemetry/shim-opentracing",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "opentracing": "^0.14.4"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/propagator-jaeger": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/propagator-jaeger": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -36405,11 +36405,11 @@
     },
     "packages/sdk-metrics": {
       "name": "@opentelemetry/sdk-metrics",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
         "lodash.merge": "^4.6.2"
       },
       "devDependencies": {
@@ -36714,7 +36714,7 @@
     },
     "packages/template": {
       "name": "@opentelemetry/template",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -36728,19 +36728,19 @@
     },
     "selenium-tests": {
       "name": "@opentelemetry/selenium-tests",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-zipkin": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/instrumentation-fetch": "0.49.1",
-        "@opentelemetry/instrumentation-xml-http-request": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-web": "1.22.0",
+        "@opentelemetry/context-zone-peer-dep": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-zipkin": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/instrumentation-fetch": "0.50.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-web": "1.23.0",
         "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
       },
       "devDependencies": {
@@ -40220,6 +40220,7 @@
       "version": "file:experimental/packages/api-events",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/api-logs": "0.50.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/webpack-env": "1.16.3",
@@ -40402,7 +40403,7 @@
     "@opentelemetry/context-zone": {
       "version": "file:packages/opentelemetry-context-zone",
       "requires": {
-        "@opentelemetry/context-zone-peer-dep": "1.22.0",
+        "@opentelemetry/context-zone-peer-dep": "1.23.0",
         "cross-var": "1.1.0",
         "lerna": "6.6.2",
         "typescript": "4.4.4",
@@ -40590,7 +40591,7 @@
       "version": "file:packages/opentelemetry-core",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40677,10 +40678,10 @@
       "version": "file:packages/opentelemetry-exporter-jaeger",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40702,13 +40703,13 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40730,12 +40731,12 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40904,14 +40905,14 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41078,12 +41079,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.50.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41105,11 +41106,11 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41276,13 +41277,13 @@
       "version": "file:experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
       "requires": {
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.50.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41302,10 +41303,10 @@
       "version": "file:experimental/packages/opentelemetry-exporter-prometheus",
       "requires": {
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41325,12 +41326,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41352,11 +41353,11 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41525,12 +41526,12 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41697,10 +41698,10 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -41870,7 +41871,7 @@
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
         "@opentelemetry/api-logs": "0.47.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -42065,13 +42066,13 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-zone": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-web": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/context-zone": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-web": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -42240,12 +42241,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@protobuf-ts/grpc-transport": "2.9.3",
         "@protobuf-ts/runtime": "2.9.3",
         "@protobuf-ts/runtime-rpc": "2.9.3",
@@ -42268,13 +42269,13 @@
       "version": "file:experimental/packages/opentelemetry-instrumentation-http",
       "requires": {
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
@@ -42314,13 +42315,13 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-zone": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-web": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/context-zone": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-web": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -42726,8 +42727,8 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -42893,7 +42894,7 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -43058,11 +43059,11 @@
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -43086,8 +43087,8 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -43108,12 +43109,12 @@
       "version": "file:experimental/packages/otlp-transformer",
       "requires": {
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/webpack-env": "1.16.3",
         "babel-plugin-istanbul": "6.1.1",
@@ -43197,7 +43198,7 @@
       "version": "file:packages/opentelemetry-propagator-b3",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -43214,7 +43215,7 @@
       "version": "file:packages/opentelemetry-propagator-jaeger",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -43301,9 +43302,9 @@
       "version": "file:packages/opentelemetry-resources",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/core": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -43491,9 +43492,9 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.4.0 <1.9.0",
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -43693,8 +43694,8 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.3.0 <1.9.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
         "@types/lodash.merge": "4.6.9",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -43860,21 +43861,21 @@
       "version": "file:experimental/packages/opentelemetry-sdk-node",
       "requires": {
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-jaeger": "1.22.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-        "@opentelemetry/exporter-zipkin": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-jaeger": "1.23.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+        "@opentelemetry/exporter-zipkin": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -43895,9 +43896,9 @@
       "version": "file:packages/opentelemetry-sdk-trace-base",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -43985,13 +43986,13 @@
       "version": "file:packages/opentelemetry-sdk-trace-node",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/propagator-jaeger": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/propagator-jaeger": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.6",
@@ -44013,12 +44014,12 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/context-zone": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/context-zone": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/jquery": "3.5.29",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -44192,16 +44193,16 @@
         "@babel/plugin-transform-runtime": "7.22.15",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-zone-peer-dep": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-zipkin": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/instrumentation-fetch": "0.49.1",
-        "@opentelemetry/instrumentation-xml-http-request": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-web": "1.22.0",
+        "@opentelemetry/context-zone-peer-dep": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-zipkin": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/instrumentation-fetch": "0.50.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-web": "1.23.0",
         "babel-loader": "8.3.0",
         "babel-polyfill": "6.26.0",
         "browserstack-local": "1.4.8",
@@ -44567,11 +44568,11 @@
       "requires": {
         "@opencensus/core": "0.1.0",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -44591,11 +44592,11 @@
       "version": "file:packages/opentelemetry-shim-opentracing",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/propagator-jaeger": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/propagator-jaeger": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -47335,8 +47336,8 @@
     "backcompat-node14": {
       "version": "file:experimental/backwards-compatibility/node14",
       "requires": {
-        "@opentelemetry/sdk-node": "0.49.1",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-node": "0.50.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/node": "14.18.25",
         "typescript": "4.4.4"
       },
@@ -47350,8 +47351,8 @@
     "backcompat-node16": {
       "version": "file:experimental/backwards-compatibility/node16",
       "requires": {
-        "@opentelemetry/sdk-node": "0.49.1",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/sdk-node": "0.50.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "@types/node": "16.11.52",
         "typescript": "4.4.4"
       },
@@ -49977,13 +49978,13 @@
       "version": "file:examples/esm-http-ts",
       "requires": {
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/instrumentation-http": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/instrumentation-http": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "espree": {
@@ -50116,17 +50117,17 @@
       "version": "file:examples/otlp-exporter-node",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.49.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.50.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "execa": {
@@ -51737,14 +51738,14 @@
       "version": "file:examples/http",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.22.0",
-        "@opentelemetry/exporter-zipkin": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/instrumentation-http": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/exporter-jaeger": "1.23.0",
+        "@opentelemetry/exporter-zipkin": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/instrumentation-http": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "cross-env": "^6.0.0"
       }
     },
@@ -51830,14 +51831,14 @@
       "version": "file:examples/https",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.22.0",
-        "@opentelemetry/exporter-zipkin": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/instrumentation-http": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/exporter-jaeger": "1.23.0",
+        "@opentelemetry/exporter-zipkin": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/instrumentation-http": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "cross-env": "^6.0.0"
       }
     },
@@ -53567,8 +53568,8 @@
       "version": "file:experimental/examples/logs",
       "requires": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/sdk-logs": "0.49.1",
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
         "@types/node": "18.6.5",
         "ts-node": "^10.9.1"
       },
@@ -55997,13 +55998,13 @@
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/exporter-prometheus": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
-        "@opentelemetry/shim-opencensus": "0.49.1"
+        "@opentelemetry/exporter-prometheus": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
+        "@opentelemetry/shim-opencensus": "0.50.0"
       }
     },
     "opentracing": {
@@ -56819,8 +56820,8 @@
       "version": "file:experimental/examples/prometheus",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-prometheus": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0"
+        "@opentelemetry/exporter-prometheus": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0"
       }
     },
     "promise-all-reject-late": {
@@ -56858,9 +56859,9 @@
       "version": "file:integration-tests/propagation-validation-server",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "axios": "1.5.1",
         "body-parser": "1.19.0",
         "express": "4.19.2",
@@ -60573,20 +60574,20 @@
         "@babel/core": "^7.23.6",
         "@babel/preset-env": "^7.22.20",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-        "@opentelemetry/exporter-zipkin": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/instrumentation-fetch": "0.49.1",
-        "@opentelemetry/instrumentation-xml-http-request": "0.49.1",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-web": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/context-zone": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+        "@opentelemetry/exporter-zipkin": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/instrumentation-fetch": "0.50.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.50.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-web": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "babel-loader": "^8.0.6",
         "ts-loader": "^9.2.6",
         "typescript": "^4.5.2",

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -55,7 +55,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.22.0",
+    "@opentelemetry/context-zone-peer-dep": "1.23.0",
     "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
   },
   "sideEffects": true,

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,7 +91,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core",
   "sideEffects": false

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/resources": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -63,9 +63,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0",
     "jaeger-client": "^3.15.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,10 +93,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin",
   "sideEffects": false

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0"
+    "@opentelemetry/core": "1.23.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.9.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -81,7 +81,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0"
+    "@opentelemetry/core": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger",
   "sideEffects": false

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -91,8 +91,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,9 +93,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,8 +46,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.9.0",
-    "@opentelemetry/resources": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0",
+    "@opentelemetry/resources": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.6",
@@ -65,11 +65,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.22.0",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/propagator-b3": "1.22.0",
-    "@opentelemetry/propagator-jaeger": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/context-async-hooks": "1.23.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/propagator-b3": "1.23.0",
+    "@opentelemetry/propagator-jaeger": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
     "semver": "^7.5.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -58,9 +58,9 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": ">=1.0.0 <1.9.0",
-    "@opentelemetry/context-zone": "1.22.0",
-    "@opentelemetry/propagator-b3": "1.22.0",
-    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/context-zone": "1.23.0",
+    "@opentelemetry/propagator-b3": "1.23.0",
+    "@opentelemetry/resources": "1.23.0",
     "@types/jquery": "3.5.29",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -93,9 +93,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0"
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web",
   "sideEffects": false

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -43,9 +43,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.9.0",
-    "@opentelemetry/propagator-b3": "1.22.0",
-    "@opentelemetry/propagator-jaeger": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
+    "@opentelemetry/propagator-b3": "1.23.0",
+    "@opentelemetry/propagator-jaeger": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
@@ -60,8 +60,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.9.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/semantic-conventions": "1.22.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/semantic-conventions": "1.23.0",
     "opentracing": "^0.14.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing",

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -85,8 +85,8 @@
     "@opentelemetry/api": ">=1.3.0 <1.9.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/resources": "1.22.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/resources": "1.23.0",
     "lodash.merge": "^4.6.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-metrics",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
@@ -56,16 +56,16 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.22.0",
-    "@opentelemetry/core": "1.22.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-    "@opentelemetry/exporter-zipkin": "1.22.0",
-    "@opentelemetry/instrumentation": "0.49.1",
-    "@opentelemetry/instrumentation-fetch": "0.49.1",
-    "@opentelemetry/instrumentation-xml-http-request": "0.49.1",
-    "@opentelemetry/sdk-metrics": "1.22.0",
-    "@opentelemetry/sdk-trace-base": "1.22.0",
-    "@opentelemetry/sdk-trace-web": "1.22.0",
+    "@opentelemetry/context-zone-peer-dep": "1.23.0",
+    "@opentelemetry/core": "1.23.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+    "@opentelemetry/exporter-zipkin": "1.23.0",
+    "@opentelemetry/instrumentation": "0.50.0",
+    "@opentelemetry/instrumentation-fetch": "0.50.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.50.0",
+    "@opentelemetry/sdk-metrics": "1.23.0",
+    "@opentelemetry/sdk-trace-base": "1.23.0",
+    "@opentelemetry/sdk-trace-web": "1.23.0",
     "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
   }
 }


### PR DESCRIPTION
## 1.23.0

### :rocket: (Enhancement)

* perf(sdk-trace-base): do not allocate arrays if resource has no pending async attributes [#4576](https://github.com/open-telemetry/opentelemetry-js/pull/4576) @Samuron
* feat(sdk-metrics): added experimental synchronous gauge to SDK [#4565](https://github.com/open-telemetry/opentelemetry-js/pull/4565) @clintonb
  * this change will become user-facing in an upcoming release

### :bug: (Bug Fix)

* fix(sdk-metrics): increase the depth of the output to the console such that objects in the metric are printed fully to the console [#4522](https://github.com/open-telemetry/opentelemetry-js/pull/4522) @JacksonWeber

## 0.50.0

### :boom: Breaking Change

* fix(exporter-*-otlp-grpc)!: lazy load gRPC to improve compatibility with `@opentelemetry/instrumenation-grpc` [#4432](https://github.com/open-telemetry/opentelemetry-js/pull/4432) @pichlermarc
  * Fixes a bug where requiring up the gRPC exporter before enabling the instrumentation from `@opentelemetry/instrumentation-grpc` would lead to missing telemetry
  * Breaking changes, removes several functions and properties that were used internally and were not intended for end-users
    * `getServiceClientType()`
      * this returned a static enum value that would denote the export type (`SPAN`, `METRICS`, `LOGS`)
    * `getServiceProtoPath()`
      * this returned a static enum value that would correspond to the gRPC service path
    * `metadata`
      * was used internally to access metadata, but as a side effect allowed end-users to modify metadata on runtime.
    * `serviceClient`
      * was used internally to keep track of the service client used by the exporter, as a side effect it allowed end-users to modify the gRPC service client that was used
    * `compression`
      * was used internally to keep track of the compression to use but was unintentionally exposed to the users. It allowed to read and write the value, writing, however, would have no effect.
* feat(api-events)!: removed domain from the Events API [#4569](https://github.com/open-telemetry/opentelemetry-js/pull/4569) @martinkuba
* fix(api-events)!: renamed EventEmitter to EventLogger in the Events API [#4569](https://github.com/open-telemetry/opentelemetry-js/pull/4568) @martinkuba
* feat(api-logs)!: changed LogRecord body data type to AnyValue [#4575](https://github.com/open-telemetry/opentelemetry-js/pull/4575) @martinkuba
and AnyValueMap types [#4575](https://github.com/open-telemetry/opentelemetry-js/pull/4575) @martinkuba

### :rocket: (Enhancement)

* feat(instrumentation-xhr): optionally ignore network events [#4571](https://github.com/open-telemetry/opentelemetry-js/pull/4571/) @mustafahaddara
* refactor(instrumentation-http): use exported strings for semconv [#4573](https://github.com/open-telemetry/opentelemetry-js/pull/4573/) @JamieDanielson
* perf(instrumentation-http): remove obvious temp allocations [#4576](https://github.com/open-telemetry/opentelemetry-js/pull/4576) @Samuron
* feat(sdk-node): add `HostDetector` as default resource detector [#4566](https://github.com/open-telemetry/opentelemetry-js/pull/4566) @maryliag
* feat(api-events): added data field to the Event interface [#4575](https://github.com/open-telemetry/opentelemetry-js/pull/4575) @martinkuba

### :bug: (Bug Fix)

* fix(exporter-*-otlp-*): use parseHeaders() to ensure header-values are not 'undefined' #4540
  * Fixes a bug where passing `undefined` as a header value would crash the end-user app after the export timeout elapsed.
* fix(sdk-logs): ensure default resource attributes are used as fallbacks when a resource is passed to LoggerProvider.

### :books: (Refine Doc)

* docs(instrumentation-http): document semantic conventions and attributes in use. [#4587](https://github.com/open-telemetry/opentelemetry-js/pull/4587/) @JamieDanielson
