### PR TITLE
 refactor(otlp-transformer): use explicit exports

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :rocket: (Enhancement)
 
 * refactor(instrumentation-fetch): move fetch to use SEMATRR [#4632](https://github.com/open-telemetry/opentelemetry-js/pull/4632)
-* refactor(otlp-transformer): use explicit exports @pichelermarc
+* refactor(otlp-transformer): use explicit exports [#4785](https://github.com/open-telemetry/opentelemetry-js/pull/4785) @pichlermarc 
 
 ### :bug: (Bug Fix)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :rocket: (Enhancement)
 
 * refactor(instrumentation-fetch): move fetch to use SEMATRR [#4632](https://github.com/open-telemetry/opentelemetry-js/pull/4632)
-* refactor(otlp-transformer): use explicit exports [#4785](https://github.com/open-telemetry/opentelemetry-js/pull/4785) @pichlermarc 
+* refactor(otlp-transformer): use explicit exports [#4785](https://github.com/open-telemetry/opentelemetry-js/pull/4785) @pichlermarc
 
 ### :bug: (Bug Fix)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :rocket: (Enhancement)
 
 * refactor(instrumentation-fetch): move fetch to use SEMATRR [#4632](https://github.com/open-telemetry/opentelemetry-js/pull/4632)
+* refactor(otlp-transformer): use explicit exports @pichelermarc
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/otlp-transformer/src/index.ts
+++ b/experimental/packages/otlp-transformer/src/index.ts
@@ -14,12 +14,71 @@
  * limitations under the License.
  */
 
-export * from './common/types';
-export * from './common';
-export * from './metrics/types';
-export * from './resource/types';
-export * from './trace/types';
-export * from './logs/types';
+export {
+  OtlpEncodingOptions,
+  IKeyValueList,
+  IKeyValue,
+  IInstrumentationScope,
+  IArrayValue,
+  LongBits,
+  IAnyValue,
+  Fixed64,
+} from './common/types';
+export {
+  SpanContextEncodeFunction,
+  toLongBits,
+  OptionalSpanContextEncodeFunction,
+  getOtlpEncoder,
+  Encoder,
+  HrTimeEncodeFunction,
+  encodeAsLongBits,
+  encodeAsString,
+  hrTimeToNanos,
+} from './common';
+export {
+  IExportMetricsPartialSuccess,
+  IValueAtQuantile,
+  ISummaryDataPoint,
+  ISummary,
+  ISum,
+  IScopeMetrics,
+  IResourceMetrics,
+  INumberDataPoint,
+  IHistogramDataPoint,
+  IHistogram,
+  IExponentialHistogramDataPoint,
+  IExponentialHistogram,
+  IMetric,
+  IGauge,
+  IExemplar,
+  EAggregationTemporality,
+  IExportMetricsServiceRequest,
+  IExportMetricsServiceResponse,
+  IBuckets,
+} from './metrics/types';
+export { IResource } from './resource/types';
+export {
+  IExportTracePartialSuccess,
+  IStatus,
+  EStatusCode,
+  ILink,
+  IEvent,
+  IScopeSpans,
+  ISpan,
+  IResourceSpans,
+  ESpanKind,
+  IExportTraceServiceResponse,
+  IExportTraceServiceRequest,
+} from './trace/types';
+export {
+  IExportLogsServiceResponse,
+  IScopeLogs,
+  IExportLogsServiceRequest,
+  IResourceLogs,
+  ILogRecord,
+  IExportLogsPartialSuccess,
+  ESeverityNumber,
+} from './logs/types';
 
 export { createExportTraceServiceRequest } from './trace';
 export { createExportMetricsServiceRequest } from './metrics';


### PR DESCRIPTION
This PR changes the exports of the `@opentelemetry/otlp-transformer` package to be explicit over `export * from`. This will help us reduce the API surface of the `@opentelemetry/otlp-transformer` package now that #4581 and #4542 is merged in and many of these types are not needed anymore.

By first converting to explicit exports, it will be easier to review future PRs that will remove those exports.

Part of #4583 