### PR TITLE
feat(sdk-trace-base): log resource attributes in ConsoleSpanExporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :rocket: (Enhancement)
 
+feat(sdk-trace-base): log resource attributes in ConsoleSpanExporter [#4605](https://github.com/open-telemetry/opentelemetry-js/pull/4605) @pichlermarc
+
 ### :bug: (Bug Fix)
 
 ### :books: (Refine Doc)

--- a/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
@@ -62,6 +62,9 @@ export class ConsoleSpanExporter implements SpanExporter {
    */
   private _exportInfo(span: ReadableSpan) {
     return {
+      resource: {
+        attributes: span.resource.attributes,
+      },
       traceId: span.spanContext().traceId,
       parentId: span.parentSpanId,
       traceState: span.spanContext().traceState?.serialize(),

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/ConsoleSpanExporter.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/ConsoleSpanExporter.test.ts
@@ -84,6 +84,7 @@ describe('ConsoleSpanExporter', () => {
           'links',
           'name',
           'parentId',
+          'resource',
           'status',
           'timestamp',
           'traceId',


### PR DESCRIPTION
## Which problem is this PR solving?

It's currently impossible to troubleshoot resource setup without explicitly logging the resource before setting up the SDK. 
This PR adds the span's resource to the output that's logged to the console to aid troubleshooting.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
