### PR TITLE
chore: move haddasbronfman from approver to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,6 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 
 #### Approvers ([@open-telemetry/javascript-approvers](https://github.com/orgs/open-telemetry/teams/javascript-approvers))
 
-- [Haddas Bronfman](https://github.com/haddasbronfman), Cisco
 - [Hector Hernandez](https://github.com/hectorhdzg), Microsoft
 - [Jamie Danielson](https://github.com/JamieDanielson), Honeycomb
 - [Martin Kuba](https://github.com/martinkuba), Lightstep
@@ -246,6 +245,7 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 - [Mark Wolff](https://github.com/markwolff), Microsoft, Approver
 - [Olivier Albertini](https://github.com/OlivierAlbertini), Ville de Montréal, Approver
 - [Gerhard Stöbich](https://github.com/Flarna), Dynatrace, Approver
+- [Haddas Bronfman](https://github.com/haddasbronfman), Cisco
 
 *Find more about the emeritus role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#emeritus-maintainerapprovertriager).*
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 - [Mark Wolff](https://github.com/markwolff), Microsoft, Approver
 - [Olivier Albertini](https://github.com/OlivierAlbertini), Ville de Montréal, Approver
 - [Gerhard Stöbich](https://github.com/Flarna), Dynatrace, Approver
-- [Haddas Bronfman](https://github.com/haddasbronfman), Cisco
+- [Haddas Bronfman](https://github.com/haddasbronfman), Cisco, Approver
 
 *Find more about the emeritus role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#emeritus-maintainerapprovertriager).*
 


### PR DESCRIPTION
To accurately reflect the number of active approvers in the OTel JS SIG, we need to periodically move inactive approvers to emeritus.

This PR moves @haddasbronfman from approver to emeritus. Thank you for your work on the project. 
If anything changes w.r.t. available time to work on the project, please feel free to reach out to the JS SIG's maintainers group. :slightly_smiling_face: 

cc @open-telemetry/javascript-maintainers 