### PR TITLE
feat(sdk-metrics): add aggregation cardinality limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 
 ### :boom: Breaking Change
 
+* feat(sdk-metrics): Add support for aggregation cardinality limit with a default limit of 2000. This limit can be customized via views [#5182](https://github.com/open-telemetry/opentelemetry-js/pull/5128)
+
 ### :rocket: (Enhancement)
 
 ### :bug: (Bug Fix)

--- a/packages/sdk-metrics/src/export/CardinalitySelector.ts
+++ b/packages/sdk-metrics/src/export/CardinalitySelector.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InstrumentType } from '../InstrumentDescriptor';
+/**
+ * Cardinality Limit selector based on metric instrument types.
+ */
+export type CardinalitySelector = (instrumentType: InstrumentType) => number;

--- a/packages/sdk-metrics/src/export/MetricReader.ts
+++ b/packages/sdk-metrics/src/export/MetricReader.ts
@@ -32,6 +32,7 @@ import {
   DEFAULT_AGGREGATION_SELECTOR,
   DEFAULT_AGGREGATION_TEMPORALITY_SELECTOR,
 } from './AggregationSelector';
+import { CardinalitySelector } from './CardinalitySelector';
 
 export interface MetricReaderOptions {
   /**
@@ -45,6 +46,11 @@ export interface MetricReaderOptions {
    * not configured, cumulative is used for all instruments.
    */
   aggregationTemporalitySelector?: AggregationTemporalitySelector;
+  /**
+   * Cardinality selector based on metric instrument types. If not configured,
+   * a default value is used.
+   */
+  cardinalitySelector?: CardinalitySelector;
   /**
    * **Note, this option is experimental**. Additional MetricProducers to use as a source of
    * aggregated metric data in addition to the SDK's metric data. The resource returned by
@@ -68,6 +74,7 @@ export abstract class MetricReader {
   private _sdkMetricProducer?: MetricProducer;
   private readonly _aggregationTemporalitySelector: AggregationTemporalitySelector;
   private readonly _aggregationSelector: AggregationSelector;
+  private readonly _cardinalitySelector?: CardinalitySelector;
 
   constructor(options?: MetricReaderOptions) {
     this._aggregationSelector =
@@ -76,6 +83,7 @@ export abstract class MetricReader {
       options?.aggregationTemporalitySelector ??
       DEFAULT_AGGREGATION_TEMPORALITY_SELECTOR;
     this._metricProducers = options?.metricProducers ?? [];
+    this._cardinalitySelector = options?.cardinalitySelector;
   }
 
   /**
@@ -114,6 +122,16 @@ export abstract class MetricReader {
     instrumentType: InstrumentType
   ): AggregationTemporality {
     return this._aggregationTemporalitySelector(instrumentType);
+  }
+
+  /**
+   * Select the cardinality limit for the given {@link InstrumentType} for this
+   * reader.
+   */
+  selectCardinalityLimit(instrumentType: InstrumentType): number {
+    return this._cardinalitySelector
+      ? this._cardinalitySelector(instrumentType)
+      : 2000; // default value if no selector is provided
   }
 
   /**

--- a/packages/sdk-metrics/src/state/AsyncMetricStorage.ts
+++ b/packages/sdk-metrics/src/state/AsyncMetricStorage.ts
@@ -43,10 +43,14 @@ export class AsyncMetricStorage<T extends Maybe<Accumulation>>
     _instrumentDescriptor: InstrumentDescriptor,
     aggregator: Aggregator<T>,
     private _attributesProcessor: AttributesProcessor,
-    collectorHandles: MetricCollectorHandle[]
+    collectorHandles: MetricCollectorHandle[],
+    private _aggregationCardinalityLimit?: number
   ) {
     super(_instrumentDescriptor);
-    this._deltaMetricStorage = new DeltaMetricProcessor(aggregator);
+    this._deltaMetricStorage = new DeltaMetricProcessor(
+      aggregator,
+      this._aggregationCardinalityLimit
+    );
     this._temporalMetricStorage = new TemporalMetricProcessor(
       aggregator,
       collectorHandles

--- a/packages/sdk-metrics/src/state/DeltaMetricProcessor.ts
+++ b/packages/sdk-metrics/src/state/DeltaMetricProcessor.ts
@@ -36,7 +36,7 @@ export class DeltaMetricProcessor<T extends Maybe<Accumulation>> {
     private _aggregator: Aggregator<T>,
     aggregationCardinalityLimit?: number
   ) {
-    this._cardinalityLimit = aggregationCardinalityLimit ?? 2000;
+    this._cardinalityLimit = (aggregationCardinalityLimit ?? 2000) - 1;
   }
 
   record(

--- a/packages/sdk-metrics/src/state/MeterSharedState.ts
+++ b/packages/sdk-metrics/src/state/MeterSharedState.ts
@@ -163,12 +163,17 @@ export class MeterSharedState {
           if (compatibleStorage != null) {
             return compatibleStorage;
           }
+
           const aggregator = aggregation.createAggregator(descriptor);
+          const cardinalityLimit = collector.selectCardinalityLimit(
+            descriptor.type
+          );
           const storage = new MetricStorageType(
             descriptor,
             aggregator,
             AttributesProcessor.Noop(),
-            [collector]
+            [collector],
+            cardinalityLimit
           ) as R;
           this.metricStorageRegistry.registerForCollector(collector, storage);
           return storage;

--- a/packages/sdk-metrics/src/state/MeterSharedState.ts
+++ b/packages/sdk-metrics/src/state/MeterSharedState.ts
@@ -142,7 +142,8 @@ export class MeterSharedState {
         viewDescriptor,
         aggregator,
         view.attributesProcessor,
-        this._meterProviderSharedState.metricCollectors
+        this._meterProviderSharedState.metricCollectors,
+        view.aggregationCardinalityLimit
       ) as R;
       this.metricStorageRegistry.register(viewStorage);
       return viewStorage;
@@ -190,6 +191,7 @@ interface MetricStorageConstructor {
     instrumentDescriptor: InstrumentDescriptor,
     aggregator: Aggregator<Maybe<Accumulation>>,
     attributesProcessor: AttributesProcessor,
-    collectors: MetricCollectorHandle[]
+    collectors: MetricCollectorHandle[],
+    aggregationCardinalityLimit?: number
   ): MetricStorage;
 }

--- a/packages/sdk-metrics/src/state/MetricCollector.ts
+++ b/packages/sdk-metrics/src/state/MetricCollector.ts
@@ -96,7 +96,7 @@ export class MetricCollector implements MetricProducer {
    * collector.
    */
   selectCardinalityLimit(instrumentType: InstrumentType): number {
-    return this._metricReader.selectCardinalityLimit(instrumentType);
+    return this._metricReader.selectCardinalityLimit.?(instrumentType) ?? 2000;
   }
 }
 

--- a/packages/sdk-metrics/src/state/MetricCollector.ts
+++ b/packages/sdk-metrics/src/state/MetricCollector.ts
@@ -96,7 +96,7 @@ export class MetricCollector implements MetricProducer {
    * collector.
    */
   selectCardinalityLimit(instrumentType: InstrumentType): number {
-    return this._metricReader.selectCardinalityLimit.?(instrumentType) ?? 2000;
+    return this._metricReader.selectCardinalityLimit?.(instrumentType) ?? 2000;
   }
 }
 

--- a/packages/sdk-metrics/src/state/MetricCollector.ts
+++ b/packages/sdk-metrics/src/state/MetricCollector.ts
@@ -90,6 +90,14 @@ export class MetricCollector implements MetricProducer {
   selectAggregation(instrumentType: InstrumentType) {
     return this._metricReader.selectAggregation(instrumentType);
   }
+
+  /**
+   * Select the cardinality limit for the given {@link InstrumentType} for this
+   * collector.
+   */
+  selectCardinalityLimit(instrumentType: InstrumentType): number {
+    return this._metricReader.selectCardinalityLimit(instrumentType);
+  }
 }
 
 /**
@@ -98,4 +106,5 @@ export class MetricCollector implements MetricProducer {
  */
 export interface MetricCollectorHandle {
   selectAggregationTemporality: AggregationTemporalitySelector;
+  selectCardinalityLimit(instrumentType: InstrumentType): number;
 }

--- a/packages/sdk-metrics/src/state/SyncMetricStorage.ts
+++ b/packages/sdk-metrics/src/state/SyncMetricStorage.ts
@@ -42,10 +42,14 @@ export class SyncMetricStorage<T extends Maybe<Accumulation>>
     instrumentDescriptor: InstrumentDescriptor,
     aggregator: Aggregator<T>,
     private _attributesProcessor: AttributesProcessor,
