### PR TITLE
doc(instr-fetch): mention instr-undici for Node.js fetch()

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-fetch/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/README.md
@@ -6,7 +6,7 @@
 **Note: This is an experimental package under active development. New releases may include breaking changes.**
 
 This module provides auto instrumentation for web using [fetch](https://developer.mozilla.org/en-US/docs/Web/API/fetch).
-(Note: This instrumentation does **not** instrument [Node.js' fetch](https://nodejs.org/api/globals.html#fetch). See [this issue](https://github.com/open-telemetry/opentelemetry-js/issues/4333).)
+(Note: This instrumentation does **not** instrument [Node.js' fetch](https://nodejs.org/api/globals.html#fetch). See [`@opentelemetry/instrumentation-undici`](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-undici/) for that.)
 
 ## Installation
 


### PR DESCRIPTION
Now that instrumentation-undici exists, point to it for users that want
instrumentation of Node.js' fetch().
