### PR TITLE
chore(resources): update deprecated semconv to use exported strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * refactor(sdk-trace-web): Use tree-shakeable string constants for semconv [#4747](https://github.com/open-telemetry/opentelemetry-js/pull/4747) @JohannesHuster
 * refactor(sdk-trace-node): Use tree-shakeable string constants for semconv [#4748](https://github.com/open-telemetry/opentelemetry-js/pull/4748) @JohannesHuster
 * refactor(sdk-trace-base): Use tree-shakeable string constants for semconv [#4749](https://github.com/open-telemetry/opentelemetry-js/pull/4749) @JohannesHuster
-* chore(resources): update deprecated semconv to use exported strings [](https://github.com/open-telemetry/opentelemetry-js/pull)
+* chore(resources): update deprecated semconv to use exported strings [#4755](https://github.com/open-telemetry/opentelemetry-js/pull/#4755) @JamieDanielson
 
 ### :bug: (Bug Fix)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * refactor(sdk-trace-web): Use tree-shakeable string constants for semconv [#4747](https://github.com/open-telemetry/opentelemetry-js/pull/4747) @JohannesHuster
 * refactor(sdk-trace-node): Use tree-shakeable string constants for semconv [#4748](https://github.com/open-telemetry/opentelemetry-js/pull/4748) @JohannesHuster
 * refactor(sdk-trace-base): Use tree-shakeable string constants for semconv [#4749](https://github.com/open-telemetry/opentelemetry-js/pull/4749) @JohannesHuster
+* chore(resources): update deprecated semconv to use exported strings [](https://github.com/open-telemetry/opentelemetry-js/pull)
 
 ### :bug: (Bug Fix)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * refactor(sdk-trace-web): Use tree-shakeable string constants for semconv [#4747](https://github.com/open-telemetry/opentelemetry-js/pull/4747) @JohannesHuster
 * refactor(sdk-trace-node): Use tree-shakeable string constants for semconv [#4748](https://github.com/open-telemetry/opentelemetry-js/pull/4748) @JohannesHuster
 * refactor(sdk-trace-base): Use tree-shakeable string constants for semconv [#4749](https://github.com/open-telemetry/opentelemetry-js/pull/4749) @JohannesHuster
-* chore(resources): update deprecated semconv to use exported strings [#4755](https://github.com/open-telemetry/opentelemetry-js/pull/#4755) @JamieDanielson
+* refactor(resources): update deprecated semconv to use exported strings [#4755](https://github.com/open-telemetry/opentelemetry-js/pull/#4755) @JamieDanielson
 
 ### :bug: (Bug Fix)
 

--- a/packages/opentelemetry-resources/src/detectors/BrowserDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/BrowserDetectorSync.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION,
+  SEMRESATTRS_PROCESS_RUNTIME_NAME,
+  SEMRESATTRS_PROCESS_RUNTIME_VERSION,
+} from '@opentelemetry/semantic-conventions';
 import { DetectorSync, ResourceAttributes } from '../types';
 import { diag } from '@opentelemetry/api';
 import { ResourceDetectionConfig } from '../config';
@@ -36,9 +40,9 @@ class BrowserDetectorSync implements DetectorSync {
       return Resource.empty();
     }
     const browserResource: ResourceAttributes = {
-      [SemanticResourceAttributes.PROCESS_RUNTIME_NAME]: 'browser',
-      [SemanticResourceAttributes.PROCESS_RUNTIME_DESCRIPTION]: 'Web Browser',
-      [SemanticResourceAttributes.PROCESS_RUNTIME_VERSION]: navigator.userAgent,
+      [SEMRESATTRS_PROCESS_RUNTIME_NAME]: 'browser',
+      [SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION]: 'Web Browser',
+      [SEMRESATTRS_PROCESS_RUNTIME_VERSION]: navigator.userAgent,
     };
     return this._getResourceAttributes(browserResource, config);
   }
@@ -53,9 +57,7 @@ class BrowserDetectorSync implements DetectorSync {
     browserResource: ResourceAttributes,
     _config?: ResourceDetectionConfig
   ) {
-    if (
-      browserResource[SemanticResourceAttributes.PROCESS_RUNTIME_VERSION] === ''
-    ) {
+    if (browserResource[SEMRESATTRS_PROCESS_RUNTIME_VERSION] === '') {
       diag.debug(
         'BrowserDetector failed: Unable to find required browser resources. '
       );

--- a/packages/opentelemetry-resources/src/detectors/platform/node/HostDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/HostDetectorSync.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMRESATTRS_HOST_ARCH,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_NAME,
+} from '@opentelemetry/semantic-conventions';
 import { Resource } from '../../../Resource';
 import { DetectorSync, ResourceAttributes } from '../../../types';
 import { ResourceDetectionConfig } from '../../../config';
@@ -29,8 +33,8 @@ import { getMachineId } from './machine-id/getMachineId';
 class HostDetectorSync implements DetectorSync {
   detect(_config?: ResourceDetectionConfig): Resource {
     const attributes: ResourceAttributes = {
-      [SemanticResourceAttributes.HOST_NAME]: hostname(),
-      [SemanticResourceAttributes.HOST_ARCH]: normalizeArch(arch()),
+      [SEMRESATTRS_HOST_NAME]: hostname(),
+      [SEMRESATTRS_HOST_ARCH]: normalizeArch(arch()),
     };
 
     return new Resource(attributes, this._getAsyncAttributes());
@@ -40,7 +44,7 @@ class HostDetectorSync implements DetectorSync {
     return getMachineId().then(machineId => {
       const attributes: ResourceAttributes = {};
       if (machineId) {
-        attributes[SemanticResourceAttributes.HOST_ID] = machineId;
+        attributes[SEMRESATTRS_HOST_ID] = machineId;
       }
       return attributes;
     });

--- a/packages/opentelemetry-resources/src/detectors/platform/node/OSDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/OSDetectorSync.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMRESATTRS_OS_TYPE,
+  SEMRESATTRS_OS_VERSION,
+} from '@opentelemetry/semantic-conventions';
 import { Resource } from '../../../Resource';
 import { DetectorSync, ResourceAttributes } from '../../../types';
 import { ResourceDetectionConfig } from '../../../config';
@@ -28,8 +31,8 @@ import { normalizeType } from './utils';
 class OSDetectorSync implements DetectorSync {
   detect(_config?: ResourceDetectionConfig): Resource {
     const attributes: ResourceAttributes = {
-      [SemanticResourceAttributes.OS_TYPE]: normalizeType(platform()),
-      [SemanticResourceAttributes.OS_VERSION]: release(),
+      [SEMRESATTRS_OS_TYPE]: normalizeType(platform()),
+      [SEMRESATTRS_OS_VERSION]: release(),
     };
     return new Resource(attributes);
   }

--- a/packages/opentelemetry-resources/src/detectors/platform/node/ProcessDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/ProcessDetectorSync.ts
@@ -15,7 +15,17 @@
  */
 
 import { diag } from '@opentelemetry/api';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMRESATTRS_PROCESS_COMMAND,
+  SEMRESATTRS_PROCESS_COMMAND_ARGS,
+  SEMRESATTRS_PROCESS_EXECUTABLE_NAME,
+  SEMRESATTRS_PROCESS_EXECUTABLE_PATH,
+  SEMRESATTRS_PROCESS_OWNER,
+  SEMRESATTRS_PROCESS_PID,
+  SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION,
+  SEMRESATTRS_PROCESS_RUNTIME_NAME,
+  SEMRESATTRS_PROCESS_RUNTIME_VERSION,
+} from '@opentelemetry/semantic-conventions';
 import { Resource } from '../../../Resource';
 import { DetectorSync, ResourceAttributes } from '../../../types';
 import { ResourceDetectionConfig } from '../../../config';
@@ -29,27 +39,26 @@ import * as os from 'os';
 class ProcessDetectorSync implements DetectorSync {
   detect(_config?: ResourceDetectionConfig): IResource {
     const attributes: ResourceAttributes = {
-      [SemanticResourceAttributes.PROCESS_PID]: process.pid,
-      [SemanticResourceAttributes.PROCESS_EXECUTABLE_NAME]: process.title,
-      [SemanticResourceAttributes.PROCESS_EXECUTABLE_PATH]: process.execPath,
-      [SemanticResourceAttributes.PROCESS_COMMAND_ARGS]: [
+      [SEMRESATTRS_PROCESS_PID]: process.pid,
+      [SEMRESATTRS_PROCESS_EXECUTABLE_NAME]: process.title,
+      [SEMRESATTRS_PROCESS_EXECUTABLE_PATH]: process.execPath,
+      [SEMRESATTRS_PROCESS_COMMAND_ARGS]: [
         process.argv[0],
         ...process.execArgv,
         ...process.argv.slice(1),
       ],
-      [SemanticResourceAttributes.PROCESS_RUNTIME_VERSION]:
-        process.versions.node,
-      [SemanticResourceAttributes.PROCESS_RUNTIME_NAME]: 'nodejs',
-      [SemanticResourceAttributes.PROCESS_RUNTIME_DESCRIPTION]: 'Node.js',
+      [SEMRESATTRS_PROCESS_RUNTIME_VERSION]: process.versions.node,
+      [SEMRESATTRS_PROCESS_RUNTIME_NAME]: 'nodejs',
+      [SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION]: 'Node.js',
     };
 
     if (process.argv.length > 1) {
-      attributes[SemanticResourceAttributes.PROCESS_COMMAND] = process.argv[1];
+      attributes[SEMRESATTRS_PROCESS_COMMAND] = process.argv[1];
     }
 
     try {
       const userInfo = os.userInfo();
-      attributes[SemanticResourceAttributes.PROCESS_OWNER] = userInfo.username;
+      attributes[SEMRESATTRS_PROCESS_OWNER] = userInfo.username;
     } catch (e) {
       diag.debug(`error obtaining process owner: ${e}`);
     }

--- a/packages/opentelemetry-resources/test/Resource.test.ts
+++ b/packages/opentelemetry-resources/test/Resource.test.ts
@@ -18,7 +18,12 @@ import * as sinon from 'sinon';
 import * as assert from 'assert';
 import { SDK_INFO } from '@opentelemetry/core';
 import { Resource, ResourceAttributes } from '../src';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
+  SEMRESATTRS_TELEMETRY_SDK_NAME,
+  SEMRESATTRS_TELEMETRY_SDK_VERSION,
+} from '@opentelemetry/semantic-conventions';
 import { describeBrowser, describeNode } from './util';
 import { diag } from '@opentelemetry/api';
 import { Resource as Resource190 } from '@opentelemetry/resources_1.9.0';
@@ -280,19 +285,19 @@ describe('Resource', () => {
     it('should return a default resource', () => {
       const resource = Resource.default();
       assert.strictEqual(
-        resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_NAME],
-        SDK_INFO[SemanticResourceAttributes.TELEMETRY_SDK_NAME]
+        resource.attributes[SEMRESATTRS_TELEMETRY_SDK_NAME],
+        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_NAME]
       );
       assert.strictEqual(
-        resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE],
-        SDK_INFO[SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE]
+        resource.attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
+        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]
       );
       assert.strictEqual(
-        resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_VERSION],
-        SDK_INFO[SemanticResourceAttributes.TELEMETRY_SDK_VERSION]
+        resource.attributes[SEMRESATTRS_TELEMETRY_SDK_VERSION],
+        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_VERSION]
       );
       assert.strictEqual(
-        resource.attributes[SemanticResourceAttributes.SERVICE_NAME],
+        resource.attributes[SEMRESATTRS_SERVICE_NAME],
         `unknown_service:${process.argv0}`
       );
     });
@@ -302,19 +307,19 @@ describe('Resource', () => {
     it('should return a default resource', () => {
       const resource = Resource.default();
       assert.strictEqual(
-        resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_NAME],
-        SDK_INFO[SemanticResourceAttributes.TELEMETRY_SDK_NAME]
+        resource.attributes[SEMRESATTRS_TELEMETRY_SDK_NAME],
+        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_NAME]
       );
       assert.strictEqual(
-        resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE],
-        SDK_INFO[SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE]
+        resource.attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
+        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]
       );
       assert.strictEqual(
-        resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_VERSION],
-        SDK_INFO[SemanticResourceAttributes.TELEMETRY_SDK_VERSION]
+        resource.attributes[SEMRESATTRS_TELEMETRY_SDK_VERSION],
+        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_VERSION]
       );
       assert.strictEqual(
-        resource.attributes[SemanticResourceAttributes.SERVICE_NAME],
+        resource.attributes[SEMRESATTRS_SERVICE_NAME],
         'unknown_service'
       );
     });

--- a/packages/opentelemetry-resources/test/detectors/node/HostDetector.test.ts
+++ b/packages/opentelemetry-resources/test/detectors/node/HostDetector.test.ts
@@ -16,7 +16,11 @@
 
 import * as sinon from 'sinon';
 import * as assert from 'assert';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMRESATTRS_HOST_ARCH,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_NAME,
+} from '@opentelemetry/semantic-conventions';
 import { describeNode } from '../../util';
 import { hostDetector, IResource } from '../../../src';
 
@@ -39,15 +43,12 @@ describeNode('hostDetector() on Node.js', () => {
     await resource.waitForAsyncAttributes?.();
 
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_NAME],
+      resource.attributes[SEMRESATTRS_HOST_NAME],
       'opentelemetry-test'
     );
+    assert.strictEqual(resource.attributes[SEMRESATTRS_HOST_ARCH], 'amd64');
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_ARCH],
-      'amd64'
-    );
-    assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_ID],
+      resource.attributes[SEMRESATTRS_HOST_ID],
       expectedHostId
     );
   });
@@ -60,7 +61,7 @@ describeNode('hostDetector() on Node.js', () => {
     const resource: IResource = await hostDetector.detect();
 
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_ARCH],
+      resource.attributes[SEMRESATTRS_HOST_ARCH],
       'some-unknown-arch'
     );
   });
