### PR TITLE
chore(deps): update dependency webpack to v5.94.0

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -104,7 +104,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "unionfs": "4.5.4",
-    "webpack": "5.89.0"
+    "webpack": "5.94.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/api",
   "sideEffects": false

--- a/api/test/tree-shaking/tree-shaking.test.ts
+++ b/api/test/tree-shaking/tree-shaking.test.ts
@@ -88,9 +88,10 @@ describe('tree-shaking', () => {
       const fs = new Union();
       fs.use(mfs as any).use(realFs);
 
-      //direct webpack to use unionfs for file input
-      compiler.inputFileSystem = fs;
-      //direct webpack to output to memoryfs rather than to disk
+      // direct webpack to use unionfs for file input
+      // needs workaround from https://github.com/webpack/webpack/issues/18242#issuecomment-2018116985 since webpack 5.91.0
+      compiler.inputFileSystem = fs as any as typeof compiler.inputFileSystem;
+      // direct webpack to output to memoryfs rather than to disk
       compiler.outputFileSystem = {
         ...mfs,
         join: path.join,

--- a/experimental/packages/api-events/package.json
+++ b/experimental/packages/api-events/package.json
@@ -83,7 +83,7 @@
     "nyc": "15.1.0",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0"
+    "webpack": "5.94.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/api-events",
   "sideEffects": false

--- a/experimental/packages/api-logs/package.json
+++ b/experimental/packages/api-logs/package.json
@@ -82,7 +82,7 @@
     "nyc": "15.1.0",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0"
+    "webpack": "5.94.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/api-logs",
   "sideEffects": false

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -96,7 +96,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -85,7 +85,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -87,7 +87,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -84,7 +84,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -75,7 +75,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -87,7 +87,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -81,7 +81,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -81,7 +81,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -109,7 +109,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -87,7 +87,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -80,7 +80,7 @@
     "protobufjs-cli": "1.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0"
+    "webpack": "5.94.0"
   },
   "dependencies": {
     "@opentelemetry/api-logs": "0.53.0",

--- a/experimental/packages/sdk-events/package.json
+++ b/experimental/packages/sdk-events/package.json
@@ -92,7 +92,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -95,7 +95,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,58 +85,10 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "unionfs": "4.5.4",
-        "webpack": "5.89.0"
+        "webpack": "5.94.0"
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "api/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "examples/esm-http-ts": {
@@ -403,58 +355,10 @@
         "nyc": "15.1.0",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
+        "webpack": "5.94.0"
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "experimental/packages/api-events/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "experimental/packages/api-logs": {
@@ -482,58 +386,10 @@
         "nyc": "15.1.0",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
+        "webpack": "5.94.0"
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "experimental/packages/api-logs/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "experimental/packages/exporter-logs-otlp-grpc": {
@@ -608,7 +464,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -617,54 +473,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "experimental/packages/exporter-logs-otlp-http/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "experimental/packages/exporter-logs-otlp-proto": {
@@ -702,7 +510,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -711,54 +519,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "experimental/packages/exporter-logs-otlp-proto/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "experimental/packages/exporter-trace-otlp-grpc": {
@@ -831,7 +591,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -840,54 +600,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "experimental/packages/exporter-trace-otlp-http/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "experimental/packages/exporter-trace-otlp-proto": {
@@ -923,7 +635,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -932,54 +644,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "experimental/packages/exporter-trace-otlp-proto/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "experimental/packages/opentelemetry-browser-detector": {
@@ -1011,7 +675,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -1020,54 +684,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "experimental/packages/opentelemetry-browser-detector/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc": {
@@ -1141,7 +757,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -1150,54 +766,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "experimental/packages/opentelemetry-exporter-metrics-otlp-http/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-proto": {
@@ -1302,7 +870,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -1350,7 +918,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -1359,54 +927,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "experimental/packages/opentelemetry-instrumentation-fetch/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "experimental/packages/opentelemetry-instrumentation-grpc": {
@@ -1540,7 +1060,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -1549,102 +1069,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "experimental/packages/opentelemetry-instrumentation-xml-http-request/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "experimental/packages/opentelemetry-instrumentation/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "experimental/packages/opentelemetry-sdk-node": {
@@ -1724,7 +1148,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -1733,54 +1157,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "experimental/packages/otlp-exporter-base/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "experimental/packages/otlp-grpc-exporter-base": {
@@ -1848,61 +1224,13 @@
         "protobufjs-cli": "1.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
+        "webpack": "5.94.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "experimental/packages/otlp-transformer/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "experimental/packages/propagator-aws-xray-lambda": {
@@ -2512,7 +1840,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -2560,54 +1888,6 @@
         "@types/sinonjs__fake-timers": "*"
       }
     },
-    "experimental/packages/sdk-events/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
     "experimental/packages/sdk-logs": {
       "name": "@opentelemetry/sdk-logs",
       "version": "0.53.0",
@@ -2641,7 +1921,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -2717,54 +1997,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "experimental/packages/sdk-logs/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "experimental/packages/shim-opencensus": {
@@ -7964,19 +7196,11 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
       "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -8871,16 +8095,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/acorn-import-attributes": {
@@ -29128,12 +28342,11 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.93.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
-      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
+      "version": "5.94.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
       "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
@@ -29142,7 +28355,7 @@
         "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -30298,7 +29511,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "zone.js": "0.13.3"
       },
@@ -30308,54 +29521,6 @@
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "zone.js": "^0.10.2 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
-      }
-    },
-    "packages/opentelemetry-context-zone-peer-dep/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "packages/opentelemetry-context-zone-peer-dep/node_modules/zone.js": {
@@ -30396,61 +29561,13 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
+        "webpack": "5.94.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "packages/opentelemetry-core/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "packages/opentelemetry-exporter-jaeger": {
@@ -30520,7 +29637,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -30529,54 +29646,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "packages/opentelemetry-exporter-zipkin/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "packages/opentelemetry-propagator-b3": {
@@ -30633,61 +29702,13 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
+        "webpack": "5.94.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "packages/opentelemetry-propagator-jaeger/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "packages/opentelemetry-resources": {
@@ -30720,7 +29741,7 @@
         "nyc": "15.1.0",
         "sinon": "15.1.2",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -30785,54 +29806,6 @@
         "node": ">=14"
       }
     },
-    "packages/opentelemetry-resources/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
     "packages/opentelemetry-sdk-trace-base": {
       "name": "@opentelemetry/sdk-trace-base",
       "version": "1.26.0",
@@ -30864,61 +29837,13 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
+        "webpack": "5.94.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "packages/opentelemetry-sdk-trace-base/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "packages/opentelemetry-sdk-trace-node": {
@@ -30995,7 +29920,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -31004,54 +29929,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "packages/opentelemetry-sdk-trace-web/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "packages/opentelemetry-shim-opentracing": {
@@ -31110,61 +29987,13 @@
         "nyc": "15.1.0",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
+        "webpack": "5.94.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "packages/propagator-aws-xray/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "packages/sdk-metrics": {
@@ -31197,7 +30026,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -31206,54 +30035,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
-      }
-    },
-    "packages/sdk-metrics/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
       }
     },
     "packages/template": {
@@ -31304,7 +30085,7 @@
         "nightwatch": "3.0.1",
         "selenium-server": "3.141.59",
         "terser-webpack-plugin": "4.2.3",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-dev-server": "4.5.0",
         "webpack-merge": "5.10.0"
@@ -31661,54 +30442,6 @@
         "imurmurhash": "^0.1.4"
       }
     },
-    "selenium-tests/node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
-        "@webassemblyjs/ast": "^1.11.5",
-        "@webassemblyjs/wasm-edit": "^1.11.5",
-        "@webassemblyjs/wasm-parser": "^1.11.5",
-        "acorn": "^8.7.1",
-        "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.15.0",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.9",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^3.2.0",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
-        "watchpack": "^2.4.0",
-        "webpack-sources": "^3.2.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
     "selenium-tests/node_modules/webpack-dev-server": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.5.0.tgz",
@@ -31753,82 +30486,6 @@
       },
       "peerDependenciesMeta": {
         "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "selenium-tests/node_modules/webpack/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "selenium-tests/node_modules/webpack/node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
-    "selenium-tests/node_modules/webpack/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "selenium-tests/node_modules/webpack/node_modules/terser-webpack-plugin": {
-      "version": "5.3.10",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
-      "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.20",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.1",
-        "terser": "^5.26.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "uglify-js": {
           "optional": true
         }
       }
