### PR TITLE
refactor(sdk-trace-web): Use tree-shakeable string constants for semconv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * feat: support node 22 [#4666](https://github.com/open-telemetry/opentelemetry-js/pull/4666) @dyladan
 * feat(context-zone*): support zone.js 0.12.x [#4376](https://github.com/open-telemetry/opentelemetry-js/pull/4736) @maldago
 * refactor(core): Use tree-shakeable string constants for semconv [#4739](https://github.com/open-telemetry/opentelemetry-js/pull/4739) @JohannesHuster
+* refactor(sdk-trace-web): Use tree-shakeable string constants for semconv [#4747](https://github.com/open-telemetry/opentelemetry-js/pull/4747) @JohannesHuster
 
 ### :bug: (Bug Fix)
 

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -26,7 +26,10 @@ import {
   timeInputToHrTime,
   urlMatches,
 } from '@opentelemetry/core';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH,
+  SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
+} from '@opentelemetry/semantic-conventions';
 
 // Used to normalize relative URLs
 let urlNormalizingAnchor: HTMLAnchorElement | undefined;
@@ -110,16 +113,13 @@ export function addSpanNetworkEvents(
   addSpanNetworkEvent(span, PTN.RESPONSE_END, resource);
   const encodedLength = resource[PTN.ENCODED_BODY_SIZE];
   if (encodedLength !== undefined) {
-    span.setAttribute(
-      SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH,
-      encodedLength
-    );
+    span.setAttribute(SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH, encodedLength);
   }
   const decodedLength = resource[PTN.DECODED_BODY_SIZE];
   // Spec: Not set if transport encoding not used (in which case encoded and decoded sizes match)
   if (decodedLength !== undefined && encodedLength !== decodedLength) {
     span.setAttribute(
-      SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
+      SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
       decodedLength
     );
   }

--- a/packages/opentelemetry-sdk-trace-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/WebTracerProvider.test.ts
@@ -18,7 +18,7 @@ import { context, ContextManager, trace } from '@opentelemetry/api';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_TELEMETRY_SDK_LANGUAGE } from '@opentelemetry/semantic-conventions';
 import { Span, Tracer } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
 import { WebTracerConfig } from '../src';
@@ -130,9 +130,7 @@ describe('WebTracerProvider', () => {
         assert.ok(span);
         assert.ok(span.resource instanceof Resource);
         assert.equal(
-          span.resource.attributes[
-            SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE
-          ],
+          span.resource.attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
           'webjs'
         );
       });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Updates #4567

## Short description of the changes

Replace deprecated imports from `@opentelemetry/semantic-conventions` with new (tree-shakeable) string constants for package `@opentelemetry/sdk-trace-web`. What I did:
- Search for “@opentelemetry/semantic-conventions” in package path.
    - Add new imports and check that new and old strings match exactly.
    - Use new imports and remove old ones.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) (refactor)

## How Has This Been Tested?

- [x] npm test

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
  - No new functionality
- [ ] Documentation has been updated