@@ -77,16 +78,10 @@ describeNode('hostDetector() on Node.js', () => {
     await resource.waitForAsyncAttributes?.();
 
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_NAME],
+      resource.attributes[SEMRESATTRS_HOST_NAME],
       'opentelemetry-test'
     );
-    assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_ARCH],
-      'amd64'
-    );
-    assert.strictEqual(
-      false,
-      SemanticResourceAttributes.HOST_ID in resource.attributes
-    );
+    assert.strictEqual(resource.attributes[SEMRESATTRS_HOST_ARCH], 'amd64');
+    assert.strictEqual(false, SEMRESATTRS_HOST_ID in resource.attributes);
   });
 });

--- a/packages/opentelemetry-resources/test/detectors/node/OSDetector.test.ts
+++ b/packages/opentelemetry-resources/test/detectors/node/OSDetector.test.ts
@@ -16,7 +16,10 @@
 
 import * as sinon from 'sinon';
 import * as assert from 'assert';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMRESATTRS_OS_TYPE,
+  SEMRESATTRS_OS_VERSION,
+} from '@opentelemetry/semantic-conventions';
 import { describeNode } from '../../util';
 import { osDetector, IResource } from '../../../src';
 
@@ -33,12 +36,9 @@ describeNode('osDetector() on Node.js', () => {
 
     const resource: IResource = await osDetector.detect();
 
+    assert.strictEqual(resource.attributes[SEMRESATTRS_OS_TYPE], 'windows');
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.OS_TYPE],
-      'windows'
-    );
-    assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.OS_VERSION],
+      resource.attributes[SEMRESATTRS_OS_VERSION],
       '2.2.1(0.289/5/3)'
     );
   });
