### PR TITLE
refactor(core): Use (tree-shakeable) string constants for semconv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 * feat: support node 22 [#4666](https://github.com/open-telemetry/opentelemetry-js/pull/4666) @dyladan
 * feat(context-zone*): support zone.js 0.12.x [#4376](https://github.com/open-telemetry/opentelemetry-js/pull/4736) @maldago
+* refactor(core): Use tree-shakeable string constants for semconv [#4739](https://github.com/open-telemetry/opentelemetry-js/pull/4739) @JohannesHuster
 
 ### :bug: (Bug Fix)
 

--- a/packages/opentelemetry-core/src/platform/browser/sdk-info.ts
+++ b/packages/opentelemetry-core/src/platform/browser/sdk-info.ts
@@ -16,15 +16,17 @@
 
 import { VERSION } from '../../version';
 import {
-  TelemetrySdkLanguageValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_TELEMETRY_SDK_NAME,
+  SEMRESATTRS_PROCESS_RUNTIME_NAME,
+  SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
+  TELEMETRYSDKLANGUAGEVALUES_WEBJS,
+  SEMRESATTRS_TELEMETRY_SDK_VERSION,
 } from '@opentelemetry/semantic-conventions';
 
 /** Constants describing the SDK in use */
 export const SDK_INFO = {
-  [SemanticResourceAttributes.TELEMETRY_SDK_NAME]: 'opentelemetry',
-  [SemanticResourceAttributes.PROCESS_RUNTIME_NAME]: 'browser',
-  [SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE]:
-    TelemetrySdkLanguageValues.WEBJS,
-  [SemanticResourceAttributes.TELEMETRY_SDK_VERSION]: VERSION,
+  [SEMRESATTRS_TELEMETRY_SDK_NAME]: 'opentelemetry',
+  [SEMRESATTRS_PROCESS_RUNTIME_NAME]: 'browser',
+  [SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]: TELEMETRYSDKLANGUAGEVALUES_WEBJS,
+  [SEMRESATTRS_TELEMETRY_SDK_VERSION]: VERSION,
 };

--- a/packages/opentelemetry-core/src/platform/node/sdk-info.ts
+++ b/packages/opentelemetry-core/src/platform/node/sdk-info.ts
@@ -16,15 +16,17 @@
 
 import { VERSION } from '../../version';
 import {
-  TelemetrySdkLanguageValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_TELEMETRY_SDK_NAME,
+  SEMRESATTRS_PROCESS_RUNTIME_NAME,
+  SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
+  TELEMETRYSDKLANGUAGEVALUES_NODEJS,
+  SEMRESATTRS_TELEMETRY_SDK_VERSION,
 } from '@opentelemetry/semantic-conventions';
 
 /** Constants describing the SDK in use */
 export const SDK_INFO = {
-  [SemanticResourceAttributes.TELEMETRY_SDK_NAME]: 'opentelemetry',
-  [SemanticResourceAttributes.PROCESS_RUNTIME_NAME]: 'node',
-  [SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE]:
-    TelemetrySdkLanguageValues.NODEJS,
-  [SemanticResourceAttributes.TELEMETRY_SDK_VERSION]: VERSION,
+  [SEMRESATTRS_TELEMETRY_SDK_NAME]: 'opentelemetry',
+  [SEMRESATTRS_PROCESS_RUNTIME_NAME]: 'node',
+  [SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]: TELEMETRYSDKLANGUAGEVALUES_NODEJS,
+  [SEMRESATTRS_TELEMETRY_SDK_VERSION]: VERSION,
 };


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Updates #4567

## Short description of the changes

Replace deprecated imports from “@opentelemetry/semantic-conventions” with new (tree-shakeable) string constants for core package. What I did:
- Search for “@opentelemetry/semantic-conventions” in package path.
    - Add new imports and check that new and old strings match exactly.
    - Use new imports and remove old ones.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) (refactor)

## How Has This Been Tested?

- [x] npm test

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
  - No new functionality
- [ ] Documentation has been updated
  - I'm not sure if documentation, like described in https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1778, is wanted for this package at the moment. Please let me know, if I should add it.
