### PR TITLE
fix(instrumentation)!:remove unused description property from interface

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+* fix(instrumentation)!:remove unused description property from interface [#4847](https://github.com/open-telemetry/opentelemetry-js/pull/4847) @blumamir
+
 ### :rocket: (Enhancement)
 
 ### :bug: (Bug Fix)

--- a/experimental/packages/opentelemetry-instrumentation/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/types.ts
@@ -27,13 +27,6 @@ export interface Instrumentation<
   /** Instrumentation Version  */
   instrumentationVersion: string;
 
-  /**
-   * Instrumentation Description - please describe all useful information
-   * as Instrumentation might patch different version of different modules,
-   * or support different browsers etc.
-   */
-  instrumentationDescription?: string;
-
   /** Method to disable the instrumentation  */
   disable(): void;
 


### PR DESCRIPTION
As we are talking about stabilizing the `@opentelemetry/instrumentation` package, I want to suggest removing the `description` property from `Instrumentation` interface which is not used anywhere in the codebase (core + contrib).

While this is technically a breaking change, it is very unlikly that someone actually uses it out there IMO.

- The instrumentation description is well documented in `package.json` https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2202 and one can pick it up from there.
- I don't think this data is relevant in runtime
- Even if we do want it in the future, I think it should be bundled into a proper interface with other metadata, so the current property will probably not be the final one we want to use anyway.
- https://github.com/open-telemetry/opentelemetry-js/pull/4694 is an example of removing similar data which had consensus about, and we didn't here any feedback about people who were actually affected by this change.
- Addressing it in the future when the package is stable will be breaking change which we might not be able to do