### PR TITLE
refactor(shim-opentracing): Use tree-shakeable string constants for semconv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * feat: support node 22 [#4666](https://github.com/open-telemetry/opentelemetry-js/pull/4666) @dyladan
 * feat(context-zone*): support zone.js 0.12.x [#4376](https://github.com/open-telemetry/opentelemetry-js/pull/4736) @maldago
 * refactor(core): Use tree-shakeable string constants for semconv [#4739](https://github.com/open-telemetry/opentelemetry-js/pull/4739) @JohannesHuster
+* refactor(shim-opentracing): Use tree-shakeable string constants for semconv [#4746](https://github.com/open-telemetry/opentelemetry-js/pull/4746) @JohannesHuster
 
 ### :bug: (Bug Fix)
 

--- a/packages/opentelemetry-shim-opentracing/src/shim.ts
+++ b/packages/opentelemetry-shim-opentracing/src/shim.ts
@@ -22,7 +22,11 @@ import {
   TextMapPropagator,
 } from '@opentelemetry/api';
 import * as opentracing from 'opentracing';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_EXCEPTION_MESSAGE,
+  SEMATTRS_EXCEPTION_STACKTRACE,
+  SEMATTRS_EXCEPTION_TYPE,
+} from '@opentelemetry/semantic-conventions';
 
 function translateReferences(references: opentracing.Reference[]): api.Link[] {
   const links: api.Link[] = [];
@@ -325,15 +329,15 @@ export class SpanShim extends opentracing.Span {
       for (const [k, v] of entries) {
         switch (k) {
           case 'error.kind': {
-            mappedAttributes[SemanticAttributes.EXCEPTION_TYPE] = v;
+            mappedAttributes[SEMATTRS_EXCEPTION_TYPE] = v;
             break;
           }
           case 'message': {
-            mappedAttributes[SemanticAttributes.EXCEPTION_MESSAGE] = v;
+            mappedAttributes[SEMATTRS_EXCEPTION_MESSAGE] = v;
             break;
           }
           case 'stack': {
-            mappedAttributes[SemanticAttributes.EXCEPTION_STACKTRACE] = v;
+            mappedAttributes[SEMATTRS_EXCEPTION_STACKTRACE] = v;
             break;
           }
           default: {

--- a/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
+++ b/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
@@ -36,7 +36,11 @@ import {
 import { performance } from 'perf_hooks';
 import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { JaegerPropagator } from '@opentelemetry/propagator-jaeger';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_EXCEPTION_MESSAGE,
+  SEMATTRS_EXCEPTION_STACKTRACE,
+  SEMATTRS_EXCEPTION_TYPE,
+} from '@opentelemetry/semantic-conventions';
 
 describe('OpenTracing Shim', () => {
   const compositePropagator = new CompositePropagator({
@@ -378,7 +382,7 @@ describe('OpenTracing Shim', () => {
           span.logEvent('error', payload);
           assert.strictEqual(otSpan.events[0].name, 'exception');
           const expectedAttributes = {
-            [SemanticAttributes.EXCEPTION_MESSAGE]: 'boom',
+            [SEMATTRS_EXCEPTION_MESSAGE]: 'boom',
           };
           assert.deepStrictEqual(
             otSpan.events[0].attributes,
@@ -397,9 +401,9 @@ describe('OpenTracing Shim', () => {
           assert.strictEqual(otSpan.events[0].name, 'exception');
           const expectedAttributes = {
             fault: 'meow',
-            [SemanticAttributes.EXCEPTION_TYPE]: 'boom',
-            [SemanticAttributes.EXCEPTION_MESSAGE]: 'oh no!',
-            [SemanticAttributes.EXCEPTION_STACKTRACE]: 'pancakes',
+            [SEMATTRS_EXCEPTION_TYPE]: 'boom',
+            [SEMATTRS_EXCEPTION_MESSAGE]: 'oh no!',
+            [SEMATTRS_EXCEPTION_STACKTRACE]: 'pancakes',
           };
           assert.deepStrictEqual(
             otSpan.events[0].attributes,
@@ -446,7 +450,7 @@ describe('OpenTracing Shim', () => {
             Math.trunc(tomorrow / 1000)
           );
           const expectedAttributes = {
-            [SemanticAttributes.EXCEPTION_MESSAGE]: 'boom',
+            [SEMATTRS_EXCEPTION_MESSAGE]: 'boom',
           };
           assert.deepStrictEqual(
             otSpan.events[0].attributes,
@@ -471,9 +475,9 @@ describe('OpenTracing Shim', () => {
           const expectedAttributes = {
             event: 'error',
             fault: 'meow',
-            [SemanticAttributes.EXCEPTION_TYPE]: 'boom',
-            [SemanticAttributes.EXCEPTION_MESSAGE]: 'oh no!',
-            [SemanticAttributes.EXCEPTION_STACKTRACE]: 'pancakes',
+            [SEMATTRS_EXCEPTION_TYPE]: 'boom',
+            [SEMATTRS_EXCEPTION_MESSAGE]: 'oh no!',
+            [SEMATTRS_EXCEPTION_STACKTRACE]: 'pancakes',
           };
           assert.deepStrictEqual(
             otSpan.events[0].attributes,


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Updates #4567

## Short description of the changes

Replace deprecated imports from `@opentelemetry/semantic-conventions` with new (tree-shakeable) string constants for package `@opentelemetry/shim-opentracing`. What I did:
- Search for “@opentelemetry/semantic-conventions” in package path.
    - Add new imports and check that new and old strings match exactly.
    - Use new imports and remove old ones.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) (refactor)

## How Has This Been Tested?

- [x] npm test

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
  - No new functionality
- [ ] Documentation has been updated
