### PR TITLE
docs(opentelemtry-instrumentation): fix reversed jsdoc comment

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
@@ -168,10 +168,10 @@ export abstract class InstrumentationAbstract<
     return this._tracer;
   }
 
-  /* Disable plugin */
+  /* Enable plugin */
   public abstract enable(): void;
 
-  /* Enable plugin */
+  /* Disable plugin */
   public abstract disable(): void;
 
   /**


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Just a small typo I came across while browsing the code.

## Short description of the changes

Correct a mixup between the jsdoc comment of the enabled and the disable function.

## Type of change

- [x] JSDoc Documentation only

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Not tested

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated
