### PR TITLE
fix(sdk-node): use warn instead of error on unknown OTEL_NODE_RESOURCE_DETECTORS values

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to experimental packages in this project will be documented 
     * `appendResourcePathToUrlIfNeeded`
     * `configureExporterTimeout`
     * `invalidTimeout`
+* Changed `diag.error` to `diag.warn` for unknown `OTEL_NODE_RESOURCE_DETECTORS` values in [#4882](https://github.com/open-telemetry/opentelemetry-js/issues/4882).
 
 ### :books: (Refine Doc)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -46,7 +46,7 @@ All notable changes to experimental packages in this project will be documented 
     * `appendResourcePathToUrlIfNeeded`
     * `configureExporterTimeout`
     * `invalidTimeout`
-* Changed `diag.error` to `diag.warn` for unknown `OTEL_NODE_RESOURCE_DETECTORS` values in [#4882](https://github.com/open-telemetry/opentelemetry-js/issues/4882).
+* fix(sdk-node): use warn instead of error on unknown OTEL_NODE_RESOURCE_DETECTORS values [#5034](https://github.com/open-telemetry/opentelemetry-js/pull/5034))
 
 ### :books: (Refine Doc)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -46,7 +46,7 @@ All notable changes to experimental packages in this project will be documented 
     * `appendResourcePathToUrlIfNeeded`
     * `configureExporterTimeout`
     * `invalidTimeout`
-* fix(sdk-node): use warn instead of error on unknown OTEL_NODE_RESOURCE_DETECTORS values [#5034](https://github.com/open-telemetry/opentelemetry-js/pull/5034))
+* fix(sdk-node): use warn instead of error on unknown OTEL_NODE_RESOURCE_DETECTORS values [#5034](https://github.com/open-telemetry/opentelemetry-js/pull/5034)
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -54,7 +54,7 @@ export function getResourceDetectorsFromEnv(): Array<DetectorSync> {
   return resourceDetectorsFromEnv.flatMap(detector => {
     const resourceDetector = resourceDetectors.get(detector);
     if (!resourceDetector) {
-      diag.error(
+      diag.warn(
         `Invalid resource detector "${detector}" specified in the environment variable OTEL_NODE_RESOURCE_DETECTORS`
       );
     }


### PR DESCRIPTION
### Which problem is this PR solving?
This PR addresses the issue #4882, which involves logging an unrecognized OTEL_NODE_RESOURCE_DETECTORS value. According to the OpenTelemetry specification, unrecognized enum values should generate a warning rather than an error. The current implementation uses diag.error to log this issue, but it should use diag.warn instead to align with the specification and avoid unnecessary error-level logging.

Fixes: #4882

### Short description of the changes
Updated opentelemetry-sdk-node/src/utils.ts and auto-instrumentations-node/src/utils.ts to replace diag.error with diag.warn for handling unrecognized OTEL_NODE_RESOURCE_DETECTORS values.
This change ensures that unrecognized values generate a warning, as specified in the OpenTelemetry SDK environment variable guidelines.

### Type of change
 Bug fix (non-breaking change which fixes an issue)
 
### How Has This Been Tested?

- Ran the existing test suite using npm test to confirm that all tests pass successfully.

- Manually verified that unrecognized OTEL_NODE_RESOURCE_DETECTORS values log a warning instead of an error.

### Checklist:
 

- [ ] Followed the style guidelines of this project

 

- [ ] Unit tests have been added (if applicable)

 

- [ ] Documentation has been updated where necessary