### PR TITLE
chore(exporters): updated deprecated semconv to use exported strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * refactor(sdk-trace-web): Use tree-shakeable string constants for semconv [#4747](https://github.com/open-telemetry/opentelemetry-js/pull/4747) @JohannesHuster
 * refactor(sdk-trace-node): Use tree-shakeable string constants for semconv [#4748](https://github.com/open-telemetry/opentelemetry-js/pull/4748) @JohannesHuster
 * refactor(sdk-trace-base): Use tree-shakeable string constants for semconv [#4749](https://github.com/open-telemetry/opentelemetry-js/pull/4749) @JohannesHuster
-* chore(exporters): update deprecated semconv to use exported strings [#4756](https://github.com/open-telemetry/opentelemetry-js/pull/#4756) @JamieDanielson
+* refactor(exporters): update deprecated semconv to use exported strings [#4756](https://github.com/open-telemetry/opentelemetry-js/pull/#4756) @JamieDanielson
 
 ### :bug: (Bug Fix)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 * refactor(sdk-trace-web): Use tree-shakeable string constants for semconv [#4747](https://github.com/open-telemetry/opentelemetry-js/pull/4747) @JohannesHuster
 * refactor(sdk-trace-node): Use tree-shakeable string constants for semconv [#4748](https://github.com/open-telemetry/opentelemetry-js/pull/4748) @JohannesHuster
 * refactor(sdk-trace-base): Use tree-shakeable string constants for semconv [#4749](https://github.com/open-telemetry/opentelemetry-js/pull/4749) @JohannesHuster
+* chore(exporters): update deprecated semconv to use exported strings [#4756](https://github.com/open-telemetry/opentelemetry-js/pull/#4756) @JamieDanielson
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/util.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/util.ts
@@ -16,7 +16,12 @@
 
 import * as sinon from 'sinon';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
+  SEMRESATTRS_TELEMETRY_SDK_NAME,
+  SEMRESATTRS_TELEMETRY_SDK_VERSION,
+} from '@opentelemetry/semantic-conventions';
 
 export const mockedHrTimeMs = 1586347902211;
 
@@ -25,18 +30,18 @@ export function mockHrTime() {
 }
 
 export const serviceName = Resource.default()
-  .attributes[SemanticResourceAttributes.SERVICE_NAME]?.toString()
+  .attributes[SEMRESATTRS_SERVICE_NAME]?.toString()
   .replace(/\\/g, '\\\\')
   .replace(/\n/g, '\\n');
 export const sdkLanguage = Resource.default()
-  .attributes[SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE]?.toString()
+  .attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]?.toString()
   .replace(/\\/g, '\\\\')
   .replace(/\n/g, '\\n');
 export const sdkName = Resource.default()
-  .attributes[SemanticResourceAttributes.TELEMETRY_SDK_NAME]?.toString()
+  .attributes[SEMRESATTRS_TELEMETRY_SDK_NAME]?.toString()
   .replace(/\\/g, '\\\\')
   .replace(/\n/g, '\\n');
 export const sdkVersion = Resource.default()
-  .attributes[SemanticResourceAttributes.TELEMETRY_SDK_VERSION]?.toString()
+  .attributes[SEMRESATTRS_TELEMETRY_SDK_VERSION]?.toString()
   .replace(/\\/g, '\\\\')
   .replace(/\n/g, '\\n');

--- a/packages/opentelemetry-exporter-jaeger/src/jaeger.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/jaeger.ts
@@ -23,7 +23,7 @@ import {
 } from '@opentelemetry/core';
 import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { Socket } from 'dgram';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { spanToThrift } from './transform';
 import * as jaegerTypes from './types';
 
@@ -168,7 +168,7 @@ export class JaegerExporter implements SpanExporter {
     }
 
     const serviceNameTag = span.tags.find(
-      t => t.key === SemanticResourceAttributes.SERVICE_NAME
+      t => t.key === SEMRESATTRS_SERVICE_NAME
     );
     const serviceName = serviceNameTag?.vStr || 'unknown_service';
 

--- a/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
@@ -23,7 +23,7 @@ import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { TraceFlags } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
 import * as nock from 'nock';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 describe('JaegerExporter', () => {
   const readableSpan: ReadableSpan = {
@@ -47,7 +47,7 @@ describe('JaegerExporter', () => {
     events: [],
     duration: [32, 800000000],
     resource: new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: 'opentelemetry',
+      [SEMRESATTRS_SERVICE_NAME]: 'opentelemetry',
     }),
     instrumentationLibrary: {
       name: 'default',

--- a/packages/opentelemetry-exporter-zipkin/src/zipkin.ts
+++ b/packages/opentelemetry-exporter-zipkin/src/zipkin.ts
@@ -24,7 +24,7 @@ import {
   defaultStatusCodeTagName,
   defaultStatusErrorTagName,
 } from './transform';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { prepareGetHeaders } from './utils';
 
 /**
@@ -67,7 +67,7 @@ export class ZipkinExporter implements SpanExporter {
   ): void {
     const serviceName = String(
       this._serviceName ||
-        spans[0].resource.attributes[SemanticResourceAttributes.SERVICE_NAME] ||
+        spans[0].resource.attributes[SEMRESATTRS_SERVICE_NAME] ||
         this.DEFAULT_SERVICE_NAME
     );
 
@@ -140,8 +140,8 @@ export class ZipkinExporter implements SpanExporter {
       toZipkinSpan(
         span,
         String(
-          span.attributes[SemanticResourceAttributes.SERVICE_NAME] ||
-            span.resource.attributes[SemanticResourceAttributes.SERVICE_NAME] ||
+          span.attributes[SEMRESATTRS_SERVICE_NAME] ||
+            span.resource.attributes[SEMRESATTRS_SERVICE_NAME] ||
             serviceName
         ),
         this._statusCodeTagName,

--- a/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
@@ -23,7 +23,10 @@ import {
 import { Resource } from '@opentelemetry/resources';
 import { BasicTracerProvider, Span } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
+} from '@opentelemetry/semantic-conventions';
 import {
   defaultStatusCodeTagName,
   defaultStatusErrorTagName,
@@ -35,7 +38,7 @@ import * as zipkinTypes from '../../src/types';
 const tracer = new BasicTracerProvider({
   resource: Resource.default().merge(
     new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
+      [SEMRESATTRS_SERVICE_NAME]: 'zipkin-test',
       cost: '112.12',
       service: 'ui',
       version: '1',
@@ -43,8 +46,7 @@ const tracer = new BasicTracerProvider({
   ),
 }).getTracer('default');
 
-const language =
-  tracer.resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE];
+const language = tracer.resource.attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE];
 
 const parentId = '5c1c63257de34c67';
 const spanContext: api.SpanContext = {
@@ -97,7 +99,7 @@ describe('transform', () => {
         tags: {
           key1: 'value1',
           key2: 'value2',
-          [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
+          [SEMRESATTRS_SERVICE_NAME]: 'zipkin-test',
           cost: '112.12',
           service: 'ui',
           version: '1',
@@ -138,7 +140,7 @@ describe('transform', () => {
         name: span.name,
         parentId: undefined,
         tags: {
-          [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
+          [SEMRESATTRS_SERVICE_NAME]: 'zipkin-test',
           cost: '112.12',
           service: 'ui',
           version: '1',
@@ -189,7 +191,7 @@ describe('transform', () => {
           name: span.name,
           parentId: undefined,
           tags: {
-            [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
+            [SEMRESATTRS_SERVICE_NAME]: 'zipkin-test',
             cost: '112.12',
             service: 'ui',
             version: '1',
@@ -227,7 +229,7 @@ describe('transform', () => {
       assert.deepStrictEqual(tags, {
         key1: 'value1',
         key2: 'value2',
-        [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
+        [SEMRESATTRS_SERVICE_NAME]: 'zipkin-test',
         'telemetry.sdk.language': language,
         'telemetry.sdk.name': 'opentelemetry',
         'telemetry.sdk.version': VERSION,
@@ -261,7 +263,7 @@ describe('transform', () => {
       assert.deepStrictEqual(tags, {
         key1: 'value1',
         key2: 'value2',
-        [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
+        [SEMRESATTRS_SERVICE_NAME]: 'zipkin-test',
         'telemetry.sdk.language': language,
         'telemetry.sdk.name': 'opentelemetry',
         'telemetry.sdk.version': VERSION,
@@ -297,7 +299,7 @@ describe('transform', () => {
         key1: 'value1',
         key2: 'value2',
         [defaultStatusCodeTagName]: 'ERROR',
-        [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
+        [SEMRESATTRS_SERVICE_NAME]: 'zipkin-test',
         'telemetry.sdk.language': language,
         'telemetry.sdk.name': 'opentelemetry',
         'telemetry.sdk.version': VERSION,
@@ -335,7 +337,7 @@ describe('transform', () => {
         key2: 'value2',
         [defaultStatusCodeTagName]: 'ERROR',
         [defaultStatusErrorTagName]: status.message,
-        [SemanticResourceAttributes.SERVICE_NAME]: 'zipkin-test',
+        [SEMRESATTRS_SERVICE_NAME]: 'zipkin-test',
         'telemetry.sdk.language': language,
         'telemetry.sdk.name': 'opentelemetry',
         'telemetry.sdk.version': VERSION,

--- a/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
@@ -27,7 +27,7 @@ import { Resource } from '@opentelemetry/resources';
 import { ZipkinExporter } from '../../src';
 import * as zipkinTypes from '../../src/types';
 import { TraceFlags } from '@opentelemetry/api';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 const MICROS_PER_SECS = 1e6;
 
@@ -385,7 +385,7 @@ describe('Zipkin Exporter - node', () => {
         },
       ],
       resource: new Resource({
-        [SemanticResourceAttributes.SERVICE_NAME]: resource_service_name,
+        [SEMRESATTRS_SERVICE_NAME]: resource_service_name,
       }),
       instrumentationLibrary: { name: 'default', version: '0.0.1' },
       droppedAttributesCount: 0,
@@ -411,7 +411,7 @@ describe('Zipkin Exporter - node', () => {
       links: [],
       events: [],
       resource: new Resource({
-        [SemanticResourceAttributes.SERVICE_NAME]: resource_service_name_prime,
+        [SEMRESATTRS_SERVICE_NAME]: resource_service_name_prime,
       }),
       instrumentationLibrary: { name: 'default', version: '0.0.1' },
       droppedAttributesCount: 0,
@@ -470,7 +470,7 @@ describe('Zipkin Exporter - node', () => {
       attributes: {
         key1: 'value1',
         key2: 'value2',
-        [SemanticResourceAttributes.SERVICE_NAME]: span_service_name,
+        [SEMRESATTRS_SERVICE_NAME]: span_service_name,
       },
       links: [],
       events: [
@@ -502,7 +502,7 @@ describe('Zipkin Exporter - node', () => {
         code: api.SpanStatusCode.OK,
       },
       attributes: {
-        [SemanticResourceAttributes.SERVICE_NAME]: span_service_name_prime,
+        [SEMRESATTRS_SERVICE_NAME]: span_service_name_prime,
       },
       links: [],
       events: [],


### PR DESCRIPTION
## Which problem is this PR solving?

Updates #4567 

## Short description of the changes

Replace deprecated `SemanticResourceAttributes.*` usage with new exported attributes for:

- exporter-zipkin
- exporter-jaeger
- exporter-prometheus

I kept these in 1 PR because they are so small, happy to split into separate PRs if that's preferred.