### PR TITLE
test(exporter-*-grpc): use RegExp to match Deadline Exceeded error

### DIFF
--- a/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
@@ -224,9 +224,9 @@ const testCollectorExporter = (params: TestParams) => {
         setTimeout(() => {
           const result = responseSpy.args[0][0] as core.ExportResult;
           assert.strictEqual(result.code, core.ExportResultCode.FAILED);
-          assert.strictEqual(
+          assert.match(
             responseSpy.args[0][0].error.details,
-            'Deadline exceeded'
+            /Deadline exceeded.*/
           );
           done();
         }, 300);

--- a/experimental/packages/exporter-trace-otlp-grpc/test/OTLPTraceExporter.test.ts
+++ b/experimental/packages/exporter-trace-otlp-grpc/test/OTLPTraceExporter.test.ts
@@ -231,9 +231,9 @@ const testCollectorExporter = (params: TestParams) => {
         setTimeout(() => {
           const result = responseSpy.args[0][0] as core.ExportResult;
           assert.strictEqual(result.code, core.ExportResultCode.FAILED);
-          assert.strictEqual(
+          assert.match(
             responseSpy.args[0][0].error.details,
-            'Deadline exceeded'
+            /Deadline exceeded.*/
           );
           done();
         }, 300);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
+        "api",
         "packages/*",
         "experimental/packages/*",
         "experimental/examples/*",
@@ -7485,14 +7486,15 @@
       "license": "MIT"
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.21",
-      "license": "Apache-2.0",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.6.tgz",
+      "integrity": "sha512-xP58G7wDQ4TCmN/cMUHh00DS7SRDv/+lC+xFLrTkMIN8h55X5NhZMLYbvy7dSELP15qlI6hPhNCRWVMtZMwqLA==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.0",
-        "@types/node": ">=12.12.47"
+        "@grpc/proto-loader": "^0.7.10",
+        "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
-        "node": "^8.13.0 || >=10.10.0"
+        "node": ">=12.10.0"
       }
     },
     "node_modules/@grpc/proto-loader": {
@@ -7727,6 +7729,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@jsdoc/salty": {
@@ -38535,10 +38546,12 @@
       "dev": true
     },
     "@grpc/grpc-js": {
-      "version": "1.8.21",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.6.tgz",
+      "integrity": "sha512-xP58G7wDQ4TCmN/cMUHh00DS7SRDv/+lC+xFLrTkMIN8h55X5NhZMLYbvy7dSELP15qlI6hPhNCRWVMtZMwqLA==",
       "requires": {
-        "@grpc/proto-loader": "^0.7.0",
-        "@types/node": ">=12.12.47"
+        "@grpc/proto-loader": "^0.7.10",
+        "@js-sdsl/ordered-map": "^4.4.2"
       }
     },
     "@grpc/proto-loader": {
@@ -38684,6 +38697,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="
     },
     "@jsdoc/salty": {
       "version": "0.2.5",


### PR DESCRIPTION
## Which problem is this PR solving?

New versions of `@grpc/grpc-js` add more info to the `Deadline Exceeded` error, making our tests fail. The error still starts with `Deadline Exceeded` so I switched the assertion from a `strictEqual()` to a `match()`

## Short description of the changes

- Update `@grpc/grpc-js` to latest (package-lock.json only)
- Adapt tests

## How Has This Been Tested?

- [x] Modified existing tests