### PR TITLE
fix(sdk-logs): adapt versions for release

### DIFF
--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -101,7 +101,7 @@
     "webpack-merge": "5.10.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "1.25.0",
+    "@opentelemetry/api-logs": "0.52.0",
     "@opentelemetry/core": "1.25.0",
     "@opentelemetry/resources": "1.25.0"
   }

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -75,7 +75,7 @@
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
     "@opentelemetry/api": ">=1.4.0 <1.10.0",
-    "@opentelemetry/api-logs": "0.51.1",
+    "@opentelemetry/api-logs": "0.52.0",
     "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -101,8 +101,8 @@
     "webpack-merge": "5.10.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.51.0",
-    "@opentelemetry/core": "1.24.0",
-    "@opentelemetry/resources": "1.24.0"
+    "@opentelemetry/api-logs": "1.25.0",
+    "@opentelemetry/core": "1.25.0",
+    "@opentelemetry/resources": "1.25.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3719,15 +3719,15 @@
       "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.0",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0"
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": ">=1.4.0 <1.10.0",
-        "@opentelemetry/api-logs": "0.51.1",
+        "@opentelemetry/api-logs": "0.52.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -3763,49 +3763,9 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
+      "dev": true,
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "experimental/packages/sdk-logs/node_modules/@opentelemetry/api-logs": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
-      "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "experimental/packages/sdk-logs/node_modules/@opentelemetry/core": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.0.tgz",
-      "integrity": "sha512-FP2oN7mVPqcdxJDTTnKExj4mi91EH+DNuArKfHTjPuJWe2K1JfMIVXNfahw1h3onJxQnxS8K0stKkogX05s+Aw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "experimental/packages/sdk-logs/node_modules/@opentelemetry/resources": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.0.tgz",
-      "integrity": "sha512-mxC7E7ocUS1tLzepnA7O9/G8G6ZTdjCH2pXme1DDDuCuk6n2/53GADX+GWBuyX0dfIxeMInIbJAdjlfN9GNr6A==",
-      "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
       }
     },
     "experimental/packages/sdk-logs/node_modules/@opentelemetry/resources_1.9.0": {
@@ -3845,14 +3805,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.0.tgz",
       "integrity": "sha512-po7penSfQ/Z8352lRVDpaBrd9znwA5mHGqXR7nDEiVnxkDFkBIhVf/tKeAJDIq/erFpcRowKFeCsr5eqqcSyFQ==",
       "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "experimental/packages/sdk-logs/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.0.tgz",
-      "integrity": "sha512-yL0jI6Ltuz8R+Opj7jClGrul6pOoYrdfVmzQS4SITXRPH7I5IRZbrwe/6/v8v4WYMa6MYZG480S1+uc/IGfqsA==",
       "engines": {
         "node": ">=14"
       }
@@ -39258,30 +39210,6 @@
             }
           }
         },
-        "@opentelemetry/api": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.8.0.tgz",
-          "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==",
-          "dev": true
-        },
-        "@opentelemetry/api-events": {
-          "version": "https://registry.npmjs.org/@opentelemetry/api-events/-/api-events-0.51.1.tgz",
-          "integrity": "sha512-ILBRMsQaAWvmczRFK1r9eFFSTWTyfkwGWGMaLtYkBN6EleVydO1buFKgq/Y8ECNnk4Wftn4P0WurTcMHBchsMg==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/api": "^1.0.0",
-            "@opentelemetry/api-logs": "0.51.1"
-          }
-        },
-        "@opentelemetry/api-logs": {
-          "version": "0.51.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
-          "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/api": "^1.0.0"
-          }
-        },
         "@types/sinon": {
           "version": "10.0.20",
           "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
@@ -39384,9 +39312,9 @@
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": ">=1.4.0 <1.10.0",
-        "@opentelemetry/api-logs": "0.51.1",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
+        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/resources": "1.25.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -39415,33 +39343,8 @@
         "@opentelemetry/api": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
-          "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA=="
-        },
-        "@opentelemetry/api-logs": {
-          "version": "0.51.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
-          "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/api": "^1.0.0"
-          }
-        },
-        "@opentelemetry/core": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.0.tgz",
-          "integrity": "sha512-FP2oN7mVPqcdxJDTTnKExj4mi91EH+DNuArKfHTjPuJWe2K1JfMIVXNfahw1h3onJxQnxS8K0stKkogX05s+Aw==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.24.0"
-          }
-        },
-        "@opentelemetry/resources": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.0.tgz",
-          "integrity": "sha512-mxC7E7ocUS1tLzepnA7O9/G8G6ZTdjCH2pXme1DDDuCuk6n2/53GADX+GWBuyX0dfIxeMInIbJAdjlfN9GNr6A==",
-          "requires": {
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/semantic-conventions": "1.24.0"
-          }
+          "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
+          "dev": true
         },
         "@opentelemetry/resources_1.9.0": {
           "version": "npm:@opentelemetry/resources@1.9.0",
@@ -39469,11 +39372,6 @@
               "dev": true
             }
           }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.0.tgz",
-          "integrity": "sha512-yL0jI6Ltuz8R+Opj7jClGrul6pOoYrdfVmzQS4SITXRPH7I5IRZbrwe/6/v8v4WYMa6MYZG480S1+uc/IGfqsA=="
         },
         "mocha": {
           "version": "10.2.0",


### PR DESCRIPTION
Versions in `@opentelemetry/sdk-logs` were not updated correctly in the release PR (ref #4677).
This PR fixes this before actually releasing.