### PR TITLE
fix(exporter-logs-otlp-proto): Use correct config type in constructor

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to experimental packages in this project will be documented 
     * `configureExporterTimeout`
     * `invalidTimeout`
 * fix(sdk-node): use warn instead of error on unknown OTEL_NODE_RESOURCE_DETECTORS values [#5034](https://github.com/open-telemetry/opentelemetry-js/pull/5034)
+* fix(exporter-logs-otlp-proto): Use correct config type in Node constructor
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
@@ -15,8 +15,8 @@
  */
 
 import {
-  OTLPExporterConfigBase,
   OTLPExporterNodeBase,
+  OTLPExporterNodeConfigBase,
 } from '@opentelemetry/otlp-exporter-base';
 import {
   IExportLogsServiceResponse,
@@ -37,7 +37,7 @@ export class OTLPLogExporter
   extends OTLPExporterNodeBase<ReadableLogRecord, IExportLogsServiceResponse>
   implements LogRecordExporter
 {
-  constructor(config: OTLPExporterConfigBase = {}) {
+  constructor(config: OTLPExporterNodeConfigBase = {}) {
     super(
       config,
       ProtobufLogsSerializer,


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The `OTLPLogExporter` constructor doesn't specify the correct config type. This updates it from `OTLPExporterConfigBase` to `OTLPExporterNodeConfigBase`.

Fixes #5057 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