@@ -51,7 +51,7 @@ describeNode('osDetector() on Node.js', () => {
     const resource: IResource = await osDetector.detect();
 
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.OS_TYPE],
+      resource.attributes[SEMRESATTRS_OS_TYPE],
       'some-unknown-platform'
     );
   });

--- a/packages/opentelemetry-resources/test/resource-assertions.test.ts
+++ b/packages/opentelemetry-resources/test/resource-assertions.test.ts
@@ -16,10 +16,31 @@
 
 import { SDK_INFO } from '@opentelemetry/core';
 import {
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_CONTAINER_ID,
+  SEMRESATTRS_CONTAINER_IMAGE_NAME,
+  SEMRESATTRS_CONTAINER_IMAGE_TAG,
+  SEMRESATTRS_CONTAINER_NAME,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_IMAGE_ID,
+  SEMRESATTRS_HOST_IMAGE_NAME,
+  SEMRESATTRS_HOST_IMAGE_VERSION,
+  SEMRESATTRS_HOST_NAME,
+  SEMRESATTRS_HOST_TYPE,
+  SEMRESATTRS_K8S_CLUSTER_NAME,
+  SEMRESATTRS_K8S_DEPLOYMENT_NAME,
+  SEMRESATTRS_K8S_NAMESPACE_NAME,
+  SEMRESATTRS_K8S_POD_NAME,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
+  SEMRESATTRS_SERVICE_VERSION,
   SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
   SEMRESATTRS_TELEMETRY_SDK_NAME,
   SEMRESATTRS_TELEMETRY_SDK_VERSION,
-  SemanticResourceAttributes,
 } from '@opentelemetry/semantic-conventions';
 import { Resource } from '../src/Resource';
 import {
@@ -34,17 +55,17 @@ import {
 describe('assertCloudResource', () => {
   it('requires one cloud label', () => {
     const resource = new Resource({
-      [SemanticResourceAttributes.CLOUD_PROVIDER]: 'gcp',
+      [SEMRESATTRS_CLOUD_PROVIDER]: 'gcp',
     });
     assertCloudResource(resource, {});
   });
 
   it('validates optional attributes', () => {
     const resource = new Resource({
-      [SemanticResourceAttributes.CLOUD_PROVIDER]: 'gcp',
-      [SemanticResourceAttributes.CLOUD_ACCOUNT_ID]: 'opentelemetry',
-      [SemanticResourceAttributes.CLOUD_REGION]: 'us-central1',
-      [SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE]: 'us-central1-a',
+      [SEMRESATTRS_CLOUD_PROVIDER]: 'gcp',
+      [SEMRESATTRS_CLOUD_ACCOUNT_ID]: 'opentelemetry',
+      [SEMRESATTRS_CLOUD_REGION]: 'us-central1',
+      [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE]: 'us-central1-a',
     });
     assertCloudResource(resource, {
       provider: 'gcp',
@@ -58,18 +79,17 @@ describe('assertCloudResource', () => {
 describe('assertContainerResource', () => {
   it('requires one container label', () => {
     const resource = new Resource({
-      [SemanticResourceAttributes.CONTAINER_NAME]: 'opentelemetry-autoconf',
+      [SEMRESATTRS_CONTAINER_NAME]: 'opentelemetry-autoconf',
     });
     assertContainerResource(resource, {});
   });
 
   it('validates optional attributes', () => {
     const resource = new Resource({
-      [SemanticResourceAttributes.CONTAINER_NAME]: 'opentelemetry-autoconf',
-      [SemanticResourceAttributes.CONTAINER_ID]: 'abc',
-      [SemanticResourceAttributes.CONTAINER_IMAGE_NAME]:
-        'gcr.io/opentelemetry/operator',
-      [SemanticResourceAttributes.CONTAINER_IMAGE_TAG]: '0.1',
+      [SEMRESATTRS_CONTAINER_NAME]: 'opentelemetry-autoconf',
+      [SEMRESATTRS_CONTAINER_ID]: 'abc',
+      [SEMRESATTRS_CONTAINER_IMAGE_NAME]: 'gcr.io/opentelemetry/operator',
+      [SEMRESATTRS_CONTAINER_IMAGE_TAG]: '0.1',
     });
     assertContainerResource(resource, {
       name: 'opentelemetry-autoconf',
@@ -83,20 +103,20 @@ describe('assertContainerResource', () => {
 describe('assertHostResource', () => {
   it('requires one host label', () => {
     const resource = new Resource({
-      [SemanticResourceAttributes.HOST_ID]: 'opentelemetry-test-id',
+      [SEMRESATTRS_HOST_ID]: 'opentelemetry-test-id',
     });
     assertHostResource(resource, {});
   });
 
   it('validates optional attributes', () => {
     const resource = new Resource({
-      [SemanticResourceAttributes.HOST_ID]: 'opentelemetry-test-id',
-      [SemanticResourceAttributes.HOST_NAME]: 'opentelemetry-test-name',
-      [SemanticResourceAttributes.HOST_TYPE]: 'n1-standard-1',
-      [SemanticResourceAttributes.HOST_IMAGE_NAME]:
+      [SEMRESATTRS_HOST_ID]: 'opentelemetry-test-id',
+      [SEMRESATTRS_HOST_NAME]: 'opentelemetry-test-name',
+      [SEMRESATTRS_HOST_TYPE]: 'n1-standard-1',
+      [SEMRESATTRS_HOST_IMAGE_NAME]:
         'infra-ami-eks-worker-node-7d4ec78312, CentOS-8-x86_64-1905',
-      [SemanticResourceAttributes.HOST_IMAGE_ID]: 'ami-07b06b442921831e5',
-      [SemanticResourceAttributes.HOST_IMAGE_VERSION]: '0.1',
+      [SEMRESATTRS_HOST_IMAGE_ID]: 'ami-07b06b442921831e5',
+      [SEMRESATTRS_HOST_IMAGE_VERSION]: '0.1',
     });
     assertHostResource(resource, {
       hostName: 'opentelemetry-test-hostname',
@@ -113,17 +133,17 @@ describe('assertHostResource', () => {
 describe('assertK8sResource', () => {
   it('requires one k8s label', () => {
     const resource = new Resource({
-      [SemanticResourceAttributes.K8S_CLUSTER_NAME]: 'opentelemetry-cluster',
+      [SEMRESATTRS_K8S_CLUSTER_NAME]: 'opentelemetry-cluster',
     });
     assertK8sResource(resource, {});
   });
 
   it('validates optional attributes', () => {
     const resource = new Resource({
-      [SemanticResourceAttributes.K8S_CLUSTER_NAME]: 'opentelemetry-cluster',
-      [SemanticResourceAttributes.K8S_NAMESPACE_NAME]: 'default',
-      [SemanticResourceAttributes.K8S_POD_NAME]: 'opentelemetry-pod-autoconf',
-      [SemanticResourceAttributes.K8S_DEPLOYMENT_NAME]: 'opentelemetry',
+      [SEMRESATTRS_K8S_CLUSTER_NAME]: 'opentelemetry-cluster',
+      [SEMRESATTRS_K8S_NAMESPACE_NAME]: 'default',
+      [SEMRESATTRS_K8S_POD_NAME]: 'opentelemetry-pod-autoconf',
+      [SEMRESATTRS_K8S_DEPLOYMENT_NAME]: 'opentelemetry',
     });
     assertK8sResource(resource, {
       clusterName: 'opentelemetry-cluster',
@@ -137,11 +157,11 @@ describe('assertK8sResource', () => {
 describe('assertTelemetrySDKResource', () => {
   it('uses default validations', () => {
     const resource = new Resource({
-      [SemanticResourceAttributes.TELEMETRY_SDK_NAME]:
+      [SEMRESATTRS_TELEMETRY_SDK_NAME]:
         SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_NAME],
-      [SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE]:
+      [SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]:
         SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
-      [SemanticResourceAttributes.TELEMETRY_SDK_VERSION]:
+      [SEMRESATTRS_TELEMETRY_SDK_VERSION]:
         SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_VERSION],
     });
     assertTelemetrySDKResource(resource, {});
@@ -149,9 +169,9 @@ describe('assertTelemetrySDKResource', () => {
 
   it('validates optional attributes', () => {
     const resource = new Resource({
-      [SemanticResourceAttributes.TELEMETRY_SDK_NAME]: 'opentelemetry',
-      [SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE]: 'nodejs',
-      [SemanticResourceAttributes.TELEMETRY_SDK_VERSION]: '0.1.0',
+      [SEMRESATTRS_TELEMETRY_SDK_NAME]: 'opentelemetry',
+      [SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]: 'nodejs',
+      [SEMRESATTRS_TELEMETRY_SDK_VERSION]: '0.1.0',
     });
     assertTelemetrySDKResource(resource, {
       name: 'opentelemetry',
@@ -164,9 +184,8 @@ describe('assertTelemetrySDKResource', () => {
 describe('assertServiceResource', () => {
   it('validates required attributes', () => {
     const resource = new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: 'shoppingcart',
-      [SemanticResourceAttributes.SERVICE_INSTANCE_ID]:
-        '627cc493-f310-47de-96bd-71410b7dec09',
+      [SEMRESATTRS_SERVICE_NAME]: 'shoppingcart',
+      [SEMRESATTRS_SERVICE_INSTANCE_ID]: '627cc493-f310-47de-96bd-71410b7dec09',
     });
     assertServiceResource(resource, {
       name: 'shoppingcart',
@@ -176,11 +195,10 @@ describe('assertServiceResource', () => {
 
   it('validates optional attributes', () => {
     const resource = new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: 'shoppingcart',
-      [SemanticResourceAttributes.SERVICE_INSTANCE_ID]:
-        '627cc493-f310-47de-96bd-71410b7dec09',
-      [SemanticResourceAttributes.SERVICE_NAMESPACE]: 'shop',
-      [SemanticResourceAttributes.SERVICE_VERSION]: '0.1.0',
+      [SEMRESATTRS_SERVICE_NAME]: 'shoppingcart',
+      [SEMRESATTRS_SERVICE_INSTANCE_ID]: '627cc493-f310-47de-96bd-71410b7dec09',
+      [SEMRESATTRS_SERVICE_NAMESPACE]: 'shop',
+      [SEMRESATTRS_SERVICE_VERSION]: '0.1.0',
     });
     assertServiceResource(resource, {
       name: 'shoppingcart',

--- a/packages/opentelemetry-resources/test/util/resource-assertions.ts
+++ b/packages/opentelemetry-resources/test/util/resource-assertions.ts
@@ -18,9 +18,43 @@ import { SDK_INFO } from '@opentelemetry/core';
 import * as assert from 'assert';
 import { IResource } from '../../src/IResource';
 import {
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_CONTAINER_ID,
+  SEMRESATTRS_CONTAINER_IMAGE_NAME,
+  SEMRESATTRS_CONTAINER_IMAGE_TAG,
+  SEMRESATTRS_CONTAINER_NAME,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_IMAGE_ID,
+  SEMRESATTRS_HOST_IMAGE_NAME,
+  SEMRESATTRS_HOST_IMAGE_VERSION,
+  SEMRESATTRS_HOST_NAME,
+  SEMRESATTRS_HOST_TYPE,
+  SEMRESATTRS_K8S_CLUSTER_NAME,
+  SEMRESATTRS_K8S_DEPLOYMENT_NAME,
+  SEMRESATTRS_K8S_NAMESPACE_NAME,
+  SEMRESATTRS_K8S_POD_NAME,
+  SEMRESATTRS_PROCESS_COMMAND,
+  SEMRESATTRS_PROCESS_COMMAND_ARGS,
+  SEMRESATTRS_PROCESS_EXECUTABLE_NAME,
+  SEMRESATTRS_PROCESS_EXECUTABLE_PATH,
+  SEMRESATTRS_PROCESS_OWNER,
+  SEMRESATTRS_PROCESS_PID,
+  SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION,
+  SEMRESATTRS_PROCESS_RUNTIME_NAME,
+  SEMRESATTRS_PROCESS_RUNTIME_VERSION,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
+  SEMRESATTRS_SERVICE_VERSION,
   SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
   SEMRESATTRS_TELEMETRY_SDK_NAME,
   SEMRESATTRS_TELEMETRY_SDK_VERSION,
+  SEMRESATTRS_WEBENGINE_DESCRIPTION,
+  SEMRESATTRS_WEBENGINE_NAME,
+  SEMRESATTRS_WEBENGINE_VERSION,
   SemanticResourceAttributes,
 } from '@opentelemetry/semantic-conventions';
 
@@ -42,22 +76,22 @@ export const assertCloudResource = (
   assertHasOneLabel('CLOUD', resource);
   if (validations.provider)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CLOUD_PROVIDER],
+      resource.attributes[SEMRESATTRS_CLOUD_PROVIDER],
       validations.provider
     );
   if (validations.accountId)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CLOUD_ACCOUNT_ID],
+      resource.attributes[SEMRESATTRS_CLOUD_ACCOUNT_ID],
       validations.accountId
     );
   if (validations.region)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CLOUD_REGION],
+      resource.attributes[SEMRESATTRS_CLOUD_REGION],
       validations.region
     );
   if (validations.zone)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE],
+      resource.attributes[SEMRESATTRS_CLOUD_AVAILABILITY_ZONE],
       validations.zone
     );
 };
@@ -80,22 +114,22 @@ export const assertContainerResource = (
   assertHasOneLabel('CONTAINER', resource);
   if (validations.name)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CONTAINER_NAME],
+      resource.attributes[SEMRESATTRS_CONTAINER_NAME],
       validations.name
     );
   if (validations.id)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CONTAINER_ID],
+      resource.attributes[SEMRESATTRS_CONTAINER_ID],
       validations.id
     );
   if (validations.imageName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CONTAINER_IMAGE_NAME],
+      resource.attributes[SEMRESATTRS_CONTAINER_IMAGE_NAME],
       validations.imageName
     );
   if (validations.imageTag)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CONTAINER_IMAGE_TAG],
+      resource.attributes[SEMRESATTRS_CONTAINER_IMAGE_TAG],
       validations.imageTag
     );
 };
@@ -121,32 +155,32 @@ export const assertHostResource = (
   assertHasOneLabel('HOST', resource);
   if (validations.id)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_ID],
+      resource.attributes[SEMRESATTRS_HOST_ID],
       validations.id
     );
   if (validations.name)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_NAME],
+      resource.attributes[SEMRESATTRS_HOST_NAME],
       validations.name
     );
   if (validations.hostType)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_TYPE],
+      resource.attributes[SEMRESATTRS_HOST_TYPE],
       validations.hostType
     );
   if (validations.imageName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_IMAGE_NAME],
+      resource.attributes[SEMRESATTRS_HOST_IMAGE_NAME],
       validations.imageName
     );
   if (validations.imageId)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_IMAGE_ID],
+      resource.attributes[SEMRESATTRS_HOST_IMAGE_ID],
       validations.imageId
     );
   if (validations.imageVersion)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_IMAGE_VERSION],
+      resource.attributes[SEMRESATTRS_HOST_IMAGE_VERSION],
       validations.imageVersion
     );
 };
@@ -169,22 +203,22 @@ export const assertK8sResource = (
   assertHasOneLabel('K8S', resource);
   if (validations.clusterName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.K8S_CLUSTER_NAME],
+      resource.attributes[SEMRESATTRS_K8S_CLUSTER_NAME],
       validations.clusterName
     );
   if (validations.namespaceName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.K8S_NAMESPACE_NAME],
+      resource.attributes[SEMRESATTRS_K8S_NAMESPACE_NAME],
       validations.namespaceName
     );
   if (validations.podName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.K8S_POD_NAME],
+      resource.attributes[SEMRESATTRS_K8S_POD_NAME],
       validations.podName
     );
   if (validations.deploymentName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.K8S_DEPLOYMENT_NAME],
+      resource.attributes[SEMRESATTRS_K8S_DEPLOYMENT_NAME],
       validations.deploymentName
     );
 };
@@ -212,17 +246,17 @@ export const assertTelemetrySDKResource = (
 
   if (validations.name)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_NAME],
+      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_NAME],
       validations.name
     );
   if (validations.language)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE],
+      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
       validations.language
     );
   if (validations.version)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_VERSION],
+      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_VERSION],
       validations.version
     );
 };
@@ -243,21 +277,21 @@ export const assertServiceResource = (
   }
 ) => {
   assert.strictEqual(
-    resource.attributes[SemanticResourceAttributes.SERVICE_NAME],
+    resource.attributes[SEMRESATTRS_SERVICE_NAME],
     validations.name
   );
   assert.strictEqual(
-    resource.attributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID],
+    resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID],
     validations.instanceId
   );
   if (validations.namespace)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.SERVICE_NAMESPACE],
+      resource.attributes[SEMRESATTRS_SERVICE_NAMESPACE],
       validations.namespace
     );
   if (validations.version)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.SERVICE_VERSION],
+      resource.attributes[SEMRESATTRS_SERVICE_VERSION],
       validations.version
     );
 };
@@ -283,56 +317,54 @@ export const assertResource = (
   }
 ) => {
   assert.strictEqual(
-    resource.attributes[SemanticResourceAttributes.PROCESS_PID],
+    resource.attributes[SEMRESATTRS_PROCESS_PID],
     validations.pid
   );
   if (validations.name) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.PROCESS_EXECUTABLE_NAME],
+      resource.attributes[SEMRESATTRS_PROCESS_EXECUTABLE_NAME],
       validations.name
     );
   }
   if (validations.command) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.PROCESS_COMMAND],
+      resource.attributes[SEMRESATTRS_PROCESS_COMMAND],
       validations.command
     );
   }
   if (validations.commandArgs) {
     assert.deepStrictEqual(
-      resource.attributes[SemanticResourceAttributes.PROCESS_COMMAND_ARGS],
+      resource.attributes[SEMRESATTRS_PROCESS_COMMAND_ARGS],
       validations.commandArgs
     );
   }
   if (validations.executablePath) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.PROCESS_EXECUTABLE_PATH],
