### PR TITLE
refactor(instrumentation-http): replace `SpanAttributes` and `MetricAttributes` with `Attributes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 * deps: set `@opentelemetry/api` dependency min version to 1.3.0 in `examples`, `experimental/packages`, `integration-tests` and `selenium-tests`
   [#4992](https://github.com/open-telemetry/opentelemetry-js/pull/4992)
 * refactor(sdk-metrics): replace `MetricsAttributes` with `Attributes` [#5021](https://github.com/open-telemetry/opentelemetry-js/pull/5021) @david-luna
+* refactor(instrumentation-http): replace `SpanAttributes` and `MetricsAttributes` with `Attributes` [#5023](https://github.com/open-telemetry/opentelemetry-js/pull/5023) @david-luna
 
 ## 1.26.0
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -26,7 +26,7 @@ import {
   SpanStatusCode,
   trace,
   Histogram,
-  MetricAttributes,
+  Attributes,
   ValueType,
 } from '@opentelemetry/api';
 import {
@@ -331,7 +331,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
     request: http.ClientRequest,
     span: Span,
     startTime: HrTime,
-    metricAttributes: MetricAttributes
+    metricAttributes: Attributes
   ): http.ClientRequest {
     if (this.getConfig().requestHook) {
       this._callRequestHook(span, request);
@@ -691,7 +691,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
       );
 
       const startTime = hrTime();
-      const metricAttributes: MetricAttributes =
+      const metricAttributes: Attributes =
         getOutgoingRequestMetricAttributes(attributes);
 
       const spanOptions: SpanOptions = {
@@ -756,7 +756,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
     request: http.IncomingMessage,
     response: http.ServerResponse,
     span: Span,
-    metricAttributes: MetricAttributes,
+    metricAttributes: Attributes,
     startTime: HrTime
   ) {
     const attributes = getIncomingRequestAttributesOnResponse(
@@ -800,7 +800,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
 
   private _onServerResponseError(
     span: Span,
-    metricAttributes: MetricAttributes,
+    metricAttributes: Attributes,
     startTime: HrTime,
     error: Err
   ) {
@@ -840,7 +840,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
     span: Span,
     spanKind: SpanKind,
     startTime: HrTime,
-    metricAttributes: MetricAttributes
+    metricAttributes: Attributes
   ) {
     if (!this._spanNotEnded.has(span)) {
       return;

--- a/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Span, SpanAttributes } from '@opentelemetry/api';
+import { Span, Attributes } from '@opentelemetry/api';
 import type * as http from 'http';
 import type * as https from 'https';
 import {
@@ -73,11 +73,11 @@ export interface HttpResponseCustomAttributeFunction {
 }
 
 export interface StartIncomingSpanCustomAttributeFunction {
-  (request: IncomingMessage): SpanAttributes;
+  (request: IncomingMessage): Attributes;
 }
 
 export interface StartOutgoingSpanCustomAttributeFunction {
-  (request: RequestOptions): SpanAttributes;
+  (request: RequestOptions): Attributes;
 }
 
 /**

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 import {
-  MetricAttributes,
-  SpanAttributes,
+  Attributes,
   SpanStatusCode,
   Span,
   context,
   SpanKind,
-  Attributes,
 } from '@opentelemetry/api';
 import {
   ATTR_CLIENT_ADDRESS,
@@ -212,11 +210,11 @@ export const setSpanWithError = (
 /**
  * Adds attributes for request content-length and content-encoding HTTP headers
  * @param { IncomingMessage } Request object whose headers will be analyzed
- * @param { SpanAttributes } SpanAttributes object to be modified
+ * @param { Attributes } Attributes object to be modified
  */
 export const setRequestContentLengthAttribute = (
   request: IncomingMessage,
-  attributes: SpanAttributes
+  attributes: Attributes
 ): void => {
   const length = getContentLength(request.headers);
   if (length === null) return;
@@ -231,13 +229,13 @@ export const setRequestContentLengthAttribute = (
 /**
  * Adds attributes for response content-length and content-encoding HTTP headers
  * @param { IncomingMessage } Response object whose headers will be analyzed
- * @param { SpanAttributes } SpanAttributes object to be modified
+ * @param { Attributes } Attributes object to be modified
  *
  * @deprecated this is for an older version of semconv. It is retained for compatibility using OTEL_SEMCONV_STABILITY_OPT_IN
  */
 export const setResponseContentLengthAttribute = (
   response: IncomingMessage,
-  attributes: SpanAttributes
+  attributes: Attributes
 ): void => {
   const length = getContentLength(response.headers);
   if (length === null) return;
@@ -380,7 +378,7 @@ export const extractHostnameAndPort = (
 /**
  * Returns outgoing request attributes scoped to the options passed to the request
  * @param {ParsedRequestOptions} requestOptions the same options used to make the request
- * @param {{ component: string, hostname: string, hookAttributes?: SpanAttributes }} options used to pass data needed to create attributes
+ * @param {{ component: string, hostname: string, hookAttributes?: Attributes }} options used to pass data needed to create attributes
  * @param {SemconvStability} semconvStability determines which semconv version to use
  */
 export const getOutgoingRequestAttributes = (
@@ -389,10 +387,10 @@ export const getOutgoingRequestAttributes = (
     component: string;
     hostname: string;
     port: string | number;
-    hookAttributes?: SpanAttributes;
+    hookAttributes?: Attributes;
   },
   semconvStability: SemconvStability
-): SpanAttributes => {
+): Attributes => {
   const hostname = options.hostname;
   const port = options.port;
   const method = requestOptions.method ?? 'GET';
@@ -404,7 +402,7 @@ export const getOutgoingRequestAttributes = (
     headers,
     `${options.component}:`
   );
-  const oldAttributes: SpanAttributes = {
+  const oldAttributes: Attributes = {
     [SEMATTRS_HTTP_URL]: urlFull,
     [SEMATTRS_HTTP_METHOD]: method,
     [SEMATTRS_HTTP_TARGET]: requestOptions.path || '/',
@@ -446,12 +444,12 @@ export const getOutgoingRequestAttributes = (
 
 /**
  * Returns outgoing request Metric attributes scoped to the request data
- * @param {SpanAttributes} spanAttributes the span attributes
+ * @param {Attributes} spanAttributes the span attributes
  */
 export const getOutgoingRequestMetricAttributes = (
-  spanAttributes: SpanAttributes
-): MetricAttributes => {
-  const metricAttributes: MetricAttributes = {};
+  spanAttributes: Attributes
+): Attributes => {
+  const metricAttributes: Attributes = {};
   metricAttributes[SEMATTRS_HTTP_METHOD] = spanAttributes[SEMATTRS_HTTP_METHOD];
   metricAttributes[SEMATTRS_NET_PEER_NAME] =
     spanAttributes[SEMATTRS_NET_PEER_NAME];
@@ -465,7 +463,7 @@ export const getOutgoingRequestMetricAttributes = (
  */
 export const setAttributesFromHttpKind = (
   kind: string | undefined,
-  attributes: SpanAttributes
+  attributes: Attributes
 ): void => {
   if (kind) {
     attributes[SEMATTRS_HTTP_FLAVOR] = kind;
@@ -485,9 +483,9 @@ export const setAttributesFromHttpKind = (
 export const getOutgoingRequestAttributesOnResponse = (
   response: IncomingMessage,
   semconvStability: SemconvStability
-): SpanAttributes => {
+): Attributes => {
   const { statusCode, statusMessage, httpVersion, socket } = response;
-  const oldAttributes: SpanAttributes = {};
+  const oldAttributes: Attributes = {};
   const stableAttributes: Attributes = {};
 
   if (statusCode != null) {
@@ -527,12 +525,12 @@ export const getOutgoingRequestAttributesOnResponse = (
 
 /**
  * Returns outgoing request Metric attributes scoped to the response data
- * @param {SpanAttributes} spanAttributes the span attributes
+ * @param {Attributes} spanAttributes the span attributes
  */
 export const getOutgoingRequestMetricAttributesOnResponse = (
-  spanAttributes: SpanAttributes
-): MetricAttributes => {
-  const metricAttributes: MetricAttributes = {};
+  spanAttributes: Attributes
+): Attributes => {
+  const metricAttributes: Attributes = {};
   metricAttributes[SEMATTRS_NET_PEER_PORT] =
     spanAttributes[SEMATTRS_NET_PEER_PORT];
   metricAttributes[SEMATTRS_HTTP_STATUS_CODE] =
@@ -694,7 +692,7 @@ export function getRemoteClientAddress(
 /**
  * Returns incoming request attributes scoped to the request data
  * @param {IncomingMessage} request the request object
- * @param {{ component: string, serverName?: string, hookAttributes?: SpanAttributes }} options used to pass data needed to create attributes
+ * @param {{ component: string, serverName?: string, hookAttributes?: Attributes }} options used to pass data needed to create attributes
  * @param {SemconvStability} semconvStability determines which semconv version to use
  */
 export const getIncomingRequestAttributes = (
@@ -702,10 +700,10 @@ export const getIncomingRequestAttributes = (
   options: {
     component: 'http' | 'https';
     serverName?: string;
-    hookAttributes?: SpanAttributes;
+    hookAttributes?: Attributes;
     semconvStability: SemconvStability;
   }
-): SpanAttributes => {
+): Attributes => {
   const headers = request.headers;
   const userAgent = headers['user-agent'];
   const ips = headers['x-forwarded-for'];
@@ -794,13 +792,13 @@ export const getIncomingRequestAttributes = (
 
 /**
  * Returns incoming request Metric attributes scoped to the request data
- * @param {SpanAttributes} spanAttributes the span attributes
+ * @param {Attributes} spanAttributes the span attributes
  * @param {{ component: string }} options used to pass data needed to create attributes
  */
 export const getIncomingRequestMetricAttributes = (
-  spanAttributes: SpanAttributes
-): MetricAttributes => {
-  const metricAttributes: MetricAttributes = {};
+  spanAttributes: Attributes
+): Attributes => {
+  const metricAttributes: Attributes = {};
   metricAttributes[SEMATTRS_HTTP_SCHEME] = spanAttributes[SEMATTRS_HTTP_SCHEME];
   metricAttributes[SEMATTRS_HTTP_METHOD] = spanAttributes[SEMATTRS_HTTP_METHOD];
   metricAttributes[SEMATTRS_NET_HOST_NAME] =
@@ -818,7 +816,7 @@ export const getIncomingRequestAttributesOnResponse = (
   request: IncomingMessage,
   response: ServerResponse,
   semconvStability: SemconvStability
-): SpanAttributes => {
+): Attributes => {
   // take socket from the request,
   // since it may be detached from the response object in keep-alive mode
   const { socket } = request;
@@ -829,7 +827,7 @@ export const getIncomingRequestAttributesOnResponse = (
   };
 
   const rpcMetadata = getRPCMetadata(context.active());
-  const oldAttributes: SpanAttributes = {};
+  const oldAttributes: Attributes = {};
   if (socket) {
     const { localAddress, localPort, remoteAddress, remotePort } = socket;
     oldAttributes[SEMATTRS_NET_HOST_IP] = localAddress;
@@ -858,12 +856,12 @@ export const getIncomingRequestAttributesOnResponse = (
 
 /**
  * Returns incoming request Metric attributes scoped to the request data
- * @param {SpanAttributes} spanAttributes the span attributes
+ * @param {Attributes} spanAttributes the span attributes
  */
 export const getIncomingRequestMetricAttributesOnResponse = (
-  spanAttributes: SpanAttributes
-): MetricAttributes => {
-  const metricAttributes: MetricAttributes = {};
+  spanAttributes: Attributes
+): Attributes => {
+  const metricAttributes: Attributes = {};
   metricAttributes[SEMATTRS_HTTP_STATUS_CODE] =
     spanAttributes[SEMATTRS_HTTP_STATUS_CODE];
   metricAttributes[SEMATTRS_NET_HOST_PORT] =

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
@@ -21,7 +21,7 @@ import {
   Span as ISpan,
   SpanKind,
   trace,
-  SpanAttributes,
+  Attributes,
   DiagConsoleLogger,
 } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
@@ -144,13 +144,13 @@ export const responseHookFunction = (
 
 export const startIncomingSpanHookFunction = (
   request: IncomingMessage
-): SpanAttributes => {
+): Attributes => {
   return { guid: request.headers?.guid };
 };
 
 export const startOutgoingSpanHookFunction = (
   request: RequestOptions
-): SpanAttributes => {
+): Attributes => {
   return { guid: request.headers?.guid };
 };
 

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 import {
-  SpanAttributes,
+  Attributes,
   SpanStatusCode,
   ROOT_CONTEXT,
   SpanKind,
   TraceFlags,
   context,
-  Attributes,
 } from '@opentelemetry/api';
 import { BasicTracerProvider, Span } from '@opentelemetry/sdk-trace-base';
 import {
@@ -362,7 +361,7 @@ describe('Utility', () => {
   // Verify the key in the given attributes is set to the given value,
   // and that no other HTTP Content Length attributes are set.
   function verifyValueInAttributes(
-    attributes: SpanAttributes,
+    attributes: Attributes,
     key: string | undefined,
     value: number
   ) {
@@ -384,7 +383,7 @@ describe('Utility', () => {
 
   describe('setRequestContentLengthAttributes()', () => {
     it('should set request content-length uncompressed attribute with no content-encoding header', () => {
-      const attributes: SpanAttributes = {};
+      const attributes: Attributes = {};
       const request = {} as IncomingMessage;
 
       request.headers = {
@@ -400,7 +399,7 @@ describe('Utility', () => {
     });
 
     it('should set request content-length uncompressed attribute with "identity" content-encoding header', () => {
-      const attributes: SpanAttributes = {};
+      const attributes: Attributes = {};
       const request = {} as IncomingMessage;
       request.headers = {
         'content-length': '1200',
@@ -416,7 +415,7 @@ describe('Utility', () => {
     });
 
     it('should set request content-length compressed attribute with "gzip" content-encoding header', () => {
-      const attributes: SpanAttributes = {};
+      const attributes: Attributes = {};
       const request = {} as IncomingMessage;
       request.headers = {
         'content-length': '1200',
@@ -434,7 +433,7 @@ describe('Utility', () => {
 
   describe('setResponseContentLengthAttributes()', () => {
     it('should set response content-length uncompressed attribute with no content-encoding header', () => {
-      const attributes: SpanAttributes = {};
+      const attributes: Attributes = {};
 
       const response = {} as IncomingMessage;
 
@@ -451,7 +450,7 @@ describe('Utility', () => {
     });
 
     it('should set response content-length uncompressed attribute with "identity" content-encoding header', () => {
-      const attributes: SpanAttributes = {};
+      const attributes: Attributes = {};
 
       const response = {} as IncomingMessage;
 
@@ -470,7 +469,7 @@ describe('Utility', () => {
     });
 
     it('should set response content-length compressed attribute with "gzip" content-encoding header', () => {
-      const attributes: SpanAttributes = {};
+      const attributes: Attributes = {};
 
       const response = {} as IncomingMessage;
 
@@ -489,7 +488,7 @@ describe('Utility', () => {
     });
 
     it('should set no attributes with no content-length header', () => {
-      const attributes: SpanAttributes = {};
+      const attributes: Attributes = {};
       const message = {} as IncomingMessage;
 
       message.headers = {


### PR DESCRIPTION
## Which problem is this PR solving?

Replaces `SpanAttributes` and `MetricsAttributes` with `Attributes`. Mote this is not marked as a breaking change since `@opentelemetry/api` dependency is already at `v1.3.0` and types do not break.

Refs #4175

## Type of change

Please delete options that are not relevant.

- [X] refactor

## How Has This Been Tested?

compile and ran the test suite for instrumentation

## Checklist:

- [X] Followed the style guidelines of this project
