### PR TITLE
chore: add @trentm to maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 - [Chengzhong Wu](https://github.com/legendecas), Bloomberg
 - [Daniel Dyla](https://github.com/dyladan), Dynatrace
 - [Marc Pichler](https://github.com/pichlermarc), Dynatrace
+- [Trent Mick](https://github.com/trentm), Elastic
 
 *Find more about the maintainer role in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).*
 
@@ -222,7 +223,6 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 - [Neville Wylie](https://github.com/MSNev), Microsoft
 - [Purvi Kanal](https://github.com/pkanal), Honeycomb
 - [Svetlana Brennan](https://github.com/svetlanabrennan), New Relic
-- [Trent Mick](https://github.com/trentm), Elastic
 - [David Luna](https://github.com/david-luna), Elastic
 
 *Find more about the approver role in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).*


### PR DESCRIPTION
Recognizing his contributions to the project and excellent technical judgement, I propose we add @trentm to the list of JS Maintainers.

cc @open-telemetry/javascript-maintainers