### PR TITLE
ci: use codecov token when uploading reports

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -48,6 +48,8 @@ jobs:
         run: npm run test
       - name: Report Coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           verbose: true
   node-windows-tests:
@@ -102,6 +104,8 @@ jobs:
         run: npm run test:browser
       - name: Report Coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           verbose: true
   webworker-tests:
@@ -128,6 +132,8 @@ jobs:
         run: npm run test:webworker
       - name: Report Coverage
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           verbose: true
   api-eol-node-test:


### PR DESCRIPTION
## Which problem is this PR solving?

Noticed that all the PR states that the coverage from `main` is behind. Looks like on main the permissions are not enough to create a new main commit in codecov. 

So I'm now passing the token to see if that makes a difference. This is what the Go SIG does:
https://github.com/open-telemetry/opentelemetry-go/blob/8fbaa970843f0899228bc19c1e45a31f5a5bb73e/.github/workflows/ci.yml#L124-L130

See:
- failing upload: https://github.com/open-telemetry/opentelemetry-js/actions/runs/11223167457/job/31197190624#step:9:52 
- comment on PR: https://github.com/open-telemetry/opentelemetry-js/pull/5031#issuecomment-2388633390

I've noticed the same happening on contrib, where we're hundreds of commits behind. We'll have to do the same there. 
