### PR TITLE
refactor(context-zone-peer-dep): use explicit exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :house: (Internal)
 
+* refactor(context-zone-peer-dep): use explicit exports [#4785](https://github.com/open-telemetry/opentelemetry-js/pull/4787) @pichlermarc
+
 ## 1.25.0
 
 ### :rocket: (Enhancement)

--- a/packages/opentelemetry-context-zone-peer-dep/src/index.ts
+++ b/packages/opentelemetry-context-zone-peer-dep/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './ZoneContextManager';
-export * from './types';
+export { ZoneContextManager } from './ZoneContextManager';
+export { Func, TargetWithEvents } from './types';


### PR DESCRIPTION
Changes all exports to be explicit.

Part of #4186 