### PR TITLE
chore: fix personal info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 
 #### Maintainers ([@open-telemetry/javascript-maintainers](https://github.com/orgs/open-telemetry/teams/javascript-maintainers))
 
-- [Amir Blum](https://github.com/blumamir), Keyval
+- [Amir Blum](https://github.com/blumamir), Odigos
 - [Chengzhong Wu](https://github.com/legendecas), Bloomberg
 - [Daniel Dyla](https://github.com/dyladan), Dynatrace
 - [Marc Pichler](https://github.com/pichlermarc), Dynatrace


### PR DESCRIPTION
Just updating my personal info in the README. The company I work for is called "Keyval" but we are changing it to "Odigos" to align with the name of the open-source project we maintain.