### PR TITLE
fix(instrumentation): remove unused supportedVersions from Instrumentation interface

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :books: (Refine Doc)
 
+* docs(instrumentation): better docs for supportedVersions option [#4693](https://github.com/open-telemetry/opentelemetry-js/pull/4693) @blumamir
+
 ### :house: (Internal)
 
 ## 0.51.0

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -29,8 +29,6 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :books: (Refine Doc)
 
-* docs(instrumentation): better docs for supportedVersions option [#4693](https://github.com/open-telemetry/opentelemetry-js/pull/4693) @blumamir
-
 ### :house: (Internal)
 
 ## 0.51.0

--- a/experimental/packages/opentelemetry-instrumentation/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/types.ts
@@ -54,14 +54,6 @@ export interface Instrumentation<
 
   /** Method to get instrumentation config  */
   getConfig(): ConfigType;
-
-  /**
-   * Contains all supported versions.
-   * All versions must be compatible with [semver](https://semver.org/spec/v2.0.0.html) format.
-   * If the version is not supported, we won't apply instrumentation patch (see `enable` method).
-   * If omitted, all versions of the module will be patched.
-   */
-  supportedVersions?: string[];
 }
 
 /**
@@ -101,8 +93,6 @@ export interface InstrumentationModuleFile {
 
   /** Method to patch the instrumentation  */
   patch(moduleExports: unknown, moduleVersion?: string): unknown;
-
-  /** Method to patch the instrumentation  */
 
   /** Method to unpatch the instrumentation  */
   unpatch(moduleExports?: unknown, moduleVersion?: string): void;


### PR DESCRIPTION
The [Instrumentation interface](https://github.com/open-telemetry/opentelemetry-js/blob/ca027b5eed282b4e81e098ca885db9ce27fdd562/experimental/packages/opentelemetry-instrumentation/src/types.ts#L64) in the `@opentelemetry/instrumentation` class, contains a property `supportedVersions?: string[]` which is not used anywhere, not in the package itself or by any contrib instrumentation:

```js

  /**
   * Contains all supported versions.
   * All versions must be compatible with [semver](https://semver.org/spec/v2.0.0.html) format.
   * If the version is not supported, we won't apply instrumentation patch (see `enable` method).
   * If omitted, all versions of the module will be patched.
   */
  supportedVersions?: string[];
}

```

It has no effect on anything really, just a property which downstream interface consumers can reference, and it is not set anywhere. 

There exists 2 other configurations for `supportedVersions` [here](https://github.com/open-telemetry/opentelemetry-js/blob/ca027b5eed282b4e81e098ca885db9ce27fdd562/experimental/packages/opentelemetry-instrumentation/src/types.ts#L100) and [here](https://github.com/open-telemetry/opentelemetry-js/blob/ca027b5eed282b4e81e098ca885db9ce27fdd562/experimental/packages/opentelemetry-instrumentation/src/types.ts#L122) which are being used. 

My investigation leads me to #1540 which added it to the interface but never used it. It uses the `supportedVersions` on each `InstrumentationModuleDefinition`, but the one in the `Instrumentation` interface was never utilized.

The comment on this property is also misleading and references `(see `enable` method)`, but this function uses the other 2 `supporetedVersions` definitions on `InstrumentationModuleFile` and `InstrumentationModuleDefinition` but not the one which is commented.

Therefore, I think it is safe to remove it as a cleanup