+      resource.attributes[SEMRESATTRS_PROCESS_EXECUTABLE_PATH],
       validations.executablePath
     );
   }
   if (validations.owner) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.PROCESS_OWNER],
+      resource.attributes[SEMRESATTRS_PROCESS_OWNER],
       validations.owner
     );
   }
   if (validations.version) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.PROCESS_RUNTIME_VERSION],
+      resource.attributes[SEMRESATTRS_PROCESS_RUNTIME_VERSION],
       validations.version
     );
   }
   if (validations.runtimeName) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.PROCESS_RUNTIME_NAME],
+      resource.attributes[SEMRESATTRS_PROCESS_RUNTIME_NAME],
       validations.runtimeName
     );
   }
   if (validations.runtimeDescription) {
     assert.strictEqual(
-      resource.attributes[
-        SemanticResourceAttributes.PROCESS_RUNTIME_DESCRIPTION
-      ],
+      resource.attributes[SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION],
       validations.runtimeDescription
     );
   }
@@ -348,19 +380,19 @@ export const assertWebEngineResource = (
 ) => {
   if (validations.name) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.WEBENGINE_NAME],
+      resource.attributes[SEMRESATTRS_WEBENGINE_NAME],
       validations.name
     );
   }
   if (validations.version) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.WEBENGINE_VERSION],
