### PR TITLE
chore(renovate): enable lock file maintainance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,10 @@
       "dependencyDashboardApproval": true
     }
   ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 3am on Monday"]
+  },
   "ignoreDeps": ["@opentelemetry/api", "@opentelemetry/resources_1.9.0", "@types/node"],
   "assignees": ["@blumamir", "@dyladan", "@legendecas", "@pichlermarc"],
   "labels": ["dependencies"]


### PR DESCRIPTION
Enables lock file maintenance via renovate bot so we don't have to do it manually every time.