### PR TITLE
chore(renovate): remove import-in-the-middle from the all-patch ignore list

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
       "groupName": "all patch versions",
       "groupSlug": "all-patch",
       "matchUpdateTypes": ["patch"],
-      "excludePackageNames": ["prettier", "import-in-the-middle"],
+      "excludePackageNames": ["prettier"],
       "schedule": ["before 3am every weekday"]
     },
     {


### PR DESCRIPTION
We had `import-in-the-middle` on the all-patch ignore list due to the problems outlined in #4553
`import-in-the-middle` has since been updated and those concerns are now void, this PR is adding `import-in-the-middle` back to the all-patch group.

Closes #4553 