### PR TITLE
chore(exporter-zipkin): remove usages of Span constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
   [#4992](https://github.com/open-telemetry/opentelemetry-js/pull/4992)
 * refactor(sdk-metrics): replace `MetricsAttributes` with `Attributes` [#5021](https://github.com/open-telemetry/opentelemetry-js/pull/5021) @david-luna
 * refactor(instrumentation-http): replace `SpanAttributes` and `MetricsAttributes` with `Attributes` [#5023](https://github.com/open-telemetry/opentelemetry-js/pull/5023) @david-luna
+* chore(exporter-zipkin): remove usages of Span constructor [#5030](https://github.com/open-telemetry/opentelemetry-js/pull/5030) @david-luna
 
 ## 1.26.0
 

--- a/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
@@ -73,7 +73,7 @@ function getSpan(options: Partial<ReadableSpan>): ReadableSpan {
     resource,
   } as ReadableSpan;
 
-  // Expicit `undefined` properties fro options will be removed from the
+  // Expicit `undefined` properties in options will be removed from the
   // result span.
   Object.keys(options).forEach(k => {
     if (options[k as keyof ReadableSpan] === undefined) {

--- a/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
@@ -61,7 +61,7 @@ describe('transform', () => {
       const span = tracer.startSpan(
         'my-span',
         { kind: api.SpanKind.SERVER },
-        api.ROOT_CONTEXT,
+        api.ROOT_CONTEXT
       ) as unknown as Span;
       (span as any)['_spanContext'] = spanContext;
       (span as any)['parentSpanId'] = parentId;
@@ -115,7 +115,7 @@ describe('transform', () => {
       const span = tracer.startSpan(
         'my-span',
         { kind: api.SpanKind.SERVER },
-        api.ROOT_CONTEXT,
+        api.ROOT_CONTEXT
       ) as unknown as Span;
       span.end();
 
@@ -164,7 +164,7 @@ describe('transform', () => {
         const span = tracer.startSpan(
           'my-span',
           { kind: item.ot },
-          api.ROOT_CONTEXT,
+          api.ROOT_CONTEXT
         ) as unknown as Span;
         span.end();
 
@@ -207,7 +207,7 @@ describe('transform', () => {
       const span = tracer.startSpan(
         'my-span',
         { kind: api.SpanKind.SERVER },
-        api.ROOT_CONTEXT,
+        api.ROOT_CONTEXT
       ) as unknown as Span;
 
       span.setAttributes({
@@ -240,9 +240,9 @@ describe('transform', () => {
           attributes: {
             key1: 'value1',
             key2: 'value2',
-          }
+          },
         },
-        api.ROOT_CONTEXT,
+        api.ROOT_CONTEXT
       ) as unknown as Span;
 
       const tags: zipkinTypes.Tags = _toZipkinTags(
@@ -269,7 +269,7 @@ describe('transform', () => {
         {
           kind: api.SpanKind.SERVER,
         },
-        api.ROOT_CONTEXT,
+        api.ROOT_CONTEXT
       ) as unknown as Span;
       const status: api.SpanStatus = {
         code: api.SpanStatusCode.ERROR,
@@ -304,7 +304,7 @@ describe('transform', () => {
         {
           kind: api.SpanKind.SERVER,
         },
-        api.ROOT_CONTEXT,
+        api.ROOT_CONTEXT
       ) as unknown as Span;
       const status: api.SpanStatus = {
         code: api.SpanStatusCode.ERROR,
@@ -344,7 +344,7 @@ describe('transform', () => {
         {
           kind: api.SpanKind.SERVER,
         },
-        api.ROOT_CONTEXT,
+        api.ROOT_CONTEXT
       ) as unknown as Span;
       span.addEvent('my-event1');
       span.addEvent('my-event2', { key1: 'value1' });

--- a/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/common/transform.test.ts
@@ -58,14 +58,14 @@ const spanContext: api.SpanContext = {
 describe('transform', () => {
   describe('toZipkinSpan', () => {
     it('should convert an OpenTelemetry span to a Zipkin span', () => {
-      const span = new Span(
-        tracer,
-        api.ROOT_CONTEXT,
+      const span = tracer.startSpan(
         'my-span',
-        spanContext,
-        api.SpanKind.SERVER,
-        parentId
-      );
+        { kind: api.SpanKind.SERVER },
+        api.ROOT_CONTEXT,
+      ) as unknown as Span;
+      (span as any)['_spanContext'] = spanContext;
+      (span as any)['parentSpanId'] = parentId;
+
       span.setAttributes({
         key1: 'value1',
         key2: 'value2',
@@ -112,13 +112,11 @@ describe('transform', () => {
       });
     });
     it("should skip parentSpanId if doesn't exist", () => {
-      const span = new Span(
-        tracer,
-        api.ROOT_CONTEXT,
+      const span = tracer.startSpan(
         'my-span',
-        spanContext,
-        api.SpanKind.SERVER
-      );
+        { kind: api.SpanKind.SERVER },
+        api.ROOT_CONTEXT,
+      ) as unknown as Span;
       span.end();
 
       const zipkinSpan = toZipkinSpan(
@@ -163,13 +161,11 @@ describe('transform', () => {
       it(`should map OpenTelemetry SpanKind ${
         api.SpanKind[item.ot]
       } to Zipkin ${item.zipkin}`, () => {
-        const span = new Span(
-          tracer,
-          api.ROOT_CONTEXT,
+        const span = tracer.startSpan(
           'my-span',
-          spanContext,
-          item.ot
-        );
+          { kind: item.ot },
+          api.ROOT_CONTEXT,
+        ) as unknown as Span;
         span.end();
 
         const zipkinSpan = toZipkinSpan(
@@ -208,14 +204,12 @@ describe('transform', () => {
 
   describe('_toZipkinTags', () => {
     it('should convert OpenTelemetry attributes to Zipkin tags', () => {
-      const span = new Span(
-        tracer,
-        api.ROOT_CONTEXT,
+      const span = tracer.startSpan(
         'my-span',
-        spanContext,
-        api.SpanKind.SERVER,
-        parentId
-      );
+        { kind: api.SpanKind.SERVER },
+        api.ROOT_CONTEXT,
+      ) as unknown as Span;
+
       span.setAttributes({
         key1: 'value1',
         key2: 'value2',
@@ -239,21 +233,18 @@ describe('transform', () => {
       });
     });
     it('should map OpenTelemetry constructor attributes to a Zipkin tag', () => {
-      const span = new Span(
-        tracer,
-        api.ROOT_CONTEXT,
+      const span = tracer.startSpan(
         'my-span',
-        spanContext,
-        api.SpanKind.SERVER,
-        parentId,
-        [],
-        undefined,
-        undefined,
         {
-          key1: 'value1',
-          key2: 'value2',
-        }
-      );
+          kind: api.SpanKind.SERVER,
+          attributes: {
+            key1: 'value1',
+            key2: 'value2',
+          }
+        },
+        api.ROOT_CONTEXT,
+      ) as unknown as Span;
+
       const tags: zipkinTypes.Tags = _toZipkinTags(
         span,
         defaultStatusCodeTagName,
@@ -273,14 +264,13 @@ describe('transform', () => {
       });
     });
     it('should map OpenTelemetry SpanStatus.code to a Zipkin tag', () => {
-      const span = new Span(
-        tracer,
-        api.ROOT_CONTEXT,
+      const span = tracer.startSpan(
         'my-span',
-        spanContext,
-        api.SpanKind.SERVER,
-        parentId
-      );
+        {
+          kind: api.SpanKind.SERVER,
+        },
+        api.ROOT_CONTEXT,
+      ) as unknown as Span;
       const status: api.SpanStatus = {
         code: api.SpanStatusCode.ERROR,
       };
@@ -309,14 +299,13 @@ describe('transform', () => {
       });
     });
     it('should map OpenTelemetry SpanStatus.message to a Zipkin tag', () => {
-      const span = new Span(
-        tracer,
-        api.ROOT_CONTEXT,
+      const span = tracer.startSpan(
         'my-span',
-        spanContext,
-        api.SpanKind.SERVER,
-        parentId
-      );
+        {
+          kind: api.SpanKind.SERVER,
+        },
+        api.ROOT_CONTEXT,
+      ) as unknown as Span;
       const status: api.SpanStatus = {
         code: api.SpanStatusCode.ERROR,
         message: 'my-message',
@@ -350,14 +339,13 @@ describe('transform', () => {
 
   describe('_toZipkinAnnotations', () => {
     it('should convert OpenTelemetry events to Zipkin annotations', () => {
-      const span = new Span(
-        tracer,
-        api.ROOT_CONTEXT,
+      const span = tracer.startSpan(
         'my-span',
-        spanContext,
-        api.SpanKind.SERVER,
-        parentId
-      );
+        {
+          kind: api.SpanKind.SERVER,
+        },
+        api.ROOT_CONTEXT,
+      ) as unknown as Span;
       span.addEvent('my-event1');
       span.addEvent('my-event2', { key1: 'value1' });
 


### PR DESCRIPTION


## Which problem is this PR solving?

The Span constructor from ' @opentelemetry/sdk-trace-base` is planned for removal from the public API . This PR anticipates the possible breaking changes derived from it

Refs #3597

## Short description of the changes

- Remove usage of `new Span` constructor in favour of `Tracer.startSpan`

## Type of change

Please delete options that are not relevant.

- [X] Test refactor (non-breaking change which fixes tests)

## How Has This Been Tested?

- [X] Ran zipkin unit tests

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been modified
