### PR TITLE
docs(instrumentation): better docs for supportedVersions option

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :books: (Refine Doc)
 
+* docs(instrumentation): better docs for supportedVersions option [#4693](https://github.com/open-telemetry/opentelemetry-js/pull/4693) @blumamir
+
 ### :house: (Internal)
 
 ## 0.51.0

--- a/experimental/packages/opentelemetry-instrumentation/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/types.ts
@@ -60,7 +60,7 @@ export interface Instrumentation<
    * All versions must be compatible with [semver](https://semver.org/spec/v2.0.0.html) format.
    * If the version is not supported, we won't apply instrumentation patch (see `enable` method).
    * If omitted, all versions of the module will be patched.
-  */
+   */
   supportedVersions?: string[];
 }
 
@@ -104,8 +104,11 @@ export interface InstrumentationModuleFile {
    * If the version is not supported, we won't apply instrumentation patch.
    * If omitted, all versions of the module will be patched.
    * 
+   * It is recommended to always specify a range that is bound to a major version, to avoid breaking changes.
+   * New major versions should be reviewed and tested before being added to the supportedVersions array.
+   * 
    * Example: ['>=1.2.3 <3']
-  */
+   */
   supportedVersions: string[];
 
   /** Method to patch the instrumentation  */
@@ -139,7 +142,7 @@ export interface InstrumentationModuleDefinition {
    * New major versions should be reviewed and tested before being added to the supportedVersions array.
    * 
    * Example: ['>=1.2.3 <3']
-  */
+   */
   supportedVersions: string[];
 
   /** Module internal files to be patched  */

--- a/experimental/packages/opentelemetry-instrumentation/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/types.ts
@@ -133,7 +133,7 @@ export interface InstrumentationModuleDefinition {
   /** Supported version of module.
    *
    * A module version is supported if one of the supportedVersions in the array satisfies the module version.
-   * The syntax ot the version is checked with the `satisfies` function of "The semantic versioner for npm", see
+   * The syntax of the version is checked with the `satisfies` function of "The semantic versioner for npm", see
    * [`semver` package](https://www.npmjs.com/package/semver)
    * If the version is not supported, we won't apply instrumentation patch (see `enable` method).
    * If omitted, all versions of the module will be patched.

--- a/experimental/packages/opentelemetry-instrumentation/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/types.ts
@@ -96,7 +96,16 @@ export interface InstrumentationModuleFile {
 
   moduleExports?: unknown;
 
-  /** Supported version this file */
+  /** Supported versions for the file.
+   * 
+   * A module version is supported if one of the supportedVersions in the array satisfies the module version.
+   * The syntax ot the version is checked with the `satisfies` function of "The semantic versioner for npm", see 
+   * [`semver` package](https://www.npmjs.com/package/semver)
+   * If the version is not supported, we won't apply instrumentation patch.
+   * If omitted, all versions of the module will be patched.
+   * 
+   * Example: ['>=1.2.3 <3']
+  */
   supportedVersions: string[];
 
   /** Method to patch the instrumentation  */
@@ -118,7 +127,16 @@ export interface InstrumentationModuleDefinition {
   /** Instrumented module version */
   moduleVersion?: string;
 
-  /** Supported version of module  */
+  /** Supported version of module.
+   * 
+   * A module version is supported if one of the supportedVersions in the array satisfies the module version.
+   * The syntax ot the version is checked with the `satisfies` function of "The semantic versioner for npm", see 
+   * [`semver` package](https://www.npmjs.com/package/semver)
+   * If the version is not supported, we won't apply instrumentation patch (see `enable` method).
+   * If omitted, all versions of the module will be patched.
+   * 
+   * Example: ['>=1.2.3 <3']
+  */
   supportedVersions: string[];
 
   /** Module internal files to be patched  */

--- a/experimental/packages/opentelemetry-instrumentation/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/types.ts
@@ -97,16 +97,16 @@ export interface InstrumentationModuleFile {
   moduleExports?: unknown;
 
   /** Supported versions for the file.
-   * 
+   *
    * A module version is supported if one of the supportedVersions in the array satisfies the module version.
-   * The syntax ot the version is checked with the `satisfies` function of "The semantic versioner for npm", see 
+   * The syntax ot the version is checked with the `satisfies` function of "The semantic versioner for npm", see
    * [`semver` package](https://www.npmjs.com/package/semver)
    * If the version is not supported, we won't apply instrumentation patch.
    * If omitted, all versions of the module will be patched.
-   * 
+   *
    * It is recommended to always specify a range that is bound to a major version, to avoid breaking changes.
    * New major versions should be reviewed and tested before being added to the supportedVersions array.
-   * 
+   *
    * Example: ['>=1.2.3 <3']
    */
   supportedVersions: string[];
@@ -131,16 +131,16 @@ export interface InstrumentationModuleDefinition {
   moduleVersion?: string;
 
   /** Supported version of module.
-   * 
+   *
    * A module version is supported if one of the supportedVersions in the array satisfies the module version.
-   * The syntax ot the version is checked with the `satisfies` function of "The semantic versioner for npm", see 
+   * The syntax ot the version is checked with the `satisfies` function of "The semantic versioner for npm", see
    * [`semver` package](https://www.npmjs.com/package/semver)
    * If the version is not supported, we won't apply instrumentation patch (see `enable` method).
    * If omitted, all versions of the module will be patched.
-   * 
+   *
    * It is recommended to always specify a range that is bound to a major version, to avoid breaking changes.
    * New major versions should be reviewed and tested before being added to the supportedVersions array.
-   * 
+   *
    * Example: ['>=1.2.3 <3']
    */
   supportedVersions: string[];

--- a/experimental/packages/opentelemetry-instrumentation/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/types.ts
@@ -60,11 +60,6 @@ export interface Instrumentation<
    * All versions must be compatible with [semver](https://semver.org/spec/v2.0.0.html) format.
    * If the version is not supported, we won't apply instrumentation patch (see `enable` method).
    * If omitted, all versions of the module will be patched.
-   * 
-   * It is recommended to always specify a range that is bound to a major version, to avoid breaking changes.
-   * New major versions should be reviewed and tested before being added to the supportedVersions array.
-   * 
-   * Example: ['>=1.2.3 <3']
   */
   supportedVersions?: string[];
 }

--- a/experimental/packages/opentelemetry-instrumentation/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/types.ts
@@ -99,7 +99,7 @@ export interface InstrumentationModuleFile {
   /** Supported versions for the file.
    *
    * A module version is supported if one of the supportedVersions in the array satisfies the module version.
-   * The syntax ot the version is checked with the `satisfies` function of "The semantic versioner for npm", see
+   * The syntax of the version is checked with the `satisfies` function of "The semantic versioner for npm", see
    * [`semver` package](https://www.npmjs.com/package/semver)
    * If the version is not supported, we won't apply instrumentation patch.
    * If omitted, all versions of the module will be patched.

--- a/experimental/packages/opentelemetry-instrumentation/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/types.ts
@@ -60,7 +60,12 @@ export interface Instrumentation<
    * All versions must be compatible with [semver](https://semver.org/spec/v2.0.0.html) format.
    * If the version is not supported, we won't apply instrumentation patch (see `enable` method).
    * If omitted, all versions of the module will be patched.
-   */
+   * 
+   * It is recommended to always specify a range that is bound to a major version, to avoid breaking changes.
+   * New major versions should be reviewed and tested before being added to the supportedVersions array.
+   * 
+   * Example: ['>=1.2.3 <3']
+  */
   supportedVersions?: string[];
 }
 
@@ -134,6 +139,9 @@ export interface InstrumentationModuleDefinition {
    * [`semver` package](https://www.npmjs.com/package/semver)
    * If the version is not supported, we won't apply instrumentation patch (see `enable` method).
    * If omitted, all versions of the module will be patched.
+   * 
+   * It is recommended to always specify a range that is bound to a major version, to avoid breaking changes.
+   * New major versions should be reviewed and tested before being added to the supportedVersions array.
    * 
    * Example: ['>=1.2.3 <3']
   */


### PR DESCRIPTION
This PR improves the documentation of the `supportedVersions` option on `InstrumentationModuleDefinition` and `InstrumentationModuleFile`:

- explain that the array is ORed (one needs to match)
- add guidelines on the syntax that is supported in a way that is easy to consume
- document the effect of this function, copied from [here](https://github.com/open-telemetry/opentelemetry-js/blob/ca027b5eed282b4e81e098ca885db9ce27fdd562/experimental/packages/opentelemetry-instrumentation/src/types.ts#L61)
- Add documentation about empty array behavior
- Recommendation to bind the upper supported version to a major version to avoid breaking changes that we cannot anticipate, and guarantee support and stability.

This PR is only to document existing behavior, which is something we might want to consider. I think it is unhealthy for instrumentations to attempt patching any version by default when the array is empty, as it is never guaranteed that major version patches will work out of the box, and we don't want to harm user environment stability. 

