### PR TITLE
chore: prepare release 1.25.1/0.52.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :books: (Refine Doc)
 
+### :house: (Internal)
+
+## 1.25.1
+
+### :books: (Refine Doc)
+
 * refactor(examples): added usage of @opentelemetry/semantic-conventions and @opentelemetry/resources to the examples in examples/opentelemetry-web for maintaining consistency across all examples. [#4764](https://github.com/open-telemetry/opentelemetry-js/pull/4764) @Zen-cronic
 
 ### :house: (Internal)

--- a/examples/esm-http-ts/package.json
+++ b/examples/esm-http-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "esm-http-ts",
   "private": true,
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Example of HTTP integration with OpenTelemetry using ESM and TypeScript",
   "main": "build/index.js",
   "type": "module",
@@ -32,12 +32,12 @@
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/",
   "dependencies": {
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
-    "@opentelemetry/instrumentation": "0.52.0",
-    "@opentelemetry/instrumentation-http": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
-    "@opentelemetry/sdk-trace-node": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+    "@opentelemetry/instrumentation": "0.52.1",
+    "@opentelemetry/instrumentation-http": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/sdk-trace-node": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   }
 }

--- a/examples/http/package.json
+++ b/examples/http/package.json
@@ -1,7 +1,7 @@
 {
   "name": "http-example",
   "private": true,
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Example of HTTP integration with OpenTelemetry",
   "main": "index.js",
   "scripts": {
@@ -30,14 +30,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-jaeger": "1.25.0",
-    "@opentelemetry/exporter-zipkin": "1.25.0",
-    "@opentelemetry/instrumentation": "0.52.0",
-    "@opentelemetry/instrumentation-http": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
-    "@opentelemetry/sdk-trace-node": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/exporter-jaeger": "1.25.1",
+    "@opentelemetry/exporter-zipkin": "1.25.1",
+    "@opentelemetry/instrumentation": "0.52.1",
+    "@opentelemetry/instrumentation-http": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/sdk-trace-node": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/http",
   "devDependencies": {

--- a/examples/https/package.json
+++ b/examples/https/package.json
@@ -1,7 +1,7 @@
 {
   "name": "https-example",
   "private": true,
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Example of HTTPs integration with OpenTelemetry",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -34,14 +34,14 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/exporter-jaeger": "1.25.0",
-    "@opentelemetry/exporter-zipkin": "1.25.0",
-    "@opentelemetry/instrumentation": "0.52.0",
-    "@opentelemetry/instrumentation-http": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
-    "@opentelemetry/sdk-trace-node": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/exporter-jaeger": "1.25.1",
+    "@opentelemetry/exporter-zipkin": "1.25.1",
+    "@opentelemetry/instrumentation": "0.52.1",
+    "@opentelemetry/instrumentation-http": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/sdk-trace-node": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/https",
   "devDependencies": {

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web-opentelemetry-example",
   "private": true,
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Example of using @opentelemetry/sdk-trace-web and @opentelemetry/sdk-metrics in browser",
   "main": "index.js",
   "scripts": {
@@ -45,20 +45,20 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/context-zone": "1.25.0",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
-    "@opentelemetry/exporter-zipkin": "1.25.0",
-    "@opentelemetry/instrumentation": "0.52.0",
-    "@opentelemetry/instrumentation-fetch": "0.52.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.52.0",
-    "@opentelemetry/propagator-b3": "1.25.0",
-    "@opentelemetry/sdk-metrics": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
-    "@opentelemetry/sdk-trace-web": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/context-zone": "1.25.1",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+    "@opentelemetry/exporter-zipkin": "1.25.1",
+    "@opentelemetry/instrumentation": "0.52.1",
+    "@opentelemetry/instrumentation-fetch": "0.52.1",
+    "@opentelemetry/instrumentation-xml-http-request": "0.52.1",
+    "@opentelemetry/propagator-b3": "1.25.1",
+    "@opentelemetry/sdk-metrics": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/sdk-trace-web": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web"
 }

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-otlp-exporter-node",
   "private": true,
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
@@ -30,17 +30,17 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.52.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
-    "@opentelemetry/exporter-metrics-otlp-proto": "0.52.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-metrics": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "0.52.1",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
+    "@opentelemetry/exporter-metrics-otlp-proto": "0.52.1",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-metrics": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/otlp-exporter-node"
 }

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :rocket: (Enhancement)
 
+### :bug: (Bug Fix)
+
+### :books: (Refine Doc)
+
+### :house: (Internal)
+
+## 0.52.1
+
+### :rocket: (Enhancement)
+
 * refactor(instrumentation-fetch): move fetch to use SEMATRR [#4632](https://github.com/open-telemetry/opentelemetry-js/pull/4632)
 * refactor(otlp-transformer): use explicit exports [#4785](https://github.com/open-telemetry/opentelemetry-js/pull/4785) @pichlermarc
 
@@ -16,8 +26,6 @@ All notable changes to experimental packages in this project will be documented 
 
 * fix(sdk-node): register context manager if no tracer options are provided [#4781](https://github.com/open-telemetry/opentelemetry-js/pull/4781) @pichlermarc
 * fix(instrumentation): Update `import-in-the-middle` to fix [numerous bugs](https://github.com/DataDog/import-in-the-middle/releases/tag/v1.8.1) [#4806](https://github.com/open-telemetry/opentelemetry-js/pull/4806) @timfish
-
-### :books: (Refine Doc)
 
 ### :house: (Internal)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to experimental packages in this project will be documented 
 
 * fix(sdk-node): register context manager if no tracer options are provided [#4781](https://github.com/open-telemetry/opentelemetry-js/pull/4781) @pichlermarc
 * fix(instrumentation): Update `import-in-the-middle` to fix [numerous bugs](https://github.com/DataDog/import-in-the-middle/releases/tag/v1.8.1) [#4806](https://github.com/open-telemetry/opentelemetry-js/pull/4806) @timfish
-* feat(instrumentation): Use a caret version for `import-in-the-middle` dependency [#4810](https://github.com/open-telemetry/opentelemetry-js/pull/4810) @timfish
+* chore(instrumentation): Use a caret version for `import-in-the-middle` dependency [#4810](https://github.com/open-telemetry/opentelemetry-js/pull/4810) @timfish
 
 ### :house: (Internal)
 

--- a/experimental/backwards-compatibility/node14/package.json
+++ b/experimental/backwards-compatibility/node14/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node14",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "private": true,
   "description": "Backwards compatibility app for node 14 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -10,8 +10,8 @@
     "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.52.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0"
+    "@opentelemetry/sdk-node": "0.52.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1"
   },
   "devDependencies": {
     "@types/node": "14.18.25",

--- a/experimental/backwards-compatibility/node16/package.json
+++ b/experimental/backwards-compatibility/node16/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backcompat-node16",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "private": true,
   "description": "Backwards compatibility app for node 16 types and the OpenTelemetry Node.js SDK",
   "main": "index.js",
@@ -10,8 +10,8 @@
     "align-api-deps": "node ../../../scripts/align-api-deps.js"
   },
   "dependencies": {
-    "@opentelemetry/sdk-node": "0.52.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0"
+    "@opentelemetry/sdk-node": "0.52.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1"
   },
   "devDependencies": {
     "@types/node": "16.11.52",

--- a/experimental/examples/events/package.json
+++ b/experimental/examples/events/package.json
@@ -1,17 +1,17 @@
 {
   "name": "events-example",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "private": true,
   "scripts": {
     "start": "ts-node index.ts"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/api-events": "0.52.0",
-    "@opentelemetry/api-logs": "0.52.0",
-    "@opentelemetry/exporter-logs-otlp-http": "0.52.0",
-    "@opentelemetry/sdk-events": "0.52.0",
-    "@opentelemetry/sdk-logs": "0.52.0"
+    "@opentelemetry/api-events": "0.52.1",
+    "@opentelemetry/api-logs": "0.52.1",
+    "@opentelemetry/exporter-logs-otlp-http": "0.52.1",
+    "@opentelemetry/sdk-events": "0.52.1",
+    "@opentelemetry/sdk-logs": "0.52.1"
   },
   "devDependencies": {
     "@types/node": "18.6.5",

--- a/experimental/examples/logs/package.json
+++ b/experimental/examples/logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logs-example",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "private": true,
   "scripts": {
     "start": "ts-node index.ts",
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@opentelemetry/api-logs": "0.52.0",
-    "@opentelemetry/sdk-logs": "0.52.0"
+    "@opentelemetry/api-logs": "0.52.1",
+    "@opentelemetry/sdk-logs": "0.52.1"
   },
   "devDependencies": {
     "@types/node": "18.6.5",

--- a/experimental/examples/opencensus-shim/package.json
+++ b/experimental/examples/opencensus-shim/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencensus-shim",
   "private": true,
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Example of using @opentelemetry/shim-opencensus in Node.js",
   "main": "index.js",
   "scripts": {
@@ -32,13 +32,13 @@
     "@opencensus/instrumentation-http": "0.1.0",
     "@opencensus/nodejs-base": "0.1.0",
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/exporter-prometheus": "0.52.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-metrics": "1.25.0",
-    "@opentelemetry/sdk-trace-node": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0",
-    "@opentelemetry/shim-opencensus": "0.52.0"
+    "@opentelemetry/exporter-prometheus": "0.52.1",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-metrics": "1.25.1",
+    "@opentelemetry/sdk-trace-node": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1",
+    "@opentelemetry/shim-opencensus": "0.52.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/examples/opencensus-shim"
 }

--- a/experimental/examples/prometheus/package.json
+++ b/experimental/examples/prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prometheus-example",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "private": true,
   "description": "Example of using @opentelemetry/sdk-metrics and @opentelemetry/exporter-prometheus",
   "main": "index.js",
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/exporter-prometheus": "0.52.0",
-    "@opentelemetry/sdk-metrics": "1.25.0"
+    "@opentelemetry/exporter-prometheus": "0.52.1",
+    "@opentelemetry/sdk-metrics": "1.25.1"
   }
 }

--- a/experimental/packages/api-events/package.json
+++ b/experimental/packages/api-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-events",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Public events API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/api-logs": "0.52.0"
+    "@opentelemetry/api-logs": "0.52.1"
   },
   "devDependencies": {
     "@types/mocha": "10.0.6",

--- a/experimental/packages/api-logs/package.json
+++ b/experimental/packages/api-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/api-logs",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Public logs API for OpenTelemetry",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-grpc",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry Collector Exporter allows user to send collected log records to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -52,9 +52,9 @@
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/api-logs": "0.52.0",
-    "@opentelemetry/otlp-exporter-base": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/api-logs": "0.52.1",
+    "@opentelemetry/otlp-exporter-base": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -73,10 +73,10 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
-    "@opentelemetry/otlp-transformer": "0.52.0",
-    "@opentelemetry/sdk-logs": "0.52.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
+    "@opentelemetry/otlp-transformer": "0.52.1",
+    "@opentelemetry/sdk-logs": "0.52.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-http",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "publishConfig": {
     "access": "public"
   },
@@ -75,7 +75,7 @@
     "@babel/core": "7.24.7",
     "@babel/preset-env": "7.24.7",
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/resources": "1.25.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -105,10 +105,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.52.0",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/otlp-exporter-base": "0.52.0",
-    "@opentelemetry/otlp-transformer": "0.52.0",
-    "@opentelemetry/sdk-logs": "0.52.0"
+    "@opentelemetry/api-logs": "0.52.1",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/otlp-exporter-base": "0.52.1",
+    "@opentelemetry/otlp-transformer": "0.52.1",
+    "@opentelemetry/sdk-logs": "0.52.1"
   }
 }

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-logs-otlp-proto",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "An OTLP exporter to send logs using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,13 +94,13 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.52.0",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/otlp-exporter-base": "0.52.0",
-    "@opentelemetry/otlp-transformer": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-logs": "0.52.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0"
+    "@opentelemetry/api-logs": "0.52.1",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/otlp-exporter-base": "0.52.1",
+    "@opentelemetry/otlp-transformer": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-logs": "0.52.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-logs-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-grpc",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/otlp-exporter-base": "0.52.0",
+    "@opentelemetry/otlp-exporter-base": "0.52.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -70,11 +70,11 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
-    "@opentelemetry/otlp-transformer": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
+    "@opentelemetry/otlp-transformer": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-http",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry Collector Trace Exporter allows user to send collected traces to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -96,11 +96,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/otlp-exporter-base": "0.52.0",
-    "@opentelemetry/otlp-transformer": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/otlp-exporter-base": "0.52.1",
+    "@opentelemetry/otlp-transformer": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http",
   "sideEffects": false

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-trace-otlp-proto",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry Collector Exporter allows user to send collected traces to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -93,11 +93,11 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/otlp-exporter-base": "0.52.0",
-    "@opentelemetry/otlp-transformer": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/otlp-exporter-base": "0.52.1",
+    "@opentelemetry/otlp-transformer": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/opentelemetry-browser-detector",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry Resource Detector for Browser",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -84,8 +84,8 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/browser-detector"
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -69,13 +69,13 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
-    "@opentelemetry/otlp-exporter-base": "0.52.0",
-    "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
-    "@opentelemetry/otlp-transformer": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-metrics": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
+    "@opentelemetry/otlp-exporter-base": "0.52.1",
+    "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
+    "@opentelemetry/otlp-transformer": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-metrics": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-http",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -96,11 +96,11 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/otlp-exporter-base": "0.52.0",
-    "@opentelemetry/otlp-transformer": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-metrics": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/otlp-exporter-base": "0.52.1",
+    "@opentelemetry/otlp-transformer": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-metrics": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-metrics-otlp-proto",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry Collector Metrics Exporter allows user to send collected metrics to the OpenTelemetry Collector using protobuf over HTTP",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -74,12 +74,12 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
-    "@opentelemetry/otlp-exporter-base": "0.52.0",
-    "@opentelemetry/otlp-transformer": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-metrics": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
+    "@opentelemetry/otlp-exporter-base": "0.52.1",
+    "@opentelemetry/otlp-transformer": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-metrics": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-prometheus",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry Exporter Prometheus provides a metrics endpoint for Prometheus",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/semantic-conventions": "1.25.0",
+    "@opentelemetry/semantic-conventions": "1.25.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -62,9 +62,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-metrics": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-metrics": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-prometheus",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-fetch",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry instrumentation for fetch http client in web browsers",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -58,9 +58,9 @@
     "@babel/core": "7.24.7",
     "@babel/preset-env": "7.24.7",
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/context-zone": "1.25.0",
-    "@opentelemetry/propagator-b3": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/context-zone": "1.25.1",
+    "@opentelemetry/propagator-b3": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -90,10 +90,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/instrumentation": "0.52.0",
-    "@opentelemetry/sdk-trace-web": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/instrumentation": "0.52.1",
+    "@opentelemetry/sdk-trace-web": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-fetch",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-grpc",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry instrumentation for `@grpc/grpc-js` rpc client and server for gRPC framework",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -51,10 +51,10 @@
     "@grpc/grpc-js": "^1.7.1",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/context-async-hooks": "1.25.0",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
-    "@opentelemetry/sdk-trace-node": "1.25.0",
+    "@opentelemetry/context-async-hooks": "1.25.1",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/sdk-trace-node": "1.25.1",
     "@protobuf-ts/grpc-transport": "2.9.4",
     "@protobuf-ts/runtime": "2.9.4",
     "@protobuf-ts/runtime-rpc": "2.9.4",
@@ -76,8 +76,8 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "0.52.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/instrumentation": "0.52.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-http",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry instrumentation for `node:http` and `node:https` http client and server modules",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -48,10 +48,10 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/context-async-hooks": "1.25.0",
-    "@opentelemetry/sdk-metrics": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
-    "@opentelemetry/sdk-trace-node": "1.25.0",
+    "@opentelemetry/context-async-hooks": "1.25.1",
+    "@opentelemetry/sdk-metrics": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/sdk-trace-node": "1.25.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/request-promise-native": "1.0.21",
@@ -76,9 +76,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/instrumentation": "0.52.0",
-    "@opentelemetry/semantic-conventions": "1.25.0",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/instrumentation": "0.52.1",
+    "@opentelemetry/semantic-conventions": "1.25.1",
     "semver": "^7.5.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http",

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-xml-http-request",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry instrumentation for XMLHttpRequest http client in web browsers",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -58,9 +58,9 @@
     "@babel/core": "7.24.7",
     "@babel/preset-env": "7.24.7",
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/context-zone": "1.25.0",
-    "@opentelemetry/propagator-b3": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/context-zone": "1.25.1",
+    "@opentelemetry/propagator-b3": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -90,10 +90,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/instrumentation": "0.52.0",
-    "@opentelemetry/sdk-trace-web": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/instrumentation": "0.52.1",
+    "@opentelemetry/sdk-trace-web": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-xml-http-request",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Base class for node which OpenTelemetry instrumentation modules extend",
   "author": "OpenTelemetry Authors",
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation",
@@ -72,7 +72,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js/issues"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.52.0",
+    "@opentelemetry/api-logs": "0.52.1",
     "@types/shimmer": "^1.0.2",
     "import-in-the-middle": "1.8.1",
     "require-in-the-middle": "^7.1.1",
@@ -86,7 +86,7 @@
     "@babel/core": "7.24.7",
     "@babel/preset-env": "7.24.7",
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/sdk-metrics": "1.25.0",
+    "@opentelemetry/sdk-metrics": "1.25.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.8",

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-node",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry SDK for Node.js",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -45,27 +45,27 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.52.0",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
-    "@opentelemetry/exporter-zipkin": "1.25.0",
-    "@opentelemetry/instrumentation": "0.52.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-logs": "0.52.0",
-    "@opentelemetry/sdk-metrics": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
-    "@opentelemetry/sdk-trace-node": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/api-logs": "0.52.1",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+    "@opentelemetry/exporter-zipkin": "1.25.1",
+    "@opentelemetry/instrumentation": "0.52.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-logs": "0.52.1",
+    "@opentelemetry/sdk-metrics": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/sdk-trace-node": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.3.0 <1.10.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/context-async-hooks": "1.25.0",
-    "@opentelemetry/exporter-jaeger": "1.25.0",
+    "@opentelemetry/context-async-hooks": "1.25.1",
+    "@opentelemetry/exporter-jaeger": "1.25.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.8",

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-exporter-base",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry OTLP Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -62,8 +62,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/otlp-transformer": "0.52.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/otlp-transformer": "0.52.1"
   },
   "devDependencies": {
     "@babel/core": "7.24.7",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/otlp-grpc-exporter-base",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry OTLP-gRPC Exporter base (for internal use only)",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -48,8 +48,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -68,9 +68,9 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/otlp-exporter-base": "0.52.0",
-    "@opentelemetry/otlp-transformer": "0.52.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/otlp-exporter-base": "0.52.1",
+    "@opentelemetry/otlp-transformer": "0.52.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-grpc-exporter-base",
   "sideEffects": false

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Transform OpenTelemetry SDK data into OTLP",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
@@ -84,12 +84,12 @@
     "webpack": "5.89.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.52.0",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-logs": "0.52.0",
-    "@opentelemetry/sdk-metrics": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/api-logs": "0.52.1",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-logs": "0.52.1",
+    "@opentelemetry/sdk-metrics": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
     "protobufjs": "^7.3.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-transformer",

--- a/experimental/packages/propagator-aws-xray-lambda/package.json
+++ b/experimental/packages/propagator-aws-xray-lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-aws-xray-lambda",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenTelemetry AWS Xray propagator provides context propagation for systems that are using AWS X-Ray format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -64,7 +64,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/propagator-aws-xray": "1.25.0"
+    "@opentelemetry/propagator-aws-xray": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/propagator-aws-xray-lambda#readme"
 }

--- a/experimental/packages/sdk-events/package.json
+++ b/experimental/packages/sdk-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-events",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "publishConfig": {
     "access": "public"
   },
@@ -98,8 +98,8 @@
     "webpack-merge": "5.10.0"
   },
   "dependencies": {
-    "@opentelemetry/api-events": "0.52.0",
-    "@opentelemetry/api-logs": "0.52.0",
-    "@opentelemetry/sdk-logs": "0.52.0"
+    "@opentelemetry/api-events": "0.52.1",
+    "@opentelemetry/api-logs": "0.52.1",
+    "@opentelemetry/sdk-logs": "0.52.1"
   }
 }

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-logs",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "publishConfig": {
     "access": "public"
   },
@@ -101,8 +101,8 @@
     "webpack-merge": "5.10.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.52.0",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/resources": "1.25.0"
+    "@opentelemetry/api-logs": "0.52.1",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/resources": "1.25.1"
   }
 }

--- a/experimental/packages/shim-opencensus/package.json
+++ b/experimental/packages/shim-opencensus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opencensus",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "OpenCensus to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -51,8 +51,8 @@
   "devDependencies": {
     "@opencensus/core": "0.1.0",
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/context-async-hooks": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/context-async-hooks": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -70,9 +70,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-metrics": "1.25.0",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-metrics": "1.25.1",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2"
   },

--- a/integration-tests/api/package.json
+++ b/integration-tests/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/integration-tests-api",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "propagation-validation-server",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "description": "server for w3c tests",
   "main": "validation_server.js",
   "private": true,
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/context-async-hooks": "1.25.0",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/context-async-hooks": "1.25.1",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
     "axios": "1.6.0",
     "body-parser": "1.19.0",
     "express": "4.19.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -221,17 +221,17 @@
       }
     },
     "examples/esm-http-ts": {
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/instrumentation-http": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/instrumentation-http": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "engines": {
         "node": ">=14"
@@ -239,18 +239,18 @@
     },
     "examples/http": {
       "name": "http-example",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.25.0",
-        "@opentelemetry/exporter-zipkin": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/instrumentation-http": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/exporter-jaeger": "1.25.1",
+        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/instrumentation-http": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -261,18 +261,18 @@
     },
     "examples/https": {
       "name": "https-example",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.25.0",
-        "@opentelemetry/exporter-zipkin": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/instrumentation-http": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/exporter-jaeger": "1.25.1",
+        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/instrumentation-http": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "devDependencies": {
         "cross-env": "^6.0.0"
@@ -283,24 +283,24 @@
     },
     "examples/opentelemetry-web": {
       "name": "web-opentelemetry-example",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
-        "@opentelemetry/exporter-zipkin": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/instrumentation-fetch": "0.52.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.52.0",
-        "@opentelemetry/propagator-b3": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-web": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/context-zone": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/instrumentation-fetch": "0.52.1",
+        "@opentelemetry/instrumentation-xml-http-request": "0.52.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-web": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "devDependencies": {
         "@babel/core": "^7.23.6",
@@ -332,21 +332,21 @@
     },
     "examples/otlp-exporter-node": {
       "name": "example-otlp-exporter-node",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.52.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.52.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "engines": {
         "node": ">=14"
@@ -354,11 +354,11 @@
     },
     "experimental/backwards-compatibility/node14": {
       "name": "backcompat-node14",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-node": "0.52.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0"
+        "@opentelemetry/sdk-node": "0.52.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1"
       },
       "devDependencies": {
         "@types/node": "14.18.25",
@@ -376,11 +376,11 @@
     },
     "experimental/backwards-compatibility/node16": {
       "name": "backcompat-node16",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-node": "0.52.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0"
+        "@opentelemetry/sdk-node": "0.52.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1"
       },
       "devDependencies": {
         "@types/node": "16.11.52",
@@ -398,14 +398,14 @@
     },
     "experimental/examples/events": {
       "name": "events-example",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-events": "0.52.0",
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/exporter-logs-otlp-http": "0.52.0",
-        "@opentelemetry/sdk-events": "0.52.0",
-        "@opentelemetry/sdk-logs": "0.52.0"
+        "@opentelemetry/api-events": "0.52.1",
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/exporter-logs-otlp-http": "0.52.1",
+        "@opentelemetry/sdk-events": "0.52.1",
+        "@opentelemetry/sdk-logs": "0.52.1"
       },
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -414,11 +414,11 @@
     },
     "experimental/examples/logs": {
       "name": "logs-example",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/sdk-logs": "0.52.0"
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/sdk-logs": "0.52.1"
       },
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -426,20 +426,20 @@
       }
     },
     "experimental/examples/opencensus-shim": {
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opencensus/core": "0.1.0",
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/exporter-prometheus": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
-        "@opentelemetry/shim-opencensus": "0.52.0"
+        "@opentelemetry/exporter-prometheus": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/shim-opencensus": "0.52.1"
       },
       "engines": {
         "node": ">=14"
@@ -447,21 +447,21 @@
     },
     "experimental/examples/prometheus": {
       "name": "prometheus-example",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-prometheus": "0.52.0",
-        "@opentelemetry/sdk-metrics": "1.25.0"
+        "@opentelemetry/exporter-prometheus": "0.52.1",
+        "@opentelemetry/sdk-metrics": "1.25.1"
       }
     },
     "experimental/packages/api-events": {
       "name": "@opentelemetry/api-events",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/api-logs": "0.52.0"
+        "@opentelemetry/api-logs": "0.52.1"
       },
       "devDependencies": {
         "@types/mocha": "10.0.6",
@@ -620,7 +620,7 @@
     },
     "experimental/packages/api-logs": {
       "name": "@opentelemetry/api-logs",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
@@ -782,21 +782,21 @@
     },
     "experimental/packages/exporter-logs-otlp-grpc": {
       "name": "@opentelemetry/exporter-logs-otlp-grpc",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/sdk-logs": "0.52.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/sdk-logs": "0.52.1"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -859,20 +859,20 @@
     },
     "experimental/packages/exporter-logs-otlp-http": {
       "name": "@opentelemetry/exporter-logs-otlp-http",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/sdk-logs": "0.52.0"
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/sdk-logs": "0.52.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/resources": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -1037,16 +1037,16 @@
     },
     "experimental/packages/exporter-logs-otlp-proto": {
       "name": "@opentelemetry/exporter-logs-otlp-proto",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-logs": "0.52.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0"
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-logs": "0.52.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
@@ -1214,20 +1214,20 @@
     },
     "experimental/packages/exporter-trace-otlp-grpc": {
       "name": "@opentelemetry/exporter-trace-otlp-grpc",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -1290,14 +1290,14 @@
     },
     "experimental/packages/exporter-trace-otlp-http": {
       "name": "@opentelemetry/exporter-trace-otlp-http",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
@@ -1467,14 +1467,14 @@
     },
     "experimental/packages/exporter-trace-otlp-proto": {
       "name": "@opentelemetry/exporter-trace-otlp-proto",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
@@ -1642,11 +1642,11 @@
     },
     "experimental/packages/opentelemetry-browser-detector": {
       "name": "@opentelemetry/opentelemetry-browser-detector",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
@@ -1814,17 +1814,17 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc": {
       "name": "@opentelemetry/exporter-metrics-otlp-grpc",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1"
       },
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
@@ -1891,14 +1891,14 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-http": {
       "name": "@opentelemetry/exporter-metrics-otlp-http",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
@@ -2068,15 +2068,15 @@
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-proto": {
       "name": "@opentelemetry/exporter-metrics-otlp-proto",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.9.0",
@@ -2142,16 +2142,16 @@
     },
     "experimental/packages/opentelemetry-exporter-prometheus": {
       "name": "@opentelemetry/exporter-prometheus",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -2213,10 +2213,10 @@
     },
     "experimental/packages/opentelemetry-instrumentation": {
       "name": "@opentelemetry/instrumentation",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/api-logs": "0.52.1",
         "@types/shimmer": "^1.0.2",
         "import-in-the-middle": "1.8.1",
         "require-in-the-middle": "^7.1.1",
@@ -2227,7 +2227,7 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/sdk-metrics": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -2264,21 +2264,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-fetch": {
       "name": "@opentelemetry/instrumentation-fetch",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/sdk-trace-web": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/sdk-trace-web": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/context-zone": "1.25.0",
-        "@opentelemetry/propagator-b3": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/context-zone": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -2443,21 +2443,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-grpc": {
       "name": "@opentelemetry/instrumentation-grpc",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "devDependencies": {
         "@bufbuild/buf": "1.21.0-1",
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/context-async-hooks": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
         "@protobuf-ts/grpc-transport": "2.9.4",
         "@protobuf-ts/runtime": "2.9.4",
         "@protobuf-ts/runtime-rpc": "2.9.4",
@@ -2524,20 +2524,20 @@
     },
     "experimental/packages/opentelemetry-instrumentation-http": {
       "name": "@opentelemetry/instrumentation-http",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/context-async-hooks": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
@@ -2607,21 +2607,21 @@
     },
     "experimental/packages/opentelemetry-instrumentation-xml-http-request": {
       "name": "@opentelemetry/instrumentation-xml-http-request",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/sdk-trace-web": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/sdk-trace-web": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/context-zone": "1.25.0",
-        "@opentelemetry/propagator-b3": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/context-zone": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -2916,27 +2916,27 @@
     },
     "experimental/packages/opentelemetry-sdk-node": {
       "name": "@opentelemetry/sdk-node",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
-        "@opentelemetry/exporter-zipkin": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-logs": "0.52.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-logs": "0.52.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/context-async-hooks": "1.25.0",
-        "@opentelemetry/exporter-jaeger": "1.25.0",
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/exporter-jaeger": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -3001,11 +3001,11 @@
     },
     "experimental/packages/otlp-exporter-base": {
       "name": "@opentelemetry/otlp-exporter-base",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-transformer": "0.52.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-transformer": "0.52.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
@@ -3173,18 +3173,18 @@
     },
     "experimental/packages/otlp-grpc-exporter-base": {
       "name": "@opentelemetry/otlp-grpc-exporter-base",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -3247,15 +3247,15 @@
     },
     "experimental/packages/otlp-transformer": {
       "name": "@opentelemetry/otlp-transformer",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-logs": "0.52.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-logs": "0.52.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "protobufjs": "^7.3.0"
       },
       "devDependencies": {
@@ -3419,10 +3419,10 @@
     },
     "experimental/packages/propagator-aws-xray-lambda": {
       "name": "@opentelemetry/propagator-aws-xray-lambda",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/propagator-aws-xray": "1.25.0"
+        "@opentelemetry/propagator-aws-xray": "1.25.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
@@ -3492,12 +3492,12 @@
     },
     "experimental/packages/sdk-events": {
       "name": "@opentelemetry/sdk-events",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-events": "0.52.0",
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/sdk-logs": "0.52.0"
+        "@opentelemetry/api-events": "0.52.1",
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/sdk-logs": "0.52.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
@@ -3534,6 +3534,31 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "experimental/packages/sdk-events/node_modules/@opentelemetry/api-events": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-events/-/api-events-0.52.0.tgz",
+      "integrity": "sha512-+LdOC1OK9tINoj6KQT0FZkX3enQElzLkuwAbzF7Lrdp7x7XrhQFhMz7PwfTYCgnVDOqc7pRGw0jIfmj+vJ5t4g==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/api-logs": "0.52.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "experimental/packages/sdk-events/node_modules/@opentelemetry/api-logs": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
+      "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/sdk-events/node_modules/@types/sinon": {
@@ -3677,12 +3702,12 @@
     },
     "experimental/packages/sdk-logs": {
       "name": "@opentelemetry/sdk-logs",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0"
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
@@ -3727,6 +3752,18 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "experimental/packages/sdk-logs/node_modules/@opentelemetry/api-logs": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
+      "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "experimental/packages/sdk-logs/node_modules/@opentelemetry/resources_1.9.0": {
@@ -3902,20 +3939,20 @@
     },
     "experimental/packages/shim-opencensus": {
       "name": "@opentelemetry/shim-opencensus",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opencensus/core": "0.1.0",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/context-async-hooks": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -3978,7 +4015,7 @@
     },
     "integration-tests/api": {
       "name": "@opentelemetry/integration-tests-api",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
@@ -4042,13 +4079,13 @@
       }
     },
     "integration-tests/propagation-validation-server": {
-      "version": "1.26.0",
+      "version": "1.26.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "axios": "1.6.0",
         "body-parser": "1.19.0",
         "express": "4.19.2"
@@ -31418,7 +31455,7 @@
     },
     "packages/opentelemetry-context-async-hooks": {
       "name": "@opentelemetry/context-async-hooks",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -31481,10 +31518,10 @@
     },
     "packages/opentelemetry-context-zone": {
       "name": "@opentelemetry/context-zone",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.25.0",
+        "@opentelemetry/context-zone-peer-dep": "1.25.1",
         "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
       },
       "devDependencies": {
@@ -31498,7 +31535,7 @@
     },
     "packages/opentelemetry-context-zone-peer-dep": {
       "name": "@opentelemetry/context-zone-peer-dep",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "7.24.7",
@@ -31670,10 +31707,10 @@
     },
     "packages/opentelemetry-core": {
       "name": "@opentelemetry/core",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -31838,17 +31875,17 @@
     },
     "packages/opentelemetry-exporter-jaeger": {
       "name": "@opentelemetry/exporter-jaeger",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "jaeger-client": "^3.15.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/resources": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -31911,13 +31948,13 @@
     },
     "packages/opentelemetry-exporter-zipkin": {
       "name": "@opentelemetry/exporter-zipkin",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
@@ -32088,10 +32125,10 @@
     },
     "packages/opentelemetry-propagator-b3": {
       "name": "@opentelemetry/propagator-b3",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0"
+        "@opentelemetry/core": "1.25.1"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -32155,10 +32192,10 @@
     },
     "packages/opentelemetry-propagator-jaeger": {
       "name": "@opentelemetry/propagator-jaeger",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0"
+        "@opentelemetry/core": "1.25.1"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -32323,11 +32360,11 @@
     },
     "packages/opentelemetry-resources": {
       "name": "@opentelemetry/resources",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -32545,12 +32582,12 @@
     },
     "packages/opentelemetry-sdk-trace-base": {
       "name": "@opentelemetry/sdk-trace-base",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -32716,20 +32753,20 @@
     },
     "packages/opentelemetry-sdk-trace-node": {
       "name": "@opentelemetry/sdk-trace-node",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/propagator-b3": "1.25.0",
-        "@opentelemetry/propagator-jaeger": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/propagator-jaeger": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "semver": "^7.5.2"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -32792,20 +32829,20 @@
     },
     "packages/opentelemetry-sdk-trace-web": {
       "name": "@opentelemetry/sdk-trace-web",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/context-zone": "1.25.0",
-        "@opentelemetry/propagator-b3": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/context-zone": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
         "@types/jquery": "3.5.30",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -32973,7 +33010,7 @@
     },
     "packages/opentelemetry-semantic-conventions": {
       "name": "@opentelemetry/semantic-conventions",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@size-limit/file": "^11.0.1",
@@ -33040,18 +33077,18 @@
     },
     "packages/opentelemetry-shim-opentracing": {
       "name": "@opentelemetry/shim-opentracing",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "opentracing": "^0.14.4"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/propagator-b3": "1.25.0",
-        "@opentelemetry/propagator-jaeger": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/propagator-jaeger": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -33111,10 +33148,10 @@
     },
     "packages/propagator-aws-xray": {
       "name": "@opentelemetry/propagator-aws-xray",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0"
+        "@opentelemetry/core": "1.25.1"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -33277,11 +33314,11 @@
     },
     "packages/sdk-metrics": {
       "name": "@opentelemetry/sdk-metrics",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
         "lodash.merge": "^4.6.2"
       },
       "devDependencies": {
@@ -33451,7 +33488,7 @@
     },
     "packages/template": {
       "name": "@opentelemetry/template",
-      "version": "1.25.0",
+      "version": "1.25.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "18.6.5",
@@ -33465,19 +33502,19 @@
     },
     "selenium-tests": {
       "name": "@opentelemetry/selenium-tests",
-      "version": "1.26.0",
+      "version": "1.26.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
-        "@opentelemetry/exporter-zipkin": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/instrumentation-fetch": "0.52.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.52.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/context-zone-peer-dep": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/instrumentation-fetch": "0.52.1",
+        "@opentelemetry/instrumentation-xml-http-request": "0.52.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-web": "1.25.1",
         "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
       },
       "devDependencies": {
@@ -37028,7 +37065,7 @@
       "version": "file:experimental/packages/api-events",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/api-logs": "0.52.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/webpack-env": "1.16.3",
@@ -37298,7 +37335,7 @@
     "@opentelemetry/context-zone": {
       "version": "file:packages/opentelemetry-context-zone",
       "requires": {
-        "@opentelemetry/context-zone-peer-dep": "1.25.0",
+        "@opentelemetry/context-zone-peer-dep": "1.25.1",
         "cross-var": "1.1.0",
         "lerna": "6.6.2",
         "typescript": "4.4.4",
@@ -37429,7 +37466,7 @@
       "version": "file:packages/opentelemetry-core",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37544,10 +37581,10 @@
       "version": "file:packages/opentelemetry-exporter-jaeger",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37600,13 +37637,13 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-logs": "0.52.0",
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-logs": "0.52.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37658,12 +37695,12 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-logs": "0.52.0",
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-logs": "0.52.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37783,13 +37820,13 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-logs": "0.52.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-logs": "0.52.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37907,13 +37944,13 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -37965,11 +38002,11 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38087,12 +38124,12 @@
       "version": "file:experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
       "requires": {
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38142,10 +38179,10 @@
       "version": "file:experimental/packages/opentelemetry-exporter-prometheus",
       "requires": {
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38196,12 +38233,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38253,11 +38290,11 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38377,11 +38414,11 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38499,10 +38536,10 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38623,8 +38660,8 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -38751,13 +38788,13 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/context-zone": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/propagator-b3": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-web": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/context-zone": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-web": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -38878,12 +38915,12 @@
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/context-async-hooks": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@protobuf-ts/grpc-transport": "2.9.4",
         "@protobuf-ts/runtime": "2.9.4",
         "@protobuf-ts/runtime-rpc": "2.9.4",
@@ -38937,13 +38974,13 @@
       "version": "file:experimental/packages/opentelemetry-instrumentation-http",
       "requires": {
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/context-async-hooks": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
@@ -39003,13 +39040,13 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/context-zone": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/propagator-b3": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-web": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/context-zone": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-web": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -39180,8 +39217,8 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -39299,8 +39336,8 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -39417,11 +39454,11 @@
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/otlp-exporter-base": "0.52.0",
-        "@opentelemetry/otlp-transformer": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -39471,12 +39508,12 @@
       "version": "file:experimental/packages/otlp-transformer",
       "requires": {
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-logs": "0.52.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-logs": "0.52.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/webpack-env": "1.16.3",
         "babel-plugin-istanbul": "6.1.1",
@@ -39590,7 +39627,7 @@
       "version": "file:packages/propagator-aws-xray",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/webpack-env": "1.16.3",
@@ -39705,7 +39742,7 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/propagator-aws-xray": "1.25.0",
+        "@opentelemetry/propagator-aws-xray": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -39757,7 +39794,7 @@
       "version": "file:packages/opentelemetry-propagator-b3",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -39805,7 +39842,7 @@
       "version": "file:packages/opentelemetry-propagator-jaeger",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -39920,9 +39957,9 @@
       "version": "file:packages/opentelemetry-resources",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/core": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -40075,7 +40112,7 @@
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/api-events": "0.52.0",
         "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/sdk-logs": "0.52.0",
+        "@opentelemetry/sdk-logs": "0.52.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -40102,6 +40139,25 @@
         "webpack-merge": "5.10.0"
       },
       "dependencies": {
+        "@opentelemetry/api-events": {
+          "version": "0.52.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-events/-/api-events-0.52.0.tgz",
+          "integrity": "sha512-+LdOC1OK9tINoj6KQT0FZkX3enQElzLkuwAbzF7Lrdp7x7XrhQFhMz7PwfTYCgnVDOqc7pRGw0jIfmj+vJ5t4g==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api": "^1.0.0",
+            "@opentelemetry/api-logs": "0.52.0"
+          }
+        },
+        "@opentelemetry/api-logs": {
+          "version": "0.52.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
+          "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
+        },
         "@types/sinon": {
           "version": "10.0.20",
           "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
@@ -40205,8 +40261,8 @@
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": ">=1.4.0 <1.10.0",
         "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -40237,6 +40293,15 @@
           "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
           "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
           "dev": true
+        },
+        "@opentelemetry/api-logs": {
+          "version": "0.52.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
+          "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
         },
         "@opentelemetry/resources_1.9.0": {
           "version": "npm:@opentelemetry/resources@1.9.0",
@@ -40358,8 +40423,8 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": ">=1.3.0 <1.10.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
         "@types/lodash.merge": "4.6.9",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -40477,21 +40542,21 @@
       "version": "file:experimental/packages/opentelemetry-sdk-node",
       "requires": {
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/context-async-hooks": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/exporter-jaeger": "1.25.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
-        "@opentelemetry/exporter-zipkin": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-logs": "0.52.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-jaeger": "1.25.1",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-logs": "0.52.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -40543,9 +40608,9 @@
       "version": "file:packages/opentelemetry-sdk-trace-base",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -40661,13 +40726,13 @@
       "version": "file:packages/opentelemetry-sdk-trace-node",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/context-async-hooks": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/propagator-b3": "1.25.0",
-        "@opentelemetry/propagator-jaeger": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/propagator-jaeger": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -40720,12 +40785,12 @@
         "@babel/core": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/context-zone": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/propagator-b3": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/context-zone": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/jquery": "3.5.30",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
@@ -40851,16 +40916,16 @@
         "@babel/plugin-transform-runtime": "7.22.15",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/context-zone-peer-dep": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
-        "@opentelemetry/exporter-zipkin": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/instrumentation-fetch": "0.52.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.52.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-web": "1.25.0",
+        "@opentelemetry/context-zone-peer-dep": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/instrumentation-fetch": "0.52.1",
+        "@opentelemetry/instrumentation-xml-http-request": "0.52.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-web": "1.25.1",
         "babel-loader": "8.3.0",
         "babel-polyfill": "6.26.0",
         "browserstack-local": "1.4.8",
@@ -41069,11 +41134,11 @@
       "requires": {
         "@opencensus/core": "0.1.0",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/context-async-hooks": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -41124,11 +41189,11 @@
       "version": "file:packages/opentelemetry-shim-opentracing",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/propagator-b3": "1.25.0",
-        "@opentelemetry/propagator-jaeger": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/propagator-jaeger": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "codecov": "3.8.3",
@@ -44165,8 +44230,8 @@
     "backcompat-node14": {
       "version": "file:experimental/backwards-compatibility/node14",
       "requires": {
-        "@opentelemetry/sdk-node": "0.52.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-node": "0.52.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/node": "14.18.25",
         "typescript": "4.4.4"
       },
@@ -44182,8 +44247,8 @@
     "backcompat-node16": {
       "version": "file:experimental/backwards-compatibility/node16",
       "requires": {
-        "@opentelemetry/sdk-node": "0.52.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/sdk-node": "0.52.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "@types/node": "16.11.52",
         "typescript": "4.4.4"
       },
@@ -47165,13 +47230,13 @@
       "version": "file:examples/esm-http-ts",
       "requires": {
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/instrumentation-http": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/instrumentation-http": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       }
     },
     "espree": {
@@ -47311,11 +47376,11 @@
       "version": "file:experimental/examples/events",
       "requires": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-events": "0.52.0",
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/exporter-logs-otlp-http": "0.52.0",
-        "@opentelemetry/sdk-events": "0.52.0",
-        "@opentelemetry/sdk-logs": "0.52.0",
+        "@opentelemetry/api-events": "0.52.1",
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/exporter-logs-otlp-http": "0.52.1",
+        "@opentelemetry/sdk-events": "0.52.1",
+        "@opentelemetry/sdk-logs": "0.52.1",
         "@types/node": "18.6.5",
         "ts-node": "^10.9.1"
       }
@@ -47324,17 +47389,17 @@
       "version": "file:examples/otlp-exporter-node",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.52.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0"
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.52.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
       }
     },
     "execa": {
@@ -48846,14 +48911,14 @@
       "version": "file:examples/http",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-jaeger": "1.25.0",
-        "@opentelemetry/exporter-zipkin": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/instrumentation-http": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/exporter-jaeger": "1.25.1",
+        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/instrumentation-http": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "cross-env": "^6.0.0"
       }
     },
@@ -48942,14 +49007,14 @@
       "version": "file:examples/https",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/exporter-jaeger": "1.25.0",
-        "@opentelemetry/exporter-zipkin": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/instrumentation-http": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/exporter-jaeger": "1.25.1",
+        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/instrumentation-http": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "cross-env": "^6.0.0"
       }
     },
@@ -51197,8 +51262,8 @@
       "version": "file:experimental/examples/logs",
       "requires": {
         "@opentelemetry/api": "^1.7.0",
-        "@opentelemetry/api-logs": "0.52.0",
-        "@opentelemetry/sdk-logs": "0.52.0",
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/sdk-logs": "0.52.1",
         "@types/node": "18.6.5",
         "ts-node": "^10.9.1"
       }
@@ -53483,13 +53548,13 @@
         "@opencensus/instrumentation-http": "0.1.0",
         "@opencensus/nodejs-base": "0.1.0",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/exporter-prometheus": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.0",
-        "@opentelemetry/resources": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-node": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
-        "@opentelemetry/shim-opencensus": "0.52.0"
+        "@opentelemetry/exporter-prometheus": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/shim-opencensus": "0.52.1"
       }
     },
     "opentracing": {
@@ -54384,8 +54449,8 @@
       "version": "file:experimental/examples/prometheus",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/exporter-prometheus": "0.52.0",
-        "@opentelemetry/sdk-metrics": "1.25.0"
+        "@opentelemetry/exporter-prometheus": "0.52.1",
+        "@opentelemetry/sdk-metrics": "1.25.1"
       }
     },
     "promise-all-reject-late": {
@@ -54435,9 +54500,9 @@
       "version": "file:integration-tests/propagation-validation-server",
       "requires": {
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/context-async-hooks": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
         "axios": "1.6.0",
         "body-parser": "1.19.0",
         "express": "4.19.2",
@@ -58239,20 +58304,20 @@
         "@babel/core": "^7.23.6",
         "@babel/preset-env": "^7.22.20",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-zone": "1.25.0",
-        "@opentelemetry/core": "1.25.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.52.0",
-        "@opentelemetry/exporter-zipkin": "1.25.0",
-        "@opentelemetry/instrumentation": "0.52.0",
-        "@opentelemetry/instrumentation-fetch": "0.52.0",
-        "@opentelemetry/instrumentation-xml-http-request": "0.52.0",
-        "@opentelemetry/propagator-b3": "1.25.0",
-        "@opentelemetry/sdk-metrics": "1.25.0",
-        "@opentelemetry/sdk-trace-base": "1.25.0",
-        "@opentelemetry/sdk-trace-web": "1.25.0",
-        "@opentelemetry/semantic-conventions": "1.25.0",
+        "@opentelemetry/context-zone": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/instrumentation-fetch": "0.52.1",
+        "@opentelemetry/instrumentation-xml-http-request": "0.52.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-web": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1",
         "babel-loader": "^8.0.6",
         "ts-loader": "^9.2.6",
         "typescript": "^4.5.2",

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-async-hooks",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone-peer-dep",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry Context Zone with peer dependency for zone.js",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/context-zone",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry Context Zone",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.25.0",
+    "@opentelemetry/context-zone-peer-dep": "1.25.1",
     "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
   },
   "sideEffects": true,

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/core",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry Core provides constants and utilities shared by all OpenTelemetry SDK packages.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -92,7 +92,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core",
   "sideEffects": false

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-jaeger",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry Exporter Jaeger allows user to send collected traces to Jaeger",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/resources": "1.25.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -64,9 +64,9 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1",
     "jaeger-client": "^3.15.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-jaeger",

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/exporter-zipkin",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry Zipkin Exporter allows the user to send collected traces to Zipkin.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,10 +94,10 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-exporter-zipkin",
   "sideEffects": false

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-b3",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry B3 propagator provides context propagation for systems that are using the B3 header format",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -52,7 +52,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0"
+    "@opentelemetry/core": "1.25.1"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0"

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-jaeger",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -82,7 +82,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0"
+    "@opentelemetry/core": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger",
   "sideEffects": false

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resources",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry SDK resources",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -96,8 +96,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-resources",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-base",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry Tracing",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -94,9 +94,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-base",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-node",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry Node SDK provides automatic telemetry (tracing, metrics, etc) for Node.js applications",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -47,8 +47,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
-    "@opentelemetry/resources": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0",
+    "@opentelemetry/resources": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.8",
@@ -66,11 +66,11 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/context-async-hooks": "1.25.0",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/propagator-b3": "1.25.0",
-    "@opentelemetry/propagator-jaeger": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/context-async-hooks": "1.25.1",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/propagator-b3": "1.25.1",
+    "@opentelemetry/propagator-jaeger": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
     "semver": "^7.5.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-trace-web",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry Web Tracer",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -59,9 +59,9 @@
     "@babel/core": "7.24.7",
     "@babel/preset-env": "7.24.7",
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
-    "@opentelemetry/context-zone": "1.25.0",
-    "@opentelemetry/propagator-b3": "1.25.0",
-    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/context-zone": "1.25.1",
+    "@opentelemetry/propagator-b3": "1.25.1",
+    "@opentelemetry/resources": "1.25.1",
     "@types/jquery": "3.5.30",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
@@ -94,9 +94,9 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0"
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web",
   "sideEffects": false

--- a/packages/opentelemetry-semantic-conventions/package.json
+++ b/packages/opentelemetry-semantic-conventions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/semantic-conventions",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry semantic conventions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/shim-opentracing",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTracing to OpenTelemetry shim",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -44,9 +44,9 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
-    "@opentelemetry/propagator-b3": "1.25.0",
-    "@opentelemetry/propagator-jaeger": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
+    "@opentelemetry/propagator-b3": "1.25.1",
+    "@opentelemetry/propagator-jaeger": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "codecov": "3.8.3",
@@ -61,8 +61,8 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/semantic-conventions": "1.25.0",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/semantic-conventions": "1.25.1",
     "opentracing": "^0.14.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-shim-opentracing",

--- a/packages/propagator-aws-xray/package.json
+++ b/packages/propagator-aws-xray/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-aws-xray",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry AWS Xray propagator provides context propagation for systems that are using AWS X-Ray format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -80,7 +80,7 @@
     "webpack": "5.89.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0"
+    "@opentelemetry/core": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/propagator-aws-xray#readme"
 }

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/sdk-metrics",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "description": "OpenTelemetry metrics SDK",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -86,8 +86,8 @@
     "@opentelemetry/api": ">=1.3.0 <1.10.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/resources": "1.25.0",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/resources": "1.25.1",
     "lodash.merge": "^4.6.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-metrics",

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/template",
-  "version": "1.25.0",
+  "version": "1.25.1",
   "private": true,
   "publishConfig": {
     "access": "restricted"

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/selenium-tests",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "private": true,
   "description": "OpenTelemetry Selenium Tests",
   "main": "index.js",
@@ -57,16 +57,16 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/context-zone-peer-dep": "1.25.0",
-    "@opentelemetry/core": "1.25.0",
-    "@opentelemetry/exporter-trace-otlp-http": "0.52.0",
-    "@opentelemetry/exporter-zipkin": "1.25.0",
-    "@opentelemetry/instrumentation": "0.52.0",
-    "@opentelemetry/instrumentation-fetch": "0.52.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.52.0",
-    "@opentelemetry/sdk-metrics": "1.25.0",
-    "@opentelemetry/sdk-trace-base": "1.25.0",
-    "@opentelemetry/sdk-trace-web": "1.25.0",
+    "@opentelemetry/context-zone-peer-dep": "1.25.1",
+    "@opentelemetry/core": "1.25.1",
+    "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+    "@opentelemetry/exporter-zipkin": "1.25.1",
+    "@opentelemetry/instrumentation": "0.52.1",
+    "@opentelemetry/instrumentation-fetch": "0.52.1",
+    "@opentelemetry/instrumentation-xml-http-request": "0.52.1",
+    "@opentelemetry/sdk-metrics": "1.25.1",
+    "@opentelemetry/sdk-trace-base": "1.25.1",
+    "@opentelemetry/sdk-trace-web": "1.25.1",
     "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
   }
 }


### PR DESCRIPTION
## 1.25.1

### :books: (Refine Doc)

* refactor(examples): added usage of @opentelemetry/semantic-conventions and @opentelemetry/resources to the examples in examples/opentelemetry-web for maintaining consistency across all examples. [#4764](https://github.com/open-telemetry/opentelemetry-js/pull/4764) @Zen-cronic

### :house: (Internal)

* refactor(context-zone-peer-dep): use explicit exports [#4785](https://github.com/open-telemetry/opentelemetry-js/pull/4787) @pichlermarc
* refactor(context-async-hooks): use explicit exports [#4785](https://github.com/open-telemetry/opentelemetry-js/pull/4786) @pichlermarc


## 0.52.1

### :rocket: (Enhancement)

* refactor(instrumentation-fetch): move fetch to use SEMATRR [#4632](https://github.com/open-telemetry/opentelemetry-js/pull/4632)
* refactor(otlp-transformer): use explicit exports [#4785](https://github.com/open-telemetry/opentelemetry-js/pull/4785) @pichlermarc

### :bug: (Bug Fix)

* fix(sdk-node): register context manager if no tracer options are provided [#4781](https://github.com/open-telemetry/opentelemetry-js/pull/4781) @pichlermarc
* fix(instrumentation): Update `import-in-the-middle` to fix [numerous bugs](https://github.com/DataDog/import-in-the-middle/releases/tag/v1.8.1) [#4806](https://github.com/open-telemetry/opentelemetry-js/pull/4806) @timfish

### :house: (Internal)

* test: add `npm run maint:regenerate-test-certs` maintenance script and regenerate recently expired test certs [#4777](https://github.com/open-telemetry/opentelemetry-js/pull/4777)
