### PR TITLE
Add http route to outgoing http requests, if available

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -421,6 +421,10 @@ export const getOutgoingRequestMetricAttributes = (
   metricAttributes[SEMATTRS_HTTP_METHOD] = spanAttributes[SEMATTRS_HTTP_METHOD];
   metricAttributes[SEMATTRS_NET_PEER_NAME] =
     spanAttributes[SEMATTRS_NET_PEER_NAME];
+  const route = spanAttributes[SEMATTRS_HTTP_ROUTE];
+  if (route !== undefined) {
+    metricAttributes[SEMATTRS_HTTP_ROUTE] = route;
+  }
   //TODO: http.url attribute, it should substitute any parameters to avoid high cardinality.
   return metricAttributes;
 };

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -27,6 +27,8 @@ import {
   SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
   SEMATTRS_HTTP_ROUTE,
   SEMATTRS_HTTP_TARGET,
+  SEMATTRS_HTTP_METHOD,
+  SEMATTRS_NET_PEER_NAME,
 } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import { IncomingMessage, ServerResponse } from 'http';
@@ -279,6 +281,39 @@ describe('Utility', () => {
       assert.deepEqual(metricAttributes[SEMATTRS_HTTP_ROUTE], undefined);
     });
   });
+
+  describe('getOutgoingRequestMetricAttributes()', () => {
+    it('should correctly add attributes from span', () => {
+      const spanAttributes: Attributes = {
+        [SEMATTRS_HTTP_METHOD]: 'GET',
+        [SEMATTRS_NET_PEER_NAME]: 'hostname',
+        [SEMATTRS_HTTP_ROUTE]: '/user/:id',
+      };
+      const metricAttributes =
+        utils.getOutgoingRequestMetricAttributes(spanAttributes);
+
+      assert.deepStrictEqual(metricAttributes[SEMATTRS_HTTP_METHOD], 'GET');
+      assert.deepStrictEqual(
+        metricAttributes[SEMATTRS_NET_PEER_NAME],
+        'hostname'
+      );
+      assert.deepStrictEqual(
+        metricAttributes[SEMATTRS_HTTP_ROUTE],
+        '/user/:id'
+      );
+    });
+
+    it('should not add http_route attribute if span does not have it', () => {
+      const spanAttributes: Attributes = {};
+      const metricAttributes =
+        utils.getOutgoingRequestMetricAttributes(spanAttributes);
+      assert.deepStrictEqual(metricAttributes, {
+        [SEMATTRS_HTTP_METHOD]: undefined,
+        [SEMATTRS_NET_PEER_NAME]: undefined,
+      });
+    });
+  });
+
   // Verify the key in the given attributes is set to the given value,
   // and that no other HTTP Content Length attributes are set.
   function verifyValueInAttributes(


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

We have a large mono repo and our app users have the need for the following usage:

```ts
  new HttpInstrumentation({
    startOutgoingSpanHook(request) {
      const headers = request.headers ?? {};
      if ('x-otel-path-template' in headers) {
        return {
          [SEMATTRS_HTTP_ROUTE]: headers['x-otel-path-template'], // A path template, e.g. `/users/{id}` or `/blog/{blogId}/posts/{postId}`
        };
      }
      return {};
    },
  }),
```

Since our users are tracking SLOs for their services for different endpoints, they need histograms observations to include the path tempate. This path template comes from `mappersmith` and we take care of setting it ourselves, as can be seen above. Yes, it is a bit hacky, this path template is sent via a header, but that's our problem. 😬  It's good enough for us for now at least.

But we need to patch opentelemetry to read it and put it in the histogram observation, hence the PR. 

## Short description of the changes

Ensure that `'http.route'` makes it to metric attributes, if it is available from the span attribute.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

I hesitate to check breaking. If someone today is also setting `SEMATTRS_HTTP_ROUTE` in `startOutgoingSpanHook` and NOT expecting it to result in a new label in prometheus metrics, I guess that's a _unexpected_. But not breaking.

## How Has This Been Tested?

We have had this code running in production for 1 month.

- [x] Added tests, see PR diff

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
