### PR TITLE
feat(core): add seconds converter utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
   * Exported names have changed to `ATTR_{name}` for attributes (e.g. `ATTR_HTTP_REQUEST_METHOD`), `{name}_VALUE_{value}` for enumeration values (e.g. `HTTP_REQUEST_METHOD_VALUE_POST`), and `METRIC_{name}` for metrics. Exported names from previous versions are deprecated.
   * Import `@opentelemetry/semantic-conventions` for *stable* semantic conventions. Import `@opentelemetry/semantic-conventions/incubating` for all semantic conventions, stable and unstable.
   * Note: Semantic conventions are now versioned separately from other stable artifacts, to correspond to the version of semantic conventions they provide. Changes will be in a separate changelog.
+* feat(core): add seconds converter utility
 
 ### :bug: (Bug Fix)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
   * Exported names have changed to `ATTR_{name}` for attributes (e.g. `ATTR_HTTP_REQUEST_METHOD`), `{name}_VALUE_{value}` for enumeration values (e.g. `HTTP_REQUEST_METHOD_VALUE_POST`), and `METRIC_{name}` for metrics. Exported names from previous versions are deprecated.
   * Import `@opentelemetry/semantic-conventions` for *stable* semantic conventions. Import `@opentelemetry/semantic-conventions/incubating` for all semantic conventions, stable and unstable.
   * Note: Semantic conventions are now versioned separately from other stable artifacts, to correspond to the version of semantic conventions they provide. Changes will be in a separate changelog.
-* feat(core): add seconds converter utility
+* feat(core): add seconds converter utility [#4945](https://github.com/open-telemetry/opentelemetry-js/pull/4945) @ZY-Ang 
 
 ### :bug: (Bug Fix)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
   * Exported names have changed to `ATTR_{name}` for attributes (e.g. `ATTR_HTTP_REQUEST_METHOD`), `{name}_VALUE_{value}` for enumeration values (e.g. `HTTP_REQUEST_METHOD_VALUE_POST`), and `METRIC_{name}` for metrics. Exported names from previous versions are deprecated.
   * Import `@opentelemetry/semantic-conventions` for *stable* semantic conventions. Import `@opentelemetry/semantic-conventions/incubating` for all semantic conventions, stable and unstable.
   * Note: Semantic conventions are now versioned separately from other stable artifacts, to correspond to the version of semantic conventions they provide. Changes will be in a separate changelog.
-* feat(core): add seconds converter utility [#4945](https://github.com/open-telemetry/opentelemetry-js/pull/4945) @ZY-Ang 
+* feat(core): add seconds converter utility [#4945](https://github.com/open-telemetry/opentelemetry-js/pull/4945) @ZY-Ang
 
 ### :bug: (Bug Fix)
 

--- a/packages/opentelemetry-core/src/common/time.ts
+++ b/packages/opentelemetry-core/src/common/time.ts
@@ -141,6 +141,14 @@ export function hrTimeToMicroseconds(time: api.HrTime): number {
 }
 
 /**
+ * Convert hrTime to seconds.
+ * @param time
+ */
+export function hrTimeToSeconds(time: api.HrTime): number {
+  return time[0] + time[1] / SECOND_TO_NANOSECONDS;
+}
+
+/**
  * check if time is HrTime
  * @param value
  */

--- a/packages/opentelemetry-core/test/common/time.test.ts
+++ b/packages/opentelemetry-core/test/common/time.test.ts
@@ -25,6 +25,7 @@ import {
   hrTimeToNanoseconds,
   hrTimeToMilliseconds,
   hrTimeToMicroseconds,
+  hrTimeToSeconds,
   hrTimeToTimeStamp,
   isTimeInput,
   addHrTimes,
@@ -197,6 +198,14 @@ describe('time', () => {
       assert.deepStrictEqual(output, 1200000);
     });
   });
+
+  describe('#hrTimeToSeconds', () => {
+    it('should return seconds', () => {
+      const output = hrTimeToSeconds([1, 200000000]);
+      assert.deepStrictEqual(output, 1.2);
+    });
+  });
+
   describe('#isTimeInput', () => {
     it('should return true for a number', () => {
       assert.strictEqual(isTimeInput(12), true);


### PR DESCRIPTION
## Which problem is this PR solving?

`api.HrTime` has no utility to convert to float seconds for `http.server.request.duration` and `http.client.request.duration` semantic conventions.

## Short description of the changes

Minor addition of a utility for another PR that uses that utility. Simply converts `api.HrTime` to seconds.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] #hrTimeToSeconds unit test

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated