### PR TITLE
feat: add release-pr update chores as scripts to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "_github:draft_release:experimental": "node scripts/extract-latest-release-notes.js ./experimental/CHANGELOG.md && VERSION=$(node scripts/get-version.js ./experimental/packages/ | grep -oP '^\\d+\\.\\d+\\.\\d+$') && gh release create --draft --notes-file ./.tmp/release-notes.md --target main --title experimental/v$VERSION experimental/v$VERSION",
     "_github:draft_release:stable": "node scripts/extract-latest-release-notes.js ./CHANGELOG.md && VERSION=$(node scripts/get-version.js ./packages/ | grep -oP '^\\d+\\.\\d+\\.\\d+$') && gh release create --draft --notes-file ./.tmp/release-notes.md --target main --title v$VERSION v$VERSION",
     "_github:update_release_pr_body_from_file": "gh pr edit $RELEASE_PR_OWNER:release/next-version --body-file ./.tmp/release-notes.md",
-    "_github:update_release_pr_body:api": "node scripts/extract-latest-release-notes.js api/CHANGELOG.md ./CHANGELOG.md experimental/CHANGELOG.md && npm run _github:update_release_pr_body_from_file",
+    "_github:update_release_pr_body:all": "node scripts/extract-latest-release-notes.js api/CHANGELOG.md ./CHANGELOG.md experimental/CHANGELOG.md && npm run _github:update_release_pr_body_from_file",
     "_github:update_release_pr_body:stable": "node scripts/extract-latest-release-notes.js ./CHANGELOG.md experimental/CHANGELOG.md && npm run _github:update_release_pr_body_from_file",
     "_github:update_release_pr_body:experimental": "node scripts/extract-latest-release-notes.js experimental/CHANGELOG.md && npm run _github:update_release_pr_body_from_file",
     "_verify_release_kind": "echo $RELEASE_KIND | grep -oP '^(all|sdk|experimental):(minor|patch)$'",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,14 @@
     "_github:draft_release:all": "npm run _github:draft_release:api && _github:draft_release:experimental && _github:draft_release:stable",
     "_github:draft_release:api": "node scripts/extract-latest-release-notes.js ./api/CHANGELOG.md && VERSION=$(node scripts/get-version.js ./api/package.json | grep -oP '^\\d+\\.\\d+\\.\\d+$') && gh release create --draft --notes-file ./.tmp/release-notes.md --target main --title api/v$VERSION api/v$VERSION",
     "_github:draft_release:experimental": "node scripts/extract-latest-release-notes.js ./experimental/CHANGELOG.md && VERSION=$(node scripts/get-version.js ./experimental/packages/ | grep -oP '^\\d+\\.\\d+\\.\\d+$') && gh release create --draft --notes-file ./.tmp/release-notes.md --target main --title experimental/v$VERSION experimental/v$VERSION",
