### PR TITLE
refactor(sdk-metrics)!: replace `MetricsAttributes` with `Attributes`

### DIFF
--- a/packages/sdk-metrics/src/Instruments.ts
+++ b/packages/sdk-metrics/src/Instruments.ts
@@ -18,7 +18,7 @@ import {
   context as contextApi,
   diag,
   Context,
-  MetricAttributes,
+  Attributes,
   ValueType,
   UpDownCounter,
   Counter,
@@ -46,7 +46,7 @@ export class SyncInstrument {
 
   protected _record(
     value: number,
-    attributes: MetricAttributes = {},
+    attributes: Attributes = {},
     context: Context = contextApi.active()
   ) {
     if (typeof value !== 'number') {
@@ -87,7 +87,7 @@ export class UpDownCounterInstrument
   /**
    * Increment value of counter by the input. Inputs may be negative.
    */
-  add(value: number, attributes?: MetricAttributes, ctx?: Context): void {
+  add(value: number, attributes?: Attributes, ctx?: Context): void {
     this._record(value, attributes, ctx);
   }
 }
@@ -99,7 +99,7 @@ export class CounterInstrument extends SyncInstrument implements Counter {
   /**
    * Increment value of counter by the input. Inputs may not be negative.
    */
-  add(value: number, attributes?: MetricAttributes, ctx?: Context): void {
+  add(value: number, attributes?: Attributes, ctx?: Context): void {
     if (value < 0) {
       diag.warn(
         `negative value provided to counter ${this._descriptor.name}: ${value}`
@@ -118,7 +118,7 @@ export class GaugeInstrument extends SyncInstrument implements Gauge {
   /**
    * Records a measurement.
    */
-  record(value: number, attributes?: MetricAttributes, ctx?: Context): void {
+  record(value: number, attributes?: Attributes, ctx?: Context): void {
     this._record(value, attributes, ctx);
   }
 }
@@ -130,7 +130,7 @@ export class HistogramInstrument extends SyncInstrument implements Histogram {
   /**
    * Records a measurement. Value of the measurement must not be negative.
    */
-  record(value: number, attributes?: MetricAttributes, ctx?: Context): void {
+  record(value: number, attributes?: Attributes, ctx?: Context): void {
     if (value < 0) {
       diag.warn(
         `negative value provided to histogram ${this._descriptor.name}: ${value}`

--- a/packages/sdk-metrics/src/ObservableResult.ts
+++ b/packages/sdk-metrics/src/ObservableResult.ts
@@ -17,7 +17,7 @@
 import {
   diag,
   ObservableResult,
-  MetricAttributes,
+  Attributes,
   ValueType,
   BatchObservableResult,
   Observable,
@@ -42,7 +42,7 @@ export class ObservableResultImpl implements ObservableResult {
   /**
    * Observe a measurement of the value associated with the given attributes.
    */
-  observe(value: number, attributes: MetricAttributes = {}): void {
+  observe(value: number, attributes: Attributes = {}): void {
     if (typeof value !== 'number') {
       diag.warn(
         `non-number value provided to metric ${this._instrumentName}: ${value}`
@@ -78,7 +78,7 @@ export class BatchObservableResultImpl implements BatchObservableResult {
   observe(
     metric: Observable,
     value: number,
-    attributes: MetricAttributes = {}
+    attributes: Attributes = {}
   ): void {
     if (!isObservableInstrument(metric)) {
       return;

--- a/packages/sdk-metrics/src/aggregator/types.ts
+++ b/packages/sdk-metrics/src/aggregator/types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { HrTime, MetricAttributes } from '@opentelemetry/api';
+import { HrTime, Attributes } from '@opentelemetry/api';
 import { AggregationTemporality } from '../export/AggregationTemporality';
 import { MetricData, MetricDescriptor } from '../export/MetricData';
 import { Maybe } from '../utils';
@@ -88,7 +88,7 @@ export interface Accumulation {
   record(value: number): void;
 }
 
-export type AccumulationRecord<T> = [MetricAttributes, T];
+export type AccumulationRecord<T> = [Attributes, T];
 
 /**
  * Base interface for aggregators. Aggregators are responsible for holding

--- a/packages/sdk-metrics/src/exemplar/AlignedHistogramBucketExemplarReservoir.ts
+++ b/packages/sdk-metrics/src/exemplar/AlignedHistogramBucketExemplarReservoir.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Context, HrTime, MetricAttributes } from '@opentelemetry/api';
+import { Context, HrTime, Attributes } from '@opentelemetry/api';
 import { FixedSizeExemplarReservoirBase } from './ExemplarReservoir';
 
 /**
@@ -32,7 +32,7 @@ export class AlignedHistogramBucketExemplarReservoir extends FixedSizeExemplarRe
   private _findBucketIndex(
     value: number,
     _timestamp: HrTime,
-    _attributes: MetricAttributes,
+    _attributes: Attributes,
     _ctx: Context
   ) {
     for (let i = 0; i < this._boundaries.length; i++) {
@@ -46,7 +46,7 @@ export class AlignedHistogramBucketExemplarReservoir extends FixedSizeExemplarRe
   offer(
     value: number,
     timestamp: HrTime,
-    attributes: MetricAttributes,
+    attributes: Attributes,
     ctx: Context
   ): void {
     const index = this._findBucketIndex(value, timestamp, attributes, ctx);

--- a/packages/sdk-metrics/src/exemplar/AlwaysSampleExemplarFilter.ts
+++ b/packages/sdk-metrics/src/exemplar/AlwaysSampleExemplarFilter.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { Context, HrTime, MetricAttributes } from '@opentelemetry/api';
+import { Context, HrTime, Attributes } from '@opentelemetry/api';
 import { ExemplarFilter } from './ExemplarFilter';
 
 export class AlwaysSampleExemplarFilter implements ExemplarFilter {
   shouldSample(
     _value: number,
     _timestamp: HrTime,
-    _attributes: MetricAttributes,
+    _attributes: Attributes,
     _ctx: Context
   ): boolean {
     return true;

--- a/packages/sdk-metrics/src/exemplar/Exemplar.ts
+++ b/packages/sdk-metrics/src/exemplar/Exemplar.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { HrTime, MetricAttributes } from '@opentelemetry/api';
+import { HrTime, Attributes } from '@opentelemetry/api';
 
 /**
  * A representation of an exemplar, which is a sample input measurement.
@@ -26,7 +26,7 @@ export type Exemplar = {
   // The set of key/value pairs that were filtered out by the aggregator, but
   // recorded alongside the original measurement. Only key/value pairs that were
   // filtered out by the aggregator should be included
-  filteredAttributes: MetricAttributes;
+  filteredAttributes: Attributes;
 
   // The value of the measurement that was recorded.
   value: number;

--- a/packages/sdk-metrics/src/exemplar/ExemplarFilter.ts
+++ b/packages/sdk-metrics/src/exemplar/ExemplarFilter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Context, HrTime, MetricAttributes } from '@opentelemetry/api';
+import { Context, HrTime, Attributes } from '@opentelemetry/api';
 
 /**
  * This interface represents a ExemplarFilter. Exemplar filters are
@@ -27,13 +27,13 @@ export interface ExemplarFilter {
    *
    * @param value The value of the measurement
    * @param timestamp A timestamp that best represents when the measurement was taken
-   * @param attributes The complete set of MetricAttributes of the measurement
+   * @param attributes The complete set of Attributes of the measurement
    * @param ctx The Context of the measurement
    */
   shouldSample(
     value: number,
     timestamp: HrTime,
-    attributes: MetricAttributes,
+    attributes: Attributes,
     ctx: Context
   ): boolean;
 }

--- a/packages/sdk-metrics/src/exemplar/ExemplarReservoir.ts
+++ b/packages/sdk-metrics/src/exemplar/ExemplarReservoir.ts
@@ -19,7 +19,7 @@ import {
   HrTime,
   isSpanContextValid,
   trace,
-  MetricAttributes,
+  Attributes,
 } from '@opentelemetry/api';
 import { Exemplar } from './Exemplar';
 
@@ -31,7 +31,7 @@ export interface ExemplarReservoir {
   offer(
     value: number,
     timestamp: HrTime,
-    attributes: MetricAttributes,
+    attributes: Attributes,
     ctx: Context
   ): void;
   /**
@@ -43,12 +43,12 @@ export interface ExemplarReservoir {
    * @returns a list of {@link Exemplar}s. Returned exemplars contain the attributes that were filtered out by the
    * aggregator, but recorded alongside the original measurement.
    */
-  collect(pointAttributes: MetricAttributes): Exemplar[];
+  collect(pointAttributes: Attributes): Exemplar[];
 }
 
 class ExemplarBucket {
   private value: number = 0;
-  private attributes: MetricAttributes = {};
+  private attributes: Attributes = {};
   private timestamp: HrTime = [0, 0];
   private spanId?: string;
   private traceId?: string;
@@ -57,7 +57,7 @@ class ExemplarBucket {
   offer(
     value: number,
     timestamp: HrTime,
-    attributes: MetricAttributes,
+    attributes: Attributes,
     ctx: Context
   ) {
     this.value = value;
@@ -71,7 +71,7 @@ class ExemplarBucket {
     this._offered = true;
   }
 
-  collect(pointAttributes: MetricAttributes): Exemplar | null {
+  collect(pointAttributes: Attributes): Exemplar | null {
     if (!this._offered) return null;
     const currentAttributes = this.attributes;
     // filter attributes
@@ -114,7 +114,7 @@ export abstract class FixedSizeExemplarReservoirBase
   abstract offer(
     value: number,
     timestamp: HrTime,
-    attributes: MetricAttributes,
+    attributes: Attributes,
     ctx: Context
   ): void;
 
@@ -127,7 +127,7 @@ export abstract class FixedSizeExemplarReservoirBase
    */
   protected reset(): void {}
 
-  collect(pointAttributes: MetricAttributes): Exemplar[] {
+  collect(pointAttributes: Attributes): Exemplar[] {
     const exemplars: Exemplar[] = [];
     this._reservoirStorage.forEach(storageItem => {
       const res = storageItem.collect(pointAttributes);

--- a/packages/sdk-metrics/src/exemplar/NeverSampleExemplarFilter.ts
+++ b/packages/sdk-metrics/src/exemplar/NeverSampleExemplarFilter.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { Context, HrTime, MetricAttributes } from '@opentelemetry/api';
+import { Context, HrTime, Attributes } from '@opentelemetry/api';
 import { ExemplarFilter } from './ExemplarFilter';
 
 export class NeverSampleExemplarFilter implements ExemplarFilter {
   shouldSample(
     _value: number,
     _timestamp: HrTime,
-    _attributes: MetricAttributes,
+    _attributes: Attributes,
     _ctx: Context
   ): boolean {
     return false;

--- a/packages/sdk-metrics/src/exemplar/SimpleFixedSizeExemplarReservoir.ts
+++ b/packages/sdk-metrics/src/exemplar/SimpleFixedSizeExemplarReservoir.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Context, HrTime, MetricAttributes } from '@opentelemetry/api';
+import { Context, HrTime, Attributes } from '@opentelemetry/api';
 import { FixedSizeExemplarReservoirBase } from './ExemplarReservoir';
 
 /**
@@ -37,7 +37,7 @@ export class SimpleFixedSizeExemplarReservoir extends FixedSizeExemplarReservoir
   private _findBucketIndex(
     _value: number,
     _timestamp: HrTime,
-    _attributes: MetricAttributes,
+    _attributes: Attributes,
     _ctx: Context
   ) {
     if (this._numMeasurementsSeen < this._size)
@@ -49,7 +49,7 @@ export class SimpleFixedSizeExemplarReservoir extends FixedSizeExemplarReservoir
   offer(
     value: number,
     timestamp: HrTime,
-    attributes: MetricAttributes,
+    attributes: Attributes,
     ctx: Context
   ): void {
     const index = this._findBucketIndex(value, timestamp, attributes, ctx);

--- a/packages/sdk-metrics/src/exemplar/WithTraceExemplarFilter.ts
+++ b/packages/sdk-metrics/src/exemplar/WithTraceExemplarFilter.ts
@@ -20,7 +20,7 @@ import {
   isSpanContextValid,
   trace,
   TraceFlags,
-  MetricAttributes,
+  Attributes,
 } from '@opentelemetry/api';
 import { ExemplarFilter } from './ExemplarFilter';
 
@@ -28,7 +28,7 @@ export class WithTraceExemplarFilter implements ExemplarFilter {
   shouldSample(
     value: number,
     timestamp: HrTime,
-    attributes: MetricAttributes,
+    attributes: Attributes,
     ctx: Context
   ): boolean {
     const spanContext = trace.getSpanContext(ctx);

--- a/packages/sdk-metrics/src/export/MetricData.ts
+++ b/packages/sdk-metrics/src/export/MetricData.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { HrTime, MetricAttributes, ValueType } from '@opentelemetry/api';
+import { HrTime, Attributes, ValueType } from '@opentelemetry/api';
 import { InstrumentationScope } from '@opentelemetry/core';
 import { IResource } from '@opentelemetry/resources';
 import { InstrumentType } from '../InstrumentDescriptor';
@@ -159,7 +159,7 @@ export interface DataPoint<T> {
   /**
    * The attributes associated with this DataPoint.
    */
-  readonly attributes: MetricAttributes;
+  readonly attributes: Attributes;
   /**
    * The value for this DataPoint. The type of the value is indicated by the
    * {@link DataPointType}.

--- a/packages/sdk-metrics/src/state/DeltaMetricProcessor.ts
+++ b/packages/sdk-metrics/src/state/DeltaMetricProcessor.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Context, HrTime, MetricAttributes } from '@opentelemetry/api';
+import { Context, HrTime, Attributes } from '@opentelemetry/api';
 import { Maybe } from '../utils';
 import { Accumulation, Aggregator } from '../aggregator/types';
 import { AttributeHashMap } from './HashMap';
@@ -36,7 +36,7 @@ export class DeltaMetricProcessor<T extends Maybe<Accumulation>> {
 
   record(
     value: number,
-    attributes: MetricAttributes,
+    attributes: Attributes,
     _context: Context,
     collectionTime: HrTime
   ) {

--- a/packages/sdk-metrics/src/state/HashMap.ts
+++ b/packages/sdk-metrics/src/state/HashMap.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { MetricAttributes } from '@opentelemetry/api';
+import { Attributes } from '@opentelemetry/api';
 import { hashAttributes } from '../utils';
 
 export interface Hash<ValueType, HashCodeType> {
@@ -84,7 +84,7 @@ export class HashMap<KeyType, ValueType, HashCodeType> {
 }
 
 export class AttributeHashMap<ValueType> extends HashMap<
-  MetricAttributes,
+  Attributes,
   ValueType,
   string
 > {

--- a/packages/sdk-metrics/src/state/MultiWritableMetricStorage.ts
+++ b/packages/sdk-metrics/src/state/MultiWritableMetricStorage.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Context, HrTime, MetricAttributes } from '@opentelemetry/api';
+import { Context, HrTime, Attributes } from '@opentelemetry/api';
 import { WritableMetricStorage } from './WritableMetricStorage';
 
 /**
@@ -25,7 +25,7 @@ export class MultiMetricStorage implements WritableMetricStorage {
 
   record(
     value: number,
-    attributes: MetricAttributes,
+    attributes: Attributes,
     context: Context,
     recordTime: HrTime
   ) {

--- a/packages/sdk-metrics/src/state/SyncMetricStorage.ts
+++ b/packages/sdk-metrics/src/state/SyncMetricStorage.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Context, HrTime, MetricAttributes } from '@opentelemetry/api';
+import { Context, HrTime, Attributes } from '@opentelemetry/api';
 import { WritableMetricStorage } from './WritableMetricStorage';
 import { Accumulation, Aggregator } from '../aggregator/types';
 import { InstrumentDescriptor } from '../InstrumentDescriptor';
@@ -54,7 +54,7 @@ export class SyncMetricStorage<T extends Maybe<Accumulation>>
 
   record(
     value: number,
-    attributes: MetricAttributes,
+    attributes: Attributes,
     context: Context,
     recordTime: HrTime
   ) {

--- a/packages/sdk-metrics/src/state/WritableMetricStorage.ts
+++ b/packages/sdk-metrics/src/state/WritableMetricStorage.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Context, HrTime, MetricAttributes } from '@opentelemetry/api';
+import { Context, HrTime, Attributes } from '@opentelemetry/api';
 import { AttributeHashMap } from './HashMap';
 
 /**
@@ -27,7 +27,7 @@ export interface WritableMetricStorage {
   /** Records a measurement. */
   record(
     value: number,
-    attributes: MetricAttributes,
+    attributes: Attributes,
     context: Context,
     recordTime: HrTime
   ): void;

--- a/packages/sdk-metrics/src/types.ts
+++ b/packages/sdk-metrics/src/types.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Context, MetricAttributes } from '@opentelemetry/api';
+import { Context, Attributes } from '@opentelemetry/api';
 
 export type CommonReaderOptions = {
   timeoutMillis?: number;
@@ -30,7 +30,7 @@ export type ForceFlushOptions = CommonReaderOptions;
  * In SDK 2.0 we'll be able to bump the minimum API version and remove this workaround.
  */
 export interface Gauge<
-  AttributesTypes extends MetricAttributes = MetricAttributes,
+  AttributesTypes extends Attributes = Attributes,
 > {
   /**
    * Records a measurement. Value of the measurement must not be negative.

--- a/packages/sdk-metrics/src/types.ts
+++ b/packages/sdk-metrics/src/types.ts
@@ -29,9 +29,7 @@ export type ForceFlushOptions = CommonReaderOptions;
  * This is intentionally not using the API's type as it's only available from @opentelemetry/api 1.9.0 and up.
  * In SDK 2.0 we'll be able to bump the minimum API version and remove this workaround.
  */
-export interface Gauge<
-  AttributesTypes extends Attributes = Attributes,
-> {
+export interface Gauge<AttributesTypes extends Attributes = Attributes> {
   /**
    * Records a measurement. Value of the measurement must not be negative.
    */

--- a/packages/sdk-metrics/src/utils.ts
+++ b/packages/sdk-metrics/src/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { MetricAttributes } from '@opentelemetry/api';
+import { Attributes } from '@opentelemetry/api';
 import { InstrumentationScope } from '@opentelemetry/core';
 
 export type Maybe<T> = T | undefined;
@@ -25,9 +25,9 @@ export function isNotNullish<T>(item: Maybe<T>): item is T {
 
 /**
  * Converting the unordered attributes into unique identifier string.
- * @param attributes user provided unordered MetricAttributes.
+ * @param attributes user provided unordered Attributes.
  */
-export function hashAttributes(attributes: MetricAttributes): string {
+export function hashAttributes(attributes: Attributes): string {
   let keys = Object.keys(attributes);
   if (keys.length === 0) return '';
 

--- a/packages/sdk-metrics/test/MeterProvider.test.ts
+++ b/packages/sdk-metrics/test/MeterProvider.test.ts
@@ -190,7 +190,7 @@ describe('MeterProvider', () => {
       assertPartialDeepStrictEqual(
         resourceMetrics.scopeMetrics[0].metrics[0].dataPoints[0],
         {
-          // MetricAttributes are still there.
+          // Attributes are still there.
           attributes: {
             attrib1: 'attrib_value1',
             attrib2: 'attrib_value2',

--- a/packages/sdk-metrics/test/state/HashMap.test.ts
+++ b/packages/sdk-metrics/test/state/HashMap.test.ts
@@ -15,14 +15,14 @@
  */
 
 import * as assert from 'assert';
-import { MetricAttributes } from '@opentelemetry/api';
+import { Attributes } from '@opentelemetry/api';
 import { HashMap } from '../../src/state/HashMap';
 import { hashAttributes } from '../../src/utils';
 
 describe('HashMap', () => {
   describe('set & get', () => {
     it('should get and set with attributes', () => {
-      const map = new HashMap<MetricAttributes, number, string>(hashAttributes);
+      const map = new HashMap<Attributes, number, string>(hashAttributes);
       const hash = hashAttributes({ foo: 'bar' });
 
       map.set({ foo: 'bar' }, 1);
@@ -41,7 +41,7 @@ describe('HashMap', () => {
 
   describe('has', () => {
     it('should return if the key exists in the value map', () => {
-      const map = new HashMap<MetricAttributes, number, string>(hashAttributes);
+      const map = new HashMap<Attributes, number, string>(hashAttributes);
       const hash = hashAttributes({ foo: 'bar' });
 
       // with pinned hash code
@@ -58,7 +58,7 @@ describe('HashMap', () => {
 
   describe('entries', () => {
     it('iterating with entries', () => {
-      const map = new HashMap<MetricAttributes, number, string>(hashAttributes);
+      const map = new HashMap<Attributes, number, string>(hashAttributes);
       map.set({ foo: '1' }, 1);
       map.set({ foo: '2' }, 2);
       map.set({ foo: '3' }, 3);

--- a/packages/sdk-metrics/test/state/MultiWritableMetricStorage.test.ts
+++ b/packages/sdk-metrics/test/state/MultiWritableMetricStorage.test.ts
@@ -15,7 +15,7 @@
  */
 
 import * as api from '@opentelemetry/api';
-import { MetricAttributes } from '@opentelemetry/api';
+import { Attributes } from '@opentelemetry/api';
 import { hrTime } from '@opentelemetry/core';
 import * as assert from 'assert';
 import { MultiMetricStorage } from '../../src/state/MultiWritableMetricStorage';
@@ -44,7 +44,7 @@ describe('MultiMetricStorage', () => {
         records: Measurement[] = [];
         record(
           value: number,
-          attributes: MetricAttributes,
+          attributes: Attributes,
           context: api.Context
         ): void {
           this.records.push({ value, attributes, context });

--- a/packages/sdk-metrics/test/util.ts
+++ b/packages/sdk-metrics/test/util.ts
@@ -17,7 +17,7 @@
 import {
   Context,
   BatchObservableCallback,
-  MetricAttributes,
+  Attributes,
   ObservableCallback,
   ValueType,
 } from '@opentelemetry/api';
@@ -42,8 +42,7 @@ import { AggregationTemporality } from '../src/export/AggregationTemporality';
 
 export type Measurement = {
   value: number;
-  // TODO: use common attributes
-  attributes: MetricAttributes;
+  attributes: Attributes;
   context?: Context;
 };
 
@@ -80,7 +79,7 @@ export const validNames = [
 ];
 
 export const commonValues: number[] = [1, -1, 1.0, Infinity, -Infinity, NaN];
-export const commonAttributes: MetricAttributes[] = [
+export const commonAttributes: Attributes[] = [
   {},
   { 1: '1' },
   { a: '2' },
@@ -126,7 +125,7 @@ export function assertMetricData(
 
 export function assertDataPoint(
   actual: unknown,
-  attributes: MetricAttributes,
+  attributes: Attributes,
   point: Histogram | number,
   startTime?: HrTime,
   endTime?: HrTime

--- a/packages/sdk-metrics/test/utils.test.ts
+++ b/packages/sdk-metrics/test/utils.test.ts
@@ -23,7 +23,7 @@ import {
   TimeoutError,
 } from '../src/utils';
 import { assertRejects } from './test-utils';
-import { MetricAttributes } from '@opentelemetry/api';
+import { Attributes } from '@opentelemetry/api';
 
 describe('utils', () => {
   afterEach(() => {
@@ -42,7 +42,7 @@ describe('utils', () => {
 
   describe('hashAttributes', () => {
     it('should hash all types of attribute values', () => {
-      const cases: [MetricAttributes, string][] = [
+      const cases: [Attributes, string][] = [
         [{ string: 'bar' }, '[["string","bar"]]'],
         [{ number: 1 }, '[["number",1]]'],
         [{ false: false, true: true }, '[["false",false],["true",true]]'],


### PR DESCRIPTION
## Which problem is this PR solving?

Replaces `MetricsAttributes` with `Attributes`

Refs #4175

## Short description of the changes

Replace the interfaces in sources & tests. This PR targeting `next` since the changes in exported APIs make it a breaking change. 

## How Has This Been Tested?

at the root folder
- npm run compile
- npm run test
