### PR TITLE
feat(instrumentation): Use a caret version for `import-in-the-middle` dependency

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to experimental packages in this project will be documented 
 
 * fix(sdk-node): register context manager if no tracer options are provided [#4781](https://github.com/open-telemetry/opentelemetry-js/pull/4781) @pichlermarc
 * fix(instrumentation): Update `import-in-the-middle` to fix [numerous bugs](https://github.com/DataDog/import-in-the-middle/releases/tag/v1.8.1) [#4806](https://github.com/open-telemetry/opentelemetry-js/pull/4806) @timfish
+* feat(instrumentation): Use a caret version for `import-in-the-middle` dependency [#4810](https://github.com/open-telemetry/opentelemetry-js/pull/4810) @timfish
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@opentelemetry/api-logs": "0.52.0",
     "@types/shimmer": "^1.0.2",
-    "import-in-the-middle": "1.8.1",
+    "import-in-the-middle": "^1.8.1",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2",
     "shimmer": "^1.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2218,7 +2218,7 @@
       "dependencies": {
         "@opentelemetry/api-logs": "0.52.0",
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.8.1",
+        "import-in-the-middle": "^1.8.1",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -38636,7 +38636,7 @@
         "codecov": "3.8.3",
         "cpx2": "2.0.0",
         "cross-var": "1.1.0",
-        "import-in-the-middle": "1.8.1",
+        "import-in-the-middle": "^1.8.1",
         "karma": "6.4.3",
         "karma-chrome-launcher": "3.1.0",
         "karma-coverage": "2.2.1",


### PR DESCRIPTION
Ref https://github.com/open-telemetry/opentelemetry-js/pull/4806#issuecomment-2178669926

`import-in-the-middle` is more stable and has tests to ensure otel usage won't get broken so this should mean less PRs/releases required.