### PR TITLE
chore(renovate): set releaseWhen to conflicted to improve merge-queue behavior

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,7 @@
     "enabled": true,
     "schedule": ["before 3am on Monday"]
   },
+  "rebaseWhen": "conflicted",
   "ignoreDeps": ["@opentelemetry/api", "@opentelemetry/resources_1.9.0", "@types/node"],
   "assignees": ["@blumamir", "@dyladan", "@legendecas", "@pichlermarc"],
   "labels": ["dependencies"]


### PR DESCRIPTION
Renovate force-pushes due to the [rebaseWhen](https://docs.renovatebot.com/configuration-options/#rebasewhen) config, which is set to auto. That means it'll try to rebase once it's behind the base-branch, and that breaks the queue as there was a force-push to the branch while the PR was in the queue.

With `conflicted` it only does that when there'd be a conflict when merging to main (in that case it'd be fine as the queue would break anyway if I understand the merge-queue concept correctly).