### PR TITLE
feat(otlp-exporter-base): support CONNECT proxies

### DIFF
--- a/experimental/packages/otlp-exporter-base/src/configuration/otlp-http-configuration.ts
+++ b/experimental/packages/otlp-exporter-base/src/configuration/otlp-http-configuration.ts
@@ -50,7 +50,9 @@ function mergeHeaders(
   return Object.assign(headers, requiredHeaders);
 }
 
-function validateUserProvidedUrl(url: string | undefined): string | undefined {
+export function validateUserProvidedUrl(
+  url: string | undefined
+): string | undefined {
   if (url == null) {
     return undefined;
   }

--- a/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/OTLPExporterNodeBase.ts
@@ -26,6 +26,7 @@ import { convertLegacyAgentOptions } from './convert-legacy-agent-options';
 import {
   getHttpConfigurationDefaults,
   mergeOtlpHttpConfigurationWithDefaults,
+  validateUserProvidedUrl,
 } from '../../configuration/otlp-http-configuration';
 import { getHttpConfigurationFromEnvironment } from '../../configuration/otlp-http-env-configuration';
 
@@ -75,6 +76,7 @@ export abstract class OTLPExporterNodeBase<
         compression: actualConfig.compression,
         headers: actualConfig.headers,
         url: actualConfig.url,
+        proxy: validateUserProvidedUrl(config.proxy),
       }),
     });
   }

--- a/experimental/packages/otlp-exporter-base/src/platform/node/http-exporter-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/http-exporter-transport.ts
@@ -40,10 +40,7 @@ class HttpExporterTransport implements IExporterTransport {
         createHttpAgent,
         // eslint-disable-next-line @typescript-eslint/no-var-requires
       } = require('./http-transport-utils');
-      this._agent = createHttpAgent(
-        this._parameters.url,
-        this._parameters.agentOptions
-      );
+      this._agent = createHttpAgent(this._parameters);
       this._send = sendWithHttp;
     }
 

--- a/experimental/packages/otlp-exporter-base/src/platform/node/http-transport-types.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/http-transport-types.ts
@@ -31,4 +31,5 @@ export interface HttpRequestParameters {
   headers: Record<string, string>;
   compression: 'gzip' | 'none';
   agentOptions: http.AgentOptions | https.AgentOptions;
+  proxy?: string;
 }

--- a/experimental/packages/otlp-exporter-base/src/platform/node/types.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/types.ts
@@ -24,7 +24,7 @@ import { OTLPExporterConfigBase } from '../../types';
 export interface OTLPExporterNodeConfigBase extends OTLPExporterConfigBase {
   keepAlive?: boolean;
   compression?: CompressionAlgorithm;
-  proxy?: string
+  proxy?: string;
   httpAgentOptions?: http.AgentOptions | https.AgentOptions;
 }
 

--- a/experimental/packages/otlp-exporter-base/src/platform/node/types.ts
+++ b/experimental/packages/otlp-exporter-base/src/platform/node/types.ts
@@ -24,6 +24,7 @@ import { OTLPExporterConfigBase } from '../../types';
 export interface OTLPExporterNodeConfigBase extends OTLPExporterConfigBase {
   keepAlive?: boolean;
   compression?: CompressionAlgorithm;
+  proxy?: string
   httpAgentOptions?: http.AgentOptions | https.AgentOptions;
 }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Currently it's possible to use [HTTP `CONNECT` proxies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT) with gRPC through the [`@grpc/grpc-js` environment variables](https://github.com/grpc/grpc-node/blob/master/doc/environment_variables.md), however the same is not possible for the HTTP exporters.

At the moment this can't be configured with environment variables, and as far as I'm aware OTel doesn't define any for proxies ? The option could be exposed with the same `HTTP(S)_PROXY` variables as gRPC but I don't know if that's desirable.

I haven't updated the documentation yet in case there are any suggestions for better or additional ways to configure this.

## Short description of the changes

This adds a new `proxy?: string` configuration value for `OTLPExporterNodeBase`. When provided, the transport uses a custom `Agent` which overrides the `createConnection` method to obtain the socket through an HTTP `CONNECT` request to the proxy url.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Most of the transport unit tests have been mirrored and adapted to test similar proxied scenarios.

For testing the feature in practice one can use something like <https://github.com/mock-server/mockserver> or any other proxy with `CONNECT` support.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