@@ -34858,41 +33515,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "unionfs": "4.5.4",
-        "webpack": "5.89.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
+        "webpack": "5.94.0"
       }
     },
     "@opentelemetry/api-events": {
@@ -34917,41 +33540,7 @@
         "nyc": "15.1.0",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
+        "webpack": "5.94.0"
       }
     },
     "@opentelemetry/api-logs": {
@@ -34975,41 +33564,7 @@
         "nyc": "15.1.0",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
+        "webpack": "5.94.0"
       }
     },
     "@opentelemetry/context-async-hooks": {
@@ -35063,43 +33618,11 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "zone.js": "0.13.3"
       },
       "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        },
         "zone.js": {
           "version": "0.13.3",
           "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.13.3.tgz",
@@ -35135,41 +33658,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
+        "webpack": "5.94.0"
       }
     },
     "@opentelemetry/exporter-jaeger": {
@@ -35252,43 +33741,9 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@opentelemetry/exporter-logs-otlp-proto": {
@@ -35322,43 +33777,9 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@opentelemetry/exporter-metrics-otlp-grpc": {
@@ -35418,43 +33839,9 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@opentelemetry/exporter-metrics-otlp-proto": {
@@ -35556,43 +33943,9 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@opentelemetry/exporter-trace-otlp-proto": {
@@ -35624,43 +33977,9 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@opentelemetry/exporter-zipkin": {
@@ -35694,43 +34013,9 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation": {
@@ -35768,43 +34053,9 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-fetch": {
@@ -35840,43 +34091,9 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-grpc": {
@@ -35987,43 +34204,9 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@opentelemetry/integration-tests-api": {
@@ -36065,43 +34248,9 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@opentelemetry/otlp-exporter-base": {
@@ -36130,43 +34279,9 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@opentelemetry/otlp-grpc-exporter-base": {
@@ -36220,41 +34335,7 @@
         "protobufjs-cli": "1.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
+        "webpack": "5.94.0"
       }
     },
     "@opentelemetry/propagator-aws-xray": {
@@ -36279,41 +34360,7 @@
         "nyc": "15.1.0",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
+        "webpack": "5.94.0"
       }
     },
     "@opentelemetry/propagator-aws-xray-lambda": {
@@ -36378,41 +34425,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
+        "webpack": "5.94.0"
       }
     },
     "@opentelemetry/resources": {
@@ -36441,7 +34454,7 @@
         "nyc": "15.1.0",
         "sinon": "15.1.2",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -36477,38 +34490,6 @@
               "integrity": "sha512-po7penSfQ/Z8352lRVDpaBrd9znwA5mHGqXR7nDEiVnxkDFkBIhVf/tKeAJDIq/erFpcRowKFeCsr5eqqcSyFQ==",
               "dev": true
             }
