### PR TITLE
refactor(sdk-logs): replace ResourceAtrributes with Attributes

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable changes to experimental packages in this project will be documented 
 
 * refactor(browser-detector): replace `ResourceAttributes` with `Attributes` [#5004](https://github.com/open-telemetry/opentelemetry-js/pull/5004)
 
+* refactor(sdk-logs): replace `ResourceAttributes` with `Attributes` [#5005](https://github.com/open-telemetry/opentelemetry-js/pull/5005) @david-luna
+
 ## 0.53.0
 
 ### :boom: Breaking Change

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -24,7 +24,6 @@ All notable changes to experimental packages in this project will be documented 
 * refactor(exporter-prometheus): replace `MetricAttributes` and `MetricAttributeValues` with `Attributes` and `AttributeValues` [#4993](https://github.com/open-telemetry/opentelemetry-js/pull/4993)
 
 * refactor(browser-detector): replace `ResourceAttributes` with `Attributes` [#5004](https://github.com/open-telemetry/opentelemetry-js/pull/5004)
-
 * refactor(sdk-logs): replace `ResourceAttributes` with `Attributes` [#5005](https://github.com/open-telemetry/opentelemetry-js/pull/5005) @david-luna
 
 ## 0.53.0

--- a/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
@@ -32,7 +32,8 @@ import {
 import { BatchLogRecordProcessorBase } from '../../../src/export/BatchLogRecordProcessorBase';
 import { reconfigureLimits } from '../../../src/config';
 import { LoggerProviderSharedState } from '../../../src/internal/LoggerProviderSharedState';
-import { Resource, ResourceAttributes } from '@opentelemetry/resources';
+import { Attributes } from '@opentelemetry/api';
+import { Resource } from '@opentelemetry/resources';
 
 class BatchLogRecordProcessor extends BatchLogRecordProcessorBase<BufferConfig> {
   onInit() {}
@@ -316,7 +317,7 @@ describe('BatchLogRecordProcessorBase', () => {
       const processor = new BatchLogRecordProcessor(exporter);
       const asyncResource = new Resource(
         {},
-        new Promise<ResourceAttributes>(resolve => {
+        new Promise<Attributes>(resolve => {
           setTimeout(() => resolve({ async: 'fromasync' }), 1);
         })
       );

--- a/experimental/packages/sdk-logs/test/common/export/SimpleLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/SimpleLogRecordProcessor.test.ts
@@ -21,7 +21,8 @@ import {
   loggingErrorHandler,
   setGlobalErrorHandler,
 } from '@opentelemetry/core';
-import { Resource, ResourceAttributes } from '@opentelemetry/resources';
+import { Attributes } from '@opentelemetry/api';
+import { Resource } from '@opentelemetry/resources';
 import { Resource as Resource190 } from '@opentelemetry/resources_1.9.0';
 
 import {
@@ -121,7 +122,7 @@ describe('SimpleLogRecordProcessor', () => {
       const exporter = new InMemoryLogRecordExporter();
       const asyncResource = new Resource(
         {},
-        new Promise<ResourceAttributes>(resolve => {
+        new Promise<Attributes>(resolve => {
           setTimeout(() => resolve({ async: 'fromasync' }), 1);
         })
       );
@@ -143,7 +144,7 @@ describe('SimpleLogRecordProcessor', () => {
       const testExporterWithDelay = new TestExporterWithDelay();
       const asyncResource = new Resource(
         {},
-        new Promise<ResourceAttributes>(resolve => {
+        new Promise<Attributes>(resolve => {
           setTimeout(() => resolve({ async: 'fromasync' }), 1);
         })
       );


### PR DESCRIPTION
## Which problem is this PR solving?

Replaces `ResourceAttributes` with `Attributes`

Refs #4175

## Short description of the changes

Replace the interfaces in the tests.

## How Has This Been Tested?

Ran the test suite for the logs SDK