### PR TITLE
docs: usage of SEMRESATTRS_XXXXX

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -45,14 +45,14 @@ body:
         const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
         const { ConsoleSpanExporter } = require('@opentelemetry/sdk-trace-base');
         const { Resource } = require('@opentelemetry/resources');
-        const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
+        const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
         // configure the SDK to export telemetry data to the console
         // enable all auto-instrumentations from the meta package
         const traceExporter = new ConsoleSpanExporter();
         const sdk = new opentelemetry.NodeSDK({
           resource: new Resource({
-            [SemanticResourceAttributes.SERVICE_NAME]: 'my-service',
+            [SEMRESATTRS_SERVICE_NAME]: 'my-service',
           }),
           traceExporter,
           instrumentations: [getNodeAutoInstrumentations()]

--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ const opentelemetry = require('@opentelemetry/sdk-node');
 const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
 const { ConsoleSpanExporter } = require('@opentelemetry/sdk-trace-base');
 const { Resource } = require('@opentelemetry/resources');
-const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
+const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
 // configure the SDK to export telemetry data to the console
 // enable all auto-instrumentations from the meta package
 const traceExporter = new ConsoleSpanExporter();
 const sdk = new opentelemetry.NodeSDK({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'my-service',
+    [SEMRESATTRS_SERVICE_NAME]: 'my-service',
   }),
   traceExporter,
   instrumentations: [getNodeAutoInstrumentations()]

--- a/experimental/packages/opentelemetry-browser-detector/README.md
+++ b/experimental/packages/opentelemetry-browser-detector/README.md
@@ -14,12 +14,12 @@ npm install --save @opentelemetry/opentelemetry-browser-detector
 
 ```js
 import { Resource, detectResources } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { browserDetector } from '@opentelemetry/opentelemetry-browser-detector';
 
 async function start(){
   let resource= new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'Test App Name',
+    [SEMRESATTRS_SERVICE_NAME]: 'Test App Name',
   });
   let detectedResources= await detectResources({detectors:[browserDetector]});
   resource=resource.merge(detectedResources);


### PR DESCRIPTION
Refactoring some deprecated documentation around SemanticResourceAttributes:

* https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-semantic-conventions/src/resource/SemanticResourceAttributes.ts#L575