### PR TITLE
fix: default compression to 'none'

### DIFF
--- a/experimental/packages/otlp-grpc-exporter-base/src/util.ts
+++ b/experimental/packages/otlp-grpc-exporter-base/src/util.ts
@@ -160,7 +160,8 @@ export function configureCompression(
 
   const envCompression =
     getEnv().OTEL_EXPORTER_OTLP_TRACES_COMPRESSION ||
-    getEnv().OTEL_EXPORTER_OTLP_COMPRESSION;
+    getEnv().OTEL_EXPORTER_OTLP_COMPRESSION ||
+    'none';
 
   if (envCompression === 'gzip') {
     return CompressionAlgorithm.GZIP;


### PR DESCRIPTION
## Which problem is this PR solving?

[env defaults](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-core/src/utils/environment.ts#L221-L222) of `''` lead to warning log `Unknown compression "", falling back to "none".`

## Short description of the changes

if the compression lookup produces a falsy value, it get's defaulted with `none`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

manually

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
