### PR TITLE
fix(instrumentation-http): skip malformed forwarded headers

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(instrumentation-http): skip malformed forwarded headers. [#5095](https://github.com/open-telemetry/opentelemetry-js/issues/5095) @pmlanger
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -572,7 +572,7 @@ function getServerAddress(
 ): { host: string; port?: string } | null {
   const forwardedHeader = request.headers['forwarded'];
   if (forwardedHeader) {
-    for (const entry of forwardedParse(forwardedHeader)) {
+    for (const entry of parseForwardedHeader(forwardedHeader)) {
       if (entry.host) {
         return parseHostHeader(entry.host, entry.proto);
       }
@@ -635,7 +635,7 @@ export function getRemoteClientAddress(
 ): string | null {
   const forwardedHeader = request.headers['forwarded'];
   if (forwardedHeader) {
-    for (const entry of forwardedParse(forwardedHeader)) {
+    for (const entry of parseForwardedHeader(forwardedHeader)) {
       if (entry.for) {
         return entry.for;
       }
@@ -915,4 +915,12 @@ function normalizeMethod(method?: string | null) {
   }
 
   return '_OTHER';
+}
+
+function parseForwardedHeader(header: string): Record<string, string>[] {
+  try {
+    return forwardedParse(header);
+  } catch {
+    return [];
+  }
 }

--- a/experimental/packages/opentelemetry-instrumentation-http/test/integrations/http-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/integrations/http-enable.test.ts
@@ -277,6 +277,20 @@ describe('HttpInstrumentation Integration tests', () => {
       assert.ok(result.reqHeaders[DummyPropagation.SPAN_CONTEXT_KEY]);
     });
 
+    it('should succeed even with malformed Forwarded header', async () => {
+      const spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 0);
+
+      const headers = { 'x-foo': 'foo', forwarded: 'malformed' };
+      const result = await httpRequest.get(
+        new url.URL(`${protocol}://localhost:${mockServerPort}/?query=test`),
+        { headers }
+      );
+
+      assert.ok(result.reqHeaders[DummyPropagation.TRACE_CONTEXT_KEY]);
+      assert.ok(result.reqHeaders[DummyPropagation.SPAN_CONTEXT_KEY]);
+    });
+
     it('should create a span for GET requests and add propagation headers with Expect headers', async () => {
       let spans = memoryExporter.getFinishedSpans();
       assert.strictEqual(spans.length, 0);


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Skips malformed `forwarded` headers instead of throwing an uncaught exception.

Fixes #5095 

## Short description of the changes

Introduce `parseForwardedHeader` in `experimental/packages/opentelemetry-instrumentation-http/src/utils.ts` which wraps `forwarded-parse` and returns an empty array on any caught exception.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

First, wrote a test that broke the instrumentation in the expected way (throwing `ParseError: Unexpected end of input`).
Then, fixed it and confirmed the test passes.

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been added
- [ ] Documentation has been updated
