### PR TITLE
feat(instrumentation): apply unwrap before wrap in base class

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :rocket: (Enhancement)
 
+* feat(instrumentation): apply unwrap before wrap in base class [#4692](https://github.com/open-telemetry/opentelemetry-js/pull/4692)
 * feat(instrumentation): add util to execute span customization hook in base class [#4663](https://github.com/open-telemetry/opentelemetry-js/pull/4663) @blumamir
 * feat(instrumentation): generic config type in instrumentation base [#4659](https://github.com/open-telemetry/opentelemetry-js/pull/4659) @blumamir
 * feat: support node 22 [#4666](https://github.com/open-telemetry/opentelemetry-js/pull/4666) @dyladan

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
@@ -53,7 +53,6 @@ import {
 } from '@opentelemetry/api';
 import {
   InstrumentationNodeModuleDefinition,
-  isWrapped,
   InstrumentationBase,
 } from '@opentelemetry/instrumentation';
 import {
@@ -102,9 +101,6 @@ export class GrpcInstrumentation extends InstrumentationBase<GrpcInstrumentation
         '@grpc/grpc-js',
         ['1.*'],
         moduleExports => {
-          if (isWrapped(moduleExports.Server.prototype.register)) {
-            this._unwrap(moduleExports.Server.prototype, 'register');
-          }
           // Patch Server methods
           this._wrap(
             moduleExports.Server.prototype,
@@ -112,45 +108,21 @@ export class GrpcInstrumentation extends InstrumentationBase<GrpcInstrumentation
             this._patchServer()
           );
           // Patch Client methods
-          if (isWrapped(moduleExports.makeGenericClientConstructor)) {
-            this._unwrap(moduleExports, 'makeGenericClientConstructor');
-          }
           this._wrap(
             moduleExports,
             'makeGenericClientConstructor',
             this._patchClient(moduleExports)
           );
-          if (isWrapped(moduleExports.makeClientConstructor)) {
-            this._unwrap(moduleExports, 'makeClientConstructor');
-          }
           this._wrap(
             moduleExports,
             'makeClientConstructor',
             this._patchClient(moduleExports)
           );
-          if (isWrapped(moduleExports.loadPackageDefinition)) {
-            this._unwrap(moduleExports, 'loadPackageDefinition');
-          }
           this._wrap(
             moduleExports,
             'loadPackageDefinition',
             this._patchLoadPackageDefinition(moduleExports)
           );
-          if (isWrapped(moduleExports.Client.prototype)) {
-            this._unwrap(moduleExports.Client.prototype, 'makeUnaryRequest');
-            this._unwrap(
-              moduleExports.Client.prototype,
-              'makeClientStreamRequest'
-            );
-            this._unwrap(
-              moduleExports.Client.prototype,
-              'makeServerStreamRequest'
-            );
-            this._unwrap(
-              moduleExports.Client.prototype,
-              'makeBidiStreamRequest'
-            );
-          }
           this._wrap(
             moduleExports.Client.prototype,
             'makeUnaryRequest',

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -53,7 +53,6 @@ import { VERSION } from './version';
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
-  isWrapped,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
 import { RPCMetadata, RPCType, setRPCMetadata } from '@opentelemetry/core';
@@ -111,25 +110,16 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
       'http',
       ['*'],
       (moduleExports: Http): Http => {
-        if (isWrapped(moduleExports.request)) {
-          this._unwrap(moduleExports, 'request');
-        }
         this._wrap(
           moduleExports,
           'request',
           this._getPatchOutgoingRequestFunction('http')
         );
-        if (isWrapped(moduleExports.get)) {
-          this._unwrap(moduleExports, 'get');
-        }
         this._wrap(
           moduleExports,
           'get',
           this._getPatchOutgoingGetFunction(moduleExports.request)
         );
-        if (isWrapped(moduleExports.Server.prototype.emit)) {
-          this._unwrap(moduleExports.Server.prototype, 'emit');
-        }
         this._wrap(
           moduleExports.Server.prototype,
           'emit',
@@ -152,25 +142,16 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
       'https',
       ['*'],
       (moduleExports: Https): Https => {
-        if (isWrapped(moduleExports.request)) {
-          this._unwrap(moduleExports, 'request');
-        }
         this._wrap(
           moduleExports,
           'request',
           this._getPatchHttpsOutgoingRequestFunction('https')
         );
-        if (isWrapped(moduleExports.get)) {
-          this._unwrap(moduleExports, 'get');
-        }
         this._wrap(
           moduleExports,
           'get',
           this._getPatchHttpsOutgoingGetFunction(moduleExports.request)
         );
-        if (isWrapped(moduleExports.Server.prototype.emit)) {
-          this._unwrap(moduleExports.Server.prototype, 'emit');
-        }
         this._wrap(
           moduleExports.Server.prototype,
           'emit',

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -34,6 +34,7 @@ import { diag } from '@opentelemetry/api';
 import type { OnRequireFn } from 'require-in-the-middle';
 import { Hook } from 'require-in-the-middle';
 import { readFileSync } from 'fs';
+import { isWrapped } from '../../utils';
 
 /**
  * Base abstract class for instrumenting node plugins
@@ -79,6 +80,9 @@ export abstract class InstrumentationBase<
   }
 
   protected override _wrap: typeof wrap = (moduleExports, name, wrapper) => {
+    if (isWrapped(moduleExports[name])) {
+      this._unwrap(moduleExports, name);
+    }
     if (!utilTypes.isProxy(moduleExports)) {
       return wrap(moduleExports, name, wrapper);
     } else {


### PR DESCRIPTION
This PR aims to cleanup code from instrumentations, that unwraps a patched function before attempting to patch it again.

For instrumentation implementations, there will be no need to `_unwrap` before calling `_wrap`, refactoring this:
```js
if (isWrapped(moduleExports.myFunc)) {
    this._unwrap(moduleExports, 'myFunc');
}
this._wrap(moduleExports, 'myFunc', this._getMyFuncFunctionPatch());
```

to this shorter cleaner version:
```js
this._wrap(moduleExports, 'myFunc', this._getMyFuncFunctionPatch());
```

## Improvement Opportunity 

A common implementation of instrumnetation `patch` hook looks like this:

```js 
        if (isWrapped(moduleExports.request)) {
          this._unwrap(moduleExports, 'request');
        }
        this._wrap(
          moduleExports,
          'request',
          this._getPatchOutgoingRequestFunction('http')
        );
        if (isWrapped(moduleExports.get)) {
          this._unwrap(moduleExports, 'get');
        }
        this._wrap(
          moduleExports,
          'get',
          this._getPatchOutgoingGetFunction(moduleExports.request)
        );
        if (isWrapped(moduleExports.Server.prototype.emit)) {
          this._unwrap(moduleExports.Server.prototype, 'emit');
        }
        this._wrap(
          moduleExports.Server.prototype,
          'emit',
          this._getPatchIncomingRequestFunction('http')
        );
        return moduleExports;
```

Instrumentation first checks if the function it attempts to patch is already wrapped, and if so, unwrap it before it is wrapped again. This is needed, I believe, for test to function correctly, where the tests are `enable()`d and `disabled()`d again and again to clear their state and start fresh.

## Change

The `_wrap` function is implemented in the `InstrumentationBase` class for platform node. I moved the common check `isWrapped` and `_unwrap`ing it if needed, into the `_wrap` implementation, and removed it from the 2 core instrumentation. you can already see how many lines of code are cleared from existing instrumentations, making the codebase a bit shorter and removing lines that add no real value and decrease readability in instrumentation implementation.

## Benefits

This PR moves the `unwrap` call to happen as part of the `wrap` for nodejs base instrumentation class:
- hoist common code so instrumentations are a bit lighter with shorter `patch` implementations
- makes sure instrumentation authors will not forget to call `unwrap` in implementations, thus making tests more robust.
- guarantee consistency as the usage pattern we settled upon is now done the same everywhere regardless of the caller implementation.

## Change Analysis

- For calls that are `unwrap`ed to begin with (end users, and tests where the check is already ), this addition will not do any extra work since the `isWrapped` is false.
- The other case is when we call `wrap` on an already `wrap`ed function. I think this case doesn't make sense and it will only happen if the implementation forgot to run the `unwraping`. In this case, applying the `unwrap` in base class would guarantee that we only have one active patch per function. This should never happen in end users' code, only in tests, as end users are not expected to `enable` and `disable` instrumentations back and forte in their apps. 

We can release this feature without breaking any existing instrumentation, and then create followup PRs to cleanup contrib instrumentations and take advantage of this service.