### PR TITLE
refactor: reduce and simplify usage of getEnv()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :house: (Internal)
 
+* refactor: Simplify the code for the `getEnv` function [#4799](https://github.com/open-telemetry/opentelemetry-js/pull/4799) @danstarns
+
 ## 1.25.1
 
 ### :books: (Refine Doc)
@@ -28,7 +30,6 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 * refactor(context-zone-peer-dep): use explicit exports [#4785](https://github.com/open-telemetry/opentelemetry-js/pull/4787) @pichlermarc
 * refactor(context-async-hooks): use explicit exports [#4785](https://github.com/open-telemetry/opentelemetry-js/pull/4786) @pichlermarc
-* refactor: Simplify the code for the `getEnv` function [#4799](https://github.com/open-telemetry/opentelemetry-js/pull/4799) @danstarns
 
 ## 1.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 * refactor(context-zone-peer-dep): use explicit exports [#4785](https://github.com/open-telemetry/opentelemetry-js/pull/4787) @pichlermarc
 * refactor(context-async-hooks): use explicit exports [#4785](https://github.com/open-telemetry/opentelemetry-js/pull/4786) @pichlermarc
+* refactor: Simplify the code for the `getEnv` function [#4799](https://github.com/open-telemetry/opentelemetry-js/pull/4799) @danstarns
 
 ## 1.25.0
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :house: (Internal)
 
 * test: add `npm run maint:regenerate-test-certs` maintenance script and regenerate recently expired test certs [#4777](https://github.com/open-telemetry/opentelemetry-js/pull/4777)
+* refactor: Simplify the code for the `getEnv` function [#4799](https://github.com/open-telemetry/opentelemetry-js/pull/4799) @danstarns
 
 ## 0.52.0
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :house: (Internal)
 
+* refactor: Simplify the code for the `getEnv` function [#4799](https://github.com/open-telemetry/opentelemetry-js/pull/4799) @danstarns
+
 ## 0.52.1
 
 ### :rocket: (Enhancement)
@@ -31,7 +33,6 @@ All notable changes to experimental packages in this project will be documented 
 ### :house: (Internal)
 
 * test: add `npm run maint:regenerate-test-certs` maintenance script and regenerate recently expired test certs [#4777](https://github.com/open-telemetry/opentelemetry-js/pull/4777)
-* refactor: Simplify the code for the `getEnv` function [#4799](https://github.com/open-telemetry/opentelemetry-js/pull/4799) @danstarns
 
 ## 0.52.0
 

--- a/experimental/packages/exporter-logs-otlp-http/src/platform/config.ts
+++ b/experimental/packages/exporter-logs-otlp-http/src/platform/config.ts
@@ -30,14 +30,21 @@ export const DEFAULT_COLLECTOR_URL = `http://localhost:4318/${DEFAULT_COLLECTOR_
  * @returns url string
  */
 export function getDefaultUrl(config: OTLPExporterConfigBase): string {
-  return typeof config.url === 'string'
-    ? config.url
-    : getEnv().OTEL_EXPORTER_OTLP_LOGS_ENDPOINT.length > 0
-    ? appendRootPathToUrlIfNeeded(getEnv().OTEL_EXPORTER_OTLP_LOGS_ENDPOINT)
-    : getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0
-    ? appendResourcePathToUrl(
-        getEnv().OTEL_EXPORTER_OTLP_ENDPOINT,
-        DEFAULT_COLLECTOR_RESOURCE_PATH
-      )
-    : DEFAULT_COLLECTOR_URL;
+  if (typeof config.url === 'string') {
+    return config.url;
+  }
+
+  const env = getEnv();
+  if (env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT.length > 0) {
+    return appendRootPathToUrlIfNeeded(env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT);
+  }
+
+  if (env.OTEL_EXPORTER_OTLP_ENDPOINT.length > 0) {
+    return appendResourcePathToUrl(
+      env.OTEL_EXPORTER_OTLP_ENDPOINT,
+      DEFAULT_COLLECTOR_RESOURCE_PATH
+    );
+  }
+
+  return DEFAULT_COLLECTOR_URL;
 }

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/OTLPLogExporter.ts
@@ -40,24 +40,30 @@ export class OTLPLogExporter
 {
   constructor(config: OTLPExporterConfigBase = {}) {
     super(config, ProtobufLogsSerializer, 'application/x-protobuf');
+    const env = getEnv();
     this._headers = Object.assign(
       this._headers,
-      baggageUtils.parseKeyPairsIntoRecord(
-        getEnv().OTEL_EXPORTER_OTLP_LOGS_HEADERS
-      )
+      baggageUtils.parseKeyPairsIntoRecord(env.OTEL_EXPORTER_OTLP_LOGS_HEADERS)
     );
   }
 
   getDefaultUrl(config: OTLPExporterConfigBase): string {
-    return typeof config.url === 'string'
-      ? config.url
-      : getEnv().OTEL_EXPORTER_OTLP_LOGS_ENDPOINT.length > 0
-      ? appendRootPathToUrlIfNeeded(getEnv().OTEL_EXPORTER_OTLP_LOGS_ENDPOINT)
-      : getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0
-      ? appendResourcePathToUrl(
-          getEnv().OTEL_EXPORTER_OTLP_ENDPOINT,
-          DEFAULT_COLLECTOR_RESOURCE_PATH
-        )
-      : DEFAULT_COLLECTOR_URL;
+    if (typeof config.url === 'string') {
+      return config.url;
+    }
+
+    const env = getEnv();
+    if (env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT.length > 0) {
+      return appendRootPathToUrlIfNeeded(env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT);
+    }
+
+    if (env.OTEL_EXPORTER_OTLP_ENDPOINT.length > 0) {
+      return appendResourcePathToUrl(
+        env.OTEL_EXPORTER_OTLP_ENDPOINT,
+        DEFAULT_COLLECTOR_RESOURCE_PATH
+      );
+    }
+
+    return DEFAULT_COLLECTOR_URL;
   }
 }

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
@@ -46,26 +46,34 @@ export class OTLPLogExporter
 {
   constructor(config: OTLPExporterConfigBase = {}) {
     super(config, ProtobufLogsSerializer, 'application/x-protobuf');
+    const env = getEnv();
     this.headers = {
       ...this.headers,
       ...USER_AGENT,
       ...baggageUtils.parseKeyPairsIntoRecord(
-        getEnv().OTEL_EXPORTER_OTLP_LOGS_HEADERS
+        env.OTEL_EXPORTER_OTLP_LOGS_HEADERS
       ),
       ...parseHeaders(config?.headers),
     };
   }
 
   getDefaultUrl(config: OTLPExporterConfigBase): string {
-    return typeof config.url === 'string'
-      ? config.url
-      : getEnv().OTEL_EXPORTER_OTLP_LOGS_ENDPOINT.length > 0
-      ? appendRootPathToUrlIfNeeded(getEnv().OTEL_EXPORTER_OTLP_LOGS_ENDPOINT)
-      : getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0
-      ? appendResourcePathToUrl(
-          getEnv().OTEL_EXPORTER_OTLP_ENDPOINT,
-          DEFAULT_COLLECTOR_RESOURCE_PATH
-        )
-      : DEFAULT_COLLECTOR_URL;
+    if (typeof config.url === 'string') {
+      return config.url;
+    }
+
+    const env = getEnv();
+    if (env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT.length > 0) {
+      return appendRootPathToUrlIfNeeded(env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT);
+    }
+
+    if (env.OTEL_EXPORTER_OTLP_ENDPOINT.length > 0) {
+      return appendResourcePathToUrl(
+        env.OTEL_EXPORTER_OTLP_ENDPOINT,
+        DEFAULT_COLLECTOR_RESOURCE_PATH
+      );
+    }
+
+    return DEFAULT_COLLECTOR_URL;
   }
 }

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/browser/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/browser/OTLPTraceExporter.ts
@@ -39,24 +39,34 @@ export class OTLPTraceExporter
 {
   constructor(config: OTLPExporterConfigBase = {}) {
     super(config, JsonTraceSerializer, 'application/json');
+    const env = getEnv();
     this._headers = Object.assign(
       this._headers,
       baggageUtils.parseKeyPairsIntoRecord(
-        getEnv().OTEL_EXPORTER_OTLP_TRACES_HEADERS
+        env.OTEL_EXPORTER_OTLP_TRACES_HEADERS
       )
     );
   }
 
   getDefaultUrl(config: OTLPExporterConfigBase): string {
-    return typeof config.url === 'string'
-      ? config.url
-      : getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT.length > 0
-      ? appendRootPathToUrlIfNeeded(getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
-      : getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0
-      ? appendResourcePathToUrl(
-          getEnv().OTEL_EXPORTER_OTLP_ENDPOINT,
-          DEFAULT_COLLECTOR_RESOURCE_PATH
-        )
-      : DEFAULT_COLLECTOR_URL;
+    if (typeof config.url === 'string') {
+      return config.url;
+    }
+
+    const env = getEnv();
+    if (env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT.length > 0) {
+      return appendRootPathToUrlIfNeeded(
+        env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+      );
+    }
+
+    if (env.OTEL_EXPORTER_OTLP_ENDPOINT.length > 0) {
+      return appendResourcePathToUrl(
+        env.OTEL_EXPORTER_OTLP_ENDPOINT,
+        DEFAULT_COLLECTOR_RESOURCE_PATH
+      );
+    }
+
+    return DEFAULT_COLLECTOR_URL;
   }
 }

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/node/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/node/OTLPTraceExporter.ts
@@ -44,26 +44,36 @@ export class OTLPTraceExporter
 {
   constructor(config: OTLPExporterNodeConfigBase = {}) {
     super(config, JsonTraceSerializer, 'application/json');
+    const env = getEnv();
     this.headers = {
       ...this.headers,
       ...USER_AGENT,
       ...baggageUtils.parseKeyPairsIntoRecord(
-        getEnv().OTEL_EXPORTER_OTLP_TRACES_HEADERS
+        env.OTEL_EXPORTER_OTLP_TRACES_HEADERS
       ),
       ...parseHeaders(config?.headers),
     };
   }
 
   getDefaultUrl(config: OTLPExporterNodeConfigBase): string {
-    return typeof config.url === 'string'
-      ? config.url
-      : getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT.length > 0
-      ? appendRootPathToUrlIfNeeded(getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
-      : getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0
-      ? appendResourcePathToUrl(
-          getEnv().OTEL_EXPORTER_OTLP_ENDPOINT,
-          DEFAULT_COLLECTOR_RESOURCE_PATH
-        )
-      : DEFAULT_COLLECTOR_URL;
+    if (typeof config.url === 'string') {
+      return config.url;
+    }
+
+    const env = getEnv();
+    if (env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT.length > 0) {
+      return appendRootPathToUrlIfNeeded(
+        env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+      );
+    }
+
+    if (env.OTEL_EXPORTER_OTLP_ENDPOINT.length > 0) {
+      return appendResourcePathToUrl(
+        env.OTEL_EXPORTER_OTLP_ENDPOINT,
+        DEFAULT_COLLECTOR_RESOURCE_PATH
+      );
+    }
+
+    return DEFAULT_COLLECTOR_URL;
   }
 }

--- a/experimental/packages/exporter-trace-otlp-proto/src/platform/browser/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/src/platform/browser/OTLPTraceExporter.ts
@@ -39,24 +39,34 @@ export class OTLPTraceExporter
 {
   constructor(config: OTLPExporterConfigBase = {}) {
     super(config, ProtobufTraceSerializer, 'application/x-protobuf');
+    const env = getEnv();
     this._headers = Object.assign(
       this._headers,
       baggageUtils.parseKeyPairsIntoRecord(
-        getEnv().OTEL_EXPORTER_OTLP_TRACES_HEADERS
+        env.OTEL_EXPORTER_OTLP_TRACES_HEADERS
       )
     );
   }
 
   getDefaultUrl(config: OTLPExporterConfigBase): string {
-    return typeof config.url === 'string'
-      ? config.url
-      : getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT.length > 0
-      ? appendRootPathToUrlIfNeeded(getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
-      : getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0
-      ? appendResourcePathToUrl(
-          getEnv().OTEL_EXPORTER_OTLP_ENDPOINT,
-          DEFAULT_COLLECTOR_RESOURCE_PATH
-        )
-      : DEFAULT_COLLECTOR_URL;
+    if (typeof config.url === 'string') {
+      return config.url;
+    }
+
+    const env = getEnv();
+    if (env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT.length > 0) {
+      return appendRootPathToUrlIfNeeded(
+        env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+      );
+    }
+
+    if (env.OTEL_EXPORTER_OTLP_ENDPOINT.length > 0) {
+      return appendResourcePathToUrl(
+        env.OTEL_EXPORTER_OTLP_ENDPOINT,
+        DEFAULT_COLLECTOR_RESOURCE_PATH
+      );
+    }
+
+    return DEFAULT_COLLECTOR_URL;
   }
 }

--- a/experimental/packages/exporter-trace-otlp-proto/src/platform/node/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/src/platform/node/OTLPTraceExporter.ts
@@ -44,26 +44,36 @@ export class OTLPTraceExporter
 {
   constructor(config: OTLPExporterNodeConfigBase = {}) {
     super(config, ProtobufTraceSerializer, 'application/x-protobuf');
+    const env = getEnv();
     this.headers = {
       ...this.headers,
       ...USER_AGENT,
       ...baggageUtils.parseKeyPairsIntoRecord(
-        getEnv().OTEL_EXPORTER_OTLP_TRACES_HEADERS
+        env.OTEL_EXPORTER_OTLP_TRACES_HEADERS
       ),
       ...parseHeaders(config?.headers),
     };
   }
 
   getDefaultUrl(config: OTLPExporterNodeConfigBase) {
-    return typeof config.url === 'string'
-      ? config.url
-      : getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT.length > 0
-      ? appendRootPathToUrlIfNeeded(getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
-      : getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0
-      ? appendResourcePathToUrl(
-          getEnv().OTEL_EXPORTER_OTLP_ENDPOINT,
-          DEFAULT_COLLECTOR_RESOURCE_PATH
-        )
-      : DEFAULT_COLLECTOR_URL;
+    if (typeof config.url === 'string') {
+      return config.url;
+    }
+
+    const env = getEnv();
+    if (env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT.length > 0) {
+      return appendRootPathToUrlIfNeeded(
+        env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+      );
+    }
+
+    if (env.OTEL_EXPORTER_OTLP_ENDPOINT.length > 0) {
+      return appendResourcePathToUrl(
+        env.OTEL_EXPORTER_OTLP_ENDPOINT,
+        DEFAULT_COLLECTOR_RESOURCE_PATH
+      );
+    }
+
+    return DEFAULT_COLLECTOR_URL;
   }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/browser/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/browser/OTLPMetricExporter.ts
@@ -38,27 +38,35 @@ class OTLPExporterBrowserProxy extends OTLPExporterBrowserBase<
 > {
   constructor(config?: OTLPMetricExporterOptions & OTLPExporterConfigBase) {
     super(config, JsonMetricsSerializer, 'application/json');
+    const env = getEnv();
     this._headers = Object.assign(
       this._headers,
       baggageUtils.parseKeyPairsIntoRecord(
-        getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
+        env.OTEL_EXPORTER_OTLP_METRICS_HEADERS
       )
     );
   }
 
   getDefaultUrl(config: OTLPExporterConfigBase): string {
-    return typeof config.url === 'string'
-      ? config.url
-      : getEnv().OTEL_EXPORTER_OTLP_METRICS_ENDPOINT.length > 0
-      ? appendRootPathToUrlIfNeeded(
-          getEnv().OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-        )
-      : getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0
-      ? appendResourcePathToUrl(
-          getEnv().OTEL_EXPORTER_OTLP_ENDPOINT,
-          DEFAULT_COLLECTOR_RESOURCE_PATH
-        )
-      : DEFAULT_COLLECTOR_URL;
+    if (typeof config.url === 'string') {
+      return config.url;
+    }
+
+    const env = getEnv();
+    if (env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT.length > 0) {
+      return appendRootPathToUrlIfNeeded(
+        env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+      );
+    }
+
+    if (env.OTEL_EXPORTER_OTLP_ENDPOINT.length > 0) {
+      return appendResourcePathToUrl(
+        env.OTEL_EXPORTER_OTLP_ENDPOINT,
+        DEFAULT_COLLECTOR_RESOURCE_PATH
+      );
+    }
+
+    return DEFAULT_COLLECTOR_URL;
   }
 }
 

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/OTLPMetricExporter.ts
@@ -43,29 +43,37 @@ class OTLPExporterNodeProxy extends OTLPExporterNodeBase<
 > {
   constructor(config?: OTLPExporterNodeConfigBase & OTLPMetricExporterOptions) {
     super(config, JsonMetricsSerializer, 'application/json');
+    const env = getEnv();
     this.headers = {
       ...this.headers,
       ...USER_AGENT,
       ...baggageUtils.parseKeyPairsIntoRecord(
-        getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
+        env.OTEL_EXPORTER_OTLP_METRICS_HEADERS
       ),
       ...parseHeaders(config?.headers),
     };
   }
 
   getDefaultUrl(config: OTLPExporterNodeConfigBase): string {
-    return typeof config.url === 'string'
-      ? config.url
-      : getEnv().OTEL_EXPORTER_OTLP_METRICS_ENDPOINT.length > 0
-      ? appendRootPathToUrlIfNeeded(
-          getEnv().OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-        )
-      : getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0
-      ? appendResourcePathToUrl(
-          getEnv().OTEL_EXPORTER_OTLP_ENDPOINT,
-          DEFAULT_COLLECTOR_RESOURCE_PATH
-        )
-      : DEFAULT_COLLECTOR_URL;
+    if (typeof config.url === 'string') {
+      return config.url;
+    }
+
+    const env = getEnv();
+    if (env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT.length > 0) {
+      return appendRootPathToUrlIfNeeded(
+        env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+      );
+    }
+
+    if (env.OTEL_EXPORTER_OTLP_ENDPOINT.length > 0) {
+      return appendResourcePathToUrl(
+        env.OTEL_EXPORTER_OTLP_ENDPOINT,
+        DEFAULT_COLLECTOR_RESOURCE_PATH
+      );
+    }
+
+    return DEFAULT_COLLECTOR_URL;
   }
 }
 

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/OTLPMetricExporter.ts
@@ -43,29 +43,37 @@ class OTLPMetricExporterNodeProxy extends OTLPExporterNodeBase<
 > {
   constructor(config?: OTLPExporterNodeConfigBase & OTLPMetricExporterOptions) {
     super(config, ProtobufMetricsSerializer, 'application/x-protobuf');
+    const env = getEnv();
     this.headers = {
       ...this.headers,
       ...USER_AGENT,
       ...baggageUtils.parseKeyPairsIntoRecord(
-        getEnv().OTEL_EXPORTER_OTLP_METRICS_HEADERS
+        env.OTEL_EXPORTER_OTLP_METRICS_HEADERS
       ),
       ...parseHeaders(config?.headers),
     };
   }
 
-  getDefaultUrl(config: OTLPExporterNodeConfigBase) {
-    return typeof config.url === 'string'
-      ? config.url
-      : getEnv().OTEL_EXPORTER_OTLP_METRICS_ENDPOINT.length > 0
-      ? appendRootPathToUrlIfNeeded(
-          getEnv().OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
-        )
-      : getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0
-      ? appendResourcePathToUrl(
-          getEnv().OTEL_EXPORTER_OTLP_ENDPOINT,
-          DEFAULT_COLLECTOR_RESOURCE_PATH
-        )
-      : DEFAULT_COLLECTOR_URL;
+  getDefaultUrl(config: OTLPExporterNodeConfigBase): string {
+    if (typeof config.url === 'string') {
+      return config.url;
+    }
+
+    const env = getEnv();
+    if (env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT.length > 0) {
+      return appendRootPathToUrlIfNeeded(
+        env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+      );
+    }
+
+    if (env.OTEL_EXPORTER_OTLP_ENDPOINT.length > 0) {
+      return appendResourcePathToUrl(
+        env.OTEL_EXPORTER_OTLP_ENDPOINT,
+        DEFAULT_COLLECTOR_RESOURCE_PATH
+      );
+    }
+
+    return DEFAULT_COLLECTOR_URL;
   }
 }
 

--- a/packages/opentelemetry-sdk-trace-base/src/config.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/config.ts
@@ -36,23 +36,23 @@ const DEFAULT_RATIO = 1;
 // object needs to be wrapped in this function and called when needed otherwise
 // envs are parsed before tests are ran - causes tests using these envs to fail
 export function loadDefaultConfig() {
+  const _env = getEnv();
+
   return {
     sampler: buildSamplerFromEnv(env),
     forceFlushTimeoutMillis: 30000,
     generalLimits: {
-      attributeValueLengthLimit: getEnv().OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT,
-      attributeCountLimit: getEnv().OTEL_ATTRIBUTE_COUNT_LIMIT,
+      attributeValueLengthLimit: _env.OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+      attributeCountLimit: _env.OTEL_ATTRIBUTE_COUNT_LIMIT,
     },
     spanLimits: {
-      attributeValueLengthLimit:
-        getEnv().OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
-      attributeCountLimit: getEnv().OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
-      linkCountLimit: getEnv().OTEL_SPAN_LINK_COUNT_LIMIT,
-      eventCountLimit: getEnv().OTEL_SPAN_EVENT_COUNT_LIMIT,
+      attributeValueLengthLimit: _env.OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+      attributeCountLimit: _env.OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
+      linkCountLimit: _env.OTEL_SPAN_LINK_COUNT_LIMIT,
+      eventCountLimit: _env.OTEL_SPAN_EVENT_COUNT_LIMIT,
       attributePerEventCountLimit:
-        getEnv().OTEL_SPAN_ATTRIBUTE_PER_EVENT_COUNT_LIMIT,
-      attributePerLinkCountLimit:
-        getEnv().OTEL_SPAN_ATTRIBUTE_PER_LINK_COUNT_LIMIT,
+        _env.OTEL_SPAN_ATTRIBUTE_PER_EVENT_COUNT_LIMIT,
+      attributePerLinkCountLimit: _env.OTEL_SPAN_ATTRIBUTE_PER_LINK_COUNT_LIMIT,
     },
   };
 }


### PR DESCRIPTION
* https://github.com/open-telemetry/opentelemetry-js/issues/4741

In most of the exporters, there is a function [`getEnv()`](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-core/src/platform/node/environment.ts#L27) that is called an unnecessary amount of times inside nested ternary operators. 

It looks as `getEnv()` calls `parseEnvironment()` that happens to iterate over a large static object parsing its values and performing other assertions. 

See extract from source: 

* https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/exporter-trace-otlp-http/src/platform/node/OTLPTraceExporter.ts#L57

```ts
  getDefaultUrl(config: OTLPExporterNodeConfigBase): string {
    return typeof config.url === 'string'
      ? config.url
      : getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT.length > 0
      ? appendRootPathToUrlIfNeeded(getEnv().OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
      : getEnv().OTEL_EXPORTER_OTLP_ENDPOINT.length > 0
      ? appendResourcePathToUrl(
          getEnv().OTEL_EXPORTER_OTLP_ENDPOINT,
          DEFAULT_COLLECTOR_RESOURCE_PATH
        )
      : DEFAULT_COLLECTOR_URL;
  }
```

This PR reduces the total invocations of `getEnv` along the exporters in the hope of easing performance and readability. 