### PR TITLE
chore: pin unit test to node 22.6 until 22.8 is available

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,7 +16,7 @@ jobs:
           - "16"
           - "18"
           - "20"
-          - "22"
+          - "22.6" # temp until 22.8 is released (bug in 22.7)
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_UNSAFE_PERM: true


### PR DESCRIPTION
## Which problem is this PR solving?

Failing tests on grpc exporters for latest Node 22

## Short description of the changes

There is a bug in node.js v22.7 with buffers that is causing grpc exporters to fail. Fix should be available in 22.8, pinning to 22.6 for now to keep development and releases moving.
