### PR TITLE
docs(api): add `@since` annotations to all types

### DIFF
--- a/api/src/api/context.ts
+++ b/api/src/api/context.ts
@@ -28,6 +28,8 @@ const NOOP_CONTEXT_MANAGER = new NoopContextManager();
 
 /**
  * Singleton object which represents the entry point to the OpenTelemetry Context API
+ *
+ * @since 1.0.0
  */
 export class ContextAPI {
   private static _instance?: ContextAPI;

--- a/api/src/api/diag.ts
+++ b/api/src/api/diag.ts
@@ -34,6 +34,8 @@ const API_NAME = 'diag';
 /**
  * Singleton object which represents the entry point to the OpenTelemetry internal
  * diagnostic API
+ *
+ * @since 1.0.0
  */
 export class DiagAPI implements DiagLogger, DiagLoggerApi {
   private static _instance?: DiagAPI;

--- a/api/src/api/propagation.ts
+++ b/api/src/api/propagation.ts
@@ -42,6 +42,8 @@ const NOOP_TEXT_MAP_PROPAGATOR = new NoopTextMapPropagator();
 
 /**
  * Singleton object which represents the entry point to the OpenTelemetry Propagation API
+ *
+ * @since 1.0.0
  */
 export class PropagationAPI {
   private static _instance?: PropagationAPI;

--- a/api/src/api/trace.ts
+++ b/api/src/api/trace.ts
@@ -40,6 +40,8 @@ const API_NAME = 'trace';
 
 /**
  * Singleton object which represents the entry point to the OpenTelemetry Tracing API
+ *
+ * @since 1.0.0
  */
 export class TraceAPI {
   private static _instance?: TraceAPI;

--- a/api/src/baggage/types.ts
+++ b/api/src/baggage/types.ts
@@ -32,6 +32,9 @@ import { baggageEntryMetadataSymbol } from './internal/symbol';
  * limitations under the License.
  */
 
+/**
+ * @since 1.0.0
+ */
 export interface BaggageEntry {
   /** `String` value of the `BaggageEntry`. */
   value: string;
@@ -45,6 +48,8 @@ export interface BaggageEntry {
 /**
  * Serializable Metadata defined by the W3C baggage specification.
  * It currently has no special meaning defined by the OpenTelemetry or W3C.
+ *
+ * @since 1.0.0
  */
 export type BaggageEntryMetadata = { toString(): string } & {
   __TYPE__: typeof baggageEntryMetadataSymbol;
@@ -54,6 +59,8 @@ export type BaggageEntryMetadata = { toString(): string } & {
  * Baggage represents collection of key-value pairs with optional metadata.
  * Each key of Baggage is associated with exactly one value.
  * Baggage may be used to annotate and enrich telemetry data.
+ *
+ * @since 1.0.0
  */
 export interface Baggage {
   /**

--- a/api/src/baggage/utils.ts
+++ b/api/src/baggage/utils.ts
@@ -37,6 +37,7 @@ export function createBaggage(
  *
  * @param str string metadata. Format is currently not defined by the spec and has no special meaning.
  *
+ * @since 1.0.0
  */
 export function baggageEntryMetadataFromString(
   str: string

--- a/api/src/common/Attributes.ts
+++ b/api/src/common/Attributes.ts
@@ -18,6 +18,8 @@
  * Attributes is a map from string to attribute values.
  *
  * Note: only the own enumerable keys are counted as valid attribute keys.
+ *
+ * @since 1.3.0
  */
 export interface Attributes {
   [attributeKey: string]: AttributeValue | undefined;
@@ -27,6 +29,8 @@ export interface Attributes {
  * Attribute values may be any non-nullish primitive value except an object.
  *
  * null or undefined attribute values are invalid and will result in undefined behavior.
+ *
+ * @since 1.3.0
  */
 export type AttributeValue =
   | string

--- a/api/src/common/Exception.ts
+++ b/api/src/common/Exception.ts
@@ -39,6 +39,8 @@ interface ExceptionWithName {
  * Defines Exception.
  *
  * string or an object with one of (message or name or code) and optional stack
+ *
+ * @since 1.0.0
  */
 export type Exception =
   | ExceptionWithCode

--- a/api/src/common/Time.ts
+++ b/api/src/common/Time.ts
@@ -24,6 +24,8 @@
  * The second number is calculated by converting the digits after the decimal point of the subtraction, (1609504210150 / 1000) - HrTime[0], to nanoseconds:
  * HrTime[1] = Number((1609504210.150 - HrTime[0]).toFixed(9)) * 1e9 = 150000000.
  * This is represented in HrTime format as [1609504210, 150000000].
+ *
+ * @since 1.0.0
  */
 export type HrTime = [number, number];
 
@@ -31,5 +33,7 @@ export type HrTime = [number, number];
  * Defines TimeInput.
  *
  * hrtime, epoch milliseconds, performance.now() or Date
+ *
+ * @since 1.0.0
  */
 export type TimeInput = HrTime | number | Date;

--- a/api/src/context-api.ts
+++ b/api/src/context-api.ts
@@ -17,5 +17,8 @@
 // Split module-level variable definition into separate files to allow
 // tree-shaking on each api instance.
 import { ContextAPI } from './api/context';
-/** Entrypoint for context API */
+/**
+ * Entrypoint for context API
+ * @since 1.0.0
+ */
 export const context = ContextAPI.getInstance();

--- a/api/src/context/context.ts
+++ b/api/src/context/context.ts
@@ -16,7 +16,11 @@
 
 import { Context } from './types';
 
-/** Get a key to uniquely identify a context value */
+/**
+ * Get a key to uniquely identify a context value
+ *
+ * @since 1.0.0
+ */
 export function createContextKey(description: string) {
   // The specification states that for the same input, multiple calls should
   // return different keys. Due to the nature of the JS dependency management
@@ -81,5 +85,9 @@ class BaseContext implements Context {
   public deleteValue!: (key: symbol) => Context;
 }
 
-/** The root context is used as the default parent context when there is no active context */
+/**
+ * The root context is used as the default parent context when there is no active context
+ *
+ * @since 1.0.0
+ */
 export const ROOT_CONTEXT: Context = new BaseContext();

--- a/api/src/context/types.ts
+++ b/api/src/context/types.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/**
+ * @since 1.0.0
+ */
 export interface Context {
   /**
    * Get a value from the context.
@@ -40,6 +43,9 @@ export interface Context {
   deleteValue(key: symbol): Context;
 }
 
+/**
+ * @since 1.0.0
+ */
 export interface ContextManager {
   /**
    * Get the current active context

--- a/api/src/diag-api.ts
+++ b/api/src/diag-api.ts
@@ -22,5 +22,7 @@ import { DiagAPI } from './api/diag';
  * Defines Diagnostic handler used for internal diagnostic logging operations.
  * The default provides a Noop DiagLogger implementation which may be changed via the
  * diag.setLogger(logger: DiagLogger) function.
+ *
+ * @since 1.0.0
  */
 export const diag = DiagAPI.instance();

--- a/api/src/diag/consoleLogger.ts
+++ b/api/src/diag/consoleLogger.ts
@@ -29,6 +29,8 @@ const consoleMap: { n: keyof DiagLogger; c: ConsoleMapKeys }[] = [
  * A simple Immutable Console based diagnostic logger which will output any messages to the Console.
  * If you want to limit the amount of logging to a specific level or lower use the
  * {@link createLogLevelDiagLogger}
+ *
+ * @since 1.0.0
  */
 export class DiagConsoleLogger implements DiagLogger {
   constructor() {

--- a/api/src/diag/types.ts
+++ b/api/src/diag/types.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/**
+ * @since 1.0.0
+ */
 export type DiagLogFunction = (message: string, ...args: unknown[]) => void;
 
 /**
@@ -23,6 +26,8 @@ export type DiagLogFunction = (message: string, ...args: unknown[]) => void;
  * - a No-Op {@link createNoopDiagLogger}
  * - a {@link DiagLogLevel} filtering wrapper {@link createLogLevelDiagLogger}
  * - a general Console {@link DiagConsoleLogger} version.
+ *
+ * @since 1.0.0
  */
 export interface DiagLogger {
   /** Log an error scenario that was not expected and caused the requested operation to fail. */
@@ -92,11 +97,16 @@ export enum DiagLogLevel {
 
 /**
  * Defines options for ComponentLogger
+ *
+ * @since 1.0.0
  */
 export interface ComponentLoggerOptions {
   namespace: string;
 }
 
+/**
+ * @since 1.4.1
+ */
 export interface DiagLoggerOptions {
   /**
    * The {@link DiagLogLevel} used to filter logs sent to the logger.

--- a/api/src/metrics-api.ts
+++ b/api/src/metrics-api.ts
@@ -17,5 +17,9 @@
 // Split module-level variable definition into separate files to allow
 // tree-shaking on each api instance.
 import { MetricsAPI } from './api/metrics';
-/** Entrypoint for metrics API */
+/**
+ * Entrypoint for metrics API
+ *
+ * @since 1.3.0
+ */
 export const metrics = MetricsAPI.getInstance();

--- a/api/src/metrics/Meter.ts
+++ b/api/src/metrics/Meter.ts
@@ -30,6 +30,8 @@ import {
 
 /**
  * An interface describes additional metadata of a meter.
+ *
+ * @since 1.3.0
  */
 export interface MeterOptions {
   /**
@@ -44,6 +46,8 @@ export interface MeterOptions {
  * {@link Metric}s are used for recording pre-defined aggregation (`Counter`),
  * or raw values (`Histogram`) in which the aggregation and attributes
  * for the exported metric are deferred.
+ *
+ * @since 1.3.0
  */
 export interface Meter {
   /**

--- a/api/src/metrics/MeterProvider.ts
+++ b/api/src/metrics/MeterProvider.ts
@@ -18,6 +18,8 @@ import { Meter, MeterOptions } from './Meter';
 
 /**
  * A registry for creating named {@link Meter}s.
+ *
+ * @since 1.3.0
  */
 export interface MeterProvider {
   /**

--- a/api/src/metrics/Metric.ts
+++ b/api/src/metrics/Metric.ts
@@ -20,6 +20,8 @@ import { BatchObservableResult, ObservableResult } from './ObservableResult';
 
 /**
  * Advisory options influencing aggregation configuration parameters.
+ *
+ * @since 1.7.0
  * @experimental
  */
 export interface MetricAdvice {
@@ -32,6 +34,8 @@ export interface MetricAdvice {
 
 /**
  * Options needed for metric creation
+ *
+ * @since 1.3.0
  */
 export interface MetricOptions {
   /**
@@ -55,11 +59,16 @@ export interface MetricOptions {
   /**
    * The advice influencing aggregation configuration parameters.
    * @experimental
+   * @since 1.7.0
    */
   advice?: MetricAdvice;
 }
 
-/** The Type of value. It describes how the data is reported. */
+/**
+ * The Type of value. It describes how the data is reported.
+ *
+ * @since 1.3.0
+ */
 export enum ValueType {
   INT,
   DOUBLE,
@@ -79,6 +88,8 @@ export enum ValueType {
  *   <li> count the number of checkpoints run. </li>
  *   <li> count the number of 5xx errors. </li>
  * <ol>
+ *
+ * @since 1.3.0
  */
 export interface Counter<
   AttributesTypes extends MetricAttributes = MetricAttributes,
@@ -89,6 +100,9 @@ export interface Counter<
   add(value: number, attributes?: AttributesTypes, context?: Context): void;
 }
 
+/**
+ * @since 1.3.0
+ */
 export interface UpDownCounter<
   AttributesTypes extends MetricAttributes = MetricAttributes,
 > {
@@ -98,6 +112,9 @@ export interface UpDownCounter<
   add(value: number, attributes?: AttributesTypes, context?: Context): void;
 }
 
+/**
+ * @since 1.9.0
+ */
 export interface Gauge<
   AttributesTypes extends MetricAttributes = MetricAttributes,
 > {
@@ -107,6 +124,9 @@ export interface Gauge<
   record(value: number, attributes?: AttributesTypes, context?: Context): void;
 }
 
+/**
+ * @since 1.3.0
+ */
 export interface Histogram<
   AttributesTypes extends MetricAttributes = MetricAttributes,
 > {
@@ -118,16 +138,20 @@ export interface Histogram<
 
 /**
  * @deprecated please use {@link Attributes}
+ * @since 1.3.0
  */
 export type MetricAttributes = Attributes;
 
 /**
  * @deprecated please use {@link AttributeValue}
+ * @since 1.3.0
  */
 export type MetricAttributeValue = AttributeValue;
 
 /**
  * The observable callback for Observable instruments.
+ *
+ * @since 1.3.0
  */
 export type ObservableCallback<
   AttributesTypes extends MetricAttributes = MetricAttributes,
@@ -137,6 +161,8 @@ export type ObservableCallback<
 
 /**
  * The observable callback for a batch of Observable instruments.
+ *
+ * @since 1.3.0
  */
 export type BatchObservableCallback<
   AttributesTypes extends MetricAttributes = MetricAttributes,
@@ -144,6 +170,9 @@ export type BatchObservableCallback<
   observableResult: BatchObservableResult<AttributesTypes>
 ) => void | Promise<void>;
 
+/**
+ * @since 1.3.0
+ */
 export interface Observable<
   AttributesTypes extends MetricAttributes = MetricAttributes,
 > {
@@ -160,12 +189,21 @@ export interface Observable<
   removeCallback(callback: ObservableCallback<AttributesTypes>): void;
 }
 
+/**
+ * @since 1.3.0
+ */
 export type ObservableCounter<
   AttributesTypes extends MetricAttributes = MetricAttributes,
 > = Observable<AttributesTypes>;
+/**
+ * @since 1.3.0
+ */
 export type ObservableUpDownCounter<
   AttributesTypes extends MetricAttributes = MetricAttributes,
 > = Observable<AttributesTypes>;
+/**
+ * @since 1.3.0
+ */
 export type ObservableGauge<
   AttributesTypes extends MetricAttributes = MetricAttributes,
 > = Observable<AttributesTypes>;

--- a/api/src/metrics/NoopMeter.ts
+++ b/api/src/metrics/NoopMeter.ts
@@ -164,6 +164,8 @@ export const NOOP_OBSERVABLE_UP_DOWN_COUNTER_METRIC =
 
 /**
  * Create a no-op Meter
+ *
+ * @since 1.3.0
  */
 export function createNoopMeter(): Meter {
   return NOOP_METER;

--- a/api/src/metrics/ObservableResult.ts
+++ b/api/src/metrics/ObservableResult.ts
@@ -18,6 +18,8 @@ import { MetricAttributes, Observable } from './Metric';
 
 /**
  * Interface that is being used in callback function for Observable Metric.
+ *
+ * @since 1.3.0
  */
 export interface ObservableResult<
   AttributesTypes extends MetricAttributes = MetricAttributes,

--- a/api/src/propagation-api.ts
+++ b/api/src/propagation-api.ts
@@ -17,5 +17,9 @@
 // Split module-level variable definition into separate files to allow
 // tree-shaking on each api instance.
 import { PropagationAPI } from './api/propagation';
-/** Entrypoint for propagation API */
+/**
+ * Entrypoint for propagation API
+ *
+ * @since 1.0.0
+ */
 export const propagation = PropagationAPI.getInstance();

--- a/api/src/propagation/TextMapPropagator.ts
+++ b/api/src/propagation/TextMapPropagator.ts
@@ -26,6 +26,8 @@ import { Context } from '../context/types';
  * (extractor) side is usually an object such as http headers. Propagation is
  * usually implemented via library-specific request interceptors, where the
  * client-side injects values and the server-side extracts them.
+ *
+ * @since 1.0.0
  */
 export interface TextMapPropagator<Carrier = any> {
   /**
@@ -73,7 +75,9 @@ export interface TextMapPropagator<Carrier = any> {
 
 /**
  * A setter is specified by the caller to define a specific method
- * to set key/value pairs on the carrier within a propagator.
+ * to set key/value pairs on the carrier within a propagator
+ *
+ * @since 1.0.0
  */
 export interface TextMapSetter<Carrier = any> {
   /**
@@ -92,6 +96,8 @@ export interface TextMapSetter<Carrier = any> {
 /**
  * A getter is specified by the caller to define a specific method
  * to get the value of a key from a carrier.
+ *
+ * @since 1.0.0
  */
 export interface TextMapGetter<Carrier = any> {
   /**
@@ -110,6 +116,9 @@ export interface TextMapGetter<Carrier = any> {
   get(carrier: Carrier, key: string): undefined | string | string[];
 }
 
+/**
+ * @since 1.0.0
+ */
 export const defaultTextMapGetter: TextMapGetter = {
   get(carrier, key) {
     if (carrier == null) {
@@ -126,6 +135,9 @@ export const defaultTextMapGetter: TextMapGetter = {
   },
 };
 
+/**
+ * @since 1.0.0
+ */
 export const defaultTextMapSetter: TextMapSetter = {
   set(carrier, key, value) {
     if (carrier == null) {

--- a/api/src/trace-api.ts
+++ b/api/src/trace-api.ts
@@ -17,5 +17,10 @@
 // Split module-level variable definition into separate files to allow
 // tree-shaking on each api instance.
 import { TraceAPI } from './api/trace';
-/** Entrypoint for trace API */
+
+/**
+ * Entrypoint for trace API
+ *
+ * @since 1.0.0
+ */
 export const trace = TraceAPI.getInstance();

--- a/api/src/trace/ProxyTracer.ts
+++ b/api/src/trace/ProxyTracer.ts
@@ -25,6 +25,8 @@ const NOOP_TRACER = new NoopTracer();
 
 /**
  * Proxy tracer provided by the proxy tracer provider
+ *
+ * @since 1.0.0
  */
 export class ProxyTracer implements Tracer {
   // When a real implementation is provided, this will be it
@@ -75,6 +77,9 @@ export class ProxyTracer implements Tracer {
   }
 }
 
+/**
+ * @since 1.0.3
+ */
 export interface TracerDelegator {
   getDelegateTracer(
     name: string,

--- a/api/src/trace/ProxyTracerProvider.ts
+++ b/api/src/trace/ProxyTracerProvider.ts
@@ -29,6 +29,8 @@ const NOOP_TRACER_PROVIDER = new NoopTracerProvider();
  *   When a delegate is set, traces are provided from the delegate.
  *   When a delegate is set after tracers have already been provided,
  *   all tracers already provided will use the provided delegate implementation.
+ *
+ * @since 1.0.0
  */
 export class ProxyTracerProvider implements TracerProvider {
   private _delegate?: TracerProvider;

--- a/api/src/trace/Sampler.ts
+++ b/api/src/trace/Sampler.ts
@@ -25,6 +25,8 @@ import { SpanKind } from './span_kind';
  * This interface represent a sampler. Sampling is a mechanism to control the
  * noise and overhead introduced by OpenTelemetry by reducing the number of
  * samples of traces collected and sent to the backend.
+ *
+ * @since 1.0.0
  */
 export interface Sampler {
   /**

--- a/api/src/trace/SamplingResult.ts
+++ b/api/src/trace/SamplingResult.ts
@@ -21,6 +21,8 @@ import { TraceState } from './trace_state';
  * @deprecated use the one declared in @opentelemetry/sdk-trace-base instead.
  * A sampling decision that determines how a {@link Span} will be recorded
  * and collected.
+ *
+ * @since 1.0.0
  */
 export enum SamplingDecision {
   /**
@@ -44,6 +46,8 @@ export enum SamplingDecision {
  * @deprecated use the one declared in @opentelemetry/sdk-trace-base instead.
  * A sampling result contains a decision for a {@link Span} and additional
  * attributes the sampler would like to added to the Span.
+ *
+ * @since 1.0.0
  */
 export interface SamplingResult {
   /**

--- a/api/src/trace/SpanOptions.ts
+++ b/api/src/trace/SpanOptions.ts
@@ -21,6 +21,8 @@ import { SpanKind } from './span_kind';
 
 /**
  * Options needed for span creation
+ *
+ * @since 1.0.0
  */
 export interface SpanOptions {
   /**

--- a/api/src/trace/attributes.ts
+++ b/api/src/trace/attributes.ts
@@ -18,10 +18,12 @@ import { Attributes, AttributeValue } from '../common/Attributes';
 
 /**
  * @deprecated please use {@link Attributes}
+ * @since 1.0.0
  */
 export type SpanAttributes = Attributes;
 
 /**
  * @deprecated please use {@link AttributeValue}
+ * @since 1.0.0
  */
 export type SpanAttributeValue = AttributeValue;

--- a/api/src/trace/internal/utils.ts
+++ b/api/src/trace/internal/utils.ts
@@ -17,6 +17,9 @@
 import { TraceState } from '../trace_state';
 import { TraceStateImpl } from './tracestate-impl';
 
+/**
+ * @since 1.1.0
+ */
 export function createTraceState(rawTraceState?: string): TraceState {
   return new TraceStateImpl(rawTraceState);
 }

--- a/api/src/trace/invalid-span-constants.ts
+++ b/api/src/trace/invalid-span-constants.ts
@@ -17,8 +17,19 @@
 import { SpanContext } from './span_context';
 import { TraceFlags } from './trace_flags';
 
+/**
+ * @since 1.0.0
+ */
 export const INVALID_SPANID = '0000000000000000';
+
+/**
+ * @since 1.0.0
+ */
 export const INVALID_TRACEID = '00000000000000000000000000000000';
+
+/**
+ * @since 1.0.0
+ */
 export const INVALID_SPAN_CONTEXT: SpanContext = {
   traceId: INVALID_TRACEID,
   spanId: INVALID_SPANID,

--- a/api/src/trace/link.ts
+++ b/api/src/trace/link.ts
@@ -31,6 +31,8 @@ import { SpanContext } from './span_context';
  *    However, it is desirable to associate incoming SpanContext to new trace
  *    initiated on service provider side so two traces (from Client and from
  *    Service Provider) can be correlated.
+ *
+ * @since 1.0.0
  */
 export interface Link {
   /** The {@link SpanContext} of a linked span. */

--- a/api/src/trace/span.ts
+++ b/api/src/trace/span.ts
@@ -29,6 +29,8 @@ import { Link } from './link';
  * may have children.
  *
  * Spans are created by the {@link Tracer.startSpan} method.
+ *
+ * @since 1.0.0
  */
 export interface Span {
   /**

--- a/api/src/trace/span_context.ts
+++ b/api/src/trace/span_context.ts
@@ -19,6 +19,8 @@ import { TraceState } from './trace_state';
 /**
  * A SpanContext represents the portion of a {@link Span} which must be
  * serialized and propagated along side of a {@link Baggage}.
+ *
+ * @since 1.0.0
  */
 export interface SpanContext {
   /**

--- a/api/src/trace/span_kind.ts
+++ b/api/src/trace/span_kind.ts
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * @since 1.0.0
+ */
 export enum SpanKind {
   /** Default value. Indicates that the span is used internally. */
   INTERNAL = 0,

--- a/api/src/trace/spancontext-utils.ts
+++ b/api/src/trace/spancontext-utils.ts
@@ -21,10 +21,16 @@ import { SpanContext } from './span_context';
 const VALID_TRACEID_REGEX = /^([0-9a-f]{32})$/i;
 const VALID_SPANID_REGEX = /^[0-9a-f]{16}$/i;
 
+/**
+ * @since 1.0.0
+ */
 export function isValidTraceId(traceId: string): boolean {
   return VALID_TRACEID_REGEX.test(traceId) && traceId !== INVALID_TRACEID;
 }
 
+/**
+ * @since 1.0.0
+ */
 export function isValidSpanId(spanId: string): boolean {
   return VALID_SPANID_REGEX.test(spanId) && spanId !== INVALID_SPANID;
 }
@@ -32,6 +38,8 @@ export function isValidSpanId(spanId: string): boolean {
 /**
  * Returns true if this {@link SpanContext} is valid.
  * @return true if this {@link SpanContext} is valid.
+ *
+ * @since 1.0.0
  */
 export function isSpanContextValid(spanContext: SpanContext): boolean {
   return (

--- a/api/src/trace/status.ts
+++ b/api/src/trace/status.ts
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * @since 1.0.0
+ */
 export interface SpanStatus {
   /** The status code of this message. */
   code: SpanStatusCode;
@@ -22,6 +26,8 @@ export interface SpanStatus {
 
 /**
  * An enumeration of status codes.
+ *
+ * @since 1.0.0
  */
 export enum SpanStatusCode {
   /**

--- a/api/src/trace/trace_flags.ts
+++ b/api/src/trace/trace_flags.ts
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * @since 1.0.0
+ */
 export enum TraceFlags {
   /** Represents no flag set. */
   NONE = 0x0,

--- a/api/src/trace/trace_state.ts
+++ b/api/src/trace/trace_state.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/**
+ * @since 1.0.0
+ */
 export interface TraceState {
   /**
    * Create a new TraceState which inherits from this TraceState and has the

--- a/api/src/trace/tracer.ts
+++ b/api/src/trace/tracer.ts
@@ -20,6 +20,8 @@ import { SpanOptions } from './SpanOptions';
 
 /**
  * Tracer provides an interface for creating {@link Span}s.
+ *
+ * @since 1.0.0
  */
 export interface Tracer {
   /**

--- a/api/src/trace/tracer_options.ts
+++ b/api/src/trace/tracer_options.ts
@@ -16,6 +16,8 @@
 
 /**
  * An interface describes additional metadata of a tracer.
+ *
+ * @since 1.3.0
  */
 export interface TracerOptions {
   /**

--- a/api/src/trace/tracer_provider.ts
+++ b/api/src/trace/tracer_provider.ts
@@ -19,6 +19,8 @@ import { TracerOptions } from './tracer_options';
 
 /**
  * A registry for creating named {@link Tracer}s.
+ *
+ * @since 1.0.0
  */
 export interface TracerProvider {
   /**


### PR DESCRIPTION
## Which problem is this PR solving?

See #4661. It's hard to figure out when a feature was added. When reviewing PRs, I usually have to check when a feature was added to ensure the added feature will work with the current dependency range.

In this PR I annotate each public type with `@since` to indicate when they were introduced.

Updates #4661

## How Has This Been Tested?

- [x] Manually installed each version in a package, updated the package version by version and checked for new exports.
