### PR TITLE
ci: add workflow to publish packages to npm

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,0 +1,33 @@
+name: Publish packages to NPM
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release-to-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - run: npm run compile
+
+      - name: Publish to npm
+        # only publish if a release has been created
+        if: ${{ steps.release.outputs.releases_created }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
+        run: npx lerna publish --concurrency 1 from-package --no-push --no-private --no-git-tag-version --no-verify-access --yes

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -25,8 +25,6 @@ jobs:
       - run: npm run compile
 
       - name: Publish to npm
-        # only publish if a release has been created
-        if: ${{ steps.release.outputs.releases_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Which problem is this PR solving?

We currently don't publish from a workflow, this PR adds a workflow so that we can release by dispatching it. This is not optimal yet, but it moves us closer towards a fully automated release pipeline.

I will update the `doc/contributing/releasing.md` when I've released with the new workflow at least once. I will then also remove the publish script from `package.json`.

Updates #4924 