### PR TITLE
ci: markdown linting cleanups

### DIFF
--- a/.github/markdown-lint.yml
+++ b/.github/markdown-lint.yml
@@ -1,2 +1,5 @@
+# MD004 - Unordered list style
+# This rule is triggered when the symbols used in the document for unordered list items do not match the configured unordered list style
+# * Item 1 // Error: Unordered list style [Expected: dash; Actual: asterisk]
 MD004:
   style: dash

--- a/.github/markdown-lint.yml
+++ b/.github/markdown-lint.yml
@@ -1,0 +1,2 @@
+MD004:
+  style: dash

--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -10,8 +10,8 @@ No changes
 
 ## Collaborators and Teams
 
-* There is currently no `javascript-triagers` role
-* `javascript-maintainers` has `Admin` permission
+- There is currently no `javascript-triagers` role
+- `javascript-maintainers` has `Admin` permission
 
 ## Branches
 
@@ -19,13 +19,13 @@ No changes
 
 ### `main`
 
-* Uncheck "Restrict who can push to matching branches"
-* Check "Require merge queue"
-  * Build concurrency: 5
-  * Minimum pull requests to merge: 1 or after 5 minutes
-  * Maximum pull requests to merge: 5
-  * Check "Only merge non-failing pull requests"
-  * Status check timeout: 60 minutes
+- Uncheck "Restrict who can push to matching branches"
+- Check "Require merge queue"
+  - Build concurrency: 5
+  - Minimum pull requests to merge: 1 or after 5 minutes
+  - Maximum pull requests to merge: 5
+  - Check "Only merge non-failing pull requests"
+  - Status check timeout: 60 minutes
 
 ### `dependabot/**/**`
 
@@ -37,9 +37,9 @@ Our dependencies are managed by a bot which creates PRs from a fork.
 This is a special branch which we use to publish the automatically generated docs.
 It is exempt from most protections.
  
-* "Allow force pushes from everyone" (requires write permission)
+- "Allow force pushes from everyone" (requires write permission)
 
 ## Pages
 
-* Source: Deploy from a branch
-* Branch: `gh-pages` `/ (root)`
+- Source: Deploy from a branch
+- Branch: `gh-pages` `/ (root)`

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,14 +29,14 @@ jobs:
           # TODO: adhere to, or overwrite above rule and uncomment rules
           # rules: "/lint/rules/changelog.js"
           config: "/lint/config/changelog.yml"
-          args: "./CHANGELOG.md"
+          args: "./**/CHANGELOG.md"
 
       - name: Lint markdown files
         uses: avto-dev/markdown-lint@v1
         with:
           config: '.github/markdown-lint.yml'
           args: "./**/*.md"
-          ignore: './CHANGELOG.md ./experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/protos ./experimental/packages/opentelemetry-exporter-metrics-otlp-proto/protos ./packages/exporter-trace-otlp-grpc/protos ./packages/exporter-trace-otlp-proto/protos'
+          ignore: './**/CHANGELOG.md ./experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/protos ./experimental/packages/opentelemetry-exporter-metrics-otlp-proto/protos ./packages/exporter-trace-otlp-grpc/protos ./packages/exporter-trace-otlp-proto/protos'
 
       - name: Bootstrap
         run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,11 +34,7 @@ jobs:
       - name: Lint markdown files
         uses: avto-dev/markdown-lint@v1
         with:
-          config: |
-            {
-              "default": true,
-              "MD004": { "style": "dash" }
-            }    
+          config: '.github/markdown-lint.yml'
           args: "./**/*.md"
           ignore: './CHANGELOG.md ./experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/protos ./experimental/packages/opentelemetry-exporter-metrics-otlp-proto/protos ./packages/exporter-trace-otlp-grpc/protos ./packages/exporter-trace-otlp-proto/protos'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           config: '.github/markdown-lint.yml'
           args: "./**/*.md"
-          ignore: './**/CHANGELOG.md ./experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/protos ./experimental/packages/opentelemetry-exporter-metrics-otlp-proto/protos ./packages/exporter-trace-otlp-grpc/protos ./packages/exporter-trace-otlp-proto/protos'
+          ignore: './**/CHANGELOG.md ./experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/protos ./experimental/packages/opentelemetry-exporter-metrics-otlp-proto/protos'
 
       - name: Bootstrap
         run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Lint markdown files
         uses: avto-dev/markdown-lint@v1
         with:
