### PR TITLE
 Added custom test instructions for browser-specific tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,7 +229,7 @@ Packages that are expected to run in the browser have browser specific tests:
 # Run browser-specific test
 npm run test:browser
 
-#Run web worker test
+# Run web worker test
 npm run test:webworker
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,6 +223,16 @@ To run the unit tests continuously in watch mode while developing, use:
 npm run tdd
 ```
 
+Packages that are expected to run in the browser have browser specific tests:
+
+```sh
+# Run browser-specific test
+npm run test:browser
+
+#Run web worker test
+npm run test:webworker
+```
+
 ### Linting
 
 This project uses `eslint` to lint source code. Just like tests and compilation, linting can be done for all packages or only a single package.


### PR DESCRIPTION
Fixes: #5046 

Packages that also run in browser have browser-specific tests. Adding this information in [Running tests](https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md#running-tests) CONTRIBUTING.md. 


