### PR TITLE
use sendBeacon for exporting when page is hidden

### DIFF
--- a/experimental/packages/otlp-exporter-base/src/types.ts
+++ b/experimental/packages/otlp-exporter-base/src/types.ts
@@ -52,4 +52,5 @@ export interface OTLPExporterConfigBase {
   /** Maximum time the OTLP exporter will wait for each batch export.
    * The default value is 10000ms. */
   timeoutMillis?: number;
+  alwaysUseXhr?: boolean;
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
Currently, the option to use xhr vs sendBeacon is left to the app developer when setting up the sdk. However, when a page is hidden we must use sendBeacon or otherwise risk losing the data. This PR makes this change, while still giving an option to the app developer to override and use xhr all the time.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