+          config: |
+            {
+              "default": true,
+              "MD004": { "style": "dash" }
+            }    
           args: "./**/*.md"
           ignore: './CHANGELOG.md ./experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/protos ./experimental/packages/opentelemetry-exporter-metrics-otlp-proto/protos ./packages/exporter-trace-otlp-grpc/protos ./packages/exporter-trace-otlp-proto/protos'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           config: '.github/markdown-lint.yml'
           args: "./**/*.md"
-          ignore: './**/CHANGELOG.md ./experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/protos ./experimental/packages/opentelemetry-exporter-metrics-otlp-proto/protos'
+          ignore: './**/CHANGELOG.md ./experimental/packages/otlp-transformer/protos'
 
       - name: Bootstrap
         run: npm ci

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -97,13 +97,13 @@ All notable changes to this project will be documented in this file.
 
 * export tracer options ([#154](https://www.github.com/open-telemetry/opentelemetry-js-api/issues/154)) ([b125324](https://www.github.com/open-telemetry/opentelemetry-js-api/commit/b125324438fb2f24eb80c7c6673afc8cfc99575e))
 
-### [1.0.4](https://www.github.com/open-telemetry/opentelemetry-js-api/compare/v1.0.3...v1.0.4) (2021-12-18)
+## [1.0.4](https://www.github.com/open-telemetry/opentelemetry-js-api/compare/v1.0.3...v1.0.4) (2021-12-18)
 
 ### Bug Fixes
 
 * align globalThis fallbacks with otel-core ([#126](https://www.github.com/open-telemetry/opentelemetry-js-api/issues/126)) ([3507de7](https://www.github.com/open-telemetry/opentelemetry-js-api/commit/3507de7c3b95396696657c021953b0b24a63a029))
 
-### [1.0.3](https://www.github.com/open-telemetry/opentelemetry-js-api/compare/v1.0.2...v1.0.3) (2021-08-30)
+## [1.0.3](https://www.github.com/open-telemetry/opentelemetry-js-api/compare/v1.0.2...v1.0.3) (2021-08-30)
 
 ### Bug Fixes
 

--- a/doc/contributing/dependencies.md
+++ b/doc/contributing/dependencies.md
@@ -25,7 +25,7 @@ An exception is granted for dependencies on `@opentelemetry/api`, which, if used
 
 Packages categorized as third-party and listed under the `"dependencies"` section (e.g., @grpc/grpc-js, @grpc/proto-loader, shimmer, etc.) should remain unpinned and utilize the caret (`^`) symbol. This approach offers several advantages:
 
-* Our users could get bug fixes of those 3rd-party packages easily, without waiting for us to update our library.
-* In cases where multiple packages have dependencies on different versions of the same package, npm will opt for the most recent version, saving space and preventing potential disruptions.
+- Our users could get bug fixes of those 3rd-party packages easily, without waiting for us to update our library.
+- In cases where multiple packages have dependencies on different versions of the same package, npm will opt for the most recent version, saving space and preventing potential disruptions.
 
 It's important to acknowledge that this approach does expose users to potential breaking changes arising from either human error or libraries that do not strictly follow to semver conventions. This trade-off is an inherent aspect of this approach.

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -115,9 +115,9 @@ All notable changes to experimental packages in this project will be documented 
 * fix(otlp-exporter-base)!: remove unload event from OTLPExporterBrowserBase [#4438](https://github.com/open-telemetry/opentelemetry-js/pull/4438) @eldavojohn
   * Reason: The 'unload' event prevents sites from taking advantage of Google's [backward/forward cache](https://web.dev/articles/bfcache#never_use_the_unload_event) and will be [deprecated](https://developer.chrome.com/articles/deprecating-unload/).  It is now up to the consuming site to implement these shutdown events.
   * This breaking change affects users under this scenario:
-    1. A user extends the exporter and overrides the shutdown function, and does something which is usually called by the unload listener
-    2. We remove the unload event listener
-    3. That user's overridden shutdown function no longer gets called
+    * A user extends the exporter and overrides the shutdown function, and does something which is usually called by the unload listener
+    * We remove the unload event listener
+    * That user's overridden shutdown function no longer gets called
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/exporter-logs-otlp-proto/README.md
+++ b/experimental/packages/exporter-logs-otlp-proto/README.md
@@ -48,7 +48,7 @@ The OTLPLogExporter has a timeout configuration option which is the maximum time
 
 To override the default timeout duration, use the following options:
 
-+ Set with environment variables:
+- Set with environment variables:
 
   | Environment variable         | Description |
 ------------------------------|----------------------|-------------|
@@ -57,7 +57,7 @@ To override the default timeout duration, use the following options:
 
   > `OTEL_EXPORTER_OTLP_LOGS_TIMEOUT` takes precedence and overrides `OTEL_EXPORTER_OTLP_TIMEOUT`.
 
-+ Provide `timeoutMillis` to OTLPLogExporter with `collectorOptions`:
+- Provide `timeoutMillis` to OTLPLogExporter with `collectorOptions`:
 
   ```js
   const collectorOptions = {
@@ -79,10 +79,10 @@ OTLP requires that transient errors be handled with a [retry strategy](https://g
 
 This retry policy has the following configuration, which there is currently no way to customize.
 
-+ `DEFAULT_EXPORT_MAX_ATTEMPTS`: The maximum number of attempts, including the original request. Defaults to 5.
-+ `DEFAULT_EXPORT_INITIAL_BACKOFF`: The initial backoff duration. Defaults to 1 second.
-+ `DEFAULT_EXPORT_MAX_BACKOFF`: The maximum backoff duration. Defaults to 5 seconds.
-+ `DEFAULT_EXPORT_BACKOFF_MULTIPLIER`: The backoff multiplier. Defaults to 1.5.
+- `DEFAULT_EXPORT_MAX_ATTEMPTS`: The maximum number of attempts, including the original request. Defaults to 5.
+- `DEFAULT_EXPORT_INITIAL_BACKOFF`: The initial backoff duration. Defaults to 1 second.
+- `DEFAULT_EXPORT_MAX_BACKOFF`: The maximum backoff duration. Defaults to 5 seconds.
+- `DEFAULT_EXPORT_BACKOFF_MULTIPLIER`: The backoff multiplier. Defaults to 1.5.
 
 This retry policy first checks if the response has a `'Retry-After'` header. If there is a `'Retry-After'` header, the exporter will wait the amount specified in the `'Retry-After'` header before retrying. If there is no `'Retry-After'` header, the exporter will use an exponential backoff with jitter retry strategy.
 
@@ -90,9 +90,9 @@ This retry policy first checks if the response has a `'Retry-After'` header. If 
 
 ## Useful links
 
-+ For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
-+ For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
-+ For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
 
 ## License
 

--- a/experimental/packages/exporter-trace-otlp-grpc/README.md
+++ b/experimental/packages/exporter-trace-otlp-grpc/README.md
@@ -116,7 +116,7 @@ Note, that this will only work if TLS is also configured on the server.
 
 The OTLPTraceExporter has a timeout configuration option which is the maximum time, in milliseconds, the OTLP exporter will wait for each batch export. The default value is 10000ms.
 
-+ To override the default timeout duration, provide `timeoutMillis` to OTLPTraceExporter with `collectorOptions`:
+- To override the default timeout duration, provide `timeoutMillis` to OTLPTraceExporter with `collectorOptions`:
 
   ```js
   const collectorOptions = {
@@ -177,9 +177,9 @@ const exporter = new OTLPTraceExporter(collectorOptions);
 
 ## Useful links
 
-+ For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
-+ For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
-+ For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
 
 ## License
 

--- a/experimental/packages/exporter-trace-otlp-http/README.md
+++ b/experimental/packages/exporter-trace-otlp-http/README.md
@@ -116,7 +116,7 @@ The OTLPTraceExporter has a timeout configuration option which is the maximum ti
 
 To override the default timeout duration, use the following options:
 
-+ Set with environment variables:
+- Set with environment variables:
 
   | Environment variable | Description |
   |----------------------|-------------|
@@ -125,7 +125,7 @@ To override the default timeout duration, use the following options:
 
   > `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` takes precedence and overrides `OTEL_EXPORTER_OTLP_TIMEOUT`.
 
-+ Provide `timeoutMillis` to OTLPTraceExporter with `collectorOptions`:
+- Provide `timeoutMillis` to OTLPTraceExporter with `collectorOptions`:
 
   ```js
   const collectorOptions = {
@@ -148,10 +148,10 @@ OTLP requires that transient errors be handled with a [retry strategy](https://g
 
 This retry policy has the following configuration, which there is currently no way to customize.
 
-+ `DEFAULT_EXPORT_MAX_ATTEMPTS`: The maximum number of attempts, including the original request. Defaults to 5.
-+ `DEFAULT_EXPORT_INITIAL_BACKOFF`: The initial backoff duration. Defaults to 1 second.
-+ `DEFAULT_EXPORT_MAX_BACKOFF`: The maximum backoff duration. Defaults to 5 seconds.
-+ `DEFAULT_EXPORT_BACKOFF_MULTIPLIER`: The backoff multiplier. Defaults to 1.5.
+- `DEFAULT_EXPORT_MAX_ATTEMPTS`: The maximum number of attempts, including the original request. Defaults to 5.
+- `DEFAULT_EXPORT_INITIAL_BACKOFF`: The initial backoff duration. Defaults to 1 second.
+- `DEFAULT_EXPORT_MAX_BACKOFF`: The maximum backoff duration. Defaults to 5 seconds.
+- `DEFAULT_EXPORT_BACKOFF_MULTIPLIER`: The backoff multiplier. Defaults to 1.5.
 
 This retry policy first checks if the response has a `'Retry-After'` header. If there is a `'Retry-After'` header, the exporter will wait the amount specified in the `'Retry-After'` header before retrying. If there is no `'Retry-After'` header, the exporter will use an exponential backoff with jitter retry strategy.
 
@@ -164,9 +164,9 @@ This retry policy first checks if the response has a `'Retry-After'` header. If 
 
 ## Useful links
 
-+ For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
-+ For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
-+ For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
 
 ## License
 

--- a/experimental/packages/exporter-trace-otlp-proto/README.md
+++ b/experimental/packages/exporter-trace-otlp-proto/README.md
@@ -46,7 +46,7 @@ The OTLPTraceExporter has a timeout configuration option which is the maximum ti
 
 To override the default timeout duration, use the following options:
 
-+ Set with environment variables:
+- Set with environment variables:
 
   | Environment variable | Description |
   |----------------------|-------------|
@@ -55,7 +55,7 @@ To override the default timeout duration, use the following options:
 
   > `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` takes precedence and overrides `OTEL_EXPORTER_OTLP_TIMEOUT`.
 
-+ Provide `timeoutMillis` to OTLPTraceExporter with `collectorOptions`:
+- Provide `timeoutMillis` to OTLPTraceExporter with `collectorOptions`:
 
   ```js
   const collectorOptions = {
@@ -77,10 +77,10 @@ OTLP requires that transient errors be handled with a [retry strategy](https://g
 
 This retry policy has the following configuration, which there is currently no way to customize.
 
-+ `DEFAULT_EXPORT_MAX_ATTEMPTS`: The maximum number of attempts, including the original request. Defaults to 5.
-+ `DEFAULT_EXPORT_INITIAL_BACKOFF`: The initial backoff duration. Defaults to 1 second.
-+ `DEFAULT_EXPORT_MAX_BACKOFF`: The maximum backoff duration. Defaults to 5 seconds.
-+ `DEFAULT_EXPORT_BACKOFF_MULTIPLIER`: The backoff multiplier. Defaults to 1.5.
+- `DEFAULT_EXPORT_MAX_ATTEMPTS`: The maximum number of attempts, including the original request. Defaults to 5.
+- `DEFAULT_EXPORT_INITIAL_BACKOFF`: The initial backoff duration. Defaults to 1 second.
+- `DEFAULT_EXPORT_MAX_BACKOFF`: The maximum backoff duration. Defaults to 5 seconds.
+- `DEFAULT_EXPORT_BACKOFF_MULTIPLIER`: The backoff multiplier. Defaults to 1.5.
 
 This retry policy first checks if the response has a `'Retry-After'` header. If there is a `'Retry-After'` header, the exporter will wait the amount specified in the `'Retry-After'` header before retrying. If there is no `'Retry-After'` header, the exporter will use an exponential backoff with jitter retry strategy.
 
@@ -94,9 +94,9 @@ This retry policy first checks if the response has a `'Retry-After'` header. If 
 
 ## Useful links
 
-+ For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
-+ For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
-+ For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
 
 ## License
 

--- a/experimental/packages/opentelemetry-instrumentation/README.md
+++ b/experimental/packages/opentelemetry-instrumentation/README.md
@@ -230,8 +230,8 @@ As the ESM module loader from Node.js is experimental, so is our support for it.
 
 Instrumentations for external modules (e.g. express, mongodb,...) hooks the `require` call or `import` statement. Therefore following conditions need to be met that this mechanism can work:
 
-* Instrumentations are registered **before** the module to instrument is `require`ed (CJS only)
-* modules are not included in a bundle. Tools like `esbuild`, `webpack`, ... usually have some mechanism to exclude specific modules from bundling
+- Instrumentations are registered **before** the module to instrument is `require`ed (CJS only)
+- modules are not included in a bundle. Tools like `esbuild`, `webpack`, ... usually have some mechanism to exclude specific modules from bundling
 
 ## License
 

--- a/experimental/packages/opentelemetry-instrumentation/README.md
+++ b/experimental/packages/opentelemetry-instrumentation/README.md
@@ -239,8 +239,8 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 
 ## Useful links
 
-* For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
-* For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
 
 [discussions-url]: https://github.com/open-telemetry/opentelemetry-js/discussions
 [license-url]: https://github.com/open-telemetry/opentelemetry-js/blob/main/LICENSE

--- a/experimental/packages/propagator-aws-xray-lambda/README.md
+++ b/experimental/packages/propagator-aws-xray-lambda/README.md
@@ -20,9 +20,9 @@ context active. It also automatically uses the [AWS X-Ray propagator](https://gi
 
 ## Useful links
 
-* For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
-* For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
-* For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
 
 ## License
 

--- a/packages/opentelemetry-context-async-hooks/README.md
+++ b/packages/opentelemetry-context-async-hooks/README.md
@@ -11,8 +11,8 @@ The definition of the `ContextManager` interface and the problem it solves can b
 
 Two `ContextManager` implementations are exported:
 
-* `AsyncLocalStorageContextManager`, based on [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage)
-* `AsyncHooksContextManager`, based on [`AsyncHook`](https://nodejs.org/api/async_hooks.html#async_hooks_class_asynchook)
+- `AsyncLocalStorageContextManager`, based on [`AsyncLocalStorage`](https://nodejs.org/api/async_context.html#class-asynclocalstorage)
+- `AsyncHooksContextManager`, based on [`AsyncHook`](https://nodejs.org/api/async_hooks.html#async_hooks_class_asynchook)
 
 The former should be preferred over the latter as its implementation is substantially simpler than the latter's, and according to [Node.js docs](https://github.com/nodejs/node/blame/v17.1.0/doc/api/async_context.md#L42-L45),
 
@@ -30,16 +30,16 @@ async_hooks is still seeing significant correctness and performance fixes, it's 
 
 Context propagation is a big subject when talking about tracing in Node.js. If you want more information about it here are some resources:
 
-* <https://www.npmjs.com/package/continuation-local-storage> (which was the old way of doing context propagation)
-* Datadog's own implementation for their JavaScript tracer: [here][dd-js-tracer-scope]
-* OpenTracing implementation: [here][opentracing-scope]
-* Discussion about context propagation by the Node.js Diagnostics Working Group: [here][diag-team-scope-discussion]
+- <https://www.npmjs.com/package/continuation-local-storage> (which was the old way of doing context propagation)
+- Datadog's own implementation for their JavaScript tracer: [here][dd-js-tracer-scope]
+- OpenTracing implementation: [here][opentracing-scope]
+- Discussion about context propagation by the Node.js Diagnostics Working Group: [here][diag-team-scope-discussion]
 
 ## Useful links
 
-* For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
-* For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
-* For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
 
 ## License
 

--- a/packages/opentelemetry-propagator-jaeger/README.md
+++ b/packages/opentelemetry-propagator-jaeger/README.md
@@ -8,18 +8,18 @@ OpenTelemetry Jaeger propagator provides HTTP header propagation for systems tha
 Format:
 {trace-id}:{span-id}:{parent-span-id}:{flags}
 
-* {trace-id}
-  * 64-bit or 128-bit random number in base16 format.
-  * Can be variable length, shorter values are 0-padded on the left.
-  * Value of 0 is invalid.
+- {trace-id}
+  - 64-bit or 128-bit random number in base16 format.
+  - Can be variable length, shorter values are 0-padded on the left.
+  - Value of 0 is invalid.
 
-* {span-id}
-  * 64-bit random number in base16 format.
+- {span-id}
+  - 64-bit random number in base16 format.
 
-* {parent-span-id}
-  * Set to 0 because this field is deprecated.
-* {flags}
-  * One byte bitmap, as two hex digits.
+- {parent-span-id}
+  - Set to 0 because this field is deprecated.
+- {flags}
+  - One byte bitmap, as two hex digits.
 
 Example of usage:
 
@@ -43,9 +43,9 @@ Jeager Baggage is represented as multiple headers where the names are carrier de
 
 ## Useful links
 
-* For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
-* For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
-* For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
 
 ## License
 

--- a/packages/propagator-aws-xray/README.md
+++ b/packages/propagator-aws-xray/README.md
@@ -40,28 +40,28 @@ The header consists of three parts: the root trace ID, the parent ID and the sam
 
 ### Root - The AWS X-Ray format trace ID
 
-* Format: (spec-version)-(timestamp)-(UUID)
-  * spec_version - The version of the AWS X-Ray header format. Currently, only "1" is valid.
-  * timestamp - 32-bit number in base16 format, corresponds to the first 8 characters of the OpenTelemetry trace ID. Note, while X-Ray calls this timestamp, for the purpose of propagation it is opaque and any value will work.
-  * UUID - 96-bit random number in base16 format, corresponds to the last 10 characters of the OpenTelemetry trace ID.
+- Format: (spec-version)-(timestamp)-(UUID)
+  - spec_version - The version of the AWS X-Ray header format. Currently, only "1" is valid.
+  - timestamp - 32-bit number in base16 format, corresponds to the first 8 characters of the OpenTelemetry trace ID. Note, while X-Ray calls this timestamp, for the purpose of propagation it is opaque and any value will work.
+  - UUID - 96-bit random number in base16 format, corresponds to the last 10 characters of the OpenTelemetry trace ID.
 
 Root is analogous to the [OpenTelemetry Trace ID](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#spancontext), with some small format changes.
 For additional reading, see the [AWS X-Ray Trace ID](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html#xray-api-traceids) public documentation.
 
 ### Parent - The ID of the AWS X-Ray Segment
 
-* 64-bit random number in base16 format. Populated from the [OpenTelemetry Span ID](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#spancontext).
+- 64-bit random number in base16 format. Populated from the [OpenTelemetry Span ID](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#spancontext).
 
 ### Sampled - The sampling decision
 
-* Defined in the AWS X-Ray specification as a tri-state field, with "0", "1" and "?" as valid values. Only "0" and "1" are used in this propagator. If "?", a new trace will be started.
-* Populated from the [OpenTelemetry trace flags](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#spancontext).
+- Defined in the AWS X-Ray specification as a tri-state field, with "0", "1" and "?" as valid values. Only "0" and "1" are used in this propagator. If "?", a new trace will be started.
+- Populated from the [OpenTelemetry trace flags](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/overview.md#spancontext).
 
 ## Useful links
 
-* For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
-* For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
-* For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
 
 ## License
 


### PR DESCRIPTION
This PR includes the following fixes:

- apply `Lint changelog file` CI step to all markdowns and not only the one in the repo root. This introduced few fixes to existing CHANGELOG files which now failed to lint
- exclude all CHANGELOG.md files from the next ci step `Lint markdown files`, which makes it consistent [with contrib](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/5767ab030417a964c0e02ab70914361425a711f0/.github/workflows/lint.yml#L22)
- align all our markdowns to common style - dash for unordered lists in markdown. 
- added rule to CI to enforce the list marker style
- cleanup irrelevant paths from the "ignroe" option in the ci step config for markdown-lint. they refer to times when the exporters where part of the `packages` directory and not under experimental.

see #4698  and the equivalent contrib PR: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2205