### PR TITLE
fix(jaeger-remote-sampler): Catch errors retrieving remote config

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(sampler-jaeger-remote): fixes an issue where package could emit unhandled promise rejections @Just-Sieb
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/sampler-jaeger-remote/src/JaegerRemoteSampler.ts
+++ b/experimental/packages/sampler-jaeger-remote/src/JaegerRemoteSampler.ts
@@ -58,6 +58,8 @@ export class JaegerRemoteSampler implements Sampler {
       this._syncingConfig = true;
       try {
         await this.getAndUpdateSampler();
+      } catch (err) {
+        diag.warn('Could not update sampler', err);
       } finally {
         this._syncingConfig = false;
       }

--- a/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
+++ b/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
@@ -80,12 +80,27 @@ describe('JaegerRemoteSampler', () => {
       );
       new JaegerRemoteSampler({
         endpoint,
+        poolingInterval,
+        serviceName,
+        initialSampler: alwaysOnSampler,
+      });
+      await clock.tickAsync(poolingInterval * 2);
+      sinon.assert.callCount(getAndUpdateSamplerStub, 1);
+    });
+
+    it('Doesnt throw unhandled promise rejection when failing to get remote config', async () => {
+      getAndUpdateSamplerStub.rejects();
+      const unhandledRejectionListener = sinon.fake();
+      process.once('unhandledRejection', unhandledRejectionListener);
+      new JaegerRemoteSampler({
+        endpoint,
         serviceName,
         poolingInterval,
         initialSampler: alwaysOnSampler,
       });
       await clock.tickAsync(poolingInterval * 2);
-      sinon.assert.callCount(getAndUpdateSamplerStub, 1);
+      sinon.assert.callCount(getAndUpdateSamplerStub, 2);
+      sinon.assert.callCount(unhandledRejectionListener, 0);
     });
   });
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

We need to catch errors otherwise this code throws unhandled promise rejections. These rejections can cause node processes to exit. Just using a try finally block does not suffice for catching these errors.

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I created the test first to verify it fails. Then I added the catch statement to see that it now passes.

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been added
- [X] Documentation has been updated
