### PR TITLE
chore: move flarna from approver to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 
 #### Approvers ([@open-telemetry/javascript-approvers](https://github.com/orgs/open-telemetry/teams/javascript-approvers))
 
-- [Gerhard Stöbich](https://github.com/Flarna), Dynatrace
 - [Haddas Bronfman](https://github.com/haddasbronfman), Cisco
 - [Hector Hernandez](https://github.com/hectorhdzg), Microsoft
 - [Jamie Danielson](https://github.com/JamieDanielson), Honeycomb
@@ -246,6 +245,7 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 - [John Bley](https://github.com/johnbley), Splunk, Approver
 - [Mark Wolff](https://github.com/markwolff), Microsoft, Approver
 - [Olivier Albertini](https://github.com/OlivierAlbertini), Ville de Montréal, Approver
+- [Gerhard Stöbich](https://github.com/Flarna), Dynatrace, Approver
 
 *Find more about the emeritus role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#emeritus-maintainerapprovertriager).*
 


### PR DESCRIPTION
@open-telemetry/javascript-maintainers Please adapt the needed rights/groups/.... accordingly.

I'm still around but as of now I don't find enough time to really follow the project in the needed details to really fulfill the approver role.