### PR TITLE
docs(exporter-logs-otlp-http): change OTLPLogsExporter to OTLPLogExpo…

### DIFF
--- a/experimental/packages/exporter-logs-otlp-http/README.md
+++ b/experimental/packages/exporter-logs-otlp-http/README.md
@@ -58,7 +58,7 @@ import {
   LoggerProvider,
   BatchLogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
-import { OTLPLogsExporter } from '@opentelemetry/exporter-logs-otlp-http';
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 
 // exporter options. see all options in OTLPExporterNodeConfigBase
 const collectorOptions = {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Its a leftover from #3764

## Short description of the changes

Just by accident I found a typo in README.md related to naming OTLPLogExporter vs OTLPLogsExporter.

## Type of change

Docs update.

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated
