### PR TITLE
chore: prepare release API 1.9.0/Core 1.25.0/Experimental 0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :rocket: (Enhancement)
 
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 1.25.0
+
+### :rocket: (Enhancement)
+
 * feat: support node 22 [#4666](https://github.com/open-telemetry/opentelemetry-js/pull/4666) @dyladan
 * feat(context-zone*): support zone.js 0.12.x [#4376](https://github.com/open-telemetry/opentelemetry-js/pull/4736) @maldago
 * refactor(core): Use tree-shakeable string constants for semconv [#4739](https://github.com/open-telemetry/opentelemetry-js/pull/4739) @JohannesHuster
@@ -22,8 +32,6 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * refactor(resources): update deprecated semconv to use exported strings [#4755](https://github.com/open-telemetry/opentelemetry-js/pull/#4755) @JamieDanielson
 * refactor(exporters): update deprecated semconv to use exported strings [#4756](https://github.com/open-telemetry/opentelemetry-js/pull/#4756) @JamieDanielson
 
-### :bug: (Bug Fix)
-
 ### :books: (Refine Doc)
 
 * refactor(examples): use new exported string constants for semconv in examples/esm-http-ts [#4758](https://github.com/open-telemetry/opentelemetry-js/pull/4758) @Zen-cronic
@@ -32,8 +40,6 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * refactor(examples): use new exported string constants for semconv in examples/grpc-js [#4760](https://github.com/open-telemetry/opentelemetry-js/pull/4760#pull) @Zen-cronic
 * refactor(examples): use new exported string constants for semconv in examples/otlp-exporter-node [#4762](https://github.com/open-telemetry/opentelemetry-js/pull/4762) @Zen-cronic
 * refactor(examples): use new exported string constants for semconv in examples/opentracing-shim [#4761](https://github.com/open-telemetry/opentelemetry-js/pull/4761) @Zen-cronic
-
-### :house: (Internal)
 
 ## 1.24.1
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -9,16 +9,20 @@ All notable changes to this project will be documented in this file.
 
 ### :rocket: (Enhancement)
 
-* feat(metrics): added synchronous gauge [#4528](https://github.com/open-telemetry/opentelemetry-js/pull/4528) @clintonb
-* feat(api): allow adding span links after span creation [#4536](https://github.com/open-telemetry/opentelemetry-js/pull/4536) @seemk
-  * This change is non-breaking for end-users, but breaking for Trace SDK implmentations in accordance with the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/a03382ada8afa9415266a84dafac0510ec8c160f/specification/upgrading.md?plain=1#L97-L122) as new features need to be implemented.
-* feat: support node 22 [#4666](https://github.com/open-telemetry/opentelemetry-js/pull/4666) @dyladan
-
 ### :bug: (Bug Fix)
 
 ### :books: (Refine Doc)
 
 ### :house: (Internal)
+
+## 1.9.0
+
+### :rocket: (Enhancement)
+
+* feat(metrics): added synchronous gauge [#4528](https://github.com/open-telemetry/opentelemetry-js/pull/4528) @clintonb
+* feat(api): allow adding span links after span creation [#4536](https://github.com/open-telemetry/opentelemetry-js/pull/4536) @seemk
+  * This change is non-breaking for end-users, but breaking for Trace SDK implmentations in accordance with the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/a03382ada8afa9415266a84dafac0510ec8c160f/specification/upgrading.md?plain=1#L97-L122) as new features need to be implemented.
+* feat: support node 22 [#4666](https://github.com/open-telemetry/opentelemetry-js/pull/4666) @dyladan
 
 ## 1.8.0
 

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Public API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/examples/esm-http-ts/package.json
+++ b/examples/esm-http-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esm-http-ts",
   "private": true,
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "Example of HTTP integration with OpenTelemetry using ESM and TypeScript",
   "main": "build/index.js",
   "type": "module",
@@ -31,13 +31,13 @@
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/",
   "dependencies": {
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
-    "@opentelemetry/instrumentation": "0.51.1",
-    "@opentelemetry/instrumentation-http": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
-    "@opentelemetry/sdk-trace-node": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
+    "@opentelemetry/instrumentation": "0.52.0",
+    "@opentelemetry/instrumentation-http": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/sdk-trace-node": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   }
 }

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-example",
   "private": true,
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "Example of HTTP integration with OpenTelemetry",
   "main": "index.js",
   "scripts": {
@@ -30,14 +30,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-jaeger": "1.24.1",
-    "@opentelemetry/exporter-zipkin": "1.24.1",
-    "@opentelemetry/instrumentation": "0.51.1",
-    "@opentelemetry/instrumentation-http": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
-    "@opentelemetry/sdk-trace-node": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/exporter-jaeger": "1.25.0",
+    "@opentelemetry/exporter-zipkin": "1.25.0",
+    "@opentelemetry/instrumentation": "0.52.0",
+    "@opentelemetry/instrumentation-http": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/sdk-trace-node": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/http",
   "devDependencies": {

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,7 +1,7 @@
 {
   "name": "https-example",
   "private": true,
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "Example of HTTPs integration with OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -34,14 +34,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/exporter-jaeger": "1.24.1",
-    "@opentelemetry/exporter-zipkin": "1.24.1",
-    "@opentelemetry/instrumentation": "0.51.1",
-    "@opentelemetry/instrumentation-http": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
-    "@opentelemetry/sdk-trace-node": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/exporter-jaeger": "1.25.0",
+    "@opentelemetry/exporter-zipkin": "1.25.0",
+    "@opentelemetry/instrumentation": "0.52.0",
+    "@opentelemetry/instrumentation-http": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/sdk-trace-node": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-opentelemetry-example",
   "private": true,
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "Example of using @opentelemetry/sdk-trace-web and @opentelemetry/sdk-metrics in browser",
   "main": "index.js",
   "scripts": {
@@ -45,20 +45,20 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/context-zone": "1.24.1",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
-    "@opentelemetry/exporter-zipkin": "1.24.1",
-    "@opentelemetry/instrumentation": "0.51.1",
-    "@opentelemetry/instrumentation-fetch": "0.51.1",
-    "@opentelemetry/instrumentation-xml-http-request": "0.51.1",
-    "@opentelemetry/propagator-b3": "1.24.1",
-    "@opentelemetry/sdk-metrics": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
-    "@opentelemetry/sdk-trace-web": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/context-zone": "1.25.0",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
+    "@opentelemetry/exporter-zipkin": "1.25.0",
+    "@opentelemetry/instrumentation": "0.52.0",
+    "@opentelemetry/instrumentation-fetch": "0.52.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.52.0",
+    "@opentelemetry/propagator-b3": "1.25.0",
+    "@opentelemetry/sdk-metrics": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/sdk-trace-web": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web"
 }

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-otlp-exporter-node",
   "private": true,
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
@@ -30,17 +30,17 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.51.1",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
-    "@opentelemetry/exporter-metrics-otlp-proto": "0.51.1",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.51.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-metrics": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.52.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "0.52.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-metrics": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/otlp-exporter-node"
 }

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+### :rocket: (Enhancement)
+
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 0.52.0
+
+### :boom: Breaking Change
+
 * feat(exporter-*-otlp-*)!: move serialization for Node.js exporters to `@opentelemetry/otlp-transformer` [#4542](https://github.com/open-telemetry/opentelemetry-js/pull/4542) @pichlermarc
   * Breaking changes:
     * (user-facing) `convert()` now returns an empty object and will be removed in a follow-up
@@ -48,8 +60,6 @@ All notable changes to experimental packages in this project will be documented 
 * docs(instrumentation): better docs for supportedVersions option [#4693](https://github.com/open-telemetry/opentelemetry-js/pull/4693) @blumamir
 * docs: align all supported versions to a common format [#4696](https://github.com/open-telemetry/opentelemetry-js/pull/4696) @blumamir
 * refactor(examples): use new exported string constants for semconv in experimental/examples/opencensus-shim [#4763](https://github.com/open-telemetry/opentelemetry-js/pull/4763#pull) @Zen-cronic
-
-### :house: (Internal)
 
 ## 0.51.1
 

--- a/experimental/backwards-compatibility/node14/package.json
+++ b/experimental/backwards-compatibility/node14/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node14",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "private": true,
   "description": "Backwards compatibility app for node 14 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -10,8 +10,8 @@
     "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.51.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1"
+    "@opentelemetry/sdk-node": "0.52.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0"
   },
   "devDependencies": {
     "@types/node": "14.18.25",

--- a/experimental/backwards-compatibility/node16/package.json
+++ b/experimental/backwards-compatibility/node16/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node16",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "private": true,
   "description": "Backwards compatibility app for node 16 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -10,8 +10,8 @@
     "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.51.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1"
+    "@opentelemetry/sdk-node": "0.52.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0"
   },
   "devDependencies": {
     "@types/node": "16.11.52",

--- a/experimental/examples/events/package.json
+++ b/experimental/examples/events/package.json
@@ -1,17 +1,17 @@
 {
   "name": "events-example",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "private": true,
   "scripts": {
     "start": "ts-node index.ts"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/api-logs": "0.51.1",
-    "@opentelemetry/sdk-logs": "0.51.1",
-    "@opentelemetry/api-events": "0.51.1",
-    "@opentelemetry/sdk-events": "0.51.1",
-    "@opentelemetry/exporter-logs-otlp-http": "0.51.1"
+    "@opentelemetry/api-events": "0.52.0",
+    "@opentelemetry/api-logs": "0.52.0",
+    "@opentelemetry/exporter-logs-otlp-http": "0.52.0",
+    "@opentelemetry/sdk-events": "0.52.0",
+    "@opentelemetry/sdk-logs": "0.52.0"
   },
   "devDependencies": {
     "@types/node": "18.6.5",

--- a/experimental/examples/logs/package.json
+++ b/experimental/examples/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logs-example",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "private": true,
   "scripts": {
     "start": "ts-node index.ts",
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/api-logs": "0.51.1",
-    "@opentelemetry/sdk-logs": "0.51.1"
+    "@opentelemetry/api-logs": "0.52.0",
+    "@opentelemetry/sdk-logs": "0.52.0"
   },
   "devDependencies": {
     "@types/node": "18.6.5",

--- a/experimental/examples/opencensus-shim/package.json
+++ b/experimental/examples/opencensus-shim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencensus-shim",
   "private": true,
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "Example of using @opentelemetry/shim-opencensus in Node.js",
   "main": "index.js",
   "scripts": {
@@ -31,14 +31,14 @@
     "@opencensus/core": "0.1.0",
     "@opencensus/instrumentation-http": "0.1.0",
     "@opencensus/nodejs-base": "0.1.0",
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/exporter-prometheus": "0.51.1",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-metrics": "1.24.1",
-    "@opentelemetry/sdk-trace-node": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1",
-    "@opentelemetry/shim-opencensus": "0.51.1"
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/exporter-prometheus": "0.52.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-metrics": "1.25.0",
+    "@opentelemetry/sdk-trace-node": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0",
+    "@opentelemetry/shim-opencensus": "0.52.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/examples/opencensus-shim"
 }

--- a/experimental/examples/prometheus/package.json
+++ b/experimental/examples/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prometheus-example",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "private": true,
   "description": "Example of using @opentelemetry/sdk-metrics and @opentelemetry/exporter-prometheus",
   "main": "index.js",
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-prometheus": "0.51.1",
-    "@opentelemetry/sdk-metrics": "1.24.1"
+    "@opentelemetry/exporter-prometheus": "0.52.0",
+    "@opentelemetry/sdk-metrics": "1.25.0"
   }
 }

--- a/experimental/packages/api-events/package.json
+++ b/experimental/packages/api-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-events",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "Public events API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/api-logs": "0.51.1"
+    "@opentelemetry/api-logs": "0.52.0"
   },
   "devDependencies": {
     "@types/mocha": "10.0.6",

--- a/experimental/packages/api-logs/package.json
+++ b/experimental/packages/api-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-logs",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "Public logs API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-grpc",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected log records to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,10 +50,10 @@
   },
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/api-logs": "0.51.1",
-    "@opentelemetry/otlp-exporter-base": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/api-logs": "0.52.0",
+    "@opentelemetry/otlp-exporter-base": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -72,10 +72,10 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.51.1",
-    "@opentelemetry/otlp-transformer": "0.51.1",
-    "@opentelemetry/sdk-logs": "0.51.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
+    "@opentelemetry/otlp-transformer": "0.52.0",
+    "@opentelemetry/sdk-logs": "0.52.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-http",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "publishConfig": {
     "access": "public"
   },
@@ -74,8 +74,8 @@
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/resources": "1.24.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/resources": "1.25.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -105,10 +105,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.51.1",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/otlp-exporter-base": "0.51.1",
-    "@opentelemetry/otlp-transformer": "0.51.1",
-    "@opentelemetry/sdk-logs": "0.51.1"
+    "@opentelemetry/api-logs": "0.52.0",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/otlp-exporter-base": "0.52.0",
+    "@opentelemetry/otlp-transformer": "0.52.0",
+    "@opentelemetry/sdk-logs": "0.52.0"
   }
 }

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-proto",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "An OTLP exporter to send logs using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": "1.8.0",
+    "@opentelemetry/api": "1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -94,13 +94,13 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.51.1",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/otlp-exporter-base": "0.51.1",
-    "@opentelemetry/otlp-transformer": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-logs": "0.51.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1"
+    "@opentelemetry/api-logs": "0.52.0",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/otlp-exporter-base": "0.52.0",
+    "@opentelemetry/otlp-transformer": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-logs": "0.52.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-grpc",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,8 +49,8 @@
   },
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/otlp-exporter-base": "0.51.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/otlp-exporter-base": "0.52.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -69,11 +69,11 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.51.1",
-    "@opentelemetry/otlp-transformer": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
+    "@opentelemetry/otlp-transformer": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-http",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry Collector Trace Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": "1.8.0",
+    "@opentelemetry/api": "1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -96,11 +96,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/otlp-exporter-base": "0.51.1",
-    "@opentelemetry/otlp-transformer": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/otlp-exporter-base": "0.52.0",
+    "@opentelemetry/otlp-transformer": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-proto",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": "1.8.0",
+    "@opentelemetry/api": "1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -93,11 +93,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/otlp-exporter-base": "0.51.1",
-    "@opentelemetry/otlp-transformer": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/otlp-exporter-base": "0.52.0",
+    "@opentelemetry/otlp-transformer": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/opentelemetry-browser-detector",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry Resource Detector for Browser",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": "1.8.0",
+    "@opentelemetry/api": "1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -84,8 +84,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/browser-detector"
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
-    "@opentelemetry/api": "1.8.0",
+    "@opentelemetry/api": "1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -68,13 +68,13 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
-    "@opentelemetry/otlp-exporter-base": "0.51.1",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.51.1",
-    "@opentelemetry/otlp-transformer": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-metrics": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
+    "@opentelemetry/otlp-exporter-base": "0.52.0",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
+    "@opentelemetry/otlp-transformer": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-metrics": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-http",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -66,7 +66,7 @@
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": "1.8.0",
+    "@opentelemetry/api": "1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -96,11 +96,11 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/otlp-exporter-base": "0.51.1",
-    "@opentelemetry/otlp-transformer": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-metrics": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/otlp-exporter-base": "0.52.0",
+    "@opentelemetry/otlp-transformer": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-metrics": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-proto",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.8.0",
+    "@opentelemetry/api": "1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -74,12 +74,12 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
-    "@opentelemetry/otlp-exporter-base": "0.51.1",
-    "@opentelemetry/otlp-transformer": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-metrics": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
+    "@opentelemetry/otlp-exporter-base": "0.52.0",
+    "@opentelemetry/otlp-transformer": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-metrics": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,8 +44,8 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/semantic-conventions": "1.24.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/semantic-conventions": "1.25.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -62,9 +62,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-metrics": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-metrics": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-prometheus",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-fetch",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry instrumentation for fetch http client in web browsers",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,10 +57,10 @@
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/context-zone": "1.24.1",
-    "@opentelemetry/propagator-b3": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/context-zone": "1.25.0",
+    "@opentelemetry/propagator-b3": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -90,10 +90,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/instrumentation": "0.51.1",
-    "@opentelemetry/sdk-trace-web": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/instrumentation": "0.52.0",
+    "@opentelemetry/sdk-trace-web": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-grpc",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry instrumentation for `@grpc/grpc-js` rpc client and server for gRPC framework",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,11 +50,11 @@
     "@bufbuild/buf": "1.21.0-1",
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.10",
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/context-async-hooks": "1.24.1",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
-    "@opentelemetry/sdk-trace-node": "1.24.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/context-async-hooks": "1.25.0",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/sdk-trace-node": "1.25.0",
     "@protobuf-ts/grpc-transport": "2.9.4",
     "@protobuf-ts/runtime": "2.9.4",
     "@protobuf-ts/runtime-rpc": "2.9.4",
@@ -76,8 +76,8 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "0.51.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/instrumentation": "0.52.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-http",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry instrumentation for `node:http` and `node:https` http client and server modules",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,11 +46,11 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/context-async-hooks": "1.24.1",
-    "@opentelemetry/sdk-metrics": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
-    "@opentelemetry/sdk-trace-node": "1.24.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/context-async-hooks": "1.25.0",
+    "@opentelemetry/sdk-metrics": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/sdk-trace-node": "1.25.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/request-promise-native": "1.0.21",
@@ -75,9 +75,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/instrumentation": "0.51.1",
-    "@opentelemetry/semantic-conventions": "1.24.1",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/instrumentation": "0.52.0",
+    "@opentelemetry/semantic-conventions": "1.25.0",
     "semver": "^7.5.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http",

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-xml-http-request",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry instrumentation for XMLHttpRequest http client in web browsers",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,10 +57,10 @@
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/context-zone": "1.24.1",
-    "@opentelemetry/propagator-b3": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/context-zone": "1.25.0",
+    "@opentelemetry/propagator-b3": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -90,10 +90,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/instrumentation": "0.51.1",
-    "@opentelemetry/sdk-trace-web": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/instrumentation": "0.52.0",
+    "@opentelemetry/sdk-trace-web": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "Base class for node which OpenTelemetry instrumentation modules extend",
   "author": "OpenTelemetry Authors",
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation",
@@ -72,7 +72,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.51.1",
+    "@opentelemetry/api-logs": "0.52.0",
     "@types/shimmer": "^1.0.2",
     "import-in-the-middle": "1.8.0",
     "require-in-the-middle": "^7.1.1",
@@ -85,8 +85,8 @@
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/sdk-metrics": "1.24.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/sdk-metrics": "1.25.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.8",

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-node",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry SDK for Node.js",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,27 +45,27 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.51.1",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.51.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
-    "@opentelemetry/exporter-zipkin": "1.24.1",
-    "@opentelemetry/instrumentation": "0.51.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-logs": "0.51.1",
-    "@opentelemetry/sdk-metrics": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
-    "@opentelemetry/sdk-trace-node": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/api-logs": "0.52.0",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
+    "@opentelemetry/exporter-zipkin": "1.25.0",
+    "@opentelemetry/instrumentation": "0.52.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-logs": "0.52.0",
+    "@opentelemetry/sdk-metrics": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/sdk-trace-node": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.3.0 <1.9.0"
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/context-async-hooks": "1.24.1",
-    "@opentelemetry/exporter-jaeger": "1.24.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/context-async-hooks": "1.25.0",
+    "@opentelemetry/exporter-jaeger": "1.25.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.8",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-exporter-base",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry OTLP Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -62,13 +62,13 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/otlp-transformer": "0.51.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/otlp-transformer": "0.52.0"
   },
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": "1.8.0",
+    "@opentelemetry/api": "1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-grpc-exporter-base",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry OTLP-gRPC Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,9 +46,9 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -67,9 +67,9 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/otlp-exporter-base": "0.51.1",
-    "@opentelemetry/otlp-transformer": "0.51.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/otlp-exporter-base": "0.52.0",
+    "@opentelemetry/otlp-transformer": "0.52.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-grpc-exporter-base",
   "sideEffects": false

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "Transform OpenTelemetry SDK data into OTLP",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
@@ -59,10 +59,10 @@
     "README.md"
   ],
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.3.0 <1.9.0"
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.8.0",
+    "@opentelemetry/api": "1.9.0",
     "@types/mocha": "10.0.6",
     "@types/webpack-env": "1.16.3",
     "babel-plugin-istanbul": "6.1.1",
@@ -77,19 +77,19 @@
     "lerna": "6.6.2",
     "mocha": "10.2.0",
     "nyc": "15.1.0",
+    "protobufjs-cli": "1.1.2",
     "ts-loader": "9.5.1",
     "ts-mocha": "10.0.0",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
-    "protobufjs-cli": "1.1.2"
+    "webpack": "5.89.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.51.1",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-logs": "0.51.1",
-    "@opentelemetry/sdk-metrics": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
+    "@opentelemetry/api-logs": "0.52.0",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-logs": "0.52.0",
+    "@opentelemetry/sdk-metrics": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
     "protobufjs": "^7.3.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-transformer",

--- a/experimental/packages/propagator-aws-xray-lambda/package.json
+++ b/experimental/packages/propagator-aws-xray-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-aws-xray-lambda",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenTelemetry AWS Xray propagator provides context propagation for systems that are using AWS X-Ray format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -42,12 +42,12 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.3.0 <1.9.0"
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
   },
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": "1.8.0",
+    "@opentelemetry/api": "1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -64,7 +64,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/propagator-aws-xray": "1.24.1"
+    "@opentelemetry/propagator-aws-xray": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/propagator-aws-xray-lambda#readme"
 }

--- a/experimental/packages/sdk-events/package.json
+++ b/experimental/packages/sdk-events/package.json
@@ -38,7 +38,8 @@
     "test": "nyc ts-mocha -p tsconfig.json test/**/*.test.ts",
     "test:browser": "karma start --single-run",
     "version": "node ../../../scripts/version-update.js",
-    "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json"
+    "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",
@@ -64,13 +65,13 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.4.0 <1.9.0"
+    "@opentelemetry/api": ">=1.4.0 <1.10.0"
   },
   "devDependencies": {
     "@babel/core": "7.22.20",
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/api-events": "0.51.1",
-    "@opentelemetry/api-logs": "0.51.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/api-events": "0.52.0",
+    "@opentelemetry/api-logs": "0.52.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",

--- a/experimental/packages/sdk-events/package.json
+++ b/experimental/packages/sdk-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-events",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "publishConfig": {
     "access": "public"
   },
@@ -69,8 +69,8 @@
   "devDependencies": {
     "@babel/core": "7.22.20",
     "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/api-logs": "0.51.1",
     "@opentelemetry/api-events": "0.51.1",
+    "@opentelemetry/api-logs": "0.51.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -97,8 +97,8 @@
     "webpack-merge": "5.10.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.51.1",
-    "@opentelemetry/api-events": "0.51.1",
-    "@opentelemetry/sdk-logs": "0.51.1"
+    "@opentelemetry/api-events": "0.52.0",
+    "@opentelemetry/api-logs": "0.52.0",
+    "@opentelemetry/sdk-logs": "0.52.0"
   }
 }

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-logs",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "publishConfig": {
     "access": "public"
   },
@@ -69,12 +69,12 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.4.0 <1.9.0"
+    "@opentelemetry/api": ">=1.4.0 <1.10.0"
   },
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": ">=1.4.0 <1.9.0",
+    "@opentelemetry/api": ">=1.4.0 <1.10.0",
     "@opentelemetry/api-logs": "0.51.1",
     "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
     "@types/mocha": "10.0.6",

--- a/experimental/packages/shim-opencensus/package.json
+++ b/experimental/packages/shim-opencensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opencensus",
-  "version": "0.51.1",
+  "version": "0.52.0",
   "description": "OpenCensus to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -50,9 +50,9 @@
   },
   "devDependencies": {
     "@opencensus/core": "0.1.0",
-    "@opentelemetry/api": "1.8.0",
-    "@opentelemetry/context-async-hooks": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
+    "@opentelemetry/api": "1.9.0",
+    "@opentelemetry/context-async-hooks": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -70,9 +70,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-metrics": "1.24.1",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-metrics": "1.25.0",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2"
   },

--- a/integration-tests/api/package.json
+++ b/integration-tests/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/integration-tests-api",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.24.1",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
+    "@opentelemetry/context-async-hooks": "1.25.0",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
     "axios": "1.6.0",
     "body-parser": "1.19.0",
     "express": "4.19.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3501,9 +3501,9 @@
       },
       "devDependencies": {
         "@babel/core": "7.22.20",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-events": "0.51.1",
-        "@opentelemetry/api-logs": "0.51.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/api-events": "0.52.0",
+        "@opentelemetry/api-logs": "0.52.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -3533,7 +3533,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.9.0"
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
     "experimental/packages/sdk-events/node_modules/@babel/core": {
@@ -3573,40 +3573,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "experimental/packages/sdk-events/node_modules/@opentelemetry/api": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
-      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "experimental/packages/sdk-events/node_modules/@opentelemetry/api-events": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-events/-/api-events-0.51.1.tgz",
-      "integrity": "sha512-ILBRMsQaAWvmczRFK1r9eFFSTWTyfkwGWGMaLtYkBN6EleVydO1buFKgq/Y8ECNnk4Wftn4P0WurTcMHBchsMg==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/api-logs": "0.51.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "experimental/packages/sdk-events/node_modules/@opentelemetry/api-logs": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
-      "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "experimental/packages/sdk-events/node_modules/@types/sinon": {
@@ -39231,9 +39197,9 @@
       "version": "file:experimental/packages/sdk-events",
       "requires": {
         "@babel/core": "7.22.20",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-events": "0.51.1",
-        "@opentelemetry/api-logs": "0.51.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/api-events": "0.52.0",
+        "@opentelemetry/api-logs": "0.52.0",
         "@opentelemetry/sdk-logs": "0.52.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -39299,8 +39265,7 @@
           "dev": true
         },
         "@opentelemetry/api-events": {
-          "version": "0.51.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api-events/-/api-events-0.51.1.tgz",
+          "version": "https://registry.npmjs.org/@opentelemetry/api-events/-/api-events-0.51.1.tgz",
           "integrity": "sha512-ILBRMsQaAWvmczRFK1r9eFFSTWTyfkwGWGMaLtYkBN6EleVydO1buFKgq/Y8ECNnk4Wftn4P0WurTcMHBchsMg==",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
     },
     "api": {
       "name": "@opentelemetry/api",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/mocha": "10.0.6",
@@ -221,17 +221,17 @@
       }
     },
     "examples/esm-http-ts": {
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/instrumentation-http": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/instrumentation-http": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
@@ -239,18 +239,18 @@
     },
     "examples/http": {
       "name": "http-example",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.24.1",
-        "@opentelemetry/exporter-zipkin": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/instrumentation-http": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/exporter-jaeger": "1.25.0",
+        "@opentelemetry/exporter-zipkin": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/instrumentation-http": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -261,18 +261,18 @@
     },
     "examples/https": {
       "name": "https-example",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.24.1",
-        "@opentelemetry/exporter-zipkin": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/instrumentation-http": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/exporter-jaeger": "1.25.0",
+        "@opentelemetry/exporter-zipkin": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/instrumentation-http": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -283,24 +283,24 @@
     },
     "examples/opentelemetry-web": {
       "name": "web-opentelemetry-example",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
-        "@opentelemetry/exporter-zipkin": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/instrumentation-fetch": "0.51.1",
-        "@opentelemetry/instrumentation-xml-http-request": "0.51.1",
-        "@opentelemetry/propagator-b3": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-web": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/context-zone": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
+        "@opentelemetry/exporter-zipkin": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/instrumentation-fetch": "0.52.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.52.0",
+        "@opentelemetry/propagator-b3": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.6",
@@ -332,21 +332,21 @@
     },
     "examples/otlp-exporter-node": {
       "name": "example-otlp-exporter-node",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.51.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.52.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "engines": {
         "node": ">=14"
@@ -354,11 +354,11 @@
     },
     "experimental/backwards-compatibility/node14": {
       "name": "backcompat-node14",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-node": "0.51.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1"
+        "@opentelemetry/sdk-node": "0.52.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0"
       },
       "devDependencies": {
         "@types/node": "14.18.25",
@@ -376,11 +376,11 @@
     },
     "experimental/backwards-compatibility/node16": {
       "name": "backcompat-node16",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-node": "0.51.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1"
+        "@opentelemetry/sdk-node": "0.52.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0"
       },
       "devDependencies": {
         "@types/node": "16.11.52",
@@ -398,14 +398,14 @@
     },
     "experimental/examples/events": {
       "name": "events-example",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-events": "0.51.1",
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/exporter-logs-otlp-http": "0.51.1",
-        "@opentelemetry/sdk-events": "0.51.1",
-        "@opentelemetry/sdk-logs": "0.51.1"
+        "@opentelemetry/api-events": "0.52.0",
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.52.0",
+        "@opentelemetry/sdk-events": "0.52.0",
+        "@opentelemetry/sdk-logs": "0.52.0"
       },
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -414,11 +414,11 @@
     },
     "experimental/examples/logs": {
       "name": "logs-example",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/sdk-logs": "0.51.1"
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/sdk-logs": "0.52.0"
       },
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -426,20 +426,20 @@
       }
     },
     "experimental/examples/opencensus-shim": {
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opencensus/core": "0.1.0",
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/exporter-prometheus": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
-        "@opentelemetry/shim-opencensus": "0.51.1"
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/exporter-prometheus": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/shim-opencensus": "0.52.0"
       },
       "engines": {
         "node": ">=14"
@@ -447,21 +447,21 @@
     },
     "experimental/examples/prometheus": {
       "name": "prometheus-example",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-prometheus": "0.51.1",
-        "@opentelemetry/sdk-metrics": "1.24.1"
+        "@opentelemetry/exporter-prometheus": "0.52.0",
+        "@opentelemetry/sdk-metrics": "1.25.0"
       }
     },
     "experimental/packages/api-events": {
       "name": "@opentelemetry/api-events",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/api-logs": "0.51.1"
+        "@opentelemetry/api-logs": "0.52.0"
       },
       "devDependencies": {
         "@types/mocha": "10.0.6",
@@ -620,7 +620,7 @@
     },
     "experimental/packages/api-logs": {
       "name": "@opentelemetry/api-logs",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
@@ -782,21 +782,21 @@
     },
     "experimental/packages/exporter-logs-otlp-grpc": {
       "name": "@opentelemetry/exporter-logs-otlp-grpc",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/sdk-logs": "0.51.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/sdk-logs": "0.52.0"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -859,20 +859,20 @@
     },
     "experimental/packages/exporter-logs-otlp-http": {
       "name": "@opentelemetry/exporter-logs-otlp-http",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/sdk-logs": "0.51.1"
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/sdk-logs": "0.52.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/resources": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -1037,21 +1037,21 @@
     },
     "experimental/packages/exporter-logs-otlp-proto": {
       "name": "@opentelemetry/exporter-logs-otlp-proto",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-logs": "0.51.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1"
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-logs": "0.52.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
+        "@opentelemetry/api": "1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -1214,20 +1214,20 @@
     },
     "experimental/packages/exporter-trace-otlp-grpc": {
       "name": "@opentelemetry/exporter-trace-otlp-grpc",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -1290,19 +1290,19 @@
     },
     "experimental/packages/exporter-trace-otlp-http": {
       "name": "@opentelemetry/exporter-trace-otlp-http",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
+        "@opentelemetry/api": "1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -1467,19 +1467,19 @@
     },
     "experimental/packages/exporter-trace-otlp-proto": {
       "name": "@opentelemetry/exporter-trace-otlp-proto",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
+        "@opentelemetry/api": "1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -1642,16 +1642,16 @@
     },
     "experimental/packages/opentelemetry-browser-detector": {
       "name": "@opentelemetry/opentelemetry-browser-detector",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
+        "@opentelemetry/api": "1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -1814,21 +1814,21 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc": {
       "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.8.0",
+        "@opentelemetry/api": "1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -1891,19 +1891,19 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-http": {
       "name": "@opentelemetry/exporter-metrics-otlp-http",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
+        "@opentelemetry/api": "1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -2068,18 +2068,18 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-proto": {
       "name": "@opentelemetry/exporter-metrics-otlp-proto",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": "1.8.0",
+        "@opentelemetry/api": "1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -2142,16 +2142,16 @@
     },
     "experimental/packages/opentelemetry-exporter-prometheus": {
       "name": "@opentelemetry/exporter-prometheus",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -2213,10 +2213,10 @@
     },
     "experimental/packages/opentelemetry-instrumentation": {
       "name": "@opentelemetry/instrumentation",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.1",
+        "@opentelemetry/api-logs": "0.52.0",
         "@types/shimmer": "^1.0.2",
         "import-in-the-middle": "1.8.0",
         "require-in-the-middle": "^7.1.1",
@@ -2226,8 +2226,8 @@
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -2264,21 +2264,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-fetch": {
       "name": "@opentelemetry/instrumentation-fetch",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/sdk-trace-web": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-zone": "1.24.1",
-        "@opentelemetry/propagator-b3": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/context-zone": "1.25.0",
+        "@opentelemetry/propagator-b3": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -2443,21 +2443,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-grpc": {
       "name": "@opentelemetry/instrumentation-grpc",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "devDependencies": {
         "@bufbuild/buf": "1.21.0-1",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
         "@protobuf-ts/grpc-transport": "2.9.4",
         "@protobuf-ts/runtime": "2.9.4",
         "@protobuf-ts/runtime-rpc": "2.9.4",
@@ -2524,20 +2524,20 @@
     },
     "experimental/packages/opentelemetry-instrumentation-http": {
       "name": "@opentelemetry/instrumentation-http",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "semver": "^7.5.2"
       },
       "devDependencies": {
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
@@ -2607,21 +2607,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-xml-http-request": {
       "name": "@opentelemetry/instrumentation-xml-http-request",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/sdk-trace-web": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-zone": "1.24.1",
-        "@opentelemetry/propagator-b3": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/context-zone": "1.25.0",
+        "@opentelemetry/propagator-b3": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -2916,27 +2916,27 @@
     },
     "experimental/packages/opentelemetry-sdk-node": {
       "name": "@opentelemetry/sdk-node",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
-        "@opentelemetry/exporter-zipkin": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-logs": "0.51.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
+        "@opentelemetry/exporter-zipkin": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-logs": "0.52.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.24.1",
-        "@opentelemetry/exporter-jaeger": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/exporter-jaeger": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -2956,7 +2956,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.9.0"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "experimental/packages/opentelemetry-sdk-node/node_modules/mocha": {
@@ -3001,16 +3001,16 @@
     },
     "experimental/packages/otlp-exporter-base": {
       "name": "@opentelemetry/otlp-exporter-base",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-transformer": "0.51.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-transformer": "0.52.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
+        "@opentelemetry/api": "1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -3173,18 +3173,18 @@
     },
     "experimental/packages/otlp-grpc-exporter-base": {
       "name": "@opentelemetry/otlp-grpc-exporter-base",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -3247,19 +3247,19 @@
     },
     "experimental/packages/otlp-transformer": {
       "name": "@opentelemetry/otlp-transformer",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-logs": "0.51.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-logs": "0.52.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "protobufjs": "^7.3.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": "1.8.0",
+        "@opentelemetry/api": "1.9.0",
         "@types/mocha": "10.0.6",
         "@types/webpack-env": "1.16.3",
         "babel-plugin-istanbul": "6.1.1",
@@ -3284,7 +3284,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.9.0"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "experimental/packages/otlp-transformer/node_modules/mocha": {
@@ -3419,15 +3419,15 @@
     },
     "experimental/packages/propagator-aws-xray-lambda": {
       "name": "@opentelemetry/propagator-aws-xray-lambda",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/propagator-aws-xray": "1.24.1"
+        "@opentelemetry/propagator-aws-xray": "1.25.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
+        "@opentelemetry/api": "1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -3447,7 +3447,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.9.0"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "experimental/packages/propagator-aws-xray-lambda/node_modules/mocha": {
@@ -3492,12 +3492,12 @@
     },
     "experimental/packages/sdk-events": {
       "name": "@opentelemetry/sdk-events",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-events": "0.51.1",
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/sdk-logs": "0.51.1"
+        "@opentelemetry/api-events": "0.52.0",
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/sdk-logs": "0.52.0"
       },
       "devDependencies": {
         "@babel/core": "7.22.20",
@@ -3573,6 +3573,40 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "experimental/packages/sdk-events/node_modules/@opentelemetry/api": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+      "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "experimental/packages/sdk-events/node_modules/@opentelemetry/api-events": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-events/-/api-events-0.51.1.tgz",
+      "integrity": "sha512-ILBRMsQaAWvmczRFK1r9eFFSTWTyfkwGWGMaLtYkBN6EleVydO1buFKgq/Y8ECNnk4Wftn4P0WurTcMHBchsMg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/api-logs": "0.51.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "experimental/packages/sdk-events/node_modules/@opentelemetry/api-logs": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
+      "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/sdk-events/node_modules/@types/sinon": {
@@ -3716,7 +3750,7 @@
     },
     "experimental/packages/sdk-logs": {
       "name": "@opentelemetry/sdk-logs",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.51.0",
@@ -3726,7 +3760,7 @@
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": ">=1.4.0 <1.9.0",
+        "@opentelemetry/api": ">=1.4.0 <1.10.0",
         "@opentelemetry/api-logs": "0.51.1",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
@@ -3756,7 +3790,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.9.0"
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
     "experimental/packages/sdk-logs/node_modules/@opentelemetry/api": {
@@ -3765,6 +3799,18 @@
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "experimental/packages/sdk-logs/node_modules/@opentelemetry/api-logs": {
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
+      "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/sdk-logs/node_modules/@opentelemetry/core": {
@@ -3977,20 +4023,20 @@
     },
     "experimental/packages/shim-opencensus": {
       "name": "@opentelemetry/shim-opencensus",
-      "version": "0.51.1",
+      "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opencensus/core": "0.1.0",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -4053,7 +4099,7 @@
     },
     "integration-tests/api": {
       "name": "@opentelemetry/integration-tests-api",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
@@ -4117,13 +4163,13 @@
       }
     },
     "integration-tests/propagation-validation-server": {
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "axios": "1.6.0",
         "body-parser": "1.19.0",
         "express": "4.19.2"
@@ -30566,10 +30612,10 @@
     },
     "packages/opentelemetry-context-async-hooks": {
       "name": "@opentelemetry/context-async-hooks",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -30584,7 +30630,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "packages/opentelemetry-context-async-hooks/node_modules/mocha": {
@@ -30629,10 +30675,10 @@
     },
     "packages/opentelemetry-context-zone": {
       "name": "@opentelemetry/context-zone",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.24.1",
+        "@opentelemetry/context-zone-peer-dep": "1.25.0",
         "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
       },
       "devDependencies": {
@@ -30646,12 +30692,12 @@
     },
     "packages/opentelemetry-context-zone-peer-dep": {
       "name": "@opentelemetry/context-zone-peer-dep",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -30682,7 +30728,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "zone.js": "^0.10.2 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
       }
     },
@@ -30818,13 +30864,13 @@
     },
     "packages/opentelemetry-core": {
       "name": "@opentelemetry/core",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -30851,7 +30897,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "packages/opentelemetry-core/node_modules/mocha": {
@@ -30986,17 +31032,17 @@
     },
     "packages/opentelemetry-exporter-jaeger": {
       "name": "@opentelemetry/exporter-jaeger",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "jaeger-client": "^3.15.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/resources": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -31059,13 +31105,13 @@
     },
     "packages/opentelemetry-exporter-zipkin": {
       "name": "@opentelemetry/exporter-zipkin",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
@@ -31236,13 +31282,13 @@
     },
     "packages/opentelemetry-propagator-b3": {
       "name": "@opentelemetry/propagator-b3",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1"
+        "@opentelemetry/core": "1.25.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -31258,7 +31304,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "packages/opentelemetry-propagator-b3/node_modules/mocha": {
@@ -31303,13 +31349,13 @@
     },
     "packages/opentelemetry-propagator-jaeger": {
       "name": "@opentelemetry/propagator-jaeger",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1"
+        "@opentelemetry/core": "1.25.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -31336,7 +31382,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "packages/opentelemetry-propagator-jaeger/node_modules/mocha": {
@@ -31471,14 +31517,14 @@
     },
     "packages/opentelemetry-resources": {
       "name": "@opentelemetry/resources",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -31508,7 +31554,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "packages/opentelemetry-resources/node_modules/@opentelemetry/api": {
@@ -31693,15 +31739,15 @@
     },
     "packages/opentelemetry-sdk-trace-base": {
       "name": "@opentelemetry/sdk-trace-base",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -31729,7 +31775,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "packages/opentelemetry-sdk-trace-base/node_modules/mocha": {
@@ -31864,20 +31910,20 @@
     },
     "packages/opentelemetry-sdk-trace-node": {
       "name": "@opentelemetry/sdk-trace-node",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/propagator-b3": "1.24.1",
-        "@opentelemetry/propagator-jaeger": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/propagator-b3": "1.25.0",
+        "@opentelemetry/propagator-jaeger": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "semver": "^7.5.2"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -31895,7 +31941,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "packages/opentelemetry-sdk-trace-node/node_modules/mocha": {
@@ -31940,20 +31986,20 @@
     },
     "packages/opentelemetry-sdk-trace-web": {
       "name": "@opentelemetry/sdk-trace-web",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/context-zone": "1.24.1",
-        "@opentelemetry/propagator-b3": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/context-zone": "1.25.0",
+        "@opentelemetry/propagator-b3": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
         "@types/jquery": "3.5.30",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -31986,7 +32032,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "packages/opentelemetry-sdk-trace-web/node_modules/mocha": {
@@ -32121,7 +32167,7 @@
     },
     "packages/opentelemetry-semantic-conventions": {
       "name": "@opentelemetry/semantic-conventions",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@size-limit/file": "^11.0.1",
@@ -32188,18 +32234,18 @@
     },
     "packages/opentelemetry-shim-opentracing": {
       "name": "@opentelemetry/shim-opentracing",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "opentracing": "^0.14.4"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/propagator-b3": "1.24.1",
-        "@opentelemetry/propagator-jaeger": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/propagator-b3": "1.25.0",
+        "@opentelemetry/propagator-jaeger": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -32214,7 +32260,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "packages/opentelemetry-shim-opentracing/node_modules/mocha": {
@@ -32259,13 +32305,13 @@
     },
     "packages/propagator-aws-xray": {
       "name": "@opentelemetry/propagator-aws-xray",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1"
+        "@opentelemetry/core": "1.25.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/webpack-env": "1.16.3",
@@ -32290,7 +32336,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "packages/propagator-aws-xray/node_modules/mocha": {
@@ -32425,17 +32471,17 @@
     },
     "packages/sdk-metrics": {
       "name": "@opentelemetry/sdk-metrics",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
         "lodash.merge": "^4.6.2"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": ">=1.3.0 <1.9.0",
+        "@opentelemetry/api": ">=1.3.0 <1.10.0",
         "@types/lodash.merge": "4.6.9",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -32464,7 +32510,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.9.0"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "packages/sdk-metrics/node_modules/mocha": {
@@ -32599,7 +32645,7 @@
     },
     "packages/template": {
       "name": "@opentelemetry/template",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -32613,19 +32659,19 @@
     },
     "selenium-tests": {
       "name": "@opentelemetry/selenium-tests",
-      "version": "1.25.1",
+      "version": "1.26.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
-        "@opentelemetry/exporter-zipkin": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/instrumentation-fetch": "0.51.1",
-        "@opentelemetry/instrumentation-xml-http-request": "0.51.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-web": "1.24.1",
+        "@opentelemetry/context-zone-peer-dep": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
+        "@opentelemetry/exporter-zipkin": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/instrumentation-fetch": "0.52.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.52.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
         "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
       },
       "devDependencies": {
@@ -32634,7 +32680,7 @@
         "@babel/plugin-proposal-decorators": "7.22.15",
         "@babel/plugin-transform-runtime": "7.22.15",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
+        "@opentelemetry/api": "1.9.0",
         "babel-loader": "8.3.0",
         "babel-polyfill": "6.26.0",
         "browserstack-local": "1.4.8",
@@ -36141,7 +36187,7 @@
       "version": "file:experimental/packages/api-events",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/api-logs": "0.51.1",
+        "@opentelemetry/api-logs": "0.52.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/webpack-env": "1.16.3",
@@ -36365,7 +36411,7 @@
     "@opentelemetry/context-async-hooks": {
       "version": "file:packages/opentelemetry-context-async-hooks",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -36411,7 +36457,7 @@
     "@opentelemetry/context-zone": {
       "version": "file:packages/opentelemetry-context-zone",
       "requires": {
-        "@opentelemetry/context-zone-peer-dep": "1.24.1",
+        "@opentelemetry/context-zone-peer-dep": "1.25.0",
         "cross-var": "1.1.0",
         "lerna": "6.6.2",
         "typescript": "4.4.4",
@@ -36423,7 +36469,7 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -36541,8 +36587,8 @@
     "@opentelemetry/core": {
       "version": "file:packages/opentelemetry-core",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -36657,10 +36703,10 @@
       "version": "file:packages/opentelemetry-exporter-jaeger",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -36712,14 +36758,14 @@
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-logs": "0.51.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-logs": "0.52.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -36770,13 +36816,13 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-logs": "0.51.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-logs": "0.52.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -36895,14 +36941,14 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-logs": "0.51.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-logs": "0.52.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37019,14 +37065,14 @@
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37077,12 +37123,12 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37199,13 +37245,13 @@
     "@opentelemetry/exporter-metrics-otlp-proto": {
       "version": "file:experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
       "requires": {
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37254,11 +37300,11 @@
     "@opentelemetry/exporter-prometheus": {
       "version": "file:experimental/packages/opentelemetry-exporter-prometheus",
       "requires": {
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37308,13 +37354,13 @@
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37365,12 +37411,12 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37489,12 +37535,12 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37612,10 +37658,10 @@
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37735,9 +37781,9 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -37863,14 +37909,14 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-zone": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/propagator-b3": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-web": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/context-zone": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/propagator-b3": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37990,13 +38036,13 @@
         "@bufbuild/buf": "1.21.0-1",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@protobuf-ts/grpc-transport": "2.9.4",
         "@protobuf-ts/runtime": "2.9.4",
         "@protobuf-ts/runtime-rpc": "2.9.4",
@@ -38049,14 +38095,14 @@
     "@opentelemetry/instrumentation-http": {
       "version": "file:experimental/packages/opentelemetry-instrumentation-http",
       "requires": {
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
@@ -38115,14 +38161,14 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-zone": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/propagator-b3": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-web": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/context-zone": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/propagator-b3": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38292,9 +38338,9 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38411,9 +38457,9 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38529,12 +38575,12 @@
       "version": "file:experimental/packages/otlp-grpc-exporter-base",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/otlp-exporter-base": "0.51.1",
-        "@opentelemetry/otlp-transformer": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38583,13 +38629,13 @@
     "@opentelemetry/otlp-transformer": {
       "version": "file:experimental/packages/otlp-transformer",
       "requires": {
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-logs": "0.51.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-logs": "0.52.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/webpack-env": "1.16.3",
         "babel-plugin-istanbul": "6.1.1",
@@ -38702,8 +38748,8 @@
     "@opentelemetry/propagator-aws-xray": {
       "version": "file:packages/propagator-aws-xray",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/core": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/webpack-env": "1.16.3",
@@ -38817,8 +38863,8 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/propagator-aws-xray": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/propagator-aws-xray": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38869,8 +38915,8 @@
     "@opentelemetry/propagator-b3": {
       "version": "file:packages/opentelemetry-propagator-b3",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/core": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -38917,8 +38963,8 @@
     "@opentelemetry/propagator-jaeger": {
       "version": "file:packages/opentelemetry-propagator-jaeger",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/core": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -39032,10 +39078,10 @@
     "@opentelemetry/resources": {
       "version": "file:packages/opentelemetry-resources",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/core": "1.25.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -39188,7 +39234,7 @@
         "@opentelemetry/api": "1.8.0",
         "@opentelemetry/api-events": "0.51.1",
         "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/sdk-logs": "0.51.1",
+        "@opentelemetry/sdk-logs": "0.52.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39244,6 +39290,31 @@
               "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
               "dev": true
             }
+          }
+        },
+        "@opentelemetry/api": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
+          "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
+          "dev": true
+        },
+        "@opentelemetry/api-events": {
+          "version": "0.51.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-events/-/api-events-0.51.1.tgz",
+          "integrity": "sha512-ILBRMsQaAWvmczRFK1r9eFFSTWTyfkwGWGMaLtYkBN6EleVydO1buFKgq/Y8ECNnk4Wftn4P0WurTcMHBchsMg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api": "^1.0.0",
+            "@opentelemetry/api-logs": "0.51.1"
+          }
+        },
+        "@opentelemetry/api-logs": {
+          "version": "0.51.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
+          "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
           }
         },
         "@types/sinon": {
@@ -39347,7 +39418,7 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": ">=1.4.0 <1.9.0",
+        "@opentelemetry/api": ">=1.4.0 <1.10.0",
         "@opentelemetry/api-logs": "0.51.1",
         "@opentelemetry/core": "1.24.0",
         "@opentelemetry/resources": "1.24.0",
@@ -39380,6 +39451,15 @@
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
           "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA=="
+        },
+        "@opentelemetry/api-logs": {
+          "version": "0.51.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
+          "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
         },
         "@opentelemetry/core": {
           "version": "1.24.0",
@@ -39522,9 +39602,9 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": ">=1.3.0 <1.9.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/api": ">=1.3.0 <1.10.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
         "@types/lodash.merge": "4.6.9",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -39641,22 +39721,22 @@
     "@opentelemetry/sdk-node": {
       "version": "file:experimental/packages/opentelemetry-sdk-node",
       "requires": {
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/context-async-hooks": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-jaeger": "1.24.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
-        "@opentelemetry/exporter-zipkin": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-logs": "0.51.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-jaeger": "1.25.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
+        "@opentelemetry/exporter-zipkin": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-logs": "0.52.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -39707,10 +39787,10 @@
     "@opentelemetry/sdk-trace-base": {
       "version": "file:packages/opentelemetry-sdk-trace-base",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -39825,14 +39905,14 @@
     "@opentelemetry/sdk-trace-node": {
       "version": "file:packages/opentelemetry-sdk-trace-node",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/context-async-hooks": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/propagator-b3": "1.24.1",
-        "@opentelemetry/propagator-jaeger": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/propagator-b3": "1.25.0",
+        "@opentelemetry/propagator-jaeger": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -39884,13 +39964,13 @@
       "requires": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/context-zone": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/propagator-b3": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/context-zone": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/propagator-b3": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/jquery": "3.5.30",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -40015,17 +40095,17 @@
         "@babel/plugin-proposal-decorators": "7.22.15",
         "@babel/plugin-transform-runtime": "7.22.15",
         "@babel/preset-env": "7.24.6",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-zone-peer-dep": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
-        "@opentelemetry/exporter-zipkin": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/instrumentation-fetch": "0.51.1",
-        "@opentelemetry/instrumentation-xml-http-request": "0.51.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-web": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/context-zone-peer-dep": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
+        "@opentelemetry/exporter-zipkin": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/instrumentation-fetch": "0.52.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.52.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
         "babel-loader": "8.3.0",
         "babel-polyfill": "6.26.0",
         "browserstack-local": "1.4.8",
@@ -40233,12 +40313,12 @@
       "version": "file:experimental/packages/shim-opencensus",
       "requires": {
         "@opencensus/core": "0.1.0",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/context-async-hooks": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -40288,12 +40368,12 @@
     "@opentelemetry/shim-opentracing": {
       "version": "file:packages/opentelemetry-shim-opentracing",
       "requires": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/propagator-b3": "1.24.1",
-        "@opentelemetry/propagator-jaeger": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/propagator-b3": "1.25.0",
+        "@opentelemetry/propagator-jaeger": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -43311,8 +43391,8 @@
     "backcompat-node14": {
       "version": "file:experimental/backwards-compatibility/node14",
       "requires": {
-        "@opentelemetry/sdk-node": "0.51.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/sdk-node": "0.52.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/node": "14.18.25",
         "typescript": "4.4.4"
       },
@@ -43328,8 +43408,8 @@
     "backcompat-node16": {
       "version": "file:experimental/backwards-compatibility/node16",
       "requires": {
-        "@opentelemetry/sdk-node": "0.51.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/sdk-node": "0.52.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "@types/node": "16.11.52",
         "typescript": "4.4.4"
       },
@@ -46135,14 +46215,14 @@
     "esm-http-ts": {
       "version": "file:examples/esm-http-ts",
       "requires": {
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/instrumentation-http": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/instrumentation-http": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       }
     },
     "espree": {
@@ -46282,11 +46362,11 @@
       "version": "file:experimental/examples/events",
       "requires": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-events": "0.51.1",
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/exporter-logs-otlp-http": "0.51.1",
-        "@opentelemetry/sdk-events": "0.51.1",
-        "@opentelemetry/sdk-logs": "0.51.1",
+        "@opentelemetry/api-events": "0.52.0",
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.52.0",
+        "@opentelemetry/sdk-events": "0.52.0",
+        "@opentelemetry/sdk-logs": "0.52.0",
         "@types/node": "18.6.5",
         "ts-node": "^10.9.1"
       }
@@ -46295,17 +46375,17 @@
       "version": "file:examples/otlp-exporter-node",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.51.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1"
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.52.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0"
       }
     },
     "execa": {
@@ -47815,14 +47895,14 @@
       "version": "file:examples/http",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.24.1",
-        "@opentelemetry/exporter-zipkin": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/instrumentation-http": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/exporter-jaeger": "1.25.0",
+        "@opentelemetry/exporter-zipkin": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/instrumentation-http": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "cross-env": "^6.0.0"
       }
     },
@@ -47911,14 +47991,14 @@
       "version": "file:examples/https",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.24.1",
-        "@opentelemetry/exporter-zipkin": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/instrumentation-http": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/exporter-jaeger": "1.25.0",
+        "@opentelemetry/exporter-zipkin": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/instrumentation-http": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "cross-env": "^6.0.0"
       }
     },
@@ -49995,8 +50075,8 @@
       "version": "file:experimental/examples/logs",
       "requires": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/sdk-logs": "0.51.1",
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/sdk-logs": "0.52.0",
         "@types/node": "18.6.5",
         "ts-node": "^10.9.1"
       }
@@ -52231,14 +52311,14 @@
         "@opencensus/core": "0.1.0",
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
-        "@opentelemetry/api": "1.8.0",
-        "@opentelemetry/exporter-prometheus": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.1",
-        "@opentelemetry/resources": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-node": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
-        "@opentelemetry/shim-opencensus": "0.51.1"
+        "@opentelemetry/api": "1.9.0",
+        "@opentelemetry/exporter-prometheus": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
+        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/shim-opencensus": "0.52.0"
       }
     },
     "opentracing": {
@@ -53088,8 +53168,8 @@
       "version": "file:experimental/examples/prometheus",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-prometheus": "0.51.1",
-        "@opentelemetry/sdk-metrics": "1.24.1"
+        "@opentelemetry/exporter-prometheus": "0.52.0",
+        "@opentelemetry/sdk-metrics": "1.25.0"
       }
     },
     "promise-all-reject-late": {
@@ -53139,9 +53219,9 @@
       "version": "file:integration-tests/propagation-validation-server",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/context-async-hooks": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
         "axios": "1.6.0",
         "body-parser": "1.19.0",
         "express": "4.19.2",
@@ -56816,20 +56896,20 @@
         "@babel/core": "^7.23.6",
         "@babel/preset-env": "^7.22.20",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.24.1",
-        "@opentelemetry/core": "1.24.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
-        "@opentelemetry/exporter-zipkin": "1.24.1",
-        "@opentelemetry/instrumentation": "0.51.1",
-        "@opentelemetry/instrumentation-fetch": "0.51.1",
-        "@opentelemetry/instrumentation-xml-http-request": "0.51.1",
-        "@opentelemetry/propagator-b3": "1.24.1",
-        "@opentelemetry/sdk-metrics": "1.24.1",
-        "@opentelemetry/sdk-trace-base": "1.24.1",
-        "@opentelemetry/sdk-trace-web": "1.24.1",
-        "@opentelemetry/semantic-conventions": "1.24.1",
+        "@opentelemetry/context-zone": "1.25.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
+        "@opentelemetry/exporter-zipkin": "1.25.0",
+        "@opentelemetry/instrumentation": "0.52.0",
+        "@opentelemetry/instrumentation-fetch": "0.52.0",
+        "@opentelemetry/instrumentation-xml-http-request": "0.52.0",
+        "@opentelemetry/propagator-b3": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.0",
         "babel-loader": "^8.0.6",
         "ts-loader": "^9.2.6",
         "typescript": "^4.5.2",

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0",
+    "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
@@ -57,7 +57,7 @@
     "typescript": "4.4.4"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-context-async-hooks",
   "sideEffects": false

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": ">=1.0.0 <1.9.0",
+    "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -84,7 +84,7 @@
     "zone.js": "0.13.3"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0",
+    "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "zone.js": "^0.10.2 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
   },
   "sideEffects": false,

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.24.1",
+    "@opentelemetry/context-zone-peer-dep": "1.25.0",
     "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
   },
   "sideEffects": true,

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0",
+    "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -89,10 +89,10 @@
     "webpack": "5.89.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core",
   "sideEffects": false

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/resources": "1.24.1",
+    "@opentelemetry/resources": "1.25.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -64,9 +64,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0",
     "jaeger-client": "^3.15.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,10 +94,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin",
   "sideEffects": false

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -52,13 +52,13 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1"
+    "@opentelemetry/core": "1.25.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0",
+    "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -55,7 +55,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0",
+    "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -79,10 +79,10 @@
     "webpack": "5.89.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1"
+    "@opentelemetry/core": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger",
   "sideEffects": false

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -66,7 +66,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0",
+    "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -93,11 +93,11 @@
     "webpack-merge": "5.10.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -66,7 +66,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0",
+    "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -91,12 +91,12 @@
     "webpack": "5.89.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,9 +46,9 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0",
-    "@opentelemetry/resources": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1",
+    "@opentelemetry/api": ">=1.0.0 <1.10.0",
+    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.8",
@@ -63,14 +63,14 @@
     "typescript": "4.4.4"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.24.1",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/propagator-b3": "1.24.1",
-    "@opentelemetry/propagator-jaeger": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
+    "@opentelemetry/context-async-hooks": "1.25.0",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/propagator-b3": "1.25.0",
+    "@opentelemetry/propagator-jaeger": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
     "semver": "^7.5.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -58,10 +58,10 @@
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": ">=1.0.0 <1.9.0",
-    "@opentelemetry/context-zone": "1.24.1",
-    "@opentelemetry/propagator-b3": "1.24.1",
-    "@opentelemetry/resources": "1.24.1",
+    "@opentelemetry/api": ">=1.0.0 <1.10.0",
+    "@opentelemetry/context-zone": "1.25.0",
+    "@opentelemetry/propagator-b3": "1.25.0",
+    "@opentelemetry/resources": "1.25.0",
     "@types/jquery": "3.5.30",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -91,12 +91,12 @@
     "webpack-merge": "5.10.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1"
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web",
   "sideEffects": false

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -43,10 +43,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0",
-    "@opentelemetry/propagator-b3": "1.24.1",
-    "@opentelemetry/propagator-jaeger": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
+    "@opentelemetry/api": ">=1.0.0 <1.10.0",
+    "@opentelemetry/propagator-b3": "1.25.0",
+    "@opentelemetry/propagator-jaeger": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
@@ -58,11 +58,11 @@
     "typescript": "4.4.4"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/semantic-conventions": "1.24.1",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.0",
     "opentracing": "^0.14.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing",

--- a/packages/propagator-aws-xray/package.json
+++ b/packages/propagator-aws-xray/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-aws-xray",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry AWS Xray propagator provides context propagation for systems that are using AWS X-Ray format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -55,10 +55,10 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0"
+    "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": ">=1.0.0 <1.9.0",
+    "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/webpack-env": "1.16.3",
@@ -80,7 +80,7 @@
     "webpack": "5.89.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1"
+    "@opentelemetry/core": "1.25.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/propagator-aws-xray#readme"
 }

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "description": "OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": ">=1.3.0 <1.9.0",
+    "@opentelemetry/api": ">=1.3.0 <1.10.0",
     "@types/lodash.merge": "4.6.9",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -83,11 +83,11 @@
     "webpack-merge": "5.10.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.3.0 <1.9.0"
+    "@opentelemetry/api": ">=1.3.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/resources": "1.24.1",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/resources": "1.25.0",
     "lodash.merge": "^4.6.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-metrics",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "1.25.1",
+  "version": "1.26.0",
   "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
@@ -37,7 +37,7 @@
     "@babel/plugin-proposal-decorators": "7.22.15",
     "@babel/plugin-transform-runtime": "7.22.15",
     "@babel/preset-env": "7.24.6",
-    "@opentelemetry/api": "1.8.0",
+    "@opentelemetry/api": "1.9.0",
     "babel-loader": "8.3.0",
     "babel-polyfill": "6.26.0",
     "browserstack-local": "1.4.8",
@@ -57,16 +57,16 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.24.1",
-    "@opentelemetry/core": "1.24.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
-    "@opentelemetry/exporter-zipkin": "1.24.1",
-    "@opentelemetry/instrumentation": "0.51.1",
-    "@opentelemetry/instrumentation-fetch": "0.51.1",
-    "@opentelemetry/instrumentation-xml-http-request": "0.51.1",
-    "@opentelemetry/sdk-metrics": "1.24.1",
-    "@opentelemetry/sdk-trace-base": "1.24.1",
-    "@opentelemetry/sdk-trace-web": "1.24.1",
+    "@opentelemetry/context-zone-peer-dep": "1.25.0",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
+    "@opentelemetry/exporter-zipkin": "1.25.0",
+    "@opentelemetry/instrumentation": "0.52.0",
+    "@opentelemetry/instrumentation-fetch": "0.52.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.52.0",
+    "@opentelemetry/sdk-metrics": "1.25.0",
+    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/sdk-trace-web": "1.25.0",
     "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
   }
 }


### PR DESCRIPTION
## 1.9.0

### :rocket: (Enhancement)

* feat(metrics): added synchronous gauge [#4528](https://github.com/open-telemetry/opentelemetry-js/pull/4528) @clintonb
* feat(api): allow adding span links after span creation [#4536](https://github.com/open-telemetry/opentelemetry-js/pull/4536) @seemk
  * This change is non-breaking for end-users, but breaking for Trace SDK implmentations in accordance with the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/a03382ada8afa9415266a84dafac0510ec8c160f/specification/upgrading.md?plain=1#L97-L122) as new features need to be implemented.
* feat: support node 22 [#4666](https://github.com/open-telemetry/opentelemetry-js/pull/4666) @dyladan

## 1.25.0

### :rocket: (Enhancement)

* feat: support node 22 [#4666](https://github.com/open-telemetry/opentelemetry-js/pull/4666) @dyladan
* feat(context-zone*): support zone.js 0.12.x [#4376](https://github.com/open-telemetry/opentelemetry-js/pull/4736) @maldago
* refactor(core): Use tree-shakeable string constants for semconv [#4739](https://github.com/open-telemetry/opentelemetry-js/pull/4739) @JohannesHuster
* refactor(shim-opentracing): Use tree-shakeable string constants for semconv [#4746](https://github.com/open-telemetry/opentelemetry-js/pull/4746) @JohannesHuster
* refactor(sdk-trace-web): Use tree-shakeable string constants for semconv [#4747](https://github.com/open-telemetry/opentelemetry-js/pull/4747) @JohannesHuster
* refactor(sdk-trace-node): Use tree-shakeable string constants for semconv [#4748](https://github.com/open-telemetry/opentelemetry-js/pull/4748) @JohannesHuster
* refactor(sdk-trace-base): Use tree-shakeable string constants for semconv [#4749](https://github.com/open-telemetry/opentelemetry-js/pull/4749) @JohannesHuster
* refactor(resources): update deprecated semconv to use exported strings [#4755](https://github.com/open-telemetry/opentelemetry-js/pull/#4755) @JamieDanielson
* refactor(exporters): update deprecated semconv to use exported strings [#4756](https://github.com/open-telemetry/opentelemetry-js/pull/#4756) @JamieDanielson

### :books: (Refine Doc)

* refactor(examples): use new exported string constants for semconv in examples/esm-http-ts [#4758](https://github.com/open-telemetry/opentelemetry-js/pull/4758) @Zen-cronic
* refactor(examples): use new exported string constants for semconv in examples/basic-tracer-node [#4759](https://github.com/open-telemetry/opentelemetry-js/pull/4759#pull) @Zen-cronic
* refactor(examples): use new exported string constants for semconv in examples/http [#4750](https://github.com/open-telemetry/opentelemetry-js/pull/4750) @Zen-cronic
* refactor(examples): use new exported string constants for semconv in examples/grpc-js [#4760](https://github.com/open-telemetry/opentelemetry-js/pull/4760#pull) @Zen-cronic
* refactor(examples): use new exported string constants for semconv in examples/otlp-exporter-node [#4762](https://github.com/open-telemetry/opentelemetry-js/pull/4762) @Zen-cronic
* refactor(examples): use new exported string constants for semconv in examples/opentracing-shim [#4761](https://github.com/open-telemetry/opentelemetry-js/pull/4761) @Zen-cronic

## 0.52.0

### :boom: Breaking Change

* feat(exporter-*-otlp-*)!: move serialization for Node.js exporters to `@opentelemetry/otlp-transformer` [#4542](https://github.com/open-telemetry/opentelemetry-js/pull/4542) @pichlermarc
  * Breaking changes:
    * (user-facing) `convert()` now returns an empty object and will be removed in a follow-up
    * (internal) OTLPExporterNodeBase now has additional constructor parameters that are required
    * (internal) OTLPExporterNodeBase now has an additional `ResponseType` type parameter
* feat(exporter-*-otlp-*)!: move serialization for Node.js exporters to `@opentelemetry/otlp-transformer` [#4581](https://github.com/open-telemetry/opentelemetry-js/pull/4581) @pichlermarc
  * Breaking changes:
    * (user-facing) `convert()` has been removed from all exporters
    * (internal) OTLPExporterBrowserBase: `RequestType` has been replaced by a `ResponseType` type-argument
    * (internal) OTLPExporterNodeBase: `ServiceRequest` has been replaced by a `ServiceResponse` type-argument
    * (internal) the `@opentelemetry/otlp-exporter-proto-base` package has been removed, and will from now on be deprecated in `npm`
* feat(instrumentation): remove default value for config in base instrumentation constructor [#4695](https://github.com/open-telemetry/opentelemetry-js/pull/4695): @blumamir
* fix(instrumentation)!: remove unused supportedVersions from Instrumentation interface [#4694](https://github.com/open-telemetry/opentelemetry-js/pull/4694) @blumamir
* feat(instrumentation)!: simplify `registerInstrumentations()` API
  * Breaking changes:
    * removes `InstrumentationOptions` type
    * occurrences of `InstrumentationOptions` are now replaced by `(Instrumentation | Instrumentation[])[]`
      * migrate usages of `registerInstrumentations({instrumentations: fooInstrumentation})` to `registerInstrumentations({instrumentations: [fooInstrumentation]})`
      * passing Instrumentation classes to `registerInstrumentations()` is now not possible anymore.
* feat(sdk-node)!: simplify type of `instrumentations` option
  * Breaking changes:
    * replaces `InstrumentationOptions` with `(Instrumentation | Instrumentation[])[]`

### :rocket: (Enhancement)

* feat(instrumentation): apply unwrap before wrap in base class [#4692](https://github.com/open-telemetry/opentelemetry-js/pull/4692)
* feat(instrumentation): add util to execute span customization hook in base class [#4663](https://github.com/open-telemetry/opentelemetry-js/pull/4663) @blumamir
* feat(instrumentation): generic config type in instrumentation base [#4659](https://github.com/open-telemetry/opentelemetry-js/pull/4659) @blumamir
* feat: support node 22 [#4666](https://github.com/open-telemetry/opentelemetry-js/pull/4666) @dyladan
* feat(propagator-aws-xray-lambda): add AWS Xray Lambda propagator [4554](https://github.com/open-telemetry/opentelemetry-js/pull/4554)
* refactor(instrumentation-xml-http-request): use exported strings for semantic attributes. [#4681](https://github.com/open-telemetry/opentelemetry-js/pull/4681/files)

### :bug: (Bug Fix)

* fix(instrumentation): Update `import-in-the-middle` to fix [numerous bugs](https://github.com/DataDog/import-in-the-middle/pull/91) [#4745](https://github.com/open-telemetry/opentelemetry-js/pull/4745) @timfish

### :books: (Refine Doc)

* docs(instrumentation): better docs for supportedVersions option [#4693](https://github.com/open-telemetry/opentelemetry-js/pull/4693) @blumamir
* docs: align all supported versions to a common format [#4696](https://github.com/open-telemetry/opentelemetry-js/pull/4696) @blumamir
* refactor(examples): use new exported string constants for semconv in experimental/examples/opencensus-shim [#4763](https://github.com/open-telemetry/opentelemetry-js/pull/4763#pull) @Zen-cronic
