### PR TITLE
Dluna/3597 remove span constructor http instr

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -16,12 +16,11 @@
 import {
   Attributes,
   SpanStatusCode,
-  ROOT_CONTEXT,
   SpanKind,
-  TraceFlags,
   context,
+  Span,
 } from '@opentelemetry/api';
-import { BasicTracerProvider, Span } from '@opentelemetry/sdk-trace-base';
+// import { Span } from '@opentelemetry/sdk-trace-base';
 import {
   SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH,
   SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,
@@ -257,26 +256,28 @@ describe('Utility', () => {
   describe('setSpanWithError()', () => {
     it('should have error attributes', () => {
       const errorMessage = 'test error';
-      const span = new Span(
-        new BasicTracerProvider().getTracer('default'),
-        ROOT_CONTEXT,
-        'test',
-        { spanId: '', traceId: '', traceFlags: TraceFlags.SAMPLED },
-        SpanKind.INTERNAL
-      );
-      utils.setSpanWithError(
-        span,
-        new Error(errorMessage),
-        SemconvStability.OLD
-      );
-      const attributes = span.attributes;
-      assert.strictEqual(
-        attributes[AttributeNames.HTTP_ERROR_MESSAGE],
-        errorMessage
-      );
-      assert.strictEqual(span.events.length, 1);
-      assert.strictEqual(span.events[0].name, 'exception');
-      assert.ok(attributes[AttributeNames.HTTP_ERROR_NAME]);
+      const error = new Error(errorMessage);
+      const span = {
+        setAttribute: () => undefined,
+        setStatus: () => undefined,
+        recordException: () => undefined,
+      } as unknown as Span;
+      const mock = sinon.mock(span);
+
+      mock
+        .expects('setAttribute')
+        .calledWithExactly(AttributeNames.HTTP_ERROR_NAME, 'error');
+      mock
+        .expects('setAttribute')
+        .calledWithExactly(AttributeNames.HTTP_ERROR_MESSAGE, errorMessage);
+      mock.expects('setStatus').calledWithExactly({
+        code: SpanStatusCode.ERROR,
+        message: errorMessage,
+      });
+      mock.expects('recordException').calledWithExactly(error);
+
+      utils.setSpanWithError(span, error, SemconvStability.OLD);
+      mock.verify();
     });
   });
 
@@ -537,40 +538,51 @@ describe('Utility', () => {
 
   describe('headers to span attributes capture', () => {
     let span: Span;
+    let mock: sinon.SinonMock;
 
     beforeEach(() => {
-      span = new Span(
-        new BasicTracerProvider().getTracer('default'),
-        ROOT_CONTEXT,
-        'test',
-        { spanId: '', traceId: '', traceFlags: TraceFlags.SAMPLED },
-        SpanKind.INTERNAL
-      );
+      span = {
+        setAttribute: () => undefined,
+      } as unknown as Span;
+      mock = sinon.mock(span);
     });
 
     it('should set attributes for request and response keys', () => {
+      mock
+        .expects('setAttribute')
+        .calledWithExactly('http.request.header.origin', ['localhost']);
+      mock
+        .expects('setAttribute')
+        .calledWithExactly('http.response.header.cookie', ['token=123']);
+
       utils.headerCapture('request', ['Origin'])(span, () => 'localhost');
       utils.headerCapture('response', ['Cookie'])(span, () => 'token=123');
-      assert.deepStrictEqual(span.attributes['http.request.header.origin'], [
-        'localhost',
-      ]);
-      assert.deepStrictEqual(span.attributes['http.response.header.cookie'], [
-        'token=123',
-      ]);
+      mock.verify();
     });
 
     it('should set attributes for multiple values', () => {
+      mock
+        .expects('setAttribute')
+        .calledWithExactly('http.request.header.origin', [
+          'localhost',
+          'www.example.com',
+        ]);
+
       utils.headerCapture('request', ['Origin'])(span, () => [
         'localhost',
         'www.example.com',
       ]);
-      assert.deepStrictEqual(span.attributes['http.request.header.origin'], [
-        'localhost',
-        'www.example.com',
-      ]);
+      mock.verify();
     });
 
     it('sets attributes for multiple headers', () => {
+      mock
+        .expects('setAttribute')
+        .calledWithExactly('http.request.header.origin', ['localhost']);
+      mock
+        .expects('setAttribute')
+        .calledWithExactly('http.request.header.foo', [42]);
+
       utils.headerCapture('request', ['Origin', 'Foo'])(span, header => {
         if (header === 'origin') {
           return 'localhost';
@@ -582,22 +594,24 @@ describe('Utility', () => {
 
         return undefined;
       });
-
-      assert.deepStrictEqual(span.attributes['http.request.header.origin'], [
-        'localhost',
-      ]);
-      assert.deepStrictEqual(span.attributes['http.request.header.foo'], [42]);
+      mock.verify();
     });
 
     it('should normalize header names', () => {
+      mock
+        .expects('setAttribute')
+        .calledWithExactly('http.request.header.x_forwarded_for', ['foo']);
+
       utils.headerCapture('request', ['X-Forwarded-For'])(span, () => 'foo');
-      assert.deepStrictEqual(
-        span.attributes['http.request.header.x_forwarded_for'],
-        ['foo']
-      );
+      mock.verify();
     });
 
     it('ignores non-existent headers', () => {
+      mock
+        .expects('setAttribute')
+        .once()
+        .calledWithExactly('http.request.header.origin', ['localhost']);
+
       utils.headerCapture('request', ['Origin', 'Accept'])(span, header => {
         if (header === 'origin') {
           return 'localhost';
@@ -605,14 +619,7 @@ describe('Utility', () => {
 
         return undefined;
       });
-
-      assert.deepStrictEqual(span.attributes['http.request.header.origin'], [
-        'localhost',
-      ]);
-      assert.deepStrictEqual(
-        span.attributes['http.request.header.accept'],
-        undefined
-      );
+      mock.verify();
     });
   });
 

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -20,7 +20,6 @@ import {
   context,
   Span,
 } from '@opentelemetry/api';
-// import { Span } from '@opentelemetry/sdk-trace-base';
 import {
   SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH,
   SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED,


### PR DESCRIPTION
## Which problem is this PR solving?

The Span constructor from ' @opentelemetry/sdk-trace-base` is planned for removal from the public API . This PR anticipates the possible breaking changes derived from it

Refs #3597

## Short description of the changes

- Remove usage of `new Span` constructor in favour of using a mock Span and asserting over API calls

## Type of change

Please delete options that are not relevant.

- [X] Test refactor (non-breaking change which fixes tests)

## How Has This Been Tested?

- [X] Ran intr-http unit tests

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been modified
