### PR TITLE
docs: fix instrumentation-graphql package name in documentation

### DIFF
--- a/packages/opentelemetry-sdk-trace-node/README.md
+++ b/packages/opentelemetry-sdk-trace-node/README.md
@@ -39,7 +39,7 @@ npm install --save @opentelemetry/sdk-trace-node
 # Install instrumentation plugins
 npm install --save @opentelemetry/instrumentation-http
 # and for example one additional
-npm install --save instrumentation-graphql
+npm install --save @opentelemetry/instrumentation-graphql
 ```
 
 ## Usage


### PR DESCRIPTION
There is an issue in a package name in node sdk