### PR TITLE
feat(sdk-logs): emit resource attributes from ConsoleLogRecordExporter

### DIFF
--- a/experimental/packages/sdk-logs/src/export/ConsoleLogRecordExporter.ts
+++ b/experimental/packages/sdk-logs/src/export/ConsoleLogRecordExporter.ts
@@ -52,6 +52,9 @@ export class ConsoleLogRecordExporter implements LogRecordExporter {
    */
   private _exportInfo(logRecord: ReadableLogRecord) {
     return {
+      resource: {
+        attributes: logRecord.resource.attributes,
+      },
       timestamp: hrTimeToMicroseconds(logRecord.hrTime),
       traceId: logRecord.spanContext?.traceId,
       spanId: logRecord.spanContext?.spanId,

--- a/experimental/packages/sdk-logs/test/common/export/ConsoleLogRecordExporter.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/ConsoleLogRecordExporter.test.ts
@@ -69,6 +69,7 @@ describe('ConsoleLogRecordExporter', () => {
           'timestamp',
           'traceFlags',
           'traceId',
+          'resource'
         ].join(',');
 
         assert.ok(firstLogRecord.body === 'body1');


### PR DESCRIPTION
## Which problem is this PR solving?

Logging via the SDK emits the resource attributes, but `ConsoleLogRecordExporter` does not reflect that - which is very confusing and makes it hard to troubleshoot logging / resource-detection issues.
This PR adds the log-record's resource to the output that's logged to the console to aid troubleshooting.

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/4645

## Short description of the changes

Adding a new `resource` attribute to each log record emitted by `ConsoleLogRecordExporter`

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

By extending the current tests for `ConsoleLogRecordExporter`