### PR TITLE
test(exporter-logs-otlp-grpc): improve error reporting in particular test failure

### DIFF
--- a/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
@@ -109,12 +109,17 @@ const testCollectorExporter = (params: TestParams) => {
           server.bindAsync(
             serverAddr.protocol === 'https:' ? serverAddr.host : address,
             credentials,
-            () => {
-              server.start();
-              done();
+            err => {
+              if (err) {
+                done(err);
+              } else {
+                server.start();
+                done();
+              }
             }
           );
-        });
+        })
+        .catch(done);
     });
 
     after(() => {


### PR DESCRIPTION
Exporter tests are currently failing with the very recent Node.js 22.7.0. We believe the failures are due to a Node 22.x regression for which there is an issue/PR/discussion.
This PR is about improving the test failure to be more helpful.

Before this change the test failure output was:

```
% cd experimental/packages/exporter-logs-otlp-grpc
% npm test
...
  1) OTLPLogExporter - node with TLS, without metadata, target https://localhost:1503
       "before all" hook for "test certs are valid":
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/trentm/tm/opentelemetry-js4/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts)
      at listOnTimeout (node:internal/timers:594:17)
      at processTimers (node:internal/timers:529:7)

  2) OTLPLogExporter - node without TLS, without metadata, target https://localhost:1503
       "before all" hook in "OTLPLogExporter - node without TLS, without metadata, target https://localhost:1503":
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/trentm/tm/opentelemetry-js4/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts)
      at listOnTimeout (node:internal/timers:594:17)
      at processTimers (node:internal/timers:529:7)

  3) OTLPLogExporter - node without TLS, with metadata, target https://localhost:1503
       "before all" hook in "OTLPLogExporter - node without TLS, with metadata, target https://localhost:1503":
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/trentm/tm/opentelemetry-js4/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts)
      at listOnTimeout (node:internal/timers:594:17)
      at processTimers (node:internal/timers:529:7)

  4) OTLPLogExporter - node without TLS, without metadata, target unix:///tmp/otlp-logs.sock
       "before all" hook in "OTLPLogExporter - node without TLS, without metadata, target unix:///tmp/otlp-logs.sock":
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/trentm/tm/opentelemetry-js4/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts)
      at listOnTimeout (node:internal/timers:594:17)
      at processTimers (node:internal/timers:529:7)
```

After:

```
...
  1) OTLPLogExporter - node with TLS, without metadata, target https://localhost:1503
       "before all" hook for "test certs are valid":
     RangeError: "length" is outside of buffer bounds
      at Buffer.proto.utf8Write (node:internal/buffer:1066:13)
      at Op.writeStringBuffer [as fn] (/Users/trentm/tm/opentelemetry-js4/node_modules/protobufjs/src/writer_buffer.js:61:13)
      at BufferWriter.finish (/Users/trentm/tm/opentelemetry-js4/node_modules/protobufjs/src/writer.js:453:14)
      at /Users/trentm/tm/opentelemetry-js4/node_modules/@grpc/proto-loader/src/index.ts:382:62
      at Array.map (<anonymous>)
      at createPackageDefinition (/Users/trentm/tm/opentelemetry-js4/node_modules/@grpc/proto-loader/src/index.ts:381:47)
      at /Users/trentm/tm/opentelemetry-js4/node_modules/@grpc/proto-loader/src/index.ts:434:12

  2) OTLPLogExporter - node without TLS, without metadata, target https://localhost:1503
       "before all" hook in "OTLPLogExporter - node without TLS, without metadata, target https://localhost:1503":
     RangeError: "length" is outside of buffer bounds
      at Buffer.proto.utf8Write (node:internal/buffer:1066:13)
      at Op.writeStringBuffer [as fn] (/Users/trentm/tm/opentelemetry-js4/node_modules/protobufjs/src/writer_buffer.js:61:13)
...
```

I.e. the underlying error is no longer masked.