### PR TITLE
fix: ensure api is not dropped from workspaces in package-lock.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "comment_internal": "echo scripts below this line are for internal use",
     "_check:no_changes": "if [ ! -z \"$(git status -uall --porcelain)\" ]; then echo Please ensure all changes are committed; exit 1; fi",
     "_backup:package-json": "cp package.json package.json.backup",
-    "_restore:package-json": "mv package.json.backup package.json",
+    "_restore:package-json": "mv package.json.backup package.json && npm install --package-lock-only",
     "_lerna:remove_api": "node -e 'var fs=require(\"fs\");var p=require(\"./package.json\");p.workspaces=p.workspaces.filter(p=>p!==\"api\");fs.writeFileSync(\"package.json\",JSON.stringify(p,null,2))'",
     "_lerna:remove_stable": "node -e 'var fs=require(\"fs\");var p=require(\"./package.json\");p.workspaces=p.workspaces.filter(p=>p!==\"packages/*\");fs.writeFileSync(\"package.json\",JSON.stringify(p,null,2))'",
     "_lerna:version_patch": "npx lerna version patch --exact --no-git-tag-version --no-push --yes",


### PR DESCRIPTION
## Which problem is this PR solving?

See discussion in #4621, when releasing the API is temporarily removed. This bleeds over into `package-lock.json` where it's never rectified by the `_restore:package-json` script.

This PR adds a `npm install --package-lock-only` to sync the `package-lock.json` again after incrementing versions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] internal

## How Has This Been Tested?

- [x] Manually tested by running `prepare_release:sdk:minor`