### PR TITLE
deps(instrumentation): Move `@types/shimmer` into `devDependencies`

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -73,7 +73,6 @@
   },
   "dependencies": {
     "@opentelemetry/api-logs": "0.52.1",
-    "@types/shimmer": "^1.0.2",
     "import-in-the-middle": "^1.8.1",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2",
@@ -90,6 +89,7 @@
     "@types/mocha": "10.0.7",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.8",
+    "@types/shimmer": "^1.0.2",
     "@types/sinon": "17.0.3",
     "@types/webpack-env": "1.16.3",
     "babel-loader": "8.3.0",


### PR DESCRIPTION
## Which problem is this PR solving?

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes https://github.com/getsentry/sentry-javascript/issues/12682

## Short description of the changes

Shimmer has a harmful type definition (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69966) which conflicts with typings in certain situations (https://github.com/getsentry/sentry-javascript/issues/12682) but in general, typings should not end up in the normal dependencies.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

No tests necessary I think.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] ~Unit tests have been added~
- [ ] ~Documentation has been updated~