-    collectorHandles: MetricCollectorHandle[]
+    collectorHandles: MetricCollectorHandle[],
+    private _aggregationCardinalityLimit?: number
   ) {
     super(instrumentDescriptor);
-    this._deltaMetricStorage = new DeltaMetricProcessor(aggregator);
+    this._deltaMetricStorage = new DeltaMetricProcessor(
+      aggregator,
+      this._aggregationCardinalityLimit
+    );
     this._temporalMetricStorage = new TemporalMetricProcessor(
       aggregator,
       collectorHandles

--- a/packages/sdk-metrics/src/view/View.ts
+++ b/packages/sdk-metrics/src/view/View.ts
@@ -195,10 +195,7 @@ export class View {
    * @param viewOptions.aggregationCardinalityLimit
    * Alters the metric stream:
    *  Sets a limit on the number of unique attribute combinations (cardinality) that can be aggregated.
-   *  If not provided, the default limit will be used.
-   *
-   * @example <caption>sets the cardinality limit to 1000</caption>
-   * aggregationCardinalityLimit: 1000
+   *  If not provided, the default limit of 2000 will be used.
    *
    * @example
    * // Create a view that changes the Instrument 'my.instrument' to use to an

--- a/packages/sdk-metrics/src/view/View.ts
+++ b/packages/sdk-metrics/src/view/View.ts
@@ -62,6 +62,15 @@ export type ViewOptions = {
    */
   aggregation?: Aggregation;
   /**
+   * Alters the metric stream:
+   * Sets a limit on the number of unique attribute combinations (cardinality) that can be aggregated.
+   * If not provided, the default limit will be used.
+   *
+   * @example <caption>sets the cardinality limit to 1000</caption>
+   * aggregationCardinalityLimit: 1000
+   */
+  aggregationCardinalityLimit?: number;
+  /**
    * Instrument selection criteria:
    * The original type of the Instrument(s).
    *
@@ -138,6 +147,7 @@ export class View {
   readonly attributesProcessor: AttributesProcessor;
   readonly instrumentSelector: InstrumentSelector;
   readonly meterSelector: MeterSelector;
+  readonly aggregationCardinalityLimit?: number;
 
   /**
    * Create a new {@link View} instance.
@@ -182,6 +192,13 @@ export class View {
    * @param viewOptions.meterSchemaUrl
    * Instrument selection criteria:
    *  The schema URL of the Meter. No wildcard support, schema URL must match exactly.
+   * @param viewOptions.aggregationCardinalityLimit
+   * Alters the metric stream:
+   *  Sets a limit on the number of unique attribute combinations (cardinality) that can be aggregated.
+   *  If not provided, the default limit will be used.
+   *
+   * @example <caption>sets the cardinality limit to 1000</caption>
+   * aggregationCardinalityLimit: 1000
    *
    * @example
    * // Create a view that changes the Instrument 'my.instrument' to use to an
@@ -232,5 +249,6 @@ export class View {
       version: viewOptions.meterVersion,
       schemaUrl: viewOptions.meterSchemaUrl,
     });
+    this.aggregationCardinalityLimit = viewOptions.aggregationCardinalityLimit;
   }
 }

--- a/packages/sdk-metrics/src/view/View.ts
+++ b/packages/sdk-metrics/src/view/View.ts
@@ -171,6 +171,10 @@ export class View {
    * Alters the metric stream:
    *  If provided, the attributes that are not in the list will be ignored.
    *  If not provided, all attribute keys will be used by default.
+   * @param viewOptions.aggregationCardinalityLimit
+   * Alters the metric stream:
+   *  Sets a limit on the number of unique attribute combinations (cardinality) that can be aggregated.
+   *  If not provided, the default limit of 2000 will be used.
    * @param viewOptions.aggregation
    * Alters the metric stream:
    *  Alters the {@link Aggregation} of the metric stream.
@@ -192,10 +196,6 @@ export class View {
    * @param viewOptions.meterSchemaUrl
    * Instrument selection criteria:
    *  The schema URL of the Meter. No wildcard support, schema URL must match exactly.
-   * @param viewOptions.aggregationCardinalityLimit
-   * Alters the metric stream:
-   *  Sets a limit on the number of unique attribute combinations (cardinality) that can be aggregated.
-   *  If not provided, the default limit of 2000 will be used.
    *
    * @example
    * // Create a view that changes the Instrument 'my.instrument' to use to an

--- a/packages/sdk-metrics/test/MeterProvider.test.ts
+++ b/packages/sdk-metrics/test/MeterProvider.test.ts
@@ -624,6 +624,7 @@ describe('MeterProvider', () => {
       counter.add(1, { attr1: 'value1' });
       counter.add(1, { attr2: 'value2' });
       counter.add(1, { attr3: 'value3' });
+      counter.add(1, { attr1: 'value1' });
 
       // Perform collection
       const { resourceMetrics, errors } = await reader.collect();
@@ -633,7 +634,7 @@ describe('MeterProvider', () => {
       assert.strictEqual(resourceMetrics.scopeMetrics[0].metrics.length, 1);
 
       const metricData = resourceMetrics.scopeMetrics[0].metrics[0];
-      assert.strictEqual(metricData.dataPoints.length, 3);
+      assert.strictEqual(metricData.dataPoints.length, 2);
 
       // Check if the overflow data point is present
       const overflowDataPoint = (
@@ -645,7 +646,97 @@ describe('MeterProvider', () => {
         )
       );
       assert.ok(overflowDataPoint);
-      assert.strictEqual(overflowDataPoint.value, 1);
+      assert.strictEqual(overflowDataPoint.value, 2);
+    });
+
+    it('should respect the aggregationCardinalityLimit for observable counter', async () => {
+      const reader = new TestMetricReader();
+      const meterProvider = new MeterProvider({
+        resource: defaultResource,
+        readers: [reader],
+        views: [
+          new View({
+            instrumentName: 'test-observable-counter',
+            aggregationCardinalityLimit: 2, // Set cardinality limit to 2
+          }),
+        ],
+      });
+
+      const meter = meterProvider.getMeter('meter1', 'v1.0.0');
+      const observableCounter = meter.createObservableCounter(
+        'test-observable-counter'
+      );
+      observableCounter.addCallback(observableResult => {
+        observableResult.observe(1, { attr1: 'value1' });
+        observableResult.observe(2, { attr2: 'value2' });
+        observableResult.observe(3, { attr3: 'value3' });
+        observableResult.observe(4, { attr1: 'value1' });
+      });
+
+      // Perform collection
+      const { resourceMetrics, errors } = await reader.collect();
+
+      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(resourceMetrics.scopeMetrics.length, 1);
+      assert.strictEqual(resourceMetrics.scopeMetrics[0].metrics.length, 1);
+
+      const metricData = resourceMetrics.scopeMetrics[0].metrics[0];
+      assert.strictEqual(metricData.dataPoints.length, 2);
+
+      // Check if the overflow data point is present
+      const overflowDataPoint = (
+        metricData.dataPoints as DataPoint<number>[]
+      ).find((dataPoint: DataPoint<number>) =>
+        Object.prototype.hasOwnProperty.call(
+          dataPoint.attributes,
+          'otel.metric.overflow'
+        )
+      );
+      assert.ok(overflowDataPoint);
+      assert.strictEqual(overflowDataPoint.value, 3);
+    });
+  });
+
+  describe('aggregationCardinalityLimit via MetricReader should apply the cardinality limit', () => {
+    it('should respect the aggregationCardinalityLimit set via MetricReader', async () => {
+      const reader = new TestMetricReader({
+        cardinalitySelector: (instrumentType: InstrumentType) => 2, // Set cardinality limit to 2 via cardinalitySelector
+      });
+      const meterProvider = new MeterProvider({
+        resource: defaultResource,
+        readers: [reader],
+      });
+
+      const meter = meterProvider.getMeter('meter1', 'v1.0.0');
+      const counter = meter.createCounter('test-counter');
+
+      // Add values with different attributes
+      counter.add(1, { attr1: 'value1' });
+      counter.add(1, { attr2: 'value2' });
+      counter.add(1, { attr3: 'value3' });
+      counter.add(1, { attr1: 'value1' });
+
+      // Perform collection
+      const { resourceMetrics, errors } = await reader.collect();
+
+      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(resourceMetrics.scopeMetrics.length, 1);
+      assert.strictEqual(resourceMetrics.scopeMetrics[0].metrics.length, 1);
+
+      const metricData = resourceMetrics.scopeMetrics[0].metrics[0];
+      assert.strictEqual(metricData.dataPoints.length, 2);
+
+      // Check if the overflow data point is present
+      const overflowDataPoint = (
+        metricData.dataPoints as DataPoint<number>[]
+      ).find((dataPoint: DataPoint<number>) =>
+        Object.prototype.hasOwnProperty.call(
+          dataPoint.attributes,
+          'otel.metric.overflow'
+        )
+      );
+      assert.ok(overflowDataPoint);
+      assert.strictEqual(overflowDataPoint.value, 2);
     });
   });
 
@@ -661,7 +752,7 @@ describe('MeterProvider', () => {
       const counter = meter.createCounter('test-counter');
 
       // Add values with different attributes
-      for (let i = 0; i < 2002; i++) {
+      for (let i = 0; i < 2001; i++) {
         const attributes = { [`attr${i}`]: `value${i}` };
         counter.add(1, attributes);
       }
@@ -674,7 +765,7 @@ describe('MeterProvider', () => {
       assert.strictEqual(resourceMetrics.scopeMetrics[0].metrics.length, 1);
 
       const metricData = resourceMetrics.scopeMetrics[0].metrics[0];
-      assert.strictEqual(metricData.dataPoints.length, 2001);
+      assert.strictEqual(metricData.dataPoints.length, 2000);
 
       // Check if the overflow data point is present
       const overflowDataPoint = (

--- a/packages/sdk-metrics/test/state/AsyncMetricStorage.test.ts
+++ b/packages/sdk-metrics/test/state/AsyncMetricStorage.test.ts
@@ -34,10 +34,12 @@ import { HrTime } from '@opentelemetry/api';
 
 const deltaCollector: MetricCollectorHandle = {
   selectAggregationTemporality: () => AggregationTemporality.DELTA,
+  selectCardinalityLimit: () => 2000,
 };
 
 const cumulativeCollector: MetricCollectorHandle = {
   selectAggregationTemporality: () => AggregationTemporality.CUMULATIVE,
+  selectCardinalityLimit: () => 2000,
 };
 
 describe('AsyncMetricStorage', () => {

--- a/packages/sdk-metrics/test/state/MetricStorageRegistry.test.ts
+++ b/packages/sdk-metrics/test/state/MetricStorageRegistry.test.ts
@@ -58,9 +58,15 @@ describe('MetricStorageRegistry', () => {
     selectAggregationTemporality: () => {
       throw new Error('should not be invoked');
     },
+    selectCardinalityLimit: () => {
+      throw new Error('should not be invoked');
+    },
   };
   const collectorHandle2: MetricCollectorHandle = {
     selectAggregationTemporality: () => {
+      throw new Error('should not be invoked');
+    },
+    selectCardinalityLimit: () => {
       throw new Error('should not be invoked');
     },
   };

--- a/packages/sdk-metrics/test/state/SyncMetricStorage.test.ts
+++ b/packages/sdk-metrics/test/state/SyncMetricStorage.test.ts
@@ -33,10 +33,12 @@ import {
 
 const deltaCollector: MetricCollectorHandle = {
   selectAggregationTemporality: () => AggregationTemporality.DELTA,
+  selectCardinalityLimit: () => 2000,
 };
 
 const cumulativeCollector: MetricCollectorHandle = {
   selectAggregationTemporality: () => AggregationTemporality.CUMULATIVE,
+  selectCardinalityLimit: () => 2000,
 };
 
 describe('SyncMetricStorage', () => {

--- a/packages/sdk-metrics/test/state/TemporalMetricProcessor.test.ts
+++ b/packages/sdk-metrics/test/state/TemporalMetricProcessor.test.ts
@@ -31,14 +31,17 @@ import {
 
 const deltaCollector1: MetricCollectorHandle = {
   selectAggregationTemporality: () => AggregationTemporality.DELTA,
+  selectCardinalityLimit: () => 2000,
 };
 
 const deltaCollector2: MetricCollectorHandle = {
   selectAggregationTemporality: () => AggregationTemporality.DELTA,
+  selectCardinalityLimit: () => 2000,
 };
 
 const cumulativeCollector1: MetricCollectorHandle = {
   selectAggregationTemporality: () => AggregationTemporality.CUMULATIVE,
+  selectCardinalityLimit: () => 2000,
 };
 
 describe('TemporalMetricProcessor', () => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
implements Otel Cardinality Limit spec.

This change allows you to:
- configure View for custom aggregation cardinality limit. 
- allows specifying cardinality selector on metric reader
- also applies default 2000 limit if it's not set.

Link to the spec: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#cardinality-limits

Updated PR to support both async and sync storage

References https://github.com/open-telemetry/opentelemetry-js/issues/4095

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- added unit tests
- created a small app that uses this package via npm link

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
