### PR TITLE
test(otlp-grpc-exporter-base): do not use hard-coded version in tests, touch up changelog entries

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+* feat(exporter-*-otlp-*)!: rewrite exporter config logic for testability [#4971](https://github.com/open-telemetry/opentelemetry-js/pull/4971) @pichlermarc
+  * (user-facing) `getDefaultUrl` was intended for internal use has been removed from all exporters
+  * (user-facing) `getUrlFromConfig` was intended for internal use and has been removed from all exporters
+  * (user-facing) `hostname` was intended for internal use and has been removed from all exporters
+  * (user-facing) `url` was intended for internal use and has been removed from all exporters
+  * (user-facing) `timeoutMillis` was intended for internal use and has been removed from all exporters
+  * (user-facing) `onInit` was intended for internal use and has been removed from all exporters
+* feat(otlp-exporter-base)!: do not export functions that are intended for internal use [#4971](https://github.com/open-telemetry/opentelemetry-js/pull/4971) @pichlermarc
+  * Drops the following functions and types that were intended for internal use from the package exports:
+    * `parseHeaders`
+    * `appendResourcePathToUrl`
+    * `appendResourcePathToUrlIfNeeded`
+    * `configureExporterTimeout`
+    * `invalidTimeout`
+
 ### :rocket: (Enhancement)
 
 * feat(api-logs): Add delegating no-op logger provider [#4861](https://github.com/open-telemetry/opentelemetry-js/pull/4861) @hectorhdzg
@@ -22,13 +37,6 @@ All notable changes to experimental packages in this project will be documented 
 * fix(sdk-events): remove devDependencies to old `@opentelemetry/api-logs@0.52.0`, `@opentelemetry/api-events@0.52.0` packages [#5013](https://github.com/open-telemetry/opentelemetry-js/pull/5013) @pichlermarc
 * fix(sdk-logs): remove devDependencies to old `@opentelemetry/api-logs@0.52.0` [#5013](https://github.com/open-telemetry/opentelemetry-js/pull/5013) @pichlermarc
 * fix(sdk-logs): align LogRecord#setAttribute type with types from `@opentelemetry/api-logs@0.53.0` [#5013](https://github.com/open-telemetry/opentelemetry-js/pull/5013) @pichlermarc
-* feat(exporter-*-otlp-*)!: rewrite exporter config logic for testability [#4971](https://github.com/open-telemetry/opentelemetry-js/pull/4971) @pichlermarc
-  * (user-facing) `getDefaultUrl` was intended for internal use has been removed from all exporters
-  * (user-facing) `getUrlFromConfig` was intended for internal use and has been removed from all exporters
-  * (user-facing) `hostname` was intended for internal use and has been removed from all exporters
-  * (user-facing) `url` was intended for internal use and has been removed from all exporters
-  * (user-facing) `timeoutMillis` was intended for internal use and has been removed from all exporters
-  * (user-facing) `onInit` was intended for internal use and has been removed from all exporters
 * fix(exporter-*-otlp-*): fixes a bug where signal-specific environment variables would not be applied and the trace-specific one was used instead [#4971](https://github.com/open-telemetry/opentelemetry-js/pull/4971) @pichlermarc
   * Fixes:
     * `OTEL_EXPORTER_OTLP_METRICS_COMPRESSION`
@@ -39,13 +47,6 @@ All notable changes to experimental packages in this project will be documented 
     * `OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY`
     * `OTEL_EXPORTER_OTLP_METRICS_INSECURE`
     * `OTEL_EXPORTER_OTLP_LOGS_INSECURE`
-* feat(otlp-exporter-base)!: do not export functions that are intended for internal use [#4971](https://github.com/open-telemetry/opentelemetry-js/pull/4971) @pichlermarc
-  * Drops the following functions and types that were intended for internal use from the package exports:
-    * `parseHeaders`
-    * `appendResourcePathToUrl`
-    * `appendResourcePathToUrlIfNeeded`
-    * `configureExporterTimeout`
-    * `invalidTimeout`
 * fix(sdk-node): use warn instead of error on unknown OTEL_NODE_RESOURCE_DETECTORS values [#5034](https://github.com/open-telemetry/opentelemetry-js/pull/5034)
 
 ### :books: (Refine Doc)

--- a/experimental/packages/otlp-grpc-exporter-base/test/configuration/otlp-grpc-configuration.test.ts
+++ b/experimental/packages/otlp-grpc-exporter-base/test/configuration/otlp-grpc-configuration.test.ts
@@ -26,6 +26,7 @@ import {
   createSslCredentials,
 } from '../../src/grpc-exporter-transport';
 import * as fs from 'fs';
+import { VERSION } from '../../src/version';
 
 describe('mergeOtlpGrpcConfigurationWithDefaults', function () {
   describe('metadata', function () {
@@ -56,7 +57,7 @@ describe('mergeOtlpGrpcConfigurationWithDefaults', function () {
         foo: 'foo-user', // does not use fallback if the user has set something
         bar: 'bar-fallback', // uses fallback if there is no value set
         baz: 'baz-user', // does not drop user-set metadata if there is no fallback for it
-        'user-agent': 'OTel-OTLP-Exporter-JavaScript/0.53.0',
+        'user-agent': 'OTel-OTLP-Exporter-JavaScript/' + VERSION,
       });
     });
 
@@ -81,7 +82,7 @@ describe('mergeOtlpGrpcConfigurationWithDefaults', function () {
       );
 
       assert.deepStrictEqual(config.metadata().getMap(), {
-        'user-agent': 'OTel-OTLP-Exporter-JavaScript/0.53.0',
+        'user-agent': 'OTel-OTLP-Exporter-JavaScript/' + VERSION,
       });
     });
 
@@ -94,7 +95,7 @@ describe('mergeOtlpGrpcConfigurationWithDefaults', function () {
       );
 
       assert.deepStrictEqual(config.metadata().getMap(), {
-        'user-agent': 'OTel-OTLP-Exporter-JavaScript/0.53.0',
+        'user-agent': 'OTel-OTLP-Exporter-JavaScript/' + VERSION,
       });
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

See test failure in #5068, after we updated the versions, the tests failed because they were hardcoded. This PR fixes this, and also moves some changelog entries to the correct spot (I had put them in bugfix but they belong in the breaking changes section).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit tests