-          }
-        },
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
           }
         }
       }
@@ -36888,7 +34869,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -36919,38 +34900,6 @@
           "dev": true,
           "requires": {
             "@types/sinonjs__fake-timers": "*"
-          }
-        },
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
           }
         }
       }
@@ -36983,7 +34932,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
       },
@@ -37029,38 +34978,6 @@
           "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.0.tgz",
           "integrity": "sha512-po7penSfQ/Z8352lRVDpaBrd9znwA5mHGqXR7nDEiVnxkDFkBIhVf/tKeAJDIq/erFpcRowKFeCsr5eqqcSyFQ==",
           "dev": true
-        },
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
         }
       }
     },
@@ -37090,43 +35007,9 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@opentelemetry/sdk-node": {
@@ -37193,41 +35076,7 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
+        "webpack": "5.94.0"
       }
     },
     "@opentelemetry/sdk-trace-node": {
@@ -37290,43 +35139,9 @@
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-merge": "5.10.0"
-      },
-      "dependencies": {
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          }
-        }
       }
     },
     "@opentelemetry/selenium-tests": {
@@ -37358,7 +35173,7 @@
         "nightwatch": "3.0.1",
         "selenium-server": "3.141.59",
         "terser-webpack-plugin": "4.2.3",
-        "webpack": "5.89.0",
+        "webpack": "5.94.0",
         "webpack-cli": "5.1.4",
         "webpack-dev-server": "4.5.0",
         "webpack-merge": "5.10.0",
@@ -37604,82 +35419,6 @@
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
-          }
-        },
-        "webpack": {
-          "version": "5.89.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-          "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-          "dev": true,
-          "requires": {
-            "@types/eslint-scope": "^3.7.3",
-            "@types/estree": "^1.0.0",
-            "@webassemblyjs/ast": "^1.11.5",
-            "@webassemblyjs/wasm-edit": "^1.11.5",
-            "@webassemblyjs/wasm-parser": "^1.11.5",
-            "acorn": "^8.7.1",
-            "acorn-import-assertions": "^1.9.0",
-            "browserslist": "^4.14.5",
-            "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.15.0",
-            "es-module-lexer": "^1.2.1",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.9",
-            "json-parse-even-better-errors": "^2.3.1",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.2.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.3.7",
-            "watchpack": "^2.4.0",
-            "webpack-sources": "^3.2.3"
-          },
-          "dependencies": {
-            "jest-worker": {
-              "version": "27.5.1",
-              "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-              "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-              "dev": true,
-              "requires": {
-                "@types/node": "*",
-                "merge-stream": "^2.0.0",
-                "supports-color": "^8.0.0"
-              }
-            },
-            "serialize-javascript": {
-              "version": "6.0.2",
-              "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-              "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-              "dev": true,
-              "requires": {
-                "randombytes": "^2.1.0"
-              }
-            },
-            "supports-color": {
-              "version": "8.1.1",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-              "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            },
-            "terser-webpack-plugin": {
-              "version": "5.3.10",
-              "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
-              "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
-              "dev": true,
-              "requires": {
-                "@jridgewell/trace-mapping": "^0.3.20",
-                "jest-worker": "^27.4.5",
-                "schema-utils": "^3.1.1",
-                "serialize-javascript": "^6.0.1",
-                "terser": "^5.26.0"
-              }
-            }
           }
         },
         "webpack-dev-server": {
@@ -38332,19 +36071,11 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.0.tgz",
       "integrity": "sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
-      }
-    },
-    "@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "requires": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
       }
     },
     "@types/estree": {
@@ -39065,13 +36796,6 @@
           "dev": true
         }
       }
