### PR TITLE
fix(opentelemetry-core): confusing log extract of composite propagator

### DIFF
--- a/packages/opentelemetry-core/src/propagation/composite.ts
+++ b/packages/opentelemetry-core/src/propagation/composite.ts
@@ -91,7 +91,7 @@ export class CompositePropagator implements TextMapPropagator {
         return propagator.extract(ctx, carrier, getter);
       } catch (err) {
         diag.warn(
-          `Failed to inject with ${propagator.constructor.name}. Err: ${err.message}`
+          `Failed to extract with ${propagator.constructor.name}. Err: ${err.message}`
         );
       }
       return ctx;


### PR DESCRIPTION
## Which problem is this PR solving?

This fixes confusing diag logged warning in the composite propagator.

## Short description of the changes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The existing test were used for checking for regression.

## Checklist:

- [ x] Followed the style guidelines of this project
~- [ ] Unit tests have been added~
~- [ ] Documentation has been updated~
