### PR TITLE
feat!(instrumentation): add patch and unpatch diag log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :boom: Breaking Change
 
+* feat(instrumentation): add patch and unpatch diag log messages [#4641](https://github.com/open-telemetry/opentelemetry-js/pull/4641)
+  * Instrumentations should not log patch and unpatch messages to diag channel.
+
 ### :rocket: (Enhancement)
 
 * feat(sdk-trace-base): log resource attributes in ConsoleSpanExporter [#4605](https://github.com/open-telemetry/opentelemetry-js/pull/4605) @pichlermarc

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
@@ -101,8 +101,7 @@ export class GrpcInstrumentation extends InstrumentationBase {
       new InstrumentationNodeModuleDefinition<any>(
         '@grpc/grpc-js',
         ['1.*'],
-        (moduleExports, version) => {
-          this._diag.debug(`Applying patch for @grpc/grpc-js@${version}`);
+        moduleExports => {
           if (isWrapped(moduleExports.Server.prototype.register)) {
             this._unwrap(moduleExports.Server.prototype, 'register');
           }
@@ -174,9 +173,8 @@ export class GrpcInstrumentation extends InstrumentationBase {
           );
           return moduleExports;
         },
-        (moduleExports, version) => {
+        moduleExports => {
           if (moduleExports === undefined) return;
-          this._diag.debug(`Removing patch for @grpc/grpc-js@${version}`);
 
           this._unwrap(moduleExports.Server.prototype, 'register');
           this._unwrap(moduleExports, 'makeClientConstructor');

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -111,12 +111,10 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
   }
 
   private _getHttpInstrumentation() {
-    const version = process.versions.node;
     return new InstrumentationNodeModuleDefinition<Http>(
       'http',
       ['*'],
       moduleExports => {
-        this._diag.debug(`Applying patch for http@${version}`);
         if (isWrapped(moduleExports.request)) {
           this._unwrap(moduleExports, 'request');
         }
@@ -145,7 +143,6 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       },
       moduleExports => {
         if (moduleExports === undefined) return;
-        this._diag.debug(`Removing patch for http@${version}`);
 
         this._unwrap(moduleExports, 'request');
         this._unwrap(moduleExports, 'get');
@@ -155,12 +152,10 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
   }
 
   private _getHttpsInstrumentation() {
-    const version = process.versions.node;
     return new InstrumentationNodeModuleDefinition<Https>(
       'https',
       ['*'],
       moduleExports => {
-        this._diag.debug(`Applying patch for https@${version}`);
         if (isWrapped(moduleExports.request)) {
           this._unwrap(moduleExports, 'request');
         }
@@ -189,7 +184,6 @@ export class HttpInstrumentation extends InstrumentationBase<Http> {
       },
       moduleExports => {
         if (moduleExports === undefined) return;
-        this._diag.debug(`Removing patch for https@${version}`);
 
         this._unwrap(moduleExports, 'request');
         this._unwrap(moduleExports, 'get');

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -183,6 +183,13 @@ export abstract class InstrumentationBase<T = any>
       if (typeof module.patch === 'function') {
         module.moduleExports = exports;
         if (this._enabled) {
+          this._diag.debug(
+            'Applying instrumentation patch for nodejs core module on require hook',
+            {
+              module: module.name,
+              version: module.moduleVersion,
+            }
+          );
           return module.patch(exports);
         }
       }
@@ -199,6 +206,14 @@ export abstract class InstrumentationBase<T = any>
         if (typeof module.patch === 'function') {
           module.moduleExports = exports;
           if (this._enabled) {
+            this._diag.debug(
+              'Applying instrumentation patch for module on require hook',
+              {
+                module: module.name,
+                version: module.moduleVersion,
+                baseDir,
+              }
+            );
             return module.patch(exports, module.moduleVersion);
           }
         }
@@ -216,6 +231,15 @@ export abstract class InstrumentationBase<T = any>
     return supportedFileInstrumentations.reduce<T>((patchedExports, file) => {
       file.moduleExports = patchedExports;
       if (this._enabled) {
+        this._diag.debug(
+          'Applying instrumentation patch for nodejs module file on require hook',
+          {
+            module: module.name,
+            version: module.moduleVersion,
+            fileName: file.name,
+            baseDir,
+          }
+        );
         return file.patch(patchedExports, module.moduleVersion);
       }
       return patchedExports;
@@ -232,10 +256,25 @@ export abstract class InstrumentationBase<T = any>
     if (this._hooks.length > 0) {
       for (const module of this._modules) {
         if (typeof module.patch === 'function' && module.moduleExports) {
+          this._diag.debug(
+            'Applying instrumentation patch for nodejs module on instrumentation enabled',
+            {
+              module: module.name,
+              version: module.moduleVersion,
+            }
+          );
           module.patch(module.moduleExports, module.moduleVersion);
         }
         for (const file of module.files) {
           if (file.moduleExports) {
+            this._diag.debug(
+              'Applying instrumentation patch for nodejs module file on instrumentation enabled',
+              {
+                module: module.name,
+                version: module.moduleVersion,
+                fileName: file.name,
+              }
+            );
             file.patch(file.moduleExports, module.moduleVersion);
           }
         }
@@ -288,10 +327,25 @@ export abstract class InstrumentationBase<T = any>
 
     for (const module of this._modules) {
       if (typeof module.unpatch === 'function' && module.moduleExports) {
+        this._diag.debug(
+          'Removing instrumentation patch for nodejs module on instrumentation disabled',
+          {
+            module: module.name,
+            version: module.moduleVersion,
+          }
+        );
         module.unpatch(module.moduleExports, module.moduleVersion);
       }
       for (const file of module.files) {
         if (file.moduleExports) {
+          this._diag.debug(
+            'Removing instrumentation patch for nodejs module file on instrumentation disabled',
+            {
+              module: module.name,
+              version: module.moduleVersion,
+              fileName: file.name,
+            }
+          );
           file.unpatch(file.moduleExports, module.moduleVersion);
         }
       }

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -187,7 +187,6 @@ export abstract class InstrumentationBase<T = any>
             'Applying instrumentation patch for nodejs core module on require hook',
             {
               module: module.name,
-              version: module.moduleVersion,
             }
           );
           return module.patch(exports);


### PR DESCRIPTION
This PR introduces diag.debug message for `@opentelemetry/instrumentation` patch and unpatch function for nodejs.

It is a common practice for instrumentations that implement `InstrumentationBase` to define `patch` and `unpatch` functions for modules and module files, and emit a diag message on each invocation. Since we have dozens of instrumentations that does the same thing, the current practice introduces unnecessary repetitions, inconsistencies and degraded user and maintainer experience.

This PR hoists the diag printing to the `@opentelemetry/instrumentation` package where the diag message is written once and applied to all instrumentations.

Instrumentation implementors will need to remove the current diag.debug call in `patch` and `unpatch` if they apply any, so the message will only be printed one by the base class.

example of the message content with `DiagConsoleLogger`:

```shell
@opentelemetry/instrumentation-mongoose Applying instrumentation patch for module on require {
  module: 'mongoose',
  version: '6.12.8',
  baseDir: '/Users/amirblum/repos/node-pg/node_modules/mongoose'
}
```

The message is formatted as constant message and attributes.

I created a contrib PR: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2107 to apply the changes, so once we release this feature we can immediately rebase the contrib PR and release instrumentations based on this change 