### PR TITLE
feat(instrumentation): remove default value for config in base instrumentation constructor

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -17,8 +17,8 @@ All notable changes to experimental packages in this project will be documented 
     * (internal) OTLPExporterBrowserBase: `RequestType` has been replaced by a `ResponseType` type-argument
     * (internal) OTLPExporterNodeBase: `ServiceRequest` has been replaced by a `ServiceResponse` type-argument
     * (internal) the `@opentelemetry/otlp-exporter-proto-base` package has been removed, and will from now on be deprecated in `npm`
-    * feat(instrumentation): add default value for config in base instrumentation constuctor [#4695](https://github.com/open-telemetry/opentelemetry-js/pull/4695): @blumamir
-    * fix(instrumentation)!: remove unused supportedVersions from Instrumentation interface [#4694](https://github.com/open-telemetry/opentelemetry-js/pull/4694) @blumamir
+* feat(instrumentation): remove default value for config in base instrumentation constructor [#4695](https://github.com/open-telemetry/opentelemetry-js/pull/4695): @blumamir
+* fix(instrumentation)!: remove unused supportedVersions from Instrumentation interface [#4694](https://github.com/open-telemetry/opentelemetry-js/pull/4694) @blumamir
 
 ### :rocket: (Enhancement)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to experimental packages in this project will be documented 
     * (internal) OTLPExporterBrowserBase: `RequestType` has been replaced by a `ResponseType` type-argument
     * (internal) OTLPExporterNodeBase: `ServiceRequest` has been replaced by a `ServiceResponse` type-argument
     * (internal) the `@opentelemetry/otlp-exporter-proto-base` package has been removed, and will from now on be deprecated in `npm`
-    * fix(instrumentation)!: remove default value for config in base instrumentation constuctor [#4695](https://github.com/open-telemetry/opentelemetry-js/pull/4695): @blumamir
+    * feat(instrumentation): add default value for config in base instrumentation constuctor [#4695](https://github.com/open-telemetry/opentelemetry-js/pull/4695): @blumamir
     * fix(instrumentation)!: remove unused supportedVersions from Instrumentation interface [#4694](https://github.com/open-telemetry/opentelemetry-js/pull/4694) @blumamir
 
 ### :rocket: (Enhancement)

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to experimental packages in this project will be documented 
     * (internal) OTLPExporterBrowserBase: `RequestType` has been replaced by a `ResponseType` type-argument
     * (internal) OTLPExporterNodeBase: `ServiceRequest` has been replaced by a `ServiceResponse` type-argument
     * (internal) the `@opentelemetry/otlp-exporter-proto-base` package has been removed, and will from now on be deprecated in `npm`
-* fix(instrumentation)!: make config object required in base instrumentation [#4695](https://github.com/open-telemetry/opentelemetry-js/pull/4695): @blumamir
+* fix(instrumentation)!: remove default value for config in base instrumentation constuctor [#4695](https://github.com/open-telemetry/opentelemetry-js/pull/4695): @blumamir
 
 ### :rocket: (Enhancement)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to experimental packages in this project will be documented 
     * (internal) OTLPExporterBrowserBase: `RequestType` has been replaced by a `ResponseType` type-argument
     * (internal) OTLPExporterNodeBase: `ServiceRequest` has been replaced by a `ServiceResponse` type-argument
     * (internal) the `@opentelemetry/otlp-exporter-proto-base` package has been removed, and will from now on be deprecated in `npm`
+* fix(instrumentation)!: make config object required in base instrumentation [#4695](https://github.com/open-telemetry/opentelemetry-js/pull/4695): @blumamir
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -79,7 +79,7 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
   private _usedResources = new WeakSet<PerformanceResourceTiming>();
   private _tasksCount = 0;
 
-  constructor(config?: FetchInstrumentationConfig) {
+  constructor(config: FetchInstrumentationConfig = {}) {
     super('@opentelemetry/instrumentation-fetch', VERSION, config);
   }
 

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
@@ -91,7 +91,7 @@ import { VERSION } from './version';
 export class GrpcInstrumentation extends InstrumentationBase<GrpcInstrumentationConfig> {
   private _metadataCapture: metadataCaptureType;
 
-  constructor(config?: GrpcInstrumentationConfig) {
+  constructor(config: GrpcInstrumentationConfig = {}) {
     super('@opentelemetry/instrumentation-grpc', VERSION, config);
     this._metadataCapture = this._createMetadataCapture();
   }

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -70,7 +70,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
   private _httpServerDurationHistogram!: Histogram;
   private _httpClientDurationHistogram!: Histogram;
 
-  constructor(config?: HttpInstrumentationConfig) {
+  constructor(config: HttpInstrumentationConfig = {}) {
     super('@opentelemetry/instrumentation-http', VERSION, config);
     this._headerCapture = this._createHeaderCapture();
   }

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -90,7 +90,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
   private _xhrMem = new WeakMap<XMLHttpRequest, XhrMem>();
   private _usedResources = new WeakSet<PerformanceResourceTiming>();
 
-  constructor(config?: XMLHttpRequestInstrumentationConfig) {
+  constructor(config: XMLHttpRequestInstrumentationConfig = {}) {
     super('@opentelemetry/instrumentation-xml-http-request', VERSION, config);
   }
 

--- a/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
@@ -51,8 +51,10 @@ export abstract class InstrumentationAbstract<
   constructor(
     public readonly instrumentationName: string,
     public readonly instrumentationVersion: string,
-    config: ConfigType = {} as ConfigType // assuming ConfigType is an object with optional fields only
+    config: ConfigType
   ) {
+    // copy config first level properties to ensure they are immutable.
+    // nested properties are not copied, thus are mutable from the outside.
     this._config = {
       enabled: true,
       ...config,
@@ -144,10 +146,10 @@ export abstract class InstrumentationAbstract<
    * Sets InstrumentationConfig to this plugin
    * @param InstrumentationConfig
    */
-  public setConfig(config: ConfigType = {} as ConfigType): void {
-    // the assertion that {} is compatible with ConfigType may not be correct,
-    // ConfigType should contain only optional fields, but there is no enforcement in place for that
-    this._config = Object.assign({}, config);
+  public setConfig(config: ConfigType): void {
+    // copy config first level properties to ensure they are immutable.
+    // nested properties are not copied, thus are mutable from the outside.
+    this._config = {...config};
   }
 
   /**

--- a/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
@@ -149,7 +149,7 @@ export abstract class InstrumentationAbstract<
   public setConfig(config: ConfigType): void {
     // copy config first level properties to ensure they are immutable.
     // nested properties are not copied, thus are mutable from the outside.
-    this._config = {...config};
+    this._config = { ...config };
   }
 
   /**

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/browser/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/browser/instrumentation.ts
@@ -30,7 +30,7 @@ export abstract class InstrumentationBase<
   constructor(
     instrumentationName: string,
     instrumentationVersion: string,
-    config: ConfigType = {} as ConfigType // The cast here may be wrong as ConfigType may contain required fields
+    config: ConfigType
   ) {
     super(instrumentationName, instrumentationVersion, config);
 

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -53,7 +53,7 @@ export abstract class InstrumentationBase<
   constructor(
     instrumentationName: string,
     instrumentationVersion: string,
-    config: ConfigType = {} as ConfigType // The cast here may be wrong as ConfigType may contain required fields
+    config: ConfigType
   ) {
     super(instrumentationName, instrumentationVersion, config);
 


### PR DESCRIPTION
This PR makes the `config` object for base instrumentations (node + browser), required instead of optional with default value empty object.

## Motivation

The current implementation of instrumentation base classes requires a config object to be set. The 2 functions that accept a config object (constructor and `setConfig`) currently define the function parameter as optional, with default value `{}`. This creates the following problems:

- By making this property optional, we are unable to add additional parameters to the constructor function in a clean way, which is something I want to do soon.
- if the config object is not supplied, it is assumed to be empty object `{}`, but there is no typescript enforcement that the config object has only optional properties. Thus, this assumption may break and we needed `as ConfigType` typescript casting to ignore this justified incompatibility.
- `setConfig` is already defined as required in the [`Instrumentation` interface](https://github.com/open-telemetry/opentelemetry-js/blob/ca027b5eed282b4e81e098ca885db9ce27fdd562/experimental/packages/opentelemetry-instrumentation/src/types.ts#L53). Thus the definition of it as optional in the [`InstrumentationAbstract` implementaion](https://github.com/open-telemetry/opentelemetry-js/blob/ca027b5eed282b4e81e098ca885db9ce27fdd562/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts#L147) is not consistent with the interface.
- It allows instrumentations not to pass any config object to the base class, which renders them unuseful to be included in distributions, which needs to at least be able to pass a config object that includes the `enabled` flag.

## Change

- apply the constructor pattern we settled upon in https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2162 to core instrumentations
- Make the config argument required is `constructor` signatures and `setConfig` signatures.
- Removing the typescript casting which was needed due to type incompatibility with empty object
- Replace `Object.assign({}, config)` with `{...config}` so we are consistent in both places

## Distributions Considerations

This PR will make it so that instrumentations cannot be written like so:

```js
export class FooInstrumentation extends InstrumentationBase {

  constructor() {
    super('@opentelemetry/instrumentation-foo', VERSION);
  }
```

Since the config object is now required. Even if `FooInstrumentation` does not offer any specific config options, thus might be tempted to exclude it altogether from the constructor, it makes it so users are not able to pass generic config object which defines `enabled` value.

Making the argument required, communicates that instrumentation need to pass a value and promote better-practices and more robust implementations. This has been aligned in contrib with https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2162

## Breaking Change

- Contrib PRs has all been aligned to support this change with https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2162 .
- Core instrumentations are also aligned to use the new constructor pattern in this PR.
- There may exist other 3rd party instrumentations out there which do not pass a config object. for them this change might be breaking, but the fix is easy: there will be a typescript error about missing argument, and instrumentation will have the chance to apply good practice and refactor the constructor to receive a `config` object from the user.
