### PR TITLE
refactor(browser-detector): replace `ResourceAtrributes` with `Attributes`

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to experimental packages in this project will be documented 
 
 * refactor(exporter-prometheus): replace `MetricAttributes` and `MetricAttributeValues` with `Attributes` and `AttributeValues` [#4993](https://github.com/open-telemetry/opentelemetry-js/pull/4993)
 
+* refactor(browser-detector): replace `ResourceAttributes` with `Attributes` [#5004](https://github.com/open-telemetry/opentelemetry-js/pull/5004)
+
 ## 0.53.0
 
 ### :boom: Breaking Change

--- a/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
+++ b/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-import { diag } from '@opentelemetry/api';
+import { Attributes, diag } from '@opentelemetry/api';
 import {
   Detector,
   IResource,
   Resource,
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
-import { ResourceAttributes } from '@opentelemetry/resources';
 import { BROWSER_ATTRIBUTES, UserAgentData } from './types';
 
 /**
@@ -33,7 +32,7 @@ class BrowserDetector implements Detector {
     if (!isBrowser) {
       return Resource.empty();
     }
-    const browserResource: ResourceAttributes = getBrowserAttributes();
+    const browserResource: Attributes = getBrowserAttributes();
     return this._getResourceAttributes(browserResource, config);
   }
   /**
@@ -44,7 +43,7 @@ class BrowserDetector implements Detector {
    * @returns The sanitized resource attributes.
    */
   private _getResourceAttributes(
-    browserResource: ResourceAttributes,
+    browserResource: Attributes,
     _config?: ResourceDetectionConfig
   ) {
     if (
@@ -62,8 +61,8 @@ class BrowserDetector implements Detector {
 }
 
 // Add Browser related attributes to resources
-function getBrowserAttributes(): ResourceAttributes {
-  const browserAttribs: ResourceAttributes = {};
+function getBrowserAttributes(): Attributes {
+  const browserAttribs: Attributes = {};
   const userAgentData: UserAgentData | undefined = (navigator as any)
     .userAgentData;
   if (userAgentData) {


### PR DESCRIPTION
## Which problem is this PR solving?

Replaces `ResourceAttributes` with `Attributes`

Refs #4175

## Short description of the changes

Replace the interfaces internally. The changes are not affecting the public API of the detector so it's not marked as breaking change.

## How Has This Been Tested?

Ran the test suite for the detector