### PR TITLE
chore: remove obsolete submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "experimental/packages/otlp-proto-exporter-base/protos"]
-	path = experimental/packages/otlp-proto-exporter-base/protos
-	url = https://github.com/open-telemetry/opentelemetry-proto.git
 [submodule "experimental/packages/otlp-transformer/protos"]
 	path = experimental/packages/otlp-transformer/protos
 	url = https://github.com/open-telemetry/opentelemetry-proto.git


### PR DESCRIPTION
## Which problem is this PR solving?

`experimental/packages/otlp-proto-exporter-base` no longer exists and its submodules shall be removed.

Follow-up of https://github.com/open-telemetry/opentelemetry-js/pull/4581.

## Type of change

- [x] Internal cleanup

## Checklist:

- [x] Followed the style guidelines of this project

