### PR TITLE
fix(instrumentation): drop diag.debug on InstrumentationBase#init not returning any modules

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to experimental packages in this project will be documented 
 
 * fix(instrumentation-http): Ensure instrumentation of `http.get` and `https.get` work when used in ESM code [#4857](https://github.com/open-telemetry/opentelemetry-js/issues/4857) @trentm
 * fix(api-logs): align AnyValue to spec [#4893](https://github.com/open-telemetry/opentelemetry-js/pull/4893) @blumamir
+* fix(instrumentation): remove diag.debug() message for instrumentations that do not patch modules [#4925](https://github.com/open-telemetry/opentelemetry-js/pull/4925) @trentm
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -66,14 +66,6 @@ export abstract class InstrumentationBase<
 
     this._modules = (modules as InstrumentationModuleDefinition[]) || [];
 
-    if (this._modules.length === 0) {
-      diag.debug(
-        'No modules instrumentation has been defined for ' +
-          `'${this.instrumentationName}@${this.instrumentationVersion}'` +
-          ', nothing will be patched'
-      );
-    }
-
     if (this._config.enabled) {
       this.enable();
     }


### PR DESCRIPTION
Closes: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2237
Refs: #3308

---

Back in #3308 a diag.warn `No modules instrumentation has been defined for {instr}, nothing with be patched` was reduced to being a diag.debug to avoid confusion for users. The aws-lambda instrumentation can reasonably not patching anything.

Another more recent case: instrumentation-undici uses InstrumentationBase but its `init()` doesn't return any modules to patch because it uses diagnostics-channels to do its instrumentation. This is a second example where it is totally reasonable for an instrumentation to not return any modules for patching from `init()`.  Given it is reasonable to do so, I don't think the `diag.debug()` is worth it. Sure, it theoretically might catch a programming error in an instrumentation, but I don't think that merits a diag.debug that can cause user confusion. E.g. in https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2237
