### PR TITLE
feat: include instrumentation scope info in console span and log record exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :rocket: (Enhancement)
 
-* feat: print instrumentation library info with console span exporter [#4848](https://github.com/open-telemetry/opentelemetry-js/pull/4848) @blumamir
+* feat: include instrumentation scope info in console span and log record exporters [#4848](https://github.com/open-telemetry/opentelemetry-js/pull/4848) @blumamir
 
 ### :bug: (Bug Fix)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :rocket: (Enhancement)
 
+* feat: print instrumentation library info with console span exporter [#4848](https://github.com/open-telemetry/opentelemetry-js/pull/4848) @blumamir
+
 ### :bug: (Bug Fix)
 
 ### :books: (Refine Doc)

--- a/experimental/packages/sdk-logs/src/export/ConsoleLogRecordExporter.ts
+++ b/experimental/packages/sdk-logs/src/export/ConsoleLogRecordExporter.ts
@@ -55,6 +55,7 @@ export class ConsoleLogRecordExporter implements LogRecordExporter {
       resource: {
         attributes: logRecord.resource.attributes,
       },
+      instrumentationScope: logRecord.instrumentationScope,
       timestamp: hrTimeToMicroseconds(logRecord.hrTime),
       traceId: logRecord.spanContext?.traceId,
       spanId: logRecord.spanContext?.spanId,

--- a/experimental/packages/sdk-logs/test/common/export/ConsoleLogRecordExporter.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/ConsoleLogRecordExporter.test.ts
@@ -40,6 +40,8 @@ describe('ConsoleLogRecordExporter', () => {
   describe('export', () => {
     it('should export information about log record', () => {
       assert.doesNotThrow(() => {
+        const instrumentationScopeName = '@opentelemetry/sdk-logs/test';
+        const instrumentationScopeVersion = '1.2.3';
         const consoleExporter = new ConsoleLogRecordExporter();
         const spyConsole = sinon.spy(console, 'dir');
         const spyExport = sinon.spy(consoleExporter, 'export');
@@ -48,11 +50,13 @@ describe('ConsoleLogRecordExporter', () => {
           new SimpleLogRecordProcessor(consoleExporter)
         );
 
-        provider.getLogger('default').emit({
-          body: 'body1',
-          severityNumber: SeverityNumber.DEBUG,
-          severityText: 'DEBUG',
-        });
+        provider
+          .getLogger(instrumentationScopeName, instrumentationScopeVersion)
+          .emit({
+            body: 'body1',
+            severityNumber: SeverityNumber.DEBUG,
+            severityText: 'DEBUG',
+          });
 
         const logRecords = spyExport.args[0];
         const firstLogRecord = logRecords[0][0];
@@ -63,6 +67,7 @@ describe('ConsoleLogRecordExporter', () => {
         const expectedKeys = [
           'attributes',
           'body',
+          'instrumentationScope',
           'resource',
           'severityNumber',
           'severityText',
@@ -76,6 +81,13 @@ describe('ConsoleLogRecordExporter', () => {
         assert.ok(firstLogRecord.severityNumber === SeverityNumber.DEBUG);
         assert.ok(firstLogRecord.severityText === 'DEBUG');
         assert.ok(keys === expectedKeys, 'expectedKeys');
+        assert.ok(
+          firstLogRecord.instrumentationScope.name === instrumentationScopeName
+        );
+        assert.ok(
+          firstLogRecord.instrumentationScope.version ===
+            instrumentationScopeVersion
+        );
 
         assert.ok(spyExport.calledOnce);
       });

--- a/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
@@ -65,6 +65,7 @@ export class ConsoleSpanExporter implements SpanExporter {
       resource: {
         attributes: span.resource.attributes,
       },
+      instrumentationLibrary: span.instrumentationLibrary,
       traceId: span.spanContext().traceId,
       parentId: span.parentSpanId,
       traceState: span.spanContext().traceState?.serialize(),

--- a/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
@@ -65,7 +65,7 @@ export class ConsoleSpanExporter implements SpanExporter {
       resource: {
         attributes: span.resource.attributes,
       },
-      instrumentationLibrary: span.instrumentationLibrary,
+      instrumentationScope: span.instrumentationLibrary,
       traceId: span.spanContext().traceId,
       parentId: span.parentSpanId,
       traceState: span.spanContext().traceState?.serialize(),

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/ConsoleSpanExporter.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/ConsoleSpanExporter.test.ts
@@ -55,9 +55,12 @@ describe('ConsoleSpanExporter', () => {
           new SimpleSpanProcessor(consoleExporter)
         );
 
-        const instrumentationLibraryName = '@opentelemetry/sdk-trace-base/test';
-        const instrumentationLibraryVersion = '1.2.3';
-        const tracer = basicTracerProvider.getTracer(instrumentationLibraryName, instrumentationLibraryVersion);
+        const instrumentationScopeName = '@opentelemetry/sdk-trace-base/test';
+        const instrumentationScopeVersion = '1.2.3';
+        const tracer = basicTracerProvider.getTracer(
+          instrumentationScopeName,
+          instrumentationScopeVersion
+        );
         const context: SpanContext = {
           traceId: 'a3cda95b652f4a1592b449d5929fda1b',
           spanId: '5e0c63257de34c92',
@@ -82,7 +85,7 @@ describe('ConsoleSpanExporter', () => {
           'duration',
           'events',
           'id',
-          'instrumentationLibrary',
+          'instrumentationScope',
           'kind',
           'links',
           'name',
@@ -98,8 +101,13 @@ describe('ConsoleSpanExporter', () => {
         assert.ok(firstEvent.name === 'foobar');
         assert.ok(consoleSpan.id === firstSpan.spanContext().spanId);
         assert.ok(keys === expectedKeys, 'expectedKeys');
-        assert.ok(firstSpan.instrumentationLibrary.name === instrumentationLibraryName);
-        assert.ok(firstSpan.instrumentationLibrary.version === instrumentationLibraryVersion);
+        assert.ok(
+          firstSpan.instrumentationLibrary.name === instrumentationScopeName
+        );
+        assert.ok(
+          firstSpan.instrumentationLibrary.version ===
+            instrumentationScopeVersion
+        );
 
         assert.ok(spyExport.calledOnce);
       });

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/ConsoleSpanExporter.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/ConsoleSpanExporter.test.ts
@@ -55,7 +55,9 @@ describe('ConsoleSpanExporter', () => {
           new SimpleSpanProcessor(consoleExporter)
         );
 
-        const tracer = basicTracerProvider.getTracer('default');
+        const instrumentationLibraryName = '@opentelemetry/sdk-trace-base/test';
+        const instrumentationLibraryVersion = '1.2.3';
+        const tracer = basicTracerProvider.getTracer(instrumentationLibraryName, instrumentationLibraryVersion);
         const context: SpanContext = {
           traceId: 'a3cda95b652f4a1592b449d5929fda1b',
           spanId: '5e0c63257de34c92',
@@ -80,6 +82,7 @@ describe('ConsoleSpanExporter', () => {
           'duration',
           'events',
           'id',
+          'instrumentationLibrary',
           'kind',
           'links',
           'name',
@@ -95,6 +98,8 @@ describe('ConsoleSpanExporter', () => {
         assert.ok(firstEvent.name === 'foobar');
         assert.ok(consoleSpan.id === firstSpan.spanContext().spanId);
         assert.ok(keys === expectedKeys, 'expectedKeys');
+        assert.ok(firstSpan.instrumentationLibrary.name === instrumentationLibraryName);
+        assert.ok(firstSpan.instrumentationLibrary.version === instrumentationLibraryVersion);
 
         assert.ok(spyExport.calledOnce);
       });


### PR DESCRIPTION
The `ConsoleSpanExporter` prints many useful information to the console about a span, but it lacks the `instrumentationLibrary`. This info is present on the `ReadableSpan`, but it was probably forgotten, as the resource is included and the span info is included, but there is no way currently to view the library info for an output span:

```js
{
  resource: {
    attributes: {
      'service.name': 'coupon',
      'telemetry.sdk.language': 'nodejs',
      'telemetry.sdk.name': 'opentelemetry',
      'telemetry.sdk.version': '1.25.0',
      'telemetry.distro.name': 'odigos',
      'telemetry.distro.version': 'v1.0.76'
    }
  },
  traceId: 'cd873e9e3f16df24a8e2ebfe83d00b9c',
  parentId: '22ca73ebb95febbe',
  traceState: undefined,
  name: 'request handler - /apply-coupon',
  id: 'cb7f45d392356f99',
  kind: 0,
  timestamp: 1720132143829000,
  duration: 15.166,
  attributes: {
    'http.route': '/apply-coupon',
    'express.name': '/apply-coupon',
    'express.type': 'request_handler'
  },
  status: { code: 0 },
  events: [],
  links: []
}
```

This PR adds this info the the output.