### PR TITLE
refactor(sdk-trace-base): Use tree-shakeable string constants for semconv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * feat: support node 22 [#4666](https://github.com/open-telemetry/opentelemetry-js/pull/4666) @dyladan
 * feat(context-zone*): support zone.js 0.12.x [#4376](https://github.com/open-telemetry/opentelemetry-js/pull/4736) @maldago
 * refactor(core): Use tree-shakeable string constants for semconv [#4739](https://github.com/open-telemetry/opentelemetry-js/pull/4739) @JohannesHuster
+* refactor(sdk-trace-base): Use tree-shakeable string constants for semconv [#4749](https://github.com/open-telemetry/opentelemetry-js/pull/4749) @JohannesHuster
 
 ### :bug: (Bug Fix)
 

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -43,7 +43,11 @@ import {
   sanitizeAttributes,
 } from '@opentelemetry/core';
 import { IResource } from '@opentelemetry/resources';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_EXCEPTION_MESSAGE,
+  SEMATTRS_EXCEPTION_STACKTRACE,
+  SEMATTRS_EXCEPTION_TYPE,
+} from '@opentelemetry/semantic-conventions';
 import { ExceptionEventName } from './enums';
 import { ReadableSpan } from './export/ReadableSpan';
 import { SpanProcessor } from './SpanProcessor';
@@ -299,26 +303,25 @@ export class Span implements APISpan, ReadableSpan {
   recordException(exception: Exception, time?: TimeInput): void {
     const attributes: SpanAttributes = {};
     if (typeof exception === 'string') {
-      attributes[SemanticAttributes.EXCEPTION_MESSAGE] = exception;
+      attributes[SEMATTRS_EXCEPTION_MESSAGE] = exception;
     } else if (exception) {
       if (exception.code) {
-        attributes[SemanticAttributes.EXCEPTION_TYPE] =
-          exception.code.toString();
+        attributes[SEMATTRS_EXCEPTION_TYPE] = exception.code.toString();
       } else if (exception.name) {
-        attributes[SemanticAttributes.EXCEPTION_TYPE] = exception.name;
+        attributes[SEMATTRS_EXCEPTION_TYPE] = exception.name;
       }
       if (exception.message) {
-        attributes[SemanticAttributes.EXCEPTION_MESSAGE] = exception.message;
+        attributes[SEMATTRS_EXCEPTION_MESSAGE] = exception.message;
       }
       if (exception.stack) {
-        attributes[SemanticAttributes.EXCEPTION_STACKTRACE] = exception.stack;
+        attributes[SEMATTRS_EXCEPTION_STACKTRACE] = exception.stack;
       }
     }
 
     // these are minimum requirements from spec
     if (
-      attributes[SemanticAttributes.EXCEPTION_TYPE] ||
-      attributes[SemanticAttributes.EXCEPTION_MESSAGE]
+      attributes[SEMATTRS_EXCEPTION_TYPE] ||
+      attributes[SEMATTRS_EXCEPTION_MESSAGE]
     ) {
       this.addEvent(ExceptionEventName, attributes, time);
     } else {

--- a/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
@@ -34,7 +34,11 @@ import {
   hrTimeToNanoseconds,
   otperformance as performance,
 } from '@opentelemetry/core';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_EXCEPTION_MESSAGE,
+  SEMATTRS_EXCEPTION_STACKTRACE,
+  SEMATTRS_EXCEPTION_TYPE,
+} from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { BasicTracerProvider, Span, SpanProcessor } from '../../src';
@@ -1250,11 +1254,10 @@ describe('Span', () => {
 
           assert.ok(event.attributes);
 
-          const type = event.attributes[SemanticAttributes.EXCEPTION_TYPE];
-          const message =
-            event.attributes[SemanticAttributes.EXCEPTION_MESSAGE];
+          const type = event.attributes[SEMATTRS_EXCEPTION_TYPE];
+          const message = event.attributes[SEMATTRS_EXCEPTION_MESSAGE];
           const stacktrace = String(
-            event.attributes[SemanticAttributes.EXCEPTION_STACKTRACE]
+            event.attributes[SEMATTRS_EXCEPTION_STACKTRACE]
           );
           assert.strictEqual(type, 'Error');
           assert.strictEqual(message, 'boom');
@@ -1294,7 +1297,7 @@ describe('Span', () => {
         span.recordException({ code: 12 });
         const event = span.events[0];
         assert.deepStrictEqual(event.attributes, {
-          [SemanticAttributes.EXCEPTION_TYPE]: '12',
+          [SEMATTRS_EXCEPTION_TYPE]: '12',
         });
       });
     });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Updates #4567

## Short description of the changes

Replace deprecated imports from `@opentelemetry/semantic-conventions` with new (tree-shakeable) string constants for package `@opentelemetry/sdk-trace-base`. What I did:
- Search for “@opentelemetry/semantic-conventions” in package path.
    - Add new imports and check that new and old strings match exactly.
    - Use new imports and remove old ones.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) (refactor)

## How Has This Been Tested?

- [x] npm test

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
  - No new functionality
- [ ] Documentation has been updated
