### PR TITLE
fix(api-logs): align AnyValue to spec

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :bug: (Bug Fix)
 
 * fix(instrumentation-http): Ensure instrumentation of `http.get` and `https.get` work when used in ESM code [#4857](https://github.com/open-telemetry/opentelemetry-js/issues/4857) @trentm
+* fix(api-logs): align AnyValue to spec [#4893](https://github.com/open-telemetry/opentelemetry-js/pull/4893) @blumamir
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/api-logs/src/types/AnyValue.ts
+++ b/experimental/packages/api-logs/src/types/AnyValue.ts
@@ -14,16 +14,29 @@
  * limitations under the License.
  */
 
-import { AttributeValue } from '@opentelemetry/api';
+export type AnyValueScalar = string | number | boolean;
+
+export type AnyValueArray = Array<AnyValue>;
 
 /**
  * AnyValueMap is a map from string to AnyValue (attribute value or a nested map)
  */
 export interface AnyValueMap {
-  [attributeKey: string]: AnyValue | undefined;
+  [attributeKey: string]: AnyValue;
 }
 
 /**
- * AnyValue is a either an attribute value or a map of AnyValue(s)
+ * AnyValue can be one of the following:
+ * - a scalar value
+ * - a byte array
+ * - array of any value
+ * - map from string to any value
+ * - empty value
  */
-export type AnyValue = AttributeValue | AnyValueMap;
+export type AnyValue =
+  | AnyValueScalar
+  | Uint8Array
+  | AnyValueArray
+  | AnyValueMap
+  | null
+  | undefined;


### PR DESCRIPTION
Following [this PR in contrib](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2352) I noticed that the `AnyValue` type in `@opentelemetry/api-logs` is not accurate, as [the spec defined more allowed types](https://opentelemetry.io/docs/specs/otel/logs/data-model/#type-any). This PR aligns the `AnyValue` type to match the spec:

> Type any
> Value of type any can be one of the following:
> 
> - A scalar value: string, boolean, signed 64 bit integer, or double precision floating point (IEEE 754-1985)
> 
> - A byte array,
> 
> - An array (a list) of any values,
> 
> - A map<string, any>,
> 
> - [since 1.31.0] An empty value (e.g. null).

