### PR TITLE
Refactor to replace deprecations

### DIFF
--- a/examples/grpc-js/server.js
+++ b/examples/grpc-js/server.js
@@ -16,7 +16,6 @@ function startServer() {
   server.addService(services.GreeterService, { sayHello });
   server.bindAsync(`0.0.0.0:${PORT}`, grpc.ServerCredentials.createInsecure(), () => {
     console.log(`binding server on 0.0.0.0:${PORT}`);
-    server.start();
   });
 }
 

--- a/examples/grpc-js/tracer.js
+++ b/examples/grpc-js/tracer.js
@@ -4,7 +4,7 @@ const opentelemetry = require('@opentelemetry/api');
 const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { Resource } = require('@opentelemetry/resources');
-const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
+const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 const { SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
@@ -15,7 +15,7 @@ const EXPORTER = process.env.EXPORTER || '';
 module.exports = (serviceName) => {
   const provider = new NodeTracerProvider({
     resource: new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+      [SEMRESATTRS_SERVICE_NAME]: serviceName,
     }),
   });
 


### PR DESCRIPTION
- Replaced SemanticAttributes.ServiceName with  SEMRESATTRS_SERVICE_NAME
- Removed server.start( ) - No longer needed as of version 1.10.x