### PR TITLE
chore: unpin unit-test from 22.6

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -16,7 +16,7 @@ jobs:
           - "16"
           - "18"
           - "20"
-          - "22.6" # temp until 22.8 is released (bug in 22.7)
+          - "22"
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_UNSAFE_PERM: true


### PR DESCRIPTION
Now that Node.js 22.8 is available with a workaround
(https://github.com/nodejs/node/pull/54565) for the bug in 22.7 that
caused 'RangeError: "length" is outside of buffer bounds' errors in
exporter tests (see https://github.com/open-telemetry/opentelemetry-js/pull/4953),
we can unpin the Node.js v22 used for unit tests.
This undoes the pinning from #4957.
