### PR TITLE
fix: Update `import-in-the-middle`

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :bug: (Bug Fix)
 
 * fix(sdk-node): register context manager if no tracer options are provided [#4781](https://github.com/open-telemetry/opentelemetry-js/pull/4781) @pichlermarc
+* fix(instrumentation): Update `import-in-the-middle` to fix [numerous bugs](https://github.com/DataDog/import-in-the-middle/releases/tag/v1.8.1) [#4806](https://github.com/open-telemetry/opentelemetry-js/pull/4806) @timfish
 
 ### :books: (Refine Doc)
 
@@ -61,7 +62,7 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
-* fix(instrumentation): Update `import-in-the-middle` to fix [numerous bugs](https://github.com/DataDog/import-in-the-middle/pull/91) [#4745](https://github.com/open-telemetry/opentelemetry-js/pull/4745) @timfish
+* fix(instrumentation): Update `import-in-the-middle` to fix [numerous bugs](https://github.com/DataDog/import-in-the-middle/releases/tag/v1.8.0) [#4745](https://github.com/open-telemetry/opentelemetry-js/pull/4745) @timfish
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@opentelemetry/api-logs": "0.52.0",
     "@types/shimmer": "^1.0.2",
-    "import-in-the-middle": "1.8.0",
+    "import-in-the-middle": "1.8.1",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2",
     "shimmer": "^1.2.1"

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -25,14 +25,14 @@ import {
   Hooked,
 } from './RequireInTheMiddleSingleton';
 import type { HookFn } from 'import-in-the-middle';
-import * as ImportInTheMiddle from 'import-in-the-middle';
+import { Hook as HookImport } from 'import-in-the-middle';
 import {
   InstrumentationConfig,
   InstrumentationModuleDefinition,
 } from '../../types';
 import { diag } from '@opentelemetry/api';
 import type { OnRequireFn } from 'require-in-the-middle';
-import { Hook } from 'require-in-the-middle';
+import { Hook as HookRequire } from 'require-in-the-middle';
 import { readFileSync } from 'fs';
 import { isWrapped } from '../../utils';
 
@@ -46,7 +46,7 @@ export abstract class InstrumentationBase<
   implements types.Instrumentation<ConfigType>
 {
   private _modules: InstrumentationModuleDefinition[];
-  private _hooks: (Hooked | Hook)[] = [];
+  private _hooks: (Hooked | HookRequire)[] = [];
   private _requireInTheMiddleSingleton: RequireInTheMiddleSingleton =
     RequireInTheMiddleSingleton.getInstance();
   private _enabled = false;
@@ -305,15 +305,11 @@ export abstract class InstrumentationBase<
       // For an absolute paths, we must create a separate instance of the
       // require-in-the-middle `Hook`.
       const hook = path.isAbsolute(module.name)
-        ? new Hook([module.name], { internals: true }, onRequire)
+        ? new HookRequire([module.name], { internals: true }, onRequire)
         : this._requireInTheMiddleSingleton.register(module.name, onRequire);
 
       this._hooks.push(hook);
-      const esmHook = new (
-        ImportInTheMiddle as unknown as {
-          Hook: typeof ImportInTheMiddle.default;
-        }
-      ).Hook([module.name], { internals: false }, <HookFn>hookFn);
+      const esmHook = new HookImport([module.name], { internals: false }, <HookFn>hookFn);
       this._hooks.push(esmHook);
     }
   }

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -309,7 +309,11 @@ export abstract class InstrumentationBase<
         : this._requireInTheMiddleSingleton.register(module.name, onRequire);
 
       this._hooks.push(hook);
-      const esmHook = new HookImport([module.name], { internals: false }, <HookFn>hookFn);
+      const esmHook = new HookImport(
+        [module.name],
+        { internals: false },
+        <HookFn>hookFn
+      );
       this._hooks.push(esmHook);
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -785,7 +785,7 @@
       "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.25.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
         "@opentelemetry/otlp-transformer": "0.52.0",
@@ -1217,7 +1217,7 @@
       "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.25.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
         "@opentelemetry/otlp-transformer": "0.52.0",
@@ -1817,7 +1817,7 @@
       "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.25.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
         "@opentelemetry/otlp-exporter-base": "0.52.0",
@@ -2218,7 +2218,7 @@
       "dependencies": {
         "@opentelemetry/api-logs": "0.52.0",
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.8.0",
+        "import-in-the-middle": "1.8.1",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -2451,7 +2451,7 @@
       },
       "devDependencies": {
         "@bufbuild/buf": "1.21.0-1",
-        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/context-async-hooks": "1.25.0",
@@ -3176,7 +3176,7 @@
       "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.25.0",
         "@opentelemetry/otlp-exporter-base": "0.52.0",
         "@opentelemetry/otlp-transformer": "0.52.0"
@@ -18492,9 +18492,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.8.0.tgz",
-      "integrity": "sha512-/xQjze8szLNnJ5rvHSzn+dcVXqCAU6Plbk4P24U/jwPmg1wy7IIp9OjKIO5tYue8GSPhDpPDiApQjvBUmWwhsQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.8.1.tgz",
+      "integrity": "sha512-yhRwoHtiLGvmSozNOALgjRPFI6uYsds60EoMqqnXyyv+JOIW/BrrLejuTGBt+bq0T5tLzOHrN0T7xYTm4Qt/ng==",
       "dependencies": {
         "acorn": "^8.8.2",
         "acorn-import-attributes": "^1.9.5",
@@ -37597,7 +37597,7 @@
     "@opentelemetry/exporter-logs-otlp-grpc": {
       "version": "file:experimental/packages/exporter-logs-otlp-grpc",
       "requires": {
-        "@grpc/grpc-js": "1.10.9",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/api-logs": "0.52.0",
@@ -37904,7 +37904,7 @@
     "@opentelemetry/exporter-metrics-otlp-grpc": {
       "version": "file:experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
       "requires": {
-        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/core": "1.25.0",
@@ -38193,7 +38193,7 @@
     "@opentelemetry/exporter-trace-otlp-grpc": {
       "version": "file:experimental/packages/exporter-trace-otlp-grpc",
       "requires": {
-        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/core": "1.25.0",
@@ -38636,7 +38636,7 @@
         "codecov": "3.8.3",
         "cpx2": "2.0.0",
         "cross-var": "1.1.0",
-        "import-in-the-middle": "1.8.0",
+        "import-in-the-middle": "1.8.1",
         "karma": "6.4.3",
         "karma-chrome-launcher": "3.1.0",
         "karma-coverage": "2.2.1",
@@ -38875,7 +38875,7 @@
       "version": "file:experimental/packages/opentelemetry-instrumentation-grpc",
       "requires": {
         "@bufbuild/buf": "1.21.0-1",
-        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/context-async-hooks": "1.25.0",
@@ -39415,7 +39415,7 @@
     "@opentelemetry/otlp-grpc-exporter-base": {
       "version": "file:experimental/packages/otlp-grpc-exporter-base",
       "requires": {
-        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/core": "1.25.0",
         "@opentelemetry/otlp-exporter-base": "0.52.0",
@@ -49053,9 +49053,9 @@
       }
     },
     "import-in-the-middle": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.8.0.tgz",
-      "integrity": "sha512-/xQjze8szLNnJ5rvHSzn+dcVXqCAU6Plbk4P24U/jwPmg1wy7IIp9OjKIO5tYue8GSPhDpPDiApQjvBUmWwhsQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.8.1.tgz",
+      "integrity": "sha512-yhRwoHtiLGvmSozNOALgjRPFI6uYsds60EoMqqnXyyv+JOIW/BrrLejuTGBt+bq0T5tLzOHrN0T7xYTm4Qt/ng==",
       "requires": {
         "acorn": "^8.8.2",
         "acorn-import-attributes": "^1.9.5",


### PR DESCRIPTION
`import-in-the-middle` has had a few more bug fixes which have been released as v1.8.1 so I've bumper the version. This also included fixed types so no more type casting through `unknown` to get the types working!

The v1.8.0 release has also been added to Github so I updated the previous changelog entry to point to that.