### PR TITLE
fix(instrumentation-fetch)! Remove HTTP prefix in span name.

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to experimental packages in this project will be documented 
 ## Unreleased
 
 ### :boom: Breaking Change
-* fix(instrumentation-fetch)! Remove HTTP prefix in span name.
+
+* fix(instrumentation-fetch)! Remove HTTP prefix in span name. [#4962](https://github.com/open-telemetry/opentelemetry-js/pull/4962) @wolfgangcodes
 
 ### :rocket: (Enhancement)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to experimental packages in this project will be documented 
 ## Unreleased
 
 ### :boom: Breaking Change
+* fix(instrumentation-fetch)! Remove HTTP prefix in span name.
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -206,7 +206,7 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
       return;
     }
     const method = (options.method || 'GET').toUpperCase();
-    const spanName = `HTTP ${method}`;
+    const spanName = `${method}`;
     return this.tracer.startSpan(spanName, {
       kind: api.SpanKind.CLIENT,
       attributes: {

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -362,7 +362,7 @@ describe('fetch', () => {
 
     it('span should have correct name', () => {
       const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
-      assert.strictEqual(span.name, 'HTTP GET', 'span has wrong name');
+      assert.strictEqual(span.name, 'GET', 'span has wrong name');
     });
 
     it('span should have correct kind', () => {
@@ -932,7 +932,7 @@ describe('fetch', () => {
       );
       assert.strictEqual(
         exportSpy.args[0][0][0].name,
-        'HTTP GET',
+        'GET',
         'wrong span captured'
       );
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Remove HTTP prefix in span name to match [HTTP semantic conventions 1.18](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.18.0/specification/trace/semantic_conventions/http.md#name).

Similar to #3603 and #3672

## Short description of the changes
Remove HTTP on span name. 
## Type of change

Please delete options that are not relevant.
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Updated existing unit tests in `experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts`

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been added
- [ ] Documentation has been updated
