### PR TITLE
fix(instrumentation-http): add server attributes after they become available

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -93,7 +93,7 @@ import {
 } from './utils';
 
 /**
- * Http instrumentation instrumentation for Opentelemetry
+ * `node:http` and `node:https` instrumentation for OpenTelemetry
  */
 export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentationConfig> {
   /** keep track on spans not ended */

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -78,7 +78,8 @@ import {
   getIncomingRequestAttributes,
   getIncomingRequestAttributesOnResponse,
   getIncomingRequestMetricAttributes,
-  getIncomingRequestMetricAttributesOnResponse, getIncomingStableRequestMetricAttributesOnResponse,
+  getIncomingRequestMetricAttributesOnResponse,
+  getIncomingStableRequestMetricAttributesOnResponse,
   getOutgoingRequestAttributes,
   getOutgoingRequestAttributesOnResponse,
   getOutgoingRequestMetricAttributes,
@@ -416,7 +417,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
    * @param span representing the current operation
    * @param startTime representing the start time of the request to calculate duration in Metric
    * @param oldMetricAttributes metric attributes for old semantic conventions
-   * @param stableMetricAttributes metric attributes for old semantic conventions
+   * @param stableMetricAttributes metric attributes for new semantic conventions
    */
   private _traceClientRequest(
     request: http.ClientRequest,

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -26,6 +26,7 @@ import {
   ATTR_HTTP_REQUEST_METHOD,
   ATTR_HTTP_REQUEST_METHOD_ORIGINAL,
   ATTR_HTTP_RESPONSE_STATUS_CODE,
+  ATTR_HTTP_ROUTE,
   ATTR_NETWORK_PEER_ADDRESS,
   ATTR_NETWORK_PEER_PORT,
   ATTR_NETWORK_PROTOCOL_VERSION,
@@ -822,7 +823,7 @@ export const getIncomingRequestAttributesOnResponse = (
   const { socket } = request;
   const { statusCode, statusMessage } = response;
 
-  const newAttributes = {
+  const newAttributes: Attributes = {
     [ATTR_HTTP_RESPONSE_STATUS_CODE]: statusCode,
   };
 
@@ -842,6 +843,7 @@ export const getIncomingRequestAttributesOnResponse = (
 
   if (rpcMetadata?.type === RPCType.HTTP && rpcMetadata.route !== undefined) {
     oldAttributes[SEMATTRS_HTTP_ROUTE] = rpcMetadata.route;
+    newAttributes[ATTR_HTTP_ROUTE] = rpcMetadata.route;
   }
 
   switch (semconvStability) {
@@ -868,6 +870,22 @@ export const getIncomingRequestMetricAttributesOnResponse = (
     spanAttributes[SEMATTRS_NET_HOST_PORT];
   if (spanAttributes[SEMATTRS_HTTP_ROUTE] !== undefined) {
     metricAttributes[SEMATTRS_HTTP_ROUTE] = spanAttributes[SEMATTRS_HTTP_ROUTE];
+  }
+  return metricAttributes;
+};
+
+export const getIncomingStableRequestMetricAttributesOnResponse = (
+  spanAttributes: Attributes
+): Attributes => {
+  const metricAttributes: Attributes = {};
+  if (spanAttributes[ATTR_HTTP_ROUTE] !== undefined) {
+    metricAttributes[ATTR_HTTP_ROUTE] = spanAttributes[SEMATTRS_HTTP_ROUTE];
+  }
+
+  // required if and only if one was sent, same as span requirement
+  if (spanAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE]) {
+    metricAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE] =
+      spanAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE];
   }
   return metricAttributes;
 };

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
@@ -21,7 +21,8 @@ import {
 } from '@opentelemetry/sdk-metrics';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import {
-  ATTR_HTTP_REQUEST_METHOD, ATTR_HTTP_RESPONSE_STATUS_CODE,
+  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_HTTP_RESPONSE_STATUS_CODE,
   ATTR_HTTP_ROUTE,
   ATTR_NETWORK_PROTOCOL_VERSION,
   ATTR_SERVER_ADDRESS,

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
@@ -21,7 +21,7 @@ import {
 } from '@opentelemetry/sdk-metrics';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import {
-  ATTR_HTTP_REQUEST_METHOD,
+  ATTR_HTTP_REQUEST_METHOD, ATTR_HTTP_RESPONSE_STATUS_CODE,
   ATTR_HTTP_ROUTE,
   ATTR_NETWORK_PROTOCOL_VERSION,
   ATTR_SERVER_ADDRESS,
@@ -181,7 +181,7 @@ describe('metrics', () => {
     });
   });
 
-  describe('with no semconv stability set to stable', () => {
+  describe('with semconv stability set to stable', () => {
     before(() => {
       instrumentation['_semconvStability'] = SemconvStability.STABLE;
     });
@@ -217,7 +217,9 @@ describe('metrics', () => {
       assert.deepStrictEqual(metrics[0].dataPoints[0].attributes, {
         [ATTR_HTTP_REQUEST_METHOD]: 'GET',
         [ATTR_URL_SCHEME]: 'http',
+        [ATTR_HTTP_RESPONSE_STATUS_CODE]: 200,
         [ATTR_NETWORK_PROTOCOL_VERSION]: '1.1',
+        [ATTR_HTTP_ROUTE]: 'TheRoute',
       });
 
       assert.strictEqual(metrics[1].dataPointType, DataPointType.HISTOGRAM);
@@ -244,7 +246,7 @@ describe('metrics', () => {
     });
   });
 
-  describe('with no semconv stability set to duplicate', () => {
+  describe('with semconv stability set to duplicate', () => {
     before(() => {
       instrumentation['_semconvStability'] = SemconvStability.DUPLICATE;
     });
@@ -353,6 +355,7 @@ describe('metrics', () => {
       assert.deepStrictEqual(metrics[2].dataPoints[0].attributes, {
         [ATTR_HTTP_REQUEST_METHOD]: 'GET',
         [ATTR_URL_SCHEME]: 'http',
+        [ATTR_HTTP_RESPONSE_STATUS_CODE]: 200,
         [ATTR_NETWORK_PROTOCOL_VERSION]: '1.1',
         [ATTR_HTTP_ROUTE]: 'TheRoute',
       });


### PR DESCRIPTION
## Which problem is this PR solving?

While reviewing #5079 I noticed that we don't set `http.route` and `http.response.status` code in the server duration metrics, so this PR addresses a few problems:

- We did not add `http.route` to the `Span` on "new" metrics
- We add the `http.route` only when `DUPLICATE` emission is turned on because 
  - we also didn't add it to the Span for "new" metrics
  - but we did add it for the "old" metrics and the attribute name happens to match
-  we never added the `http.response.status` code, because 
  - it is not yet determined when we add it (before the request is handled)

**NOTE: skipping changelog because this is a bug in an unreleased feature**

Supersedes #5079
Related to #5026 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added assertions to unit tests