### PR TITLE
fix(events,logs): drop outdated API from devDependencies and align types

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to experimental packages in this project will be documented 
 
 * fix(sampler-jaeger-remote): fixes an issue where package could emit unhandled promise rejections @Just-Sieb
 * fix(otlp-grpc-exporter-base): default compression to `'none'` if env vars `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION` and `OTEL_EXPORTER_OTLP_COMPRESSION` are falsy @sjvans
+* fix(sdk-events): remove devDependencies to old `@opentelemetry/api-logs@0.52.0`, `@opentelemetry/api-events@0.52.0` packages [#5013](https://github.com/open-telemetry/opentelemetry-js/pull/5013) @pichlermarc
+* fix(sdk-logs): remove devDependencies to old `@opentelemetry/api-logs@0.52.0` [#5013](https://github.com/open-telemetry/opentelemetry-js/pull/5013) @pichlermarc
+* fix(sdk-logs): align LogRecord#setAttribute type with types from `@opentelemetry/api-logs@0.53.0` [#5013](https://github.com/open-telemetry/opentelemetry-js/pull/5013) @pichlermarc
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/sdk-events/package.json
+++ b/experimental/packages/sdk-events/package.json
@@ -68,8 +68,6 @@
   "devDependencies": {
     "@babel/core": "7.25.2",
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/api-events": "0.52.0",
-    "@opentelemetry/api-logs": "0.52.0",
     "@types/mocha": "10.0.8",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -74,7 +74,6 @@
     "@babel/core": "7.25.2",
     "@babel/preset-env": "7.25.4",
     "@opentelemetry/api": ">=1.4.0 <1.10.0",
-    "@opentelemetry/api-logs": "0.52.0",
     "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
     "@types/mocha": "10.0.8",
     "@types/node": "18.6.5",

--- a/experimental/packages/sdk-logs/src/LogRecord.ts
+++ b/experimental/packages/sdk-logs/src/LogRecord.ts
@@ -26,7 +26,7 @@ import type { IResource } from '@opentelemetry/resources';
 
 import type { ReadableLogRecord } from './export/ReadableLogRecord';
 import type { LogRecordLimits } from './types';
-import {AnyValue, LogAttributes, LogBody} from '@opentelemetry/api-logs';
+import { AnyValue, LogAttributes, LogBody } from '@opentelemetry/api-logs';
 import { LoggerProviderSharedState } from './internal/LoggerProviderSharedState';
 
 export class LogRecord implements ReadableLogRecord {

--- a/experimental/packages/sdk-logs/src/LogRecord.ts
+++ b/experimental/packages/sdk-logs/src/LogRecord.ts
@@ -26,7 +26,7 @@ import type { IResource } from '@opentelemetry/resources';
 
 import type { ReadableLogRecord } from './export/ReadableLogRecord';
 import type { LogRecordLimits } from './types';
-import { LogAttributes, LogBody } from '@opentelemetry/api-logs';
+import {AnyValue, LogAttributes, LogBody} from '@opentelemetry/api-logs';
 import { LoggerProviderSharedState } from './internal/LoggerProviderSharedState';
 
 export class LogRecord implements ReadableLogRecord {
@@ -112,7 +112,7 @@ export class LogRecord implements ReadableLogRecord {
     this.setAttributes(attributes);
   }
 
-  public setAttribute(key: string, value?: LogAttributes | AttributeValue) {
+  public setAttribute(key: string, value?: AnyValue) {
     if (this._isLogRecordReadonly()) {
       return this;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33662,22 +33662,6 @@
         "webpack-merge": "5.10.0"
       },
       "dependencies": {
-        "@opentelemetry/api-events": {
-          "version": "https://registry.npmjs.org/@opentelemetry/api-events/-/api-events-0.52.0.tgz",
-          "integrity": "sha512-+LdOC1OK9tINoj6KQT0FZkX3enQElzLkuwAbzF7Lrdp7x7XrhQFhMz7PwfTYCgnVDOqc7pRGw0jIfmj+vJ5t4g==",
-          "requires": {
-            "@opentelemetry/api": "^1.0.0",
-            "@opentelemetry/api-logs": "0.52.0"
-          }
-        },
-        "@opentelemetry/api-logs": {
-          "version": "0.52.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
-          "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
-          "requires": {
-            "@opentelemetry/api": "^1.0.0"
-          }
-        },
         "@types/sinon": {
           "version": "10.0.20",
           "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1413,8 +1413,6 @@
       "devDependencies": {
         "@babel/core": "7.25.2",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/api-events": "0.52.0",
-        "@opentelemetry/api-logs": "0.52.0",
         "@types/mocha": "10.0.8",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -1445,31 +1443,6 @@
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
-    "experimental/packages/sdk-events/node_modules/@opentelemetry/api-events": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-events/-/api-events-0.52.0.tgz",
-      "integrity": "sha512-+LdOC1OK9tINoj6KQT0FZkX3enQElzLkuwAbzF7Lrdp7x7XrhQFhMz7PwfTYCgnVDOqc7pRGw0jIfmj+vJ5t4g==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/api-logs": "0.52.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "experimental/packages/sdk-events/node_modules/@opentelemetry/api-logs": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
-      "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "experimental/packages/sdk-events/node_modules/@types/sinon": {
       "version": "10.0.20",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
@@ -1492,7 +1465,6 @@
         "@babel/core": "7.25.2",
         "@babel/preset-env": "7.25.4",
         "@opentelemetry/api": ">=1.4.0 <1.10.0",
-        "@opentelemetry/api-logs": "0.52.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.8",
         "@types/node": "18.6.5",
@@ -1529,18 +1501,6 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "experimental/packages/sdk-logs/node_modules/@opentelemetry/api-logs": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
-      "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
-      "dev": true,
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "experimental/packages/sdk-logs/node_modules/@opentelemetry/resources_1.9.0": {
@@ -33675,8 +33635,8 @@
       "requires": {
         "@babel/core": "7.25.2",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/api-events": "0.52.0",
-        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/api-events": "0.53.0",
+        "@opentelemetry/api-logs": "0.53.0",
         "@opentelemetry/sdk-logs": "0.53.0",
         "@types/mocha": "10.0.8",
         "@types/node": "18.6.5",
@@ -33703,10 +33663,8 @@
       },
       "dependencies": {
         "@opentelemetry/api-events": {
-          "version": "0.52.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api-events/-/api-events-0.52.0.tgz",
+          "version": "https://registry.npmjs.org/@opentelemetry/api-events/-/api-events-0.52.0.tgz",
           "integrity": "sha512-+LdOC1OK9tINoj6KQT0FZkX3enQElzLkuwAbzF7Lrdp7x7XrhQFhMz7PwfTYCgnVDOqc7pRGw0jIfmj+vJ5t4g==",
-          "dev": true,
           "requires": {
             "@opentelemetry/api": "^1.0.0",
             "@opentelemetry/api-logs": "0.52.0"
@@ -33716,7 +33674,6 @@
           "version": "0.52.0",
           "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
           "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
-          "dev": true,
           "requires": {
             "@opentelemetry/api": "^1.0.0"
           }
@@ -33738,7 +33695,7 @@
         "@babel/core": "7.25.2",
         "@babel/preset-env": "7.25.4",
         "@opentelemetry/api": ">=1.4.0 <1.10.0",
-        "@opentelemetry/api-logs": "0.52.0",
+        "@opentelemetry/api-logs": "0.53.0",
         "@opentelemetry/core": "1.26.0",
         "@opentelemetry/resources": "1.26.0",
         "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
@@ -33769,15 +33726,6 @@
           "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
           "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
           "dev": true
-        },
-        "@opentelemetry/api-logs": {
-          "version": "0.52.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.0.tgz",
-          "integrity": "sha512-HxjD7xH9iAE4OyhNaaSec65i1H6QZYBWSwWkowFfsc5YAcDvJG30/J1sRKXEQqdmUcKTXEAnA66UciqZha/4+Q==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/api": "^1.0.0"
-          }
         },
         "@opentelemetry/resources_1.9.0": {
           "version": "npm:@opentelemetry/resources@1.9.0",


### PR DESCRIPTION
## Which problem is this PR solving?

I saw that there's two `devDependency` entries old `@opentelemetry/api-events` and `@opentelemetry/api-logs` packages, which cause an old package to be present for these two packages.

The current version is actually specified as a `dependency` so removing the `devDependency` is safe.

Since the `devDependency` pulled in the local types, we had some type-mismatch with in `@opentelemetry/sdk-logs` where `null` was not an allowed input with the changed type.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Existing tests