### PR TITLE
chore(instrumentation): remove accidental devDep on api-logs

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -85,7 +85,6 @@
     "@babel/core": "7.23.6",
     "@babel/preset-env": "7.22.20",
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/api-logs": "0.47.0",
     "@opentelemetry/sdk-metrics": "1.23.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3119,7 +3119,6 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.47.0",
         "@opentelemetry/sdk-metrics": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -3875,18 +3874,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "experimental/packages/opentelemetry-instrumentation/node_modules/@opentelemetry/api-logs": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.47.0.tgz",
-      "integrity": "sha512-AR6UOVcWZkuibLR/7/OecYJasncAf6VstNV/KT5qHq1HShVFmJetcgim0KMog/ON23yHZQjT9GPVTwB0FEhPQA==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "experimental/packages/opentelemetry-instrumentation/node_modules/@webpack-cli/configtest": {
@@ -41888,7 +41875,7 @@
         "@babel/core": "7.23.6",
         "@babel/preset-env": "7.22.20",
         "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.47.0",
+        "@opentelemetry/api-logs": "0.50.0",
         "@opentelemetry/sdk-metrics": "1.23.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -41923,15 +41910,6 @@
         "webpack-merge": "5.10.0"
       },
       "dependencies": {
-        "@opentelemetry/api-logs": {
-          "version": "0.47.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.47.0.tgz",
-          "integrity": "sha512-AR6UOVcWZkuibLR/7/OecYJasncAf6VstNV/KT5qHq1HShVFmJetcgim0KMog/ON23yHZQjT9GPVTwB0FEhPQA==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/api": "^1.0.0"
-          }
-        },
         "@webpack-cli/configtest": {
           "version": "2.1.1",
           "dev": true,


### PR DESCRIPTION
This package accidentally got a dep and devDep on api-logs, at
different versions. The result was it being pinned at the older
version in package-lock.

* * *

@pichlermarc I am still trying to understand why the huge package-lock diff in https://github.com/open-telemetry/opentelemetry-js/pull/4621.  While playing around I noticed this buglet. I'm not sure it was causing any bugs, but I think it meant that local testing of this `instrumentation` package (i.e. when installing with package-lock) would have been using the older api-logs.

/me gives mean eyes to `npm` that blithely doesn't complain when there are incompatible entries in "dependencies" and "devDependencies".