### PR TITLE
refactor(sdk-trace-base): remove `_registeredSpanProcessors` from BasicTracerProvider

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -25,5 +25,4 @@
 * chore: remove checks for unsupported node versions [#4341](https://github.com/open-telemetry/opentelemetry-js/pull/4341) @dyladan
 * refactor(sdk-trace-base): remove `BasicTracerProvider._registeredSpanProcessors` private property. [#5134](https://github.com/open-telemetry/opentelemetry-js/pull/5177) @david-luna
 
-
 ### :bug: (Bug Fix)

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -23,5 +23,7 @@
 ### :house: (Internal)
 
 * chore: remove checks for unsupported node versions [#4341](https://github.com/open-telemetry/opentelemetry-js/pull/4341) @dyladan
+* refactor(sdk-trace-base): remove `BasicTracerProvider._registeredSpanProcessors` private property. [#5134](https://github.com/open-telemetry/opentelemetry-js/pull/5177) @david-luna
+
 
 ### :bug: (Bug Fix)

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -97,10 +97,8 @@ export class SpanImpl implements Span {
   private readonly _startTimeProvided: boolean;
 
   /**
-   * Constructs a new Span instance.
-   *
-   * @deprecated calling Span constructor directly is not supported. Please use tracer.startSpan.
-   * */
+   * Constructs a new SpanImpl instance.
+   */
   constructor(
     parentTracer: Tracer,
     context: Context,

--- a/packages/opentelemetry-sdk-trace-node/test/NodeTracerProvider.test.ts
+++ b/packages/opentelemetry-sdk-trace-node/test/NodeTracerProvider.test.ts
@@ -302,11 +302,23 @@ describe('NodeTracerProvider', () => {
 
       const provider = new CustomTracerProvider({});
       provider.register();
-      const processor = provider.getActiveSpanProcessor();
-      assert(processor instanceof BatchSpanProcessor);
-      // @ts-expect-error access configured to verify its the correct one
-      const exporter = processor._exporter;
-      assert(exporter instanceof DummyExporter);
+
+      assert.ok(
+        provider['activeSpanProcessor'].constructor.name ===
+          'MultiSpanProcessor'
+      );
+      assert.ok(
+        provider['activeSpanProcessor']['_spanProcessors'].length === 1
+      );
+      assert.ok(
+        provider['activeSpanProcessor']['_spanProcessors'][0] instanceof
+          BatchSpanProcessor
+      );
+      assert.ok(
+        provider['activeSpanProcessor']['_spanProcessors'][0][
+          '_exporter'
+        ] instanceof DummyExporter
+      );
 
       assert.strictEqual(propagation['_getGlobalPropagator'](), propagator);
     });
@@ -347,11 +359,23 @@ describe('NodeTracerProvider', () => {
 
       const provider = new CustomTracerProvider({});
       provider.register();
-      const processor = provider.getActiveSpanProcessor();
-      assert(processor instanceof BatchSpanProcessor);
-      // @ts-expect-error access configured to verify its the correct one
-      const exporter = processor._exporter;
-      assert(exporter instanceof DummyExporter);
+
+      assert.ok(
+        provider['activeSpanProcessor'].constructor.name ===
+          'MultiSpanProcessor'
+      );
+      assert.ok(
+        provider['activeSpanProcessor']['_spanProcessors'].length === 1
+      );
+      assert.ok(
+        provider['activeSpanProcessor']['_spanProcessors'][0] instanceof
+          BatchSpanProcessor
+      );
+      assert.ok(
+        provider['activeSpanProcessor']['_spanProcessors'][0][
+          '_exporter'
+        ] instanceof DummyExporter
+      );
 
       assert.strictEqual(propagation['_getGlobalPropagator'](), propagator);
     });


### PR DESCRIPTION
## Which problem is this PR solving?

After merging https://github.com/open-telemetry/opentelemetry-js/pull/5152 it is not necessary to have `_registeredSpanProcessors` private property to modify at runtime. This PR does remove the property and adapts the tests.

Fixes #5136 

## Short description of the changes

- remove `_registeredSpanProcessors` from `BasicTracerProvider`
- wrap all processors in a MultiSpanProcessor to make sure `forceFlush` works in all situations.
- add a test for it
- update tests to not access the removed property

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- compiled all packages
- tested all packages

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been added
