### PR TITLE
deps(opentelemetry-instrumentation): Bump shimmer types to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 
 ### :bug: (Bug Fix)
 
+- deps(opentelemetry-instrumentation): Bump `shimmer` types to 1.2.0 [#4865](https://github.com/open-telemetry/opentelemetry-js/pull/4865) @lforst
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@opentelemetry/api-logs": "0.52.1",
-    "@types/shimmer": "^1.0.2",
+    "@types/shimmer": "^1.2.0",
     "import-in-the-middle": "^1.8.1",
     "require-in-the-middle": "^7.1.1",
     "semver": "^7.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -782,7 +782,7 @@
       "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.10.10",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
         "@opentelemetry/otlp-transformer": "0.52.1",
@@ -1211,7 +1211,7 @@
       "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.10.10",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
         "@opentelemetry/otlp-transformer": "0.52.1",
@@ -1806,7 +1806,7 @@
       "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.10.10",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/exporter-metrics-otlp-http": "0.52.1",
         "@opentelemetry/otlp-exporter-base": "0.52.1",
@@ -2202,7 +2202,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.52.1",
-        "@types/shimmer": "^1.0.2",
+        "@types/shimmer": "^1.2.0",
         "import-in-the-middle": "^1.8.1",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
@@ -2434,7 +2434,7 @@
       },
       "devDependencies": {
         "@bufbuild/buf": "1.21.0-1",
-        "@grpc/grpc-js": "^1.10.10",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/context-async-hooks": "1.25.1",
@@ -3154,7 +3154,7 @@
       "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.10.10",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/otlp-exporter-base": "0.52.1",
         "@opentelemetry/otlp-transformer": "0.52.1"
@@ -9760,9 +9760,9 @@
       }
     },
     "node_modules/@types/shimmer": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.5.tgz",
-      "integrity": "sha512-9Hp0ObzwwO57DpLFF0InUjUm/II8GmKAvzbefxQTihCb7KI6yc9yzf0nLc4mVdby5N4DRCgQM2wCup9KTieeww=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
     },
     "node_modules/@types/sinon": {
       "version": "17.0.3",
@@ -37462,7 +37462,7 @@
     "@opentelemetry/exporter-logs-otlp-grpc": {
       "version": "file:experimental/packages/exporter-logs-otlp-grpc",
       "requires": {
-        "@grpc/grpc-js": "1.10.10",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/api-logs": "0.52.1",
@@ -37766,7 +37766,7 @@
     "@opentelemetry/exporter-metrics-otlp-grpc": {
       "version": "file:experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
       "requires": {
-        "@grpc/grpc-js": "^1.10.10",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/core": "1.25.1",
@@ -38051,7 +38051,7 @@
     "@opentelemetry/exporter-trace-otlp-grpc": {
       "version": "file:experimental/packages/exporter-trace-otlp-grpc",
       "requires": {
-        "@grpc/grpc-js": "^1.10.10",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/core": "1.25.1",
@@ -38482,7 +38482,7 @@
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
-        "@types/shimmer": "^1.0.2",
+        "@types/shimmer": "^1.2.0",
         "@types/sinon": "17.0.3",
         "@types/webpack-env": "1.16.3",
         "babel-loader": "8.3.0",
@@ -38727,7 +38727,7 @@
       "version": "file:experimental/packages/opentelemetry-instrumentation-grpc",
       "requires": {
         "@bufbuild/buf": "1.21.0-1",
-        "@grpc/grpc-js": "^1.10.10",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/context-async-hooks": "1.25.1",
@@ -39255,7 +39255,7 @@
     "@opentelemetry/otlp-grpc-exporter-base": {
       "version": "file:experimental/packages/otlp-grpc-exporter-base",
       "requires": {
-        "@grpc/grpc-js": "^1.10.10",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/otlp-exporter-base": "0.52.1",
@@ -41929,9 +41929,9 @@
       }
     },
     "@types/shimmer": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.5.tgz",
-      "integrity": "sha512-9Hp0ObzwwO57DpLFF0InUjUm/II8GmKAvzbefxQTihCb7KI6yc9yzf0nLc4mVdby5N4DRCgQM2wCup9KTieeww=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
     },
     "@types/sinon": {
       "version": "17.0.3",


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Bumps the shimmer package to a version that doesn't include an invasive type that breaks certain setups.

See PR for more details: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69966

Fixes https://github.com/getsentry/sentry-javascript/issues/12682

This PR supersedes https://github.com/open-telemetry/opentelemetry-js/pull/4835

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I don't think tests are necessary here. Feel free to let me know though!

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] ~Unit tests have been added~
- [ ] ~Documentation has been updated~