+      resource.attributes[SEMRESATTRS_WEBENGINE_VERSION],
       validations.version
     );
   }
   if (validations.description) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.WEBENGINE_DESCRIPTION],
+      resource.attributes[SEMRESATTRS_WEBENGINE_DESCRIPTION],
       validations.description
     );
   }

--- a/packages/opentelemetry-resources/test/util/sample-detector.ts
+++ b/packages/opentelemetry-resources/test/util/sample-detector.ts
@@ -14,18 +14,25 @@
  * limitations under the License.
  */
 
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_TYPE,
+} from '@opentelemetry/semantic-conventions';
 import { Detector, Resource } from '../../src';
 
 class SampleDetector implements Detector {
   async detect(): Promise<Resource> {
     return new Resource({
-      [SemanticResourceAttributes.CLOUD_PROVIDER]: 'provider',
-      [SemanticResourceAttributes.CLOUD_ACCOUNT_ID]: 'accountId',
-      [SemanticResourceAttributes.CLOUD_REGION]: 'region',
-      [SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE]: 'zone',
-      [SemanticResourceAttributes.HOST_ID]: 'instanceId',
-      [SemanticResourceAttributes.HOST_TYPE]: 'instanceType',
+      [SEMRESATTRS_CLOUD_PROVIDER]: 'provider',
+      [SEMRESATTRS_CLOUD_ACCOUNT_ID]: 'accountId',
+      [SEMRESATTRS_CLOUD_REGION]: 'region',
+      [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE]: 'zone',
+      [SEMRESATTRS_HOST_ID]: 'instanceId',
+      [SEMRESATTRS_HOST_TYPE]: 'instanceType',
     });
   }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Updates #4567 

## Short description of the changes

- Replace deprecated `SemanticResourceAttributes.*` usage with new exported attributes
- Update resource-assertions test util to match changes made in https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2210

Note some of the changes elsewhere in the package had already been made in a previous PR #4608 .