### PR TITLE
test: use venv in w3c trace context test script

### DIFF
--- a/integration-tests/tracecontext-integration-test.sh
+++ b/integration-tests/tracecontext-integration-test.sh
@@ -8,6 +8,8 @@ mkdir -p target
 rm -rf ./target/trace-context
 git clone https://github.com/w3c/trace-context ./target/trace-context
 cd ./target/trace-context && git checkout $TRACECONTEXT_GIT_TAG && cd -
+python3 -m venv ./.venv
+source ./.venv/bin/activate
 pip3 install setuptools;
 pip3 install aiohttp; 
 node ./integration-tests/propagation-validation-server/validation-server.js 1>&2 &


### PR DESCRIPTION
## Which problem is this PR solving?

Tests are currently failing (see [here](https://github.com/open-telemetry/opentelemetry-js/actions/runs/11345739893/job/31554085622?pr=5068), probably due to some changes that don't allow the use of `pip install` with an externally managed environment, like the global one that's supposed to be managed by the system and requires packages to be installed via `apt` on Ubuntu 24.04). This PR makes the test script use a `venv` instead to avoid this error. 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Local testing (I tested this on Ubuntu 24.04 and it was also happening there)
- [x] workflow here on this PR

