### PR TITLE
chore: sync package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2045,6 +2045,9 @@
       "dependencies": {
         "@opentelemetry/api-logs": "0.52.1",
         "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.52.1",
+        "@opentelemetry/exporter-logs-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
@@ -31229,33 +31232,6 @@
         }
       }
     },
-    "packages/semantic-conventions": {
-      "name": "@opentelemetry/semantic-conventions",
-      "version": "1.25.1",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "devDependencies": {
-        "@size-limit/file": "^11.0.1",
-        "@size-limit/time": "^11.0.1",
-        "@size-limit/webpack": "^11.0.1",
-        "@types/mocha": "10.0.7",
-        "@types/node": "18.6.5",
-        "@types/sinon": "17.0.3",
-        "codecov": "3.8.3",
-        "cross-var": "1.1.0",
-        "lerna": "6.6.2",
-        "mocha": "10.7.3",
-        "nock": "13.3.8",
-        "nyc": "15.1.0",
-        "sinon": "15.1.2",
-        "size-limit": "^11.0.1",
-        "ts-node": "10.9.2",
-        "typescript": "4.4.4"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "packages/template": {
       "name": "@opentelemetry/template",
       "version": "1.25.1",
@@ -36903,6 +36879,9 @@
         "@opentelemetry/context-async-hooks": "1.25.1",
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/exporter-jaeger": "1.25.1",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.52.1",
+        "@opentelemetry/exporter-logs-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
         "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",


### PR DESCRIPTION
- `package-lock.json` still had `packages/semantic-conventions` listed, even though the package was moved to `semantic-conventions/` in #4904, this PR removes that entry
- `@opentelemetry/sdk-node`'s entry did not have the newly added exporter dependencies from #4740