### PR TITLE
refactor(sdk-trace-node): Use tree-shakeable string constants for semconv

### DIFF
--- a/packages/opentelemetry-sdk-trace-node/test/NodeTracerProvider.test.ts
+++ b/packages/opentelemetry-sdk-trace-node/test/NodeTracerProvider.test.ts
@@ -39,7 +39,7 @@ import {
   SpanExporter,
 } from '@opentelemetry/sdk-trace-base';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_TELEMETRY_SDK_LANGUAGE } from '@opentelemetry/semantic-conventions';
 
 import { NodeTracerProvider } from '../src/NodeTracerProvider';
 
@@ -152,9 +152,7 @@ describe('NodeTracerProvider', () => {
       assert.ok(span);
       assert.ok(span.resource instanceof Resource);
       assert.equal(
-        span.resource.attributes[
-          SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE
-        ],
+        span.resource.attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
         'nodejs'
       );
     });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Updates #4567

## Short description of the changes

Replace deprecated imports from `@opentelemetry/semantic-conventions` with new (tree-shakeable) string constants for package `@opentelemetry/sdk-trace-node`. What I did:
- Search for “@opentelemetry/semantic-conventions” in package path.
    - Add new imports and check that new and old strings match exactly.
    - Use new imports and remove old ones.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) (refactor)

## How Has This Been Tested?

- [x] npm test

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
  - No new functionality
- [ ] Documentation has been updated