-    "_github:draft_release:stable": "node scripts/extract-latest-release-notes.js ./CHANGELOG.md && VERSION=$(node scripts/get-version.js ./packages/ | grep -oP '^\\d+\\.\\d+\\.\\d+$') && gh release create --draft --notes-file ./.tmp/release-notes.md --target main --title v$VERSION v$VERSION"
+    "_github:draft_release:stable": "node scripts/extract-latest-release-notes.js ./CHANGELOG.md && VERSION=$(node scripts/get-version.js ./packages/ | grep -oP '^\\d+\\.\\d+\\.\\d+$') && gh release create --draft --notes-file ./.tmp/release-notes.md --target main --title v$VERSION v$VERSION",
+    "_github:update_release_pr_body_from_file": "gh pr edit $RELEASE_PR_OWNER:release/next-version --body-file ./.tmp/release-notes.md",
+    "_github:update_release_pr_body:api": "node scripts/extract-latest-release-notes.js api/CHANGELOG.md ./CHANGELOG.md experimental/CHANGELOG.md && npm run _github:update_release_pr_body_from_file",
+    "_github:update_release_pr_body:stable": "node scripts/extract-latest-release-notes.js ./CHANGELOG.md experimental/CHANGELOG.md && npm run _github:update_release_pr_body_from_file",
+    "_github:update_release_pr_body:experimental": "node scripts/extract-latest-release-notes.js experimental/CHANGELOG.md && npm run _github:update_release_pr_body_from_file",
+    "_verify_release_kind": "echo $RELEASE_KIND | grep -oP '^(all|sdk|experimental):(minor|patch)$'",
+    "_verify_release_remote": "git remote get-url $RELEASE_PR_REMOTE",
+    "_github:update_release_branch": "npm run _verify_release_kind && npm run _verify_release_remote && (git checkout main && git pull upstream main && git branch -D release/next-version; git checkout -b release/next-version && npm run prepare_release:$RELEASE_KIND && git commit -am \"chore: prepare release\" && git push $RELEASE_PR_REMOTE --force release/next-version)"
   },
   "repository": "open-telemetry/opentelemetry-js",
   "keywords": [

--- a/scripts/extract-latest-release-notes.js
+++ b/scripts/extract-latest-release-notes.js
@@ -10,14 +10,19 @@
 
 const fs = require('fs');
 
-const changelog = fs.readFileSync(process.argv[2]).toString();
-// Matches everything from the first entry at h2 ('##') followed by a space and a non-prerelease semver version
-// until the next entry at h2.
-const firstReleaseNoteEntryExp = /^## \d+\.\d+\.\d\n.*?(?=^## )/ms;
+function extractLatestChangelog(changelogPath) {
+  const changelog = fs.readFileSync(changelogPath).toString();
+  // Matches everything from the first entry at h2 ('##') followed by a space and a non-prerelease semver version
+  // until the next entry at h2.
+  const firstReleaseNoteEntryExp = /^## \d+\.\d+\.\d\n.*?(?=^## )/ms;
+
+  return changelog.match(firstReleaseNoteEntryExp)[0];
+}
 
 fs.mkdirSync('./.tmp/', {
   recursive: true
 });
 
 const notesFile = './.tmp/release-notes.md'
-fs.writeFileSync(notesFile, changelog.match(firstReleaseNoteEntryExp)[0]);
+const changelogFilePaths = process.argv.slice(2);
+fs.writeFileSync(notesFile, changelogFilePaths.map(filePath => extractLatestChangelog(filePath)).join('\n'));

--- a/scripts/extract-latest-release-notes.js
+++ b/scripts/extract-latest-release-notes.js
@@ -1,11 +1,13 @@
 /**
- * This extracts the latest (non-"Unreleased") notes from a CHANGELOG.md and saves them to `./.tmp/release-notes.md`
+ * This extracts the latest (non-"Unreleased") notes from CHANGELOG.md files and saves them to `./.tmp/release-notes.md`.
+ * Concatenates the output when multiple paths are passed as arguments.
  *
  * Usage (from project root):
- * - node scripts/extract-latest-release-notes.js [PATH TO CHANGELOG]
+ * - node scripts/extract-latest-release-notes.js [PATH TO CHANGELOG]...
  * Examples:
  * - node scripts/extract-latest-release-notes.js ./packages/CHANGELOG.md
  * - node scripts/extract-latest-release-notes.js ./experimental/CHANGELOG.md
+ * - node scripts/extract-latest-release-notes.js ./api/CHANGELOG.md ./packages/CHANGELOG.md ./experimental/CHANGELOG.md
  */
 
 const fs = require('fs');


### PR DESCRIPTION
Adds a few more script for release-automation that I usually did by hand. Moving us closer to having a fully-automated solution.

**This adds:**

- scripts to auto-update release PRs with the latest changelog (I had to copy this to the body by hand before every time someone merged to main when the release PR was open, which was very cumbersome)
- scripts to update the release PR branch (now always titled `release/next-version` for simplicity) automatically

**Additional changes:**

- makes `scripts/extract-latest-release-notes.js` work with multiple changelog files so that we can list all changes in the PR body.

**Next steps:**
- script to automatically create the release PR
- tying everything together with a workflow that uses the @opentelemetrybot user to create and update PRs when main is merged
- auto-publishing when release PRs are merged to main.

