### PR TITLE
docs: [Browser] Define the support browser runtimes #4168

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 
 ### :books: (Refine Doc)
 
+* docs: [Browser] Define the support browser runtimes [Issue #4168](https://github.com/open-telemetry/opentelemetry-js/issues/4168) PR:[#5032](https://github.com/open-telemetry/opentelemetry-js/pull/5032) @MSNev
+
 ### :house: (Internal)
 
 * deps: set `@opentelemetry/api` dependency min version to 1.3.0 in `examples`, `experimental/packages`, `integration-tests` and `selenium-tests`

--- a/README.md
+++ b/README.md
@@ -135,8 +135,17 @@ Note that versions of Node.JS v8 prior to `v8.12.0` will NOT work, because OpenT
 > Client instrumentation for the browser is **experimental** and mostly **unspecified**. If you are interested in
 > helping out, get in touch with the [Client Instrumentation SIG][client-instrumentation-sig].
 
-There is currently no list of officially supported browsers. OpenTelemetry is developed using standard web
-technologies and aims to work in currently supported versions of major browsers.
+Rather that define versions of specific browsers / runtimes, OpenTelemetry sets the minimum supported version based on the
+underlying Language features used.
+
+The current minumum language feature support is set as [ECMAScript 2020](https://www.w3schools.com/jS/js_2020.asp) that are available
+in all modern browsers / runtimes.
+
+This means that if you are targeting or your end-users are using a browser / runtime that does not support ES2020, you will need
+to either transpile your code to ensure compatibility or provide any necessary polyfill's for the missing features. Any support
+issues that arise from using a browser or runtime that does not support ES2020 will be closed as "won't fix".
+
+This minimum support level is subject to change as the project evolves and as the underlying language features evolve.
 
 ## Package Version Compatibility
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The current minumum language feature support is set as [ECMAScript 2020](https:/
 in all modern browsers / runtimes.
 
 This means that if you are targeting or your end-users are using a browser / runtime that does not support ES2020, you will need
-to either transpile your code to ensure compatibility or provide any necessary polyfill's for the missing features. Any support
+to transpile the code and provide any necessary polyfill's for the missing features to ensure compatibility with your target environments. Any support
 issues that arise from using a browser or runtime that does not support ES2020 will be closed as "won't fix".
 
 This minimum support level is subject to change as the project evolves and as the underlying language features evolve.


### PR DESCRIPTION
As part of v2 preparation and defining the based supported set of browser / runtimes.

While defined as a v2 Issue, there is no readme for v2, so adding to core

Issue: https://github.com/open-telemetry/opentelemetry-js/issues/4168 [Browser] Define the support browser runtimes