### PR TITLE
fix(instrumentation): ensure .setConfig() results in config.enabled defaulting to true

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(instrumentation): ensure .setConfig() results in config.enabled defaulting to true [#4941](https://github.com/open-telemetry/opentelemetry-js/pull/4941) @trentm
 * fix(instrumentation-http): Ensure instrumentation of `http.get` and `https.get` work when used in ESM code [#4857](https://github.com/open-telemetry/opentelemetry-js/issues/4857) @trentm
 * fix(api-logs): align AnyValue to spec [#4893](https://github.com/open-telemetry/opentelemetry-js/pull/4893) @blumamir
 * fix(instrumentation): remove diag.debug() message for instrumentations that do not patch modules [#4925](https://github.com/open-telemetry/opentelemetry-js/pull/4925) @trentm

--- a/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/instrumentation.ts
@@ -41,7 +41,7 @@ export abstract class InstrumentationAbstract<
   ConfigType extends InstrumentationConfig = InstrumentationConfig,
 > implements Instrumentation<ConfigType>
 {
-  protected _config: ConfigType;
+  protected _config: ConfigType = {} as ConfigType;
 
   private _tracer: Tracer;
   private _meter: Meter;
@@ -53,12 +53,7 @@ export abstract class InstrumentationAbstract<
     public readonly instrumentationVersion: string,
     config: ConfigType
   ) {
-    // copy config first level properties to ensure they are immutable.
-    // nested properties are not copied, thus are mutable from the outside.
-    this._config = {
-      enabled: true,
-      ...config,
-    };
+    this.setConfig(config);
 
     this._diag = diag.createComponentLogger({
       namespace: instrumentationName,
@@ -144,12 +139,15 @@ export abstract class InstrumentationAbstract<
 
   /**
    * Sets InstrumentationConfig to this plugin
-   * @param InstrumentationConfig
+   * @param config
    */
   public setConfig(config: ConfigType): void {
     // copy config first level properties to ensure they are immutable.
     // nested properties are not copied, thus are mutable from the outside.
-    this._config = { ...config };
+    this._config = {
+      enabled: true,
+      ...config,
+    };
   }
 
   /**

--- a/experimental/packages/opentelemetry-instrumentation/test/common/Instrumentation.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation/test/common/Instrumentation.test.ts
@@ -30,9 +30,9 @@ interface TestInstrumentationConfig extends InstrumentationConfig {
   isActive?: boolean;
 }
 
-class TestInstrumentation extends InstrumentationBase {
-  constructor(config: TestInstrumentationConfig & InstrumentationConfig = {}) {
-    super('test', '1.0.0', Object.assign({}, config));
+class TestInstrumentation extends InstrumentationBase<TestInstrumentationConfig> {
+  constructor(config = {}) {
+    super('test', '1.0.0', config);
   }
   override enable() {}
   override disable() {}
@@ -117,7 +117,7 @@ describe('BaseInstrumentation', () => {
   });
 
   describe('getConfig', () => {
-    it('should return instrumentation config', () => {
+    it('should return instrumentation config, "enabled" should be true by default', () => {
       const instrumentation: Instrumentation = new TestInstrumentation({
         isActive: false,
       });
@@ -125,6 +125,7 @@ describe('BaseInstrumentation', () => {
         instrumentation.getConfig() as TestInstrumentationConfig;
       assert.notStrictEqual(configuration, null);
       assert.strictEqual(configuration.isActive, false);
+      assert.strictEqual(configuration.enabled, true);
     });
   });
 
@@ -137,6 +138,18 @@ describe('BaseInstrumentation', () => {
       instrumentation.setConfig(config);
       const configuration =
         instrumentation.getConfig() as TestInstrumentationConfig;
+      assert.strictEqual(configuration.isActive, true);
+    });
+
+    it('should ensure "enabled" defaults to true', () => {
+      const instrumentation: Instrumentation = new TestInstrumentation();
+      const config: TestInstrumentationConfig = {
+        isActive: true,
+      };
+      instrumentation.setConfig(config);
+      const configuration =
+        instrumentation.getConfig() as TestInstrumentationConfig;
+      assert.strictEqual(configuration.enabled, true);
       assert.strictEqual(configuration.isActive, true);
     });
   });


### PR DESCRIPTION
Before this change an instrumentation instance's config, as returned
from .getConfig(), would include {enabled: true} after construction,
`new MyInstrumentation()`; but would not include 'enabled' after
`.setConfig({})`. That inconsistency could cause bugs in usage of
`this.getConfig().enabled`.
