### PR TITLE
Allow consuming app to create their own XMLHttpRequest

### DIFF
--- a/api/test/common/internal/global.test.ts
+++ b/api/test/common/internal/global.test.ts
@@ -84,7 +84,8 @@ describe('Global Utils', () => {
     assert.notStrictEqual(manager, api1.context['_getContextManager']());
   });
 
-  it('should not register if the version is a mismatch', () => {
+  it('should not register if the version is a mismatch', function() {
+    this.timeout(6000);
     const logger1 = getMockLogger();
     const logger2 = getMockLogger();
 

--- a/api/test/tree-shaking/tree-shaking.test.ts
+++ b/api/test/tree-shaking/tree-shaking.test.ts
@@ -60,6 +60,7 @@ describe('tree-shaking', () => {
 
   for (const testAPI of testAPIs) {
     it(`verify ${testAPI.name}`, async function () {
+      this.timeout(10000);
       if (parseInt(process.versions.node.split('.')[0], 10) < 10) {
         this.skip();
       }

--- a/experimental/packages/otlp-exporter-base/src/platform/browser/util.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/browser/util.ts
@@ -85,7 +85,7 @@ export function sendWithXhr(
     retries = DEFAULT_EXPORT_MAX_ATTEMPTS,
     minDelay = DEFAULT_EXPORT_INITIAL_BACKOFF
   ) => {
-    xhr = new XMLHttpRequest();
+    xhr = createOtelJsXMLHttpRequest();
     xhr.open('POST', url);
 
     const defaultHeaders = {
@@ -160,4 +160,20 @@ export function sendWithXhr(
   };
 
   sendWithRetry();
+}
+
+declare global {
+  function createOtelJsXMLHttpRequest(): XMLHttpRequest;
+}
+
+/**
+ * function to create XMLHttpRequest but use the globalThis implementation
+ * if available
+ */
+function createOtelJsXMLHttpRequest(): XMLHttpRequest {
+  if (typeof globalThis.createOtelJsXMLHttpRequest === 'function') {
+    return globalThis.createOtelJsXMLHttpRequest();
+  }
+
+  return new XMLHttpRequest();
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Introducing createOtelJsXMLHttpRequest in sendWithXhr
- Add timeouts to some tests. They were failing on my local machine due to timeouts.

The motivation is to allow consuming to customize the type of XHR request that is created. I needed to send XHR request with Cookies. So, I needed to have the option 'withCredentials: true'. There is no good way to do it OTel JS right now and I have created an issue for it:

https://github.com/open-telemetry/opentelemetry-js/issues/4838

Of course, there is a more formal way to enable this feature but I worry that the implementation can be very complex. Being an outsider, I have limited knowledge of the full inner workings of OTel JS. Therefore, I am thinking to add this change as a stop gap measure. Just an FYI, I have a Collector extension that authenticates via Cookies, which is why I need the option 'withCredentials: true'.

I feel that the official solution should be handled by someone more experienced with this project. I don't think I am a good candidate for implementing the official solution.

Fixes # 4838
(Temporary solution)

## Short description of the changes
- Introducing createOtelJsXMLHttpRequest in sendWithXhr
- Add timeouts to some tests. They were failing on my local machine due to timeouts.

## Type of change

- [v] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

I ran the test suite locally to ensure no regression was introduced. All tests are passing right now locally.

I did not add a test as I don't think most people will want to use this feature openly in this current form. However, if the maintainers want me to add it, please let me know where I could add a test for this feature and I am happy to do so.

## Checklist:

- [v] Followed the style guidelines of this project
