### PR TITLE
deps(sdk-metrics): remove unused lodash.merge dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
     * opentelemetry-sdk-trace-web
     * propagator-aws-xray
     * sdk-metrics
- * deps(sdk-metrics): remove unused lodash.merge dependency [#4905](https://github.com/open-telemetry/opentelemetry-js/pull/4905) @pichlermarc
+* deps(sdk-metrics): remove unused lodash.merge dependency [#4905](https://github.com/open-telemetry/opentelemetry-js/pull/4905) @pichlermarc
 
 ## 1.25.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For experimental package changes, see the [experimental CHANGELOG](experimental/
 ### :house: (Internal)
 
 * refactor: Simplify the code for the `getEnv` function [#4799](https://github.com/open-telemetry/opentelemetry-js/pull/4799) @danstarns
+* deps(sdk-metrics): remove unused lodash.merge dependency [#4905](https://github.com/open-telemetry/opentelemetry-js/pull/4905) @pichlermarc
 
 ## 1.25.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9574,21 +9574,6 @@
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==",
-      "dev": true
-    },
-    "node_modules/@types/lodash.merge": {
-      "version": "4.6.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.9.tgz",
-      "integrity": "sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/markdown-it": {
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
@@ -21155,7 +21140,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/lodash.pick": {
       "version": "4.4.0",
@@ -33181,14 +33167,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "lodash.merge": "^4.6.2"
+        "@opentelemetry/resources": "1.25.1"
       },
       "devDependencies": {
         "@babel/core": "7.24.9",
         "@babel/preset-env": "7.24.7",
         "@opentelemetry/api": ">=1.3.0 <1.10.0",
-        "@types/lodash.merge": "4.6.9",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -40242,7 +40226,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0",
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/resources": "1.25.1",
-        "@types/lodash.merge": "4.6.9",
         "@types/mocha": "10.0.7",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -40256,7 +40239,6 @@
         "karma-spec-reporter": "0.0.36",
         "karma-webpack": "5.0.1",
         "lerna": "6.6.2",
-        "lodash.merge": "^4.6.2",
         "mocha": "10.2.0",
         "nyc": "15.1.0",
         "sinon": "15.1.2",
@@ -41769,21 +41751,6 @@
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true
-    },
-    "@types/lodash": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw==",
-      "dev": true
-    },
-    "@types/lodash.merge": {
-      "version": "4.6.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.9.tgz",
-      "integrity": "sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
     },
     "@types/markdown-it": {
       "version": "14.1.1",
@@ -51003,7 +50970,8 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "lodash.pick": {
       "version": "4.4.0",

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -58,7 +58,6 @@
     "@babel/core": "7.24.9",
     "@babel/preset-env": "7.24.7",
     "@opentelemetry/api": ">=1.3.0 <1.10.0",
-    "@types/lodash.merge": "4.6.9",
     "@types/mocha": "10.0.7",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -86,8 +85,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "1.25.1",
-    "@opentelemetry/resources": "1.25.1",
-    "lodash.merge": "^4.6.2"
+    "@opentelemetry/resources": "1.25.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-metrics",
   "sideEffects": false


### PR DESCRIPTION
## Which problem is this PR solving?

See #4834, `@types/lodash` are now not compatible with older typescript versions anymore, which makes it fail with Typescript 4.4.4, which we're using. I investigated why we need this dependency (and `lodash.merge`) and found that it was added some 4 years ago, before the Metrics SDK rewrite (see #1491). 

Since that rewrite, however, we don't use it anymore, so it can be safely removed.

## How Has This Been Tested?

- [x] Existing tests