### PR TITLE
fix: Hide `require.resolve` from bundlers

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix: Hide `require.resolve` from bundlers
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)


### PR DESCRIPTION
## Which problem is this PR solving?

Bundlers pick up and attempt to parse `require.resolve` and give warnings or errors because the module name is dynamic.
See https://github.com/open-telemetry/opentelemetry-js/issues/4173#issuecomment-2075469800

Fixes #4173

## Short description of the changes

I proposed this fix here https://github.com/open-telemetry/opentelemetry-js/issues/4173#issuecomment-2075816362

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

