### PR TITLE
chore: remove --openssl-legacy-provider option

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,12 +45,7 @@ jobs:
         run: npm run compile
 
       - name: Unit tests
-        run: |
-          # TODO(legendecas): webpack https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported
-          if [ "${{ matrix.node_version }}" = "18" ] || [ "${{ matrix.node_version }}" == "20" ] || [ "${{ matrix.node_version }}" == "22" ]; then
-            export NODE_OPTIONS=--openssl-legacy-provider
-          fi
-          npm run test
+        run: npm run test
       - name: Report Coverage
         uses: codecov/codecov-action@v4
         with:
@@ -81,8 +76,6 @@ jobs:
           npm run compile
 
       - name: Unit tests
-        env:
-         NODE_OPTIONS: --openssl-legacy-provider
         run: npm run test
   browser-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Saw this earlier when working on #5010. 
We needed this when we were still using webpack 4, but we've fully migrated to webpack 5, so we can drop it :slightly_smiling_face: 