### PR TITLE
fix: Update `import-in-the-middle`

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to experimental packages in this project will be documented 
 * feat(propagator-aws-xray-lambda): add AWS Xray Lambda propagator [4554](https://github.com/open-telemetry/opentelemetry-js/pull/4554)
 
 ### :bug: (Bug Fix)
+* fix(instrumentation): Update `import-in-the-middle` to fix numerous bugs [#4745]
 
 ### :books: (Refine Doc)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -31,7 +31,7 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
-* fix(instrumentation): Update `import-in-the-middle` to fix numerous bugs [#4745]
+* fix(instrumentation): Update `import-in-the-middle` to fix [numerous bugs](https://github.com/DataDog/import-in-the-middle/pull/91) [#4745](https://github.com/open-telemetry/opentelemetry-js/pull/4745) @timfish
 
 ### :books: (Refine Doc)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to experimental packages in this project will be documented 
 * feat(propagator-aws-xray-lambda): add AWS Xray Lambda propagator [4554](https://github.com/open-telemetry/opentelemetry-js/pull/4554)
 
 ### :bug: (Bug Fix)
+
 * fix(instrumentation): Update `import-in-the-middle` to fix numerous bugs [#4745]
 
 ### :books: (Refine Doc)

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@opentelemetry/api-logs": "0.51.1",
     "@types/shimmer": "^1.0.2",
-    "import-in-the-middle": "1.7.4",
+    "import-in-the-middle": "1.8.0",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2",
     "shimmer": "^1.2.1"

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -310,7 +310,7 @@ export abstract class InstrumentationBase<
 
       this._hooks.push(hook);
       const esmHook =
-        new (ImportInTheMiddle as unknown as typeof ImportInTheMiddle.default)(
+        new ((ImportInTheMiddle as unknown as { Hook: typeof ImportInTheMiddle.default }).Hook)(
           [module.name],
           { internals: false },
           <HookFn>hookFn

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -309,12 +309,11 @@ export abstract class InstrumentationBase<
         : this._requireInTheMiddleSingleton.register(module.name, onRequire);
 
       this._hooks.push(hook);
-      const esmHook =
-        new ((ImportInTheMiddle as unknown as { Hook: typeof ImportInTheMiddle.default }).Hook)(
-          [module.name],
-          { internals: false },
-          <HookFn>hookFn
-        );
+      const esmHook = new (
+        ImportInTheMiddle as unknown as {
+          Hook: typeof ImportInTheMiddle.default;
+        }
+      ).Hook([module.name], { internals: false }, <HookFn>hookFn);
       this._hooks.push(esmHook);
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2202,7 +2202,7 @@
       "dependencies": {
         "@opentelemetry/api-logs": "0.51.1",
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.4",
+        "import-in-the-middle": "1.8.0",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -17855,9 +17855,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.4.tgz",
-      "integrity": "sha512-Lk+qzWmiQuRPPulGQeK5qq0v32k2bHnWrRPFgqyvhw7Kkov5L6MOLOIU3pcWeujc9W4q54Cp3Q2WV16eQkc7Bg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.8.0.tgz",
+      "integrity": "sha512-/xQjze8szLNnJ5rvHSzn+dcVXqCAU6Plbk4P24U/jwPmg1wy7IIp9OjKIO5tYue8GSPhDpPDiApQjvBUmWwhsQ==",
       "dependencies": {
         "acorn": "^8.8.2",
         "acorn-import-attributes": "^1.9.5",
@@ -37304,7 +37304,7 @@
         "codecov": "3.8.3",
         "cpx2": "2.0.0",
         "cross-var": "1.1.0",
-        "import-in-the-middle": "1.7.4",
+        "import-in-the-middle": "1.8.0",
         "karma": "6.4.3",
         "karma-chrome-launcher": "3.1.0",
         "karma-coverage": "2.2.1",
@@ -47339,9 +47339,9 @@
       }
     },
     "import-in-the-middle": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.4.tgz",
-      "integrity": "sha512-Lk+qzWmiQuRPPulGQeK5qq0v32k2bHnWrRPFgqyvhw7Kkov5L6MOLOIU3pcWeujc9W4q54Cp3Q2WV16eQkc7Bg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.8.0.tgz",
+      "integrity": "sha512-/xQjze8szLNnJ5rvHSzn+dcVXqCAU6Plbk4P24U/jwPmg1wy7IIp9OjKIO5tYue8GSPhDpPDiApQjvBUmWwhsQ==",
       "requires": {
         "acorn": "^8.8.2",
         "acorn-import-attributes": "^1.9.5",


### PR DESCRIPTION
`import-in-the-middle` v1.8.0 [has a lot of bug fixes](https://github.com/DataDog/import-in-the-middle/pull/91). 

Closes #4547

In one of those PRs I added a named `Hook` export which should work around the default export issue which closes #4691 and closes #4717.

Unfortunately when I added the export I forgot to add it to the types so the types need fudging until [this PR](https://github.com/DataDog/import-in-the-middle/pull/92) makes it into a release.