### PR TITLE
refactor(examples/opentracing-shim): use new exported string constants for semconv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 ### :books: (Refine Doc)
 
 * refactor(examples): use new exported string constants for semconv in examples/http [#4750](https://github.com/open-telemetry/opentelemetry-js/pull/4750) @Zen-cronic
+* refactor(examples): use new exported string constants for semconv in examples/opentracing-shim-semconv [#4761](https://github.com/open-telemetry/opentelemetry-js/pull/4761) @Zen-cronic
 
 ### :house: (Internal)
 

--- a/examples/opentracing-shim/package.json
+++ b/examples/opentracing-shim/package.json
@@ -36,7 +36,7 @@
     "@opentelemetry/instrumentation": "0.25.0",
     "@opentelemetry/sdk-trace-node": "0.25.0",
     "@opentelemetry/resources": "0.25.0",
-    "@opentelemetry/semantic-conventions": "0.25.0",
+    "@opentelemetry/semantic-conventions": "^1.22.0",
     "@opentelemetry/shim-opentracing": "0.25.0",
     "@opentelemetry/sdk-trace-base": "0.25.0",
     "opentracing": "^0.14.4"

--- a/examples/opentracing-shim/shim.js
+++ b/examples/opentracing-shim/shim.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
+const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 const { Resource } = require('@opentelemetry/resources');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
@@ -10,7 +10,7 @@ const { TracerShim } = require('@opentelemetry/shim-opentracing');
 
 function shim(serviceName) {
   const provider = new NodeTracerProvider({
-    resource: new Resource({ [SemanticResourceAttributes.SERVICE_NAME]: serviceName }),
+    resource: new Resource({ [SEMRESATTRS_SERVICE_NAME]: serviceName }),
   });
 
   provider.addSpanProcessor(new SimpleSpanProcessor(getExporter(serviceName)));


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Updates https://github.com/open-telemetry/opentelemetry-js/issues/4567

## Short description of the changes

Replaced deprecated import (SemanticResourceAttributes) from @opentelemetry/semantic-conventions with new string constants (SEMRESATTRS_SERVICE_NAME) for the example `opentracing-shim` package 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] npm test

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
