### PR TITLE
feat: add api release preparation scripts, github release creation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ package.json.lerna_backup
 
 # non-aggregated benchmark results
 .benchmark-results.txt
+
+# release notes for release creation
+.tmp/

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -97,13 +97,13 @@ All notable changes to this project will be documented in this file.
 
 * export tracer options ([#154](https://www.github.com/open-telemetry/opentelemetry-js-api/issues/154)) ([b125324](https://www.github.com/open-telemetry/opentelemetry-js-api/commit/b125324438fb2f24eb80c7c6673afc8cfc99575e))
 
-### [1.0.4](https://www.github.com/open-telemetry/opentelemetry-js-api/compare/v1.0.3...v1.0.4) (2021-12-18)
+## [1.0.4](https://www.github.com/open-telemetry/opentelemetry-js-api/compare/v1.0.3...v1.0.4) (2021-12-18)
 
 ### Bug Fixes
 
 * align globalThis fallbacks with otel-core ([#126](https://www.github.com/open-telemetry/opentelemetry-js-api/issues/126)) ([3507de7](https://www.github.com/open-telemetry/opentelemetry-js-api/commit/3507de7c3b95396696657c021953b0b24a63a029))
 
-### [1.0.3](https://www.github.com/open-telemetry/opentelemetry-js-api/compare/v1.0.2...v1.0.3) (2021-08-30)
+## [1.0.3](https://www.github.com/open-telemetry/opentelemetry-js-api/compare/v1.0.2...v1.0.3) (2021-08-30)
 
 ### Bug Fixes
 

--- a/examples/esm-http-ts/package.json
+++ b/examples/esm-http-ts/package.json
@@ -7,7 +7,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc --build",
-    "start": "node --experimental-loader=@opentelemetry/instrumentation/hook.mjs ./build/index.js"
+    "start": "node --experimental-loader=@opentelemetry/instrumentation/hook.mjs ./build/index.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "repository": {
     "type": "git",

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -8,7 +8,8 @@
     "zipkin:server": "cross-env EXPORTER=zipkin node ./server.js",
     "zipkin:client": "cross-env EXPORTER=zipkin node ./client.js",
     "jaeger:server": "cross-env EXPORTER=jaeger node ./server.js",
-    "jaeger:client": "cross-env EXPORTER=jaeger node ./client.js"
+    "jaeger:client": "cross-env EXPORTER=jaeger node ./client.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "repository": {
     "type": "git",

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -12,7 +12,8 @@
     "jaeger:client": "cross-env EXPORTER=jaeger node ./client.js",
     "docker:start": "cd ./docker && docker-compose down && docker-compose up",
     "docker:startd": "cd ./docker && docker-compose down && docker-compose up -d",
-    "docker:stop": "cd ./docker && docker-compose down"
+    "docker:stop": "cd ./docker && docker-compose down",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "repository": {
     "type": "git",

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -11,7 +11,8 @@
     "start-prodnc": "webpack serve --progress --color --port 8090 --config webpack.prod.config.js --hot --host 0.0.0.0 --no-compress",
     "docker:start": "cd ./docker && docker-compose down && docker-compose up",
     "docker:startd": "cd ./docker && docker-compose down && docker-compose up -d",
-    "docker:stop": "cd ./docker && docker-compose down"
+    "docker:stop": "cd ./docker && docker-compose down",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "repository": {
     "type": "git",

--- a/examples/opentracing-shim/package.json
+++ b/examples/opentracing-shim/package.json
@@ -8,7 +8,8 @@
     "zipkin:client": "cross-env EXPORTER=zipkin node ./client.js",
     "zipkin:server": "cross-env EXPORTER=zipkin node ./server.js",
     "jaeger:client": "cross-env EXPORTER=jaeger node ./client.js",
-    "jaeger:server": "cross-env EXPORTER=jaeger node ./server.js"
+    "jaeger:server": "cross-env EXPORTER=jaeger node ./server.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "repository": {
     "type": "git",

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -9,7 +9,8 @@
     "start:metrics": "node metrics.js",
     "docker:start": "cd ./docker && docker-compose down && docker-compose up",
     "docker:startd": "cd ./docker && docker-compose down && docker-compose up -d",
-    "docker:stop": "cd ./docker && docker-compose down"
+    "docker:stop": "cd ./docker && docker-compose down",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "repository": {
     "type": "git",

--- a/experimental/backwards-compatibility/node14/package.json
+++ b/experimental/backwards-compatibility/node14/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "test:backcompat": "tsc --noEmit index.ts && tsc --noEmit --esModuleInterop index.ts",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "dependencies": {
     "@opentelemetry/sdk-node": "0.51.0",

--- a/experimental/backwards-compatibility/node16/package.json
+++ b/experimental/backwards-compatibility/node16/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "test:backcompat": "tsc --noEmit index.ts && tsc --noEmit --esModuleInterop index.ts",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "dependencies": {
     "@opentelemetry/sdk-node": "0.51.0",

--- a/experimental/examples/logs/package.json
+++ b/experimental/examples/logs/package.json
@@ -3,7 +3,8 @@
   "version": "0.51.0",
   "private": true,
   "scripts": {
-    "start": "ts-node index.ts"
+    "start": "ts-node index.ts",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",

--- a/experimental/examples/opencensus-shim/package.json
+++ b/experimental/examples/opencensus-shim/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "client": "node -r @opentelemetry/shim-opencensus/register ./client.js",
-    "server": "node -r @opentelemetry/shim-opencensus/register ./server.js"
+    "server": "node -r @opentelemetry/shim-opencensus/register ./server.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "repository": {
     "type": "git",

--- a/experimental/examples/prometheus/package.json
+++ b/experimental/examples/prometheus/package.json
@@ -5,7 +5,8 @@
   "description": "Example of using @opentelemetry/sdk-metrics and @opentelemetry/exporter-prometheus",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/experimental/packages/api-events/package.json
+++ b/experimental/packages/api-events/package.json
@@ -27,7 +27,8 @@
     "version": "node ../../../scripts/version-update.js",
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
-    "prewatch": "node ../../../scripts/version-update.js"
+    "prewatch": "node ../../../scripts/version-update.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/api-logs/package.json
+++ b/experimental/packages/api-logs/package.json
@@ -27,7 +27,8 @@
     "version": "node ../../../scripts/version-update.js",
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
-    "prewatch": "node ../../../scripts/version-update.js"
+    "prewatch": "node ../../../scripts/version-update.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -18,7 +18,8 @@
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -44,7 +44,8 @@
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -27,7 +27,8 @@
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -18,7 +18,8 @@
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -29,7 +29,8 @@
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -27,7 +27,8 @@
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -22,7 +22,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -18,7 +18,8 @@
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -29,7 +29,8 @@
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -20,7 +20,8 @@
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -18,7 +18,8 @@
     "watch": "tsc --build --watch",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -20,7 +20,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "node ../../../scripts/version-update.js",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "fetch",

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -19,7 +19,8 @@
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "node ../../../scripts/version-update.js",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "protos:generate": "cd test/fixtures && buf generate"
+    "protos:generate": "cd test/fixtures && buf generate",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -18,7 +18,8 @@
     "watch": "tsc --build --watch",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "node ../../../scripts/version-update.js",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -20,7 +20,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "node ../../../scripts/version-update.js",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -56,7 +56,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "node ../../../scripts/version-update.js",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -17,7 +17,8 @@
     "watch": "tsc --build --watch",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -28,7 +28,8 @@
     "version": "node ../../../scripts/version-update.js",
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
-    "prewatch": "npm run precompile"
+    "prewatch": "npm run precompile",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -17,7 +17,8 @@
     "version": "node ../../../scripts/version-update.js",
     "watch": "tsc -w",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
-    "prewatch": "npm run precompile"
+    "prewatch": "npm run precompile",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -28,7 +28,8 @@
     "prewatch": "node ../../../scripts/version-update.js",
     "watch": "npm run protos && tsc -w tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "peer-api-check": "node ../../../scripts/peer-api-check.js",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../"
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/propagator-aws-xray-lambda/package.json
+++ b/experimental/packages/propagator-aws-xray-lambda/package.json
@@ -15,7 +15,9 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json",
-    "prepublishOnly": "npm run compile"
+    "prepublishOnly": "npm run compile",
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -43,7 +43,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "node ../../../scripts/version-update.js",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/experimental/packages/shim-opencensus/package.json
+++ b/experimental/packages/shim-opencensus/package.json
@@ -22,7 +22,8 @@
     "watch": "tsc --build --watch",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
     "_changelog:prepare_api": "node scripts/update-changelog.js ./api/CHANGELOG.md ./api/package.json",
     "_changelog:prepare_all": "npm run _changelog:prepare_api && npm run _changelog:prepare_experimental && npm run _changelog:prepare_stable",
     "_github:draft_release:all": "npm run _github:draft_release:api && _github:draft_release:experimental && _github:draft_release:stable",
-    "_github:draft_release:api": "node scripts/extract-latest-release-notes.js ./api/CHANGELOG.md && gh release create --draft --notes-file ./.tmp/release-notes.md --target main api/v$(node scripts/get-version.js ./api/package.json)",
-    "_github:draft_release:experimental": "node scripts/extract-latest-release-notes.js ./experimental/CHANGELOG.md && gh release create --draft --notes-file ./.tmp/release-notes.md --target main api/v$(node scripts/get-version.js ./experimental/packages/)",
-    "_github:draft_release:stable": "node scripts/extract-latest-release-notes.js ./CHANGELOG.md && gh release create --draft --notes-file ./.tmp/release-notes.md --target main v$(node scripts/get-version.js ./packages/)"
+    "_github:draft_release:api": "node scripts/extract-latest-release-notes.js ./api/CHANGELOG.md && VERSION=$(node scripts/get-version.js ./api/package.json | grep -oP '^\\d+\\.\\d+\\.\\d+$') && gh release create --draft --notes-file ./.tmp/release-notes.md --target main --title api/v$VERSION api/v$VERSION",
+    "_github:draft_release:experimental": "node scripts/extract-latest-release-notes.js ./experimental/CHANGELOG.md && VERSION=$(node scripts/get-version.js ./experimental/packages/ | grep -oP '^\\d+\\.\\d+\\.\\d+$') && gh release create --draft --notes-file ./.tmp/release-notes.md --target main --title experimental/v$VERSION experimental/v$VERSION",
+    "_github:draft_release:stable": "node scripts/extract-latest-release-notes.js ./CHANGELOG.md && VERSION=$(node scripts/get-version.js ./packages/ | grep -oP '^\\d+\\.\\d+\\.\\d+$') && gh release create --draft --notes-file ./.tmp/release-notes.md --target main --title v$VERSION v$VERSION"
   },
   "repository": "open-telemetry/opentelemetry-js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "comment_prepare_3": "echo sdk preparation scripts prepare all stable and experimental packages",
     "prepare_release:sdk:patch": "npm run _check:no_changes && npm run _backup:package-json && npm run _lerna:remove_api && npm run _lerna:version_patch && npm run _restore:package-json && npm run _changelog:prepare_experimental && npm run _changelog:prepare_stable",
     "prepare_release:sdk:minor": "npm run _check:no_changes && npm run _backup:package-json && npm run _lerna:remove_api && npm run _lerna:version_minor && npm run _restore:package-json && npm run _changelog:prepare_experimental && npm run _changelog:prepare_stable",
+    "prepare_release:all:minor": "npm run _check:no_changes && npm run _backup:package-json && npm run _lerna:remove_api && npm run _lerna:version_minor && cd api/ && npm version minor && cd .. && lerna run align-api-deps && npm run _restore:package-json && npm run _changelog:prepare_all",
     "release:publish": "lerna publish from-package --no-push --no-private --no-git-tag-version --no-verify-access",
     "comment_internal": "echo scripts below this line are for internal use",
     "_check:no_changes": "if [ ! -z \"$(git status -uall --porcelain)\" ]; then echo Please ensure all changes are committed; exit 1; fi",
@@ -51,7 +52,13 @@
     "_lerna:version_patch": "npx lerna version patch --exact --no-git-tag-version --no-push --yes",
     "_lerna:version_minor": "npx lerna version minor --exact --no-git-tag-version --no-push --yes",
     "_changelog:prepare_experimental": "node scripts/update-changelog.js ./experimental/CHANGELOG.md ./experimental/packages/",
-    "_changelog:prepare_stable": "node scripts/update-changelog.js ./CHANGELOG.md ./packages/"
+    "_changelog:prepare_stable": "node scripts/update-changelog.js ./CHANGELOG.md ./packages/",
+    "_changelog:prepare_api": "node scripts/update-changelog.js ./api/CHANGELOG.md ./api/package.json",
+    "_changelog:prepare_all": "npm run _changelog:prepare_api && npm run _changelog:prepare_experimental && npm run _changelog:prepare_stable",
+    "_github:draft_release:all": "npm run _github:draft_release:api && _github:draft_release:experimental && _github:draft_release:stable",
+    "_github:draft_release:api": "node scripts/extract-latest-release-notes.js ./api/CHANGELOG.md && gh release create --draft --notes-file ./.tmp/release-notes.md --target main api/v$(node scripts/get-version.js ./api/package.json)",
+    "_github:draft_release:experimental": "node scripts/extract-latest-release-notes.js ./experimental/CHANGELOG.md && gh release create --draft --notes-file ./.tmp/release-notes.md --target main api/v$(node scripts/get-version.js ./experimental/packages/)",
+    "_github:draft_release:stable": "node scripts/extract-latest-release-notes.js ./CHANGELOG.md && gh release create --draft --notes-file ./.tmp/release-notes.md --target main v$(node scripts/get-version.js ./packages/)"
   },
   "repository": "open-telemetry/opentelemetry-js",
   "keywords": [

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -17,7 +17,8 @@
     "version": "node ../../scripts/version-update.js",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -20,7 +20,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -17,7 +17,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -30,7 +30,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -18,7 +18,8 @@
     "watch": "tsc --build --watch",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -28,7 +28,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -19,7 +19,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -22,7 +22,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -33,7 +33,8 @@
     "version": "node ../../scripts/version-update.js",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -32,7 +32,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -18,7 +18,8 @@
     "watch": "tsc --build --watch",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -22,7 +22,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -18,7 +18,8 @@
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
     "peer-api-check": "node ../../scripts/peer-api-check.js",
-    "size-check": "npm run compile && ts-mocha -p tsconfig.json 'test/**/*.test.ts'"
+    "size-check": "npm run compile && ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -17,7 +17,8 @@
     "version": "node ../../scripts/version-update.js",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/propagator-aws-xray/package.json
+++ b/packages/propagator-aws-xray/package.json
@@ -23,7 +23,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -22,7 +22,8 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "node ../../scripts/version-update.js",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -32,7 +32,8 @@
     "clean": "tsc --build --clean",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
     "prewatch": "npm run precompile",
-    "peer-api-check": "node ../../scripts/peer-api-check.js"
+    "peer-api-check": "node ../../scripts/peer-api-check.js",
+    "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "Add these to scripts": {
     "compile": "tsc --build",

--- a/scripts/align-api-deps.js
+++ b/scripts/align-api-deps.js
@@ -1,0 +1,70 @@
+/**
+ * This extracts the current version from <repository-root>/api/package.json and aligns the
+ * dependencies in `./package.json` with that new version. For instance:
+ *  - `"@opentelemetry/api": ">1.0.0 <1.9.0"` when the local `@opentelemetry/api` is at `1.9.0` will become `"@opentelemetry/api": ">1.0.0 <1.10.0"`
+ *  - `"@opentelemetry/api": "^1.1.0"` will be left as-is when the local `@opentelemetry/api` is at `1.9.0` as it's already included in the range
+ *  - `"@opentelemetry/api": "1.8.0" when the local `@opentelemetry/api` is at `1.9.0` will become `"@opentelemetry/api": "1.9.0"`
+ *
+ * Usage (from package directory):
+ * - node <repo-root>/scripts/align-api-deps.js
+ */
+
+const fs = require('fs');
+const semver = require('semver');
+const path = require('path');
+const apiVersion = require(path.resolve(__dirname, '../api/package.json')).version;
+const nextMinorApiVersion =  semver.parse(apiVersion).inc('minor');
+
+function alignIfExact(value) {
+  const exactVersionRegex = /^\d+\.\d+\.\d+$/;
+  const result = value.match(exactVersionRegex);
+  if(result == null){
+    return value;
+  }
+
+  // use current exact API version
+  return apiVersion;
+}
+
+function alignIfRange(value){
+  const limitingVersionRegex = /<(\d+\.\d+\.\d+)$/;
+  const result = value.match(limitingVersionRegex);
+  if(result == null){
+    console.debug(`${value} is not a range, nothing to do`);
+    return value;
+  }
+
+  return value.replace(limitingVersionRegex, `<${nextMinorApiVersion}`);
+}
+
+function alignDeps(dependencies) {
+  for (const key in dependencies) {
+    if(key !== '@opentelemetry/api'){
+      continue;
+    }
+
+    if (dependencies.hasOwnProperty(key)) {
+      const value = dependencies[key];
+      dependencies[key] =  alignIfRange(alignIfExact(value));
+    }
+  }
+
+  return dependencies;
+}
+
+function alignApiDeps(packageJsonPath){
+  const packageJson =  JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+  const categoriesToUpdate = ['peerDependencies', 'devDependencies', 'dependencies'];
+
+  for(const category of categoriesToUpdate){
+    if(packageJson[category] == null){
+      console.debug(`${category} in ${packageJsonPath} was null or undefined, nothing to do.`);
+      continue;
+    }
+    alignDeps(packageJson[category]);
+  }
+
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, undefined, 2) + '\n', {encoding: 'utf-8'});
+}
+
+alignApiDeps(path.join(process.cwd(), './package.json'));

--- a/scripts/extract-latest-release-notes.js
+++ b/scripts/extract-latest-release-notes.js
@@ -1,0 +1,21 @@
+/**
+ * This extracts the latest (non-"Unreleased") notes from a CHANGELOG.md and saves them to `./.tmp/release-notes.md`
+ *
+ * Usage (from project root):
+ * - node scripts/extract-latest-release-notes.js [PATH TO CHANGELOG]
+ * Examples:
+ * - node scripts/extract-latest-release-notes.js ./packages/CHANGELOG.md
+ * - node scripts/extract-latest-release-notes.js ./experimental/CHANGELOG.md
+ */
+
+const fs = require('fs');
+
+const changelog = fs.readFileSync(process.argv[2]).toString();
+const firstReleaseNoteEntryExp = /(## \d+.\d+.\d\n*(.*\n)*?)(?=## )/m;
+
+fs.mkdirSync('./.tmp/', {
+  recursive: true
+});
+
+const notesFile = './.tmp/release-notes.md'
+fs.writeFileSync(notesFile, changelog.match(firstReleaseNoteEntryExp)[0]);

--- a/scripts/extract-latest-release-notes.js
+++ b/scripts/extract-latest-release-notes.js
@@ -11,6 +11,8 @@
 const fs = require('fs');
 
 const changelog = fs.readFileSync(process.argv[2]).toString();
+// Matches everything from the first entry at h2 ('##') followed by a space and a non-prerelease semver version
+// until the next entry at h2.
 const firstReleaseNoteEntryExp = /^## \d+\.\d+\.\d\n.*?(?=^## )/ms;
 
 fs.mkdirSync('./.tmp/', {

--- a/scripts/extract-latest-release-notes.js
+++ b/scripts/extract-latest-release-notes.js
@@ -11,7 +11,7 @@
 const fs = require('fs');
 
 const changelog = fs.readFileSync(process.argv[2]).toString();
-const firstReleaseNoteEntryExp = /(## \d+.\d+.\d\n*(.*\n)*?)(?=## )/m;
+const firstReleaseNoteEntryExp = /^## \d+\.\d+\.\d\n.*?(?=^## )/ms;
 
 fs.mkdirSync('./.tmp/', {
   recursive: true

--- a/scripts/get-version.js
+++ b/scripts/get-version.js
@@ -1,0 +1,55 @@
+/**
+ * This extracts the first version of a non-private package in a directory if the provided path is a directory
+ * OR the version inside the `package.json` the provided path is a file.
+ *
+ * Usage (from project root):
+ * - node scripts/get-version.js [PATH TO DIRECTORY | PATH TO FILE]
+ * Examples:
+ * - node scripts/get-version.js ./experimental/packages/
+ * - node scripts/get-version.js ./api/package.json
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function extractVersionFromPackageJson(packageJsonPath){
+  const packageJson =  JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
+  if(packageJson.private === true || packageJson.private === 'true'){
+    console.log('Skipping version from private package at', packageJsonPath);
+    return undefined;
+  }
+
+  if(packageJson.version == null){
+    console.log('Version in', packageJsonPath, 'was null or undefined, skipping');
+    return undefined;
+  }
+
+  return packageJson.version;
+}
+
+function findFirstPackageVersion(basePath){
+  const packageDirs = fs.readdirSync(basePath);
+  for(const packageDir of packageDirs){
+    const packageJsonPath = path.join(basePath, packageDir, 'package.json');
+    try {
+      const version = extractVersionFromPackageJson(packageJsonPath)
+      if(version != null){
+        return version;
+      }
+    } catch (err) {
+      console.log('Could not get package JSON', packageJsonPath, err);
+    }
+  }
+  throw new Error('Unable to extract version from packages in ' + basePath);
+}
+
+function determineVersion(path){
+  if(fs.lstatSync(path).isDirectory()) {
+    return findFirstPackageVersion(path);
+  }
+
+  return extractVersionFromPackageJson(path);
+}
+
+console.log(determineVersion(process.argv[2]));

--- a/scripts/get-version.js
+++ b/scripts/get-version.js
@@ -16,12 +16,12 @@ function extractVersionFromPackageJson(packageJsonPath){
   const packageJson =  JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
 
   if(packageJson.private === true || packageJson.private === 'true'){
-    console.log('Skipping version from private package at', packageJsonPath);
+    console.warn('Skipping version from private package at', packageJsonPath);
     return undefined;
   }
 
   if(packageJson.version == null){
-    console.log('Version in', packageJsonPath, 'was null or undefined, skipping');
+    console.warn('Version in', packageJsonPath, 'was null or undefined, skipping');
     return undefined;
   }
 
@@ -38,7 +38,7 @@ function findFirstPackageVersion(basePath){
         return version;
       }
     } catch (err) {
-      console.log('Could not get package JSON', packageJsonPath, err);
+      console.warn('Could not get package JSON', packageJsonPath, err);
     }
   }
   throw new Error('Unable to extract version from packages in ' + basePath);

--- a/scripts/peer-api-check.js
+++ b/scripts/peer-api-check.js
@@ -34,7 +34,17 @@ function checkPackage(package) {
 
   const peerVersion = pjson.peerDependencies && pjson.peerDependencies[package];
   const devVersion = pjson.devDependencies && pjson.devDependencies[package];
+
+  if(devVersion) {
+    if(devVersion.match(/^((>=\d+\.\d+\.\d+ <\d+\.\d+\.\d+)|(\^?\d+\.\d+\.\d+))$/) == null) {
+      throw new Error(`Package ${pjson.name} does not match required pattern '>=A.B.C <X.Y.Z', '^A.B.C' or 'A.B.C`);
+    }
+  }
+
   if (peerVersion) {
+    if(peerVersion.match(/^((>=\d+\.\d+\.\d+ <\d+\.\d+\.\d+)|(\^\d+\.\d+\.\d+))$/) == null) {
+      throw new Error(`Package ${pjson.name} does not match required pattern '>=A.B.C <X.Y.Z' or '^A.B.C'`);
+    }
     if (!semver.subset(devVersion, peerVersion)) {
       throw new Error(
         `Package ${pjson.name} depends on peer API version ${peerVersion} but version ${devVersion} in development`

--- a/scripts/update-changelog.js
+++ b/scripts/update-changelog.js
@@ -1,11 +1,11 @@
 /**
- * This script updates changelogs after lerna has updated versions in the respective areas (packages/*, experimental/packages/*)
+ * This script updates changelogs after lerna has updated versions in the respective areas (packages/*, experimental/packages/*, api/)
  * - removes all empty subsections (bugs, enhancements, etc.) in the changelog.
  * - replaces the "Unreleased"-header with the version from the first non-private package in the directory (versions are expected to be uniform across a changelog)
  * - adds a new "Unreleased"-header with empty subsections at the top
  *
  * Usage (from project root):
- * - node scripts/update-changelog.js [PATH TO CHANGELOG] [DIRECTORY CONTAINING ASSOCIATED PACKAGES]
+ * - node scripts/update-changelog.js [PATH TO CHANGELOG] [DIRECTORY CONTAINING ASSOCIATED PACKAGES | PATH TO package.json]
  * Examples:
  * - node scripts/update-changelog.js ./CHANGELOG.md ./packages
  * - node scripts/update-changelog.js ./experimental/CHANGELOG.md ./experimental/packages
@@ -28,23 +28,31 @@ const EMPTY_UNRELEASED_SECTION = `## Unreleased
 
 `
 
+function extractVersionFromPackageJson(packageJsonPath){
+  const packageJson =  JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
+  if(packageJson.private === true || packageJson.private === 'true'){
+    console.log('Skipping version from private package at', packageJsonPath);
+    return undefined;
+  }
+
+  if(packageJson.version == null){
+    console.log('Version in', packageJsonPath, 'was null or undefined, skipping');
+    return undefined;
+  }
+
+  return packageJson.version;
+}
+
 function findFirstPackageVersion(basePath){
   const packageDirs = fs.readdirSync(basePath);
   for(const packageDir of packageDirs){
     const packageJsonPath = path.join(basePath, packageDir, 'package.json');
     try {
-      const packageJson =  JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-
-      if(packageJson.private === true || packageJson.private === 'true'){
-        console.log('Skipping version from private package at', packageJsonPath);
-        continue;
+      const version = extractVersionFromPackageJson(packageJsonPath)
+      if(version != null){
+        return version;
       }
-
-      if(packageJson.version != null){
-        return packageJson.version;
-      }
-
-      console.log('Version in', packageJsonPath, 'was null or undefined, skipping');
     } catch (err) {
       console.log('Could not get package JSON', packageJsonPath, err);
     }
@@ -52,9 +60,18 @@ function findFirstPackageVersion(basePath){
   throw new Error('Unable to extract version from packages in ' + basePath);
 }
 
+function determineVersion(path){
+  if(fs.lstatSync(process.argv[3]).isDirectory()) {
+    return findFirstPackageVersion(path);
+  }
+
+  return extractVersionFromPackageJson(path);
+}
+
 // no special handling for bad args as this is only intended for use via predefined npm scripts.
 const changelogPath = path.resolve(process.argv[2]);
-const version = findFirstPackageVersion(path.resolve(process.argv[3]));
+
+const version = determineVersion(path.resolve(process.argv[3]));
 
 const changelog = fs.readFileSync(changelogPath, 'utf8').toString()
   // replace all empty sections

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -12,7 +12,8 @@
     "local:bs:xhr": "node scripts/local.runner.js --test ./tests/xhr/xhr.js --parallel --env browserstack.local_chrome,browserstack.local_firefox,browserstack.local_ie,browserstack.local_safari",
     "local:fetch": "nightwatch ./tests/fetch/fetch.js --env selenium.chrome",
     "local:xhr": "nightwatch ./tests/xhr/xhr.js --env selenium.chrome",
-    "server": "webpack serve --progress --port 8090 --config webpack.dev.js --hot --host 0.0.0.0"
+    "server": "webpack serve --progress --port 8090 --config webpack.dev.js --hot --host 0.0.0.0",
+    "align-api-deps": "node ../scripts/align-api-deps.js"
   },
   "keywords": [
     "opentelemetry",


### PR DESCRIPTION
## Which problem is this PR solving?

Adds a few more script for release-automation that I usually did by hand. Moving us closer to having a fully-automated solution.
This adds:
- automatic minor version bumps for API releases
  - we only had Experimental/Stable changes automated previously. We cannot use lerna for this as there's no way to just bump the API package and have it widen the `<` version ranges. Before this I used to manually update all dependencies, which was error-prone and tedious.
  - this adds the script to align the dependencies to each package so that we can call it via lerna
- a restriction on how API dependencies can be written to simplify the automatic version bumps from the script mentioned above:
  - `A.B.C` is allowed
  - `^A.B.C` is allowed (default for instrumentation packages)
  - `>=A.B.C <X.Y.Z` is allowed (default for SDK packages) 
- script to automatically create draft github releases
  - this was also done manually, by manually copying from the respective `CHANGELOG.md` (up to 3 times per release), manually typing the release title and manually creating a tag.
- script to automate updating `api/CHANGELOG.md`

PR creation, publishing packages and publishing Github Releases remains manual.

Additional changes:
- adds `peer-api-check` to some packages where it was missing
- aligns headings in `api/CHANGELOG.md` to avoid having them removed by the automatic updating of `api/CHANGELOG.md`

Next steps:
- scripts to automatically create a release PRs
- automatically create release PRs via @opentelemetrybot
- scripts to automatically push to npm when a release PR is merged

## How Has This Been Tested?

- [x] Manual testing