-    },
-    "acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-      "dev": true,
-      "requires": {}
     },
     "acorn-import-attributes": {
       "version": "1.9.5",
@@ -54575,12 +52299,11 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.93.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
-      "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
+      "version": "5.94.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
       "requires": {
-        "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
         "@webassemblyjs/wasm-edit": "^1.12.1",
@@ -54589,7 +52312,7 @@
         "acorn-import-attributes": "^1.9.5",
         "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.0",
+        "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -78,7 +78,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "zone.js": "0.13.3"
   },

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -85,7 +85,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0"
+    "webpack": "5.94.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0"

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -85,7 +85,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -75,7 +75,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0"
+    "webpack": "5.94.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0"

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -87,7 +87,7 @@
     "nyc": "15.1.0",
     "sinon": "15.1.2",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -87,7 +87,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0"
+    "webpack": "5.94.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0"

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -85,7 +85,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/packages/propagator-aws-xray/package.json
+++ b/packages/propagator-aws-xray/package.json
@@ -76,7 +76,7 @@
     "nyc": "15.1.0",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0"
+    "webpack": "5.94.0"
   },
   "dependencies": {
     "@opentelemetry/core": "1.26.0"

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -76,7 +76,7 @@
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
   },

--- a/selenium-tests/package.json
+++ b/selenium-tests/package.json
@@ -48,7 +48,7 @@
     "nightwatch": "3.0.1",
     "selenium-server": "3.141.59",
     "terser-webpack-plugin": "4.2.3",
-    "webpack": "5.89.0",
+    "webpack": "5.94.0",
     "webpack-cli": "5.1.4",
     "webpack-dev-server": "4.5.0",
     "webpack-merge": "5.10.0"


### PR DESCRIPTION
Supersedes #4958 . 

Types are incorrect not only on `memfs` but also `unionfs`. The additional commit https://github.com/open-telemetry/opentelemetry-js/pull/4961/commits/b4c9a968b6786f0fb72c22a7bfb24b2b9997da11 applies the workaround from https://github.com/webpack/webpack/issues/18242#issuecomment-2018116985