### PR TITLE
refactor(experimental/examples/opencensus-shim): use new exported string constants for semconv

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to experimental packages in this project will be documented 
 
 * docs(instrumentation): better docs for supportedVersions option [#4693](https://github.com/open-telemetry/opentelemetry-js/pull/4693) @blumamir
 * docs: align all supported versions to a common format [#4696](https://github.com/open-telemetry/opentelemetry-js/pull/4696) @blumamir
+* refactor(examples): use new exported string constants for semconv in experimental/examples/opencensus-shim [#4763](https://github.com/open-telemetry/opentelemetry-js/pull/4763#pull) @Zen-cronic
 
 ### :house: (Internal)
 

--- a/experimental/examples/opencensus-shim/setup.js
+++ b/experimental/examples/opencensus-shim/setup.js
@@ -27,7 +27,7 @@ const {
 const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
 const { Resource } = require('@opentelemetry/resources');
 const {
-  SemanticResourceAttributes,
+  SEMRESATTRS_SERVICE_NAME,
 } = require('@opentelemetry/semantic-conventions');
 const { OpenCensusMetricProducer } = require('@opentelemetry/shim-opencensus');
 const instrumentationHttp = require('@opencensus/instrumentation-http');
@@ -46,7 +46,7 @@ module.exports = function setup(serviceName) {
   tracing.tracer = new oc.CoreTracer();
 
   const resource = new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+    [SEMRESATTRS_SERVICE_NAME]: serviceName,
   });
   const tracerProvider = new NodeTracerProvider({ resource });
   tracerProvider.addSpanProcessor(


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Updates https://github.com/open-telemetry/opentelemetry-js/issues/4567

## Short description of the changes

Replaced deprecated import (SemanticResourceAttributes) from @opentelemetry/semantic-conventions with new string constants (SEMRESATTRS_SERVICE_NAME) for the experimental example `opencensus-shim` package 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] npm test

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
