### PR TITLE
feat(prometheus-exporter): add unref function check to improve compat…

### DIFF
--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -79,7 +79,10 @@ export class PrometheusExporter extends MetricReader {
         ? config.appendTimestamp
         : PrometheusExporter.DEFAULT_OPTIONS.appendTimestamp;
     // unref to prevent prometheus exporter from holding the process open on exit
-    this._server = createServer(this._requestHandler).unref();
+    this._server = createServer(this._requestHandler);
+    if (typeof this._server.unref === 'function') {
+      this._server.unref();
+    }
     this._serializer = new PrometheusSerializer(
       this._prefix,
       this._appendTimestamp


### PR DESCRIPTION
## Which problem is this PR solving?

This PR introduces a conditional unref feature to the Prometheus Exporter within the OpenTelemetry JavaScript project. Previously, the unref method was called unconditionally, which could lead to potential issues in environments where unref is not available or not needed, thus keeping the process open unnecessarily. This change enhances compatibility and reliability, especially in diverse runtime environments.

Fixes # https://github.com/open-telemetry/opentelemetry-js/issues/4488

## Short description of the changes
* Added a check to ensure unref is only called if it is a function, preventing potential runtime errors in environments where unref might not be available.
* This ensures the HTTP server created by the Prometheus exporter does not keep the process open when not required, allowing for cleaner shutdowns and resource management.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

The changes were tested by:

- [x] Existing tests pass

## Checklist:

- [x] Followed the style guidelines of this project
