### PR TITLE
fix(instrumentation): Fix optional property types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 * fix(sdk-node): avoid spurious diag errors for unknown OTEL_NODE_RESOURCE_DETECTORS values [#4879](https://github.com/open-telemetry/opentelemetry-js/pull/4879) @trentm
 * deps(opentelemetry-instrumentation): Bump `shimmer` types to 1.2.0 [#4865](https://github.com/open-telemetry/opentelemetry-js/pull/4865) @lforst
+* fix(instrumentation): Fix optional property types [#4833](https://github.com/open-telemetry/opentelemetry-js/pull/4833) @alecmev
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-instrumentation/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/types.ts
@@ -136,11 +136,15 @@ export interface InstrumentationModuleDefinition {
 
   /** Method to patch the instrumentation  */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  patch?: (moduleExports: any, moduleVersion?: string) => any;
+  patch?:
+    | ((moduleExports: any, moduleVersion?: string | undefined) => any)
+    | undefined;
 
   /** Method to unpatch the instrumentation  */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  unpatch?: (moduleExports: any, moduleVersion?: string) => void;
+  unpatch?:
+    | ((moduleExports: any, moduleVersion?: string | undefined) => void)
+    | undefined;
 }
 
 /**


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fix #4712, related to #3713.

TypeScript emits `InstrumentationNodeModuleDefinition` with ` | undefined` for some reason, making it incompatible with `InstrumentationModuleDefinition` under `exactOptionalPropertyTypes: true`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I'm using OpenTelemetry indirectly via Sentry. I applied this patch locally to the latest version of `@opentelemetry/instrumentation` and it resolved the issue.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
