### PR TITLE
chore(resources): update semconv usage to modern ATTR_ export names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 
 ### :house: (Internal)
 
+* chore(resources): Update semconv usage to modern `ATTR_` export names. [#5187](https://github.com/open-telemetry/opentelemetry-js/pull/5187)
+
 ## 1.28.0
 
 ### :rocket: (Enhancement)

--- a/packages/opentelemetry-resources/README.md
+++ b/packages/opentelemetry-resources/README.md
@@ -16,16 +16,18 @@ npm install --save @opentelemetry/resources
 ## Usage
 
 ```typescript
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import {
+    ATTR_SERVICE_NAME,
+    ATTR_SERVICE_VERSION,
+} from '@opentelemetry/semantic-conventions';
 import { Resource } from '@opentelemetry/resources';
 
 const resource = new Resource({
-    [SEMRESATTRS_SERVICE_NAME]: 'api-service',
+    [ATTR_SERVICE_NAME]: 'api-service',
 });
 
 const anotherResource = new Resource({
-    'service.version': '2.0.0',
-    'service.group': 'instrumentation-group'
+    [ATTR_SERVICE_VERSION]: '2.0.0'
 });
 const mergedResource = resource.merge(anotherResource);
 ```

--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -16,10 +16,10 @@
 
 import { diag } from '@opentelemetry/api';
 import {
-  SEMRESATTRS_SERVICE_NAME,
-  SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
-  SEMRESATTRS_TELEMETRY_SDK_NAME,
-  SEMRESATTRS_TELEMETRY_SDK_VERSION,
+  ATTR_SERVICE_NAME,
+  ATTR_TELEMETRY_SDK_LANGUAGE,
+  ATTR_TELEMETRY_SDK_NAME,
+  ATTR_TELEMETRY_SDK_VERSION,
 } from '@opentelemetry/semantic-conventions';
 import { SDK_INFO } from '@opentelemetry/core';
 import { ResourceAttributes } from './types';
@@ -56,13 +56,10 @@ export class Resource implements IResource {
    */
   static default(): IResource {
     return new Resource({
-      [SEMRESATTRS_SERVICE_NAME]: defaultServiceName(),
-      [SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]:
-        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
-      [SEMRESATTRS_TELEMETRY_SDK_NAME]:
-        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_NAME],
-      [SEMRESATTRS_TELEMETRY_SDK_VERSION]:
-        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_VERSION],
+      [ATTR_SERVICE_NAME]: defaultServiceName(),
+      [ATTR_TELEMETRY_SDK_LANGUAGE]: SDK_INFO[ATTR_TELEMETRY_SDK_LANGUAGE],
+      [ATTR_TELEMETRY_SDK_NAME]: SDK_INFO[ATTR_TELEMETRY_SDK_NAME],
+      [ATTR_TELEMETRY_SDK_VERSION]: SDK_INFO[ATTR_TELEMETRY_SDK_VERSION],
     });
   }
 

--- a/packages/opentelemetry-resources/src/detectors/BrowserDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/BrowserDetectorSync.ts
@@ -18,7 +18,7 @@ import {
   ATTR_PROCESS_RUNTIME_DESCRIPTION,
   ATTR_PROCESS_RUNTIME_NAME,
   ATTR_PROCESS_RUNTIME_VERSION,
-} from '@opentelemetry/semantic-conventions/incubating';
+} from '../semconv';
 import { DetectorSync, ResourceAttributes } from '../types';
 import { diag } from '@opentelemetry/api';
 import { ResourceDetectionConfig } from '../config';

--- a/packages/opentelemetry-resources/src/detectors/BrowserDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/BrowserDetectorSync.ts
@@ -15,10 +15,10 @@
  */
 
 import {
-  SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION,
-  SEMRESATTRS_PROCESS_RUNTIME_NAME,
-  SEMRESATTRS_PROCESS_RUNTIME_VERSION,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_PROCESS_RUNTIME_DESCRIPTION,
+  ATTR_PROCESS_RUNTIME_NAME,
+  ATTR_PROCESS_RUNTIME_VERSION,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { DetectorSync, ResourceAttributes } from '../types';
 import { diag } from '@opentelemetry/api';
 import { ResourceDetectionConfig } from '../config';
@@ -40,9 +40,9 @@ class BrowserDetectorSync implements DetectorSync {
       return Resource.empty();
     }
     const browserResource: ResourceAttributes = {
-      [SEMRESATTRS_PROCESS_RUNTIME_NAME]: 'browser',
-      [SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION]: 'Web Browser',
-      [SEMRESATTRS_PROCESS_RUNTIME_VERSION]: navigator.userAgent,
+      [ATTR_PROCESS_RUNTIME_NAME]: 'browser',
+      [ATTR_PROCESS_RUNTIME_DESCRIPTION]: 'Web Browser',
+      [ATTR_PROCESS_RUNTIME_VERSION]: navigator.userAgent,
     };
     return this._getResourceAttributes(browserResource, config);
   }
@@ -57,7 +57,7 @@ class BrowserDetectorSync implements DetectorSync {
     browserResource: ResourceAttributes,
     _config?: ResourceDetectionConfig
   ) {
-    if (browserResource[SEMRESATTRS_PROCESS_RUNTIME_VERSION] === '') {
+    if (browserResource[ATTR_PROCESS_RUNTIME_VERSION] === '') {
       diag.debug(
         'BrowserDetector failed: Unable to find required browser resources. '
       );

--- a/packages/opentelemetry-resources/src/detectors/EnvDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/EnvDetectorSync.ts
@@ -16,7 +16,7 @@
 
 import { diag } from '@opentelemetry/api';
 import { getEnv } from '@opentelemetry/core';
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { Resource } from '../Resource';
 import { DetectorSync, ResourceAttributes } from '../types';
 import { ResourceDetectionConfig } from '../config';
@@ -70,7 +70,7 @@ class EnvDetectorSync implements DetectorSync {
     }
 
     if (serviceName) {
-      attributes[SEMRESATTRS_SERVICE_NAME] = serviceName;
+      attributes[ATTR_SERVICE_NAME] = serviceName;
     }
 
     return new Resource(attributes);

--- a/packages/opentelemetry-resources/src/detectors/platform/node/HostDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/HostDetectorSync.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  ATTR_HOST_ARCH,
-  ATTR_HOST_ID,
-  ATTR_HOST_NAME,
-} from '@opentelemetry/semantic-conventions/incubating';
+import { ATTR_HOST_ARCH, ATTR_HOST_ID, ATTR_HOST_NAME } from '../../../semconv';
 import { Resource } from '../../../Resource';
 import { DetectorSync, ResourceAttributes } from '../../../types';
 import { ResourceDetectionConfig } from '../../../config';

--- a/packages/opentelemetry-resources/src/detectors/platform/node/HostDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/HostDetectorSync.ts
@@ -15,10 +15,10 @@
  */
 
 import {
-  SEMRESATTRS_HOST_ARCH,
-  SEMRESATTRS_HOST_ID,
-  SEMRESATTRS_HOST_NAME,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_HOST_ARCH,
+  ATTR_HOST_ID,
+  ATTR_HOST_NAME,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { Resource } from '../../../Resource';
 import { DetectorSync, ResourceAttributes } from '../../../types';
 import { ResourceDetectionConfig } from '../../../config';
@@ -33,8 +33,8 @@ import { getMachineId } from './machine-id/getMachineId';
 class HostDetectorSync implements DetectorSync {
   detect(_config?: ResourceDetectionConfig): Resource {
     const attributes: ResourceAttributes = {
-      [SEMRESATTRS_HOST_NAME]: hostname(),
-      [SEMRESATTRS_HOST_ARCH]: normalizeArch(arch()),
+      [ATTR_HOST_NAME]: hostname(),
+      [ATTR_HOST_ARCH]: normalizeArch(arch()),
     };
 
     return new Resource(attributes, this._getAsyncAttributes());
@@ -44,7 +44,7 @@ class HostDetectorSync implements DetectorSync {
     return getMachineId().then(machineId => {
       const attributes: ResourceAttributes = {};
       if (machineId) {
-        attributes[SEMRESATTRS_HOST_ID] = machineId;
+        attributes[ATTR_HOST_ID] = machineId;
       }
       return attributes;
     });

--- a/packages/opentelemetry-resources/src/detectors/platform/node/OSDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/OSDetectorSync.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  ATTR_OS_TYPE,
-  ATTR_OS_VERSION,
-} from '@opentelemetry/semantic-conventions/incubating';
+import { ATTR_OS_TYPE, ATTR_OS_VERSION } from '../../../semconv';
 import { Resource } from '../../../Resource';
 import { DetectorSync, ResourceAttributes } from '../../../types';
 import { ResourceDetectionConfig } from '../../../config';

--- a/packages/opentelemetry-resources/src/detectors/platform/node/OSDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/OSDetectorSync.ts
@@ -15,9 +15,9 @@
  */
 
 import {
-  SEMRESATTRS_OS_TYPE,
-  SEMRESATTRS_OS_VERSION,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_OS_TYPE,
+  ATTR_OS_VERSION,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { Resource } from '../../../Resource';
 import { DetectorSync, ResourceAttributes } from '../../../types';
 import { ResourceDetectionConfig } from '../../../config';
@@ -31,8 +31,8 @@ import { normalizeType } from './utils';
 class OSDetectorSync implements DetectorSync {
   detect(_config?: ResourceDetectionConfig): Resource {
     const attributes: ResourceAttributes = {
-      [SEMRESATTRS_OS_TYPE]: normalizeType(platform()),
-      [SEMRESATTRS_OS_VERSION]: release(),
+      [ATTR_OS_TYPE]: normalizeType(platform()),
+      [ATTR_OS_VERSION]: release(),
     };
     return new Resource(attributes);
   }

--- a/packages/opentelemetry-resources/src/detectors/platform/node/ProcessDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/ProcessDetectorSync.ts
@@ -25,7 +25,7 @@ import {
   ATTR_PROCESS_RUNTIME_DESCRIPTION,
   ATTR_PROCESS_RUNTIME_NAME,
   ATTR_PROCESS_RUNTIME_VERSION,
-} from '@opentelemetry/semantic-conventions/incubating';
+} from '../../../semconv';
 import { Resource } from '../../../Resource';
 import { DetectorSync, ResourceAttributes } from '../../../types';
 import { ResourceDetectionConfig } from '../../../config';

--- a/packages/opentelemetry-resources/src/detectors/platform/node/ProcessDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/ProcessDetectorSync.ts
@@ -16,16 +16,16 @@
 
 import { diag } from '@opentelemetry/api';
 import {
-  SEMRESATTRS_PROCESS_COMMAND,
-  SEMRESATTRS_PROCESS_COMMAND_ARGS,
-  SEMRESATTRS_PROCESS_EXECUTABLE_NAME,
-  SEMRESATTRS_PROCESS_EXECUTABLE_PATH,
-  SEMRESATTRS_PROCESS_OWNER,
-  SEMRESATTRS_PROCESS_PID,
-  SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION,
-  SEMRESATTRS_PROCESS_RUNTIME_NAME,
-  SEMRESATTRS_PROCESS_RUNTIME_VERSION,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_PROCESS_COMMAND,
+  ATTR_PROCESS_COMMAND_ARGS,
+  ATTR_PROCESS_EXECUTABLE_NAME,
+  ATTR_PROCESS_EXECUTABLE_PATH,
+  ATTR_PROCESS_OWNER,
+  ATTR_PROCESS_PID,
+  ATTR_PROCESS_RUNTIME_DESCRIPTION,
+  ATTR_PROCESS_RUNTIME_NAME,
+  ATTR_PROCESS_RUNTIME_VERSION,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { Resource } from '../../../Resource';
 import { DetectorSync, ResourceAttributes } from '../../../types';
 import { ResourceDetectionConfig } from '../../../config';
@@ -39,26 +39,26 @@ import * as os from 'os';
 class ProcessDetectorSync implements DetectorSync {
   detect(_config?: ResourceDetectionConfig): IResource {
     const attributes: ResourceAttributes = {
-      [SEMRESATTRS_PROCESS_PID]: process.pid,
-      [SEMRESATTRS_PROCESS_EXECUTABLE_NAME]: process.title,
-      [SEMRESATTRS_PROCESS_EXECUTABLE_PATH]: process.execPath,
-      [SEMRESATTRS_PROCESS_COMMAND_ARGS]: [
+      [ATTR_PROCESS_PID]: process.pid,
+      [ATTR_PROCESS_EXECUTABLE_NAME]: process.title,
+      [ATTR_PROCESS_EXECUTABLE_PATH]: process.execPath,
+      [ATTR_PROCESS_COMMAND_ARGS]: [
         process.argv[0],
         ...process.execArgv,
         ...process.argv.slice(1),
       ],
-      [SEMRESATTRS_PROCESS_RUNTIME_VERSION]: process.versions.node,
-      [SEMRESATTRS_PROCESS_RUNTIME_NAME]: 'nodejs',
-      [SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION]: 'Node.js',
+      [ATTR_PROCESS_RUNTIME_VERSION]: process.versions.node,
+      [ATTR_PROCESS_RUNTIME_NAME]: 'nodejs',
+      [ATTR_PROCESS_RUNTIME_DESCRIPTION]: 'Node.js',
     };
 
     if (process.argv.length > 1) {
-      attributes[SEMRESATTRS_PROCESS_COMMAND] = process.argv[1];
+      attributes[ATTR_PROCESS_COMMAND] = process.argv[1];
     }
 
     try {
       const userInfo = os.userInfo();
-      attributes[SEMRESATTRS_PROCESS_OWNER] = userInfo.username;
+      attributes[ATTR_PROCESS_OWNER] = userInfo.username;
     } catch (e) {
       diag.debug(`error obtaining process owner: ${e}`);
     }

--- a/packages/opentelemetry-resources/src/detectors/platform/node/ServiceInstanceIdDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/ServiceInstanceIdDetectorSync.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SEMRESATTRS_SERVICE_INSTANCE_ID } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_INSTANCE_ID } from '@opentelemetry/semantic-conventions/incubating';
 import { Resource } from '../../../Resource';
 import { DetectorSync, ResourceAttributes } from '../../../types';
 import { ResourceDetectionConfig } from '../../../config';
@@ -26,7 +26,7 @@ import { randomUUID } from 'crypto';
 class ServiceInstanceIdDetectorSync implements DetectorSync {
   detect(_config?: ResourceDetectionConfig): Resource {
     const attributes: ResourceAttributes = {
-      [SEMRESATTRS_SERVICE_INSTANCE_ID]: randomUUID(),
+      [ATTR_SERVICE_INSTANCE_ID]: randomUUID(),
     };
 
     return new Resource(attributes);

--- a/packages/opentelemetry-resources/src/detectors/platform/node/ServiceInstanceIdDetectorSync.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/ServiceInstanceIdDetectorSync.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ATTR_SERVICE_INSTANCE_ID } from '@opentelemetry/semantic-conventions/incubating';
+import { ATTR_SERVICE_INSTANCE_ID } from '../../../semconv';
 import { Resource } from '../../../Resource';
 import { DetectorSync, ResourceAttributes } from '../../../types';
 import { ResourceDetectionConfig } from '../../../config';

--- a/packages/opentelemetry-resources/src/semconv.ts
+++ b/packages/opentelemetry-resources/src/semconv.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A local copy of *unstable* semantic conventions.
+ * https://github.com/open-telemetry/opentelemetry-js/blob/main/semantic-conventions/README.md#unstable-semconv
+ */
+export const ATTR_HOST_ARCH = 'host.arch';
+export const ATTR_HOST_ID = 'host.id';
+export const ATTR_HOST_NAME = 'host.name';
+export const ATTR_OS_TYPE = 'os.type';
+export const ATTR_OS_VERSION = 'os.version';
+export const ATTR_PROCESS_COMMAND = 'process.command';
+export const ATTR_PROCESS_COMMAND_ARGS = 'process.command_args';
+export const ATTR_PROCESS_EXECUTABLE_NAME = 'process.executable.name';
+export const ATTR_PROCESS_EXECUTABLE_PATH = 'process.executable.path';
+export const ATTR_PROCESS_OWNER = 'process.owner';
+export const ATTR_PROCESS_PID = 'process.pid';
+export const ATTR_PROCESS_RUNTIME_DESCRIPTION = 'process.runtime.description';
+export const ATTR_PROCESS_RUNTIME_NAME = 'process.runtime.name';
+export const ATTR_PROCESS_RUNTIME_VERSION = 'process.runtime.version';
+export const ATTR_SERVICE_INSTANCE_ID = 'service.instance.id';

--- a/packages/opentelemetry-resources/test/Resource.test.ts
+++ b/packages/opentelemetry-resources/test/Resource.test.ts
@@ -19,10 +19,10 @@ import * as assert from 'assert';
 import { SDK_INFO } from '@opentelemetry/core';
 import { Resource, ResourceAttributes } from '../src';
 import {
-  SEMRESATTRS_SERVICE_NAME,
-  SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
-  SEMRESATTRS_TELEMETRY_SDK_NAME,
-  SEMRESATTRS_TELEMETRY_SDK_VERSION,
+  ATTR_SERVICE_NAME,
+  ATTR_TELEMETRY_SDK_LANGUAGE,
+  ATTR_TELEMETRY_SDK_NAME,
+  ATTR_TELEMETRY_SDK_VERSION,
 } from '@opentelemetry/semantic-conventions';
 import { describeBrowser, describeNode } from './util';
 import { diag } from '@opentelemetry/api';
@@ -285,19 +285,19 @@ describe('Resource', () => {
     it('should return a default resource', () => {
       const resource = Resource.default();
       assert.strictEqual(
-        resource.attributes[SEMRESATTRS_TELEMETRY_SDK_NAME],
-        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_NAME]
+        resource.attributes[ATTR_TELEMETRY_SDK_NAME],
+        SDK_INFO[ATTR_TELEMETRY_SDK_NAME]
       );
       assert.strictEqual(
-        resource.attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
-        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]
+        resource.attributes[ATTR_TELEMETRY_SDK_LANGUAGE],
+        SDK_INFO[ATTR_TELEMETRY_SDK_LANGUAGE]
       );
       assert.strictEqual(
-        resource.attributes[SEMRESATTRS_TELEMETRY_SDK_VERSION],
-        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_VERSION]
+        resource.attributes[ATTR_TELEMETRY_SDK_VERSION],
+        SDK_INFO[ATTR_TELEMETRY_SDK_VERSION]
       );
       assert.strictEqual(
-        resource.attributes[SEMRESATTRS_SERVICE_NAME],
+        resource.attributes[ATTR_SERVICE_NAME],
         `unknown_service:${process.argv0}`
       );
     });
@@ -307,19 +307,19 @@ describe('Resource', () => {
     it('should return a default resource', () => {
       const resource = Resource.default();
       assert.strictEqual(
-        resource.attributes[SEMRESATTRS_TELEMETRY_SDK_NAME],
-        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_NAME]
+        resource.attributes[ATTR_TELEMETRY_SDK_NAME],
+        SDK_INFO[ATTR_TELEMETRY_SDK_NAME]
       );
       assert.strictEqual(
-        resource.attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
-        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]
+        resource.attributes[ATTR_TELEMETRY_SDK_LANGUAGE],
+        SDK_INFO[ATTR_TELEMETRY_SDK_LANGUAGE]
       );
       assert.strictEqual(
-        resource.attributes[SEMRESATTRS_TELEMETRY_SDK_VERSION],
-        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_VERSION]
+        resource.attributes[ATTR_TELEMETRY_SDK_VERSION],
+        SDK_INFO[ATTR_TELEMETRY_SDK_VERSION]
       );
       assert.strictEqual(
-        resource.attributes[SEMRESATTRS_SERVICE_NAME],
+        resource.attributes[ATTR_SERVICE_NAME],
         'unknown_service'
       );
     });

--- a/packages/opentelemetry-resources/test/detectors/node/HostDetector.test.ts
+++ b/packages/opentelemetry-resources/test/detectors/node/HostDetector.test.ts
@@ -17,10 +17,10 @@
 import * as sinon from 'sinon';
 import * as assert from 'assert';
 import {
-  SEMRESATTRS_HOST_ARCH,
-  SEMRESATTRS_HOST_ID,
-  SEMRESATTRS_HOST_NAME,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_HOST_ARCH,
+  ATTR_HOST_ID,
+  ATTR_HOST_NAME,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { describeNode } from '../../util';
 import { hostDetector, IResource } from '../../../src';
 
@@ -43,14 +43,11 @@ describeNode('hostDetector() on Node.js', () => {
     await resource.waitForAsyncAttributes?.();
 
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_NAME],
+      resource.attributes[ATTR_HOST_NAME],
       'opentelemetry-test'
     );
-    assert.strictEqual(resource.attributes[SEMRESATTRS_HOST_ARCH], 'amd64');
-    assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_ID],
-      expectedHostId
-    );
+    assert.strictEqual(resource.attributes[ATTR_HOST_ARCH], 'amd64');
+    assert.strictEqual(resource.attributes[ATTR_HOST_ID], expectedHostId);
   });
 
   it('should pass through arch string if unknown', async () => {
@@ -61,7 +58,7 @@ describeNode('hostDetector() on Node.js', () => {
     const resource: IResource = await hostDetector.detect();
 
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_ARCH],
+      resource.attributes[ATTR_HOST_ARCH],
       'some-unknown-arch'
     );
   });
@@ -78,10 +75,10 @@ describeNode('hostDetector() on Node.js', () => {
     await resource.waitForAsyncAttributes?.();
 
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_NAME],
+      resource.attributes[ATTR_HOST_NAME],
       'opentelemetry-test'
     );
-    assert.strictEqual(resource.attributes[SEMRESATTRS_HOST_ARCH], 'amd64');
-    assert.strictEqual(false, SEMRESATTRS_HOST_ID in resource.attributes);
+    assert.strictEqual(resource.attributes[ATTR_HOST_ARCH], 'amd64');
+    assert.strictEqual(false, ATTR_HOST_ID in resource.attributes);
   });
 });

--- a/packages/opentelemetry-resources/test/detectors/node/OSDetector.test.ts
+++ b/packages/opentelemetry-resources/test/detectors/node/OSDetector.test.ts
@@ -17,9 +17,9 @@
 import * as sinon from 'sinon';
 import * as assert from 'assert';
 import {
-  SEMRESATTRS_OS_TYPE,
-  SEMRESATTRS_OS_VERSION,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_OS_TYPE,
+  ATTR_OS_VERSION,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { describeNode } from '../../util';
 import { osDetector, IResource } from '../../../src';
 
@@ -36,9 +36,9 @@ describeNode('osDetector() on Node.js', () => {
 
     const resource: IResource = await osDetector.detect();
 
-    assert.strictEqual(resource.attributes[SEMRESATTRS_OS_TYPE], 'windows');
+    assert.strictEqual(resource.attributes[ATTR_OS_TYPE], 'windows');
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_OS_VERSION],
+      resource.attributes[ATTR_OS_VERSION],
       '2.2.1(0.289/5/3)'
     );
   });
@@ -51,7 +51,7 @@ describeNode('osDetector() on Node.js', () => {
     const resource: IResource = await osDetector.detect();
 
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_OS_TYPE],
+      resource.attributes[ATTR_OS_TYPE],
       'some-unknown-platform'
     );
   });

--- a/packages/opentelemetry-resources/test/resource-assertions.test.ts
+++ b/packages/opentelemetry-resources/test/resource-assertions.test.ts
@@ -16,32 +16,32 @@
 
 import { SDK_INFO } from '@opentelemetry/core';
 import {
-  SEMRESATTRS_CLOUD_ACCOUNT_ID,
-  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
-  SEMRESATTRS_CLOUD_PROVIDER,
-  SEMRESATTRS_CLOUD_REGION,
-  SEMRESATTRS_CONTAINER_ID,
-  SEMRESATTRS_CONTAINER_IMAGE_NAME,
-  SEMRESATTRS_CONTAINER_IMAGE_TAG,
-  SEMRESATTRS_CONTAINER_NAME,
-  SEMRESATTRS_HOST_ID,
-  SEMRESATTRS_HOST_IMAGE_ID,
-  SEMRESATTRS_HOST_IMAGE_NAME,
-  SEMRESATTRS_HOST_IMAGE_VERSION,
-  SEMRESATTRS_HOST_NAME,
-  SEMRESATTRS_HOST_TYPE,
-  SEMRESATTRS_K8S_CLUSTER_NAME,
-  SEMRESATTRS_K8S_DEPLOYMENT_NAME,
-  SEMRESATTRS_K8S_NAMESPACE_NAME,
-  SEMRESATTRS_K8S_POD_NAME,
-  SEMRESATTRS_SERVICE_INSTANCE_ID,
-  SEMRESATTRS_SERVICE_NAME,
-  SEMRESATTRS_SERVICE_NAMESPACE,
-  SEMRESATTRS_SERVICE_VERSION,
-  SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
-  SEMRESATTRS_TELEMETRY_SDK_NAME,
-  SEMRESATTRS_TELEMETRY_SDK_VERSION,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_CLOUD_ACCOUNT_ID,
+  ATTR_CLOUD_AVAILABILITY_ZONE,
+  ATTR_CLOUD_PROVIDER,
+  ATTR_CLOUD_REGION,
+  ATTR_CONTAINER_ID,
+  ATTR_CONTAINER_IMAGE_NAME,
+  ATTR_CONTAINER_IMAGE_TAGS,
+  ATTR_CONTAINER_NAME,
+  ATTR_HOST_ID,
+  ATTR_HOST_IMAGE_ID,
+  ATTR_HOST_IMAGE_NAME,
+  ATTR_HOST_IMAGE_VERSION,
+  ATTR_HOST_NAME,
+  ATTR_HOST_TYPE,
+  ATTR_K8S_CLUSTER_NAME,
+  ATTR_K8S_DEPLOYMENT_NAME,
+  ATTR_K8S_NAMESPACE_NAME,
+  ATTR_K8S_POD_NAME,
+  ATTR_SERVICE_INSTANCE_ID,
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_NAMESPACE,
+  ATTR_SERVICE_VERSION,
+  ATTR_TELEMETRY_SDK_LANGUAGE,
+  ATTR_TELEMETRY_SDK_NAME,
+  ATTR_TELEMETRY_SDK_VERSION,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { Resource } from '../src/Resource';
 import {
   assertCloudResource,
@@ -55,17 +55,17 @@ import {
 describe('assertCloudResource', () => {
   it('requires one cloud label', () => {
     const resource = new Resource({
-      [SEMRESATTRS_CLOUD_PROVIDER]: 'gcp',
+      [ATTR_CLOUD_PROVIDER]: 'gcp',
     });
     assertCloudResource(resource, {});
   });
 
   it('validates optional attributes', () => {
     const resource = new Resource({
-      [SEMRESATTRS_CLOUD_PROVIDER]: 'gcp',
-      [SEMRESATTRS_CLOUD_ACCOUNT_ID]: 'opentelemetry',
-      [SEMRESATTRS_CLOUD_REGION]: 'us-central1',
-      [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE]: 'us-central1-a',
+      [ATTR_CLOUD_PROVIDER]: 'gcp',
+      [ATTR_CLOUD_ACCOUNT_ID]: 'opentelemetry',
+      [ATTR_CLOUD_REGION]: 'us-central1',
+      [ATTR_CLOUD_AVAILABILITY_ZONE]: 'us-central1-a',
     });
     assertCloudResource(resource, {
       provider: 'gcp',
@@ -79,23 +79,23 @@ describe('assertCloudResource', () => {
 describe('assertContainerResource', () => {
   it('requires one container label', () => {
     const resource = new Resource({
-      [SEMRESATTRS_CONTAINER_NAME]: 'opentelemetry-autoconf',
+      [ATTR_CONTAINER_NAME]: 'opentelemetry-autoconf',
     });
     assertContainerResource(resource, {});
   });
 
   it('validates optional attributes', () => {
     const resource = new Resource({
-      [SEMRESATTRS_CONTAINER_NAME]: 'opentelemetry-autoconf',
-      [SEMRESATTRS_CONTAINER_ID]: 'abc',
-      [SEMRESATTRS_CONTAINER_IMAGE_NAME]: 'gcr.io/opentelemetry/operator',
-      [SEMRESATTRS_CONTAINER_IMAGE_TAG]: '0.1',
+      [ATTR_CONTAINER_NAME]: 'opentelemetry-autoconf',
+      [ATTR_CONTAINER_ID]: 'abc',
+      [ATTR_CONTAINER_IMAGE_NAME]: 'gcr.io/opentelemetry/operator',
+      [ATTR_CONTAINER_IMAGE_TAGS]: ['0.1'],
     });
     assertContainerResource(resource, {
       name: 'opentelemetry-autoconf',
       id: 'abc',
       imageName: 'gcr.io/opentelemetry/operator',
-      imageTag: '0.1',
+      imageTags: ['0.1'],
     });
   });
 });
@@ -103,20 +103,20 @@ describe('assertContainerResource', () => {
 describe('assertHostResource', () => {
   it('requires one host label', () => {
     const resource = new Resource({
-      [SEMRESATTRS_HOST_ID]: 'opentelemetry-test-id',
+      [ATTR_HOST_ID]: 'opentelemetry-test-id',
     });
     assertHostResource(resource, {});
   });
 
   it('validates optional attributes', () => {
     const resource = new Resource({
-      [SEMRESATTRS_HOST_ID]: 'opentelemetry-test-id',
-      [SEMRESATTRS_HOST_NAME]: 'opentelemetry-test-name',
-      [SEMRESATTRS_HOST_TYPE]: 'n1-standard-1',
-      [SEMRESATTRS_HOST_IMAGE_NAME]:
+      [ATTR_HOST_ID]: 'opentelemetry-test-id',
+      [ATTR_HOST_NAME]: 'opentelemetry-test-name',
+      [ATTR_HOST_TYPE]: 'n1-standard-1',
+      [ATTR_HOST_IMAGE_NAME]:
         'infra-ami-eks-worker-node-7d4ec78312, CentOS-8-x86_64-1905',
-      [SEMRESATTRS_HOST_IMAGE_ID]: 'ami-07b06b442921831e5',
-      [SEMRESATTRS_HOST_IMAGE_VERSION]: '0.1',
+      [ATTR_HOST_IMAGE_ID]: 'ami-07b06b442921831e5',
+      [ATTR_HOST_IMAGE_VERSION]: '0.1',
     });
     assertHostResource(resource, {
       hostName: 'opentelemetry-test-hostname',
@@ -133,17 +133,17 @@ describe('assertHostResource', () => {
 describe('assertK8sResource', () => {
   it('requires one k8s label', () => {
     const resource = new Resource({
-      [SEMRESATTRS_K8S_CLUSTER_NAME]: 'opentelemetry-cluster',
+      [ATTR_K8S_CLUSTER_NAME]: 'opentelemetry-cluster',
     });
     assertK8sResource(resource, {});
   });
 
   it('validates optional attributes', () => {
     const resource = new Resource({
-      [SEMRESATTRS_K8S_CLUSTER_NAME]: 'opentelemetry-cluster',
-      [SEMRESATTRS_K8S_NAMESPACE_NAME]: 'default',
-      [SEMRESATTRS_K8S_POD_NAME]: 'opentelemetry-pod-autoconf',
-      [SEMRESATTRS_K8S_DEPLOYMENT_NAME]: 'opentelemetry',
+      [ATTR_K8S_CLUSTER_NAME]: 'opentelemetry-cluster',
+      [ATTR_K8S_NAMESPACE_NAME]: 'default',
+      [ATTR_K8S_POD_NAME]: 'opentelemetry-pod-autoconf',
+      [ATTR_K8S_DEPLOYMENT_NAME]: 'opentelemetry',
     });
     assertK8sResource(resource, {
       clusterName: 'opentelemetry-cluster',
@@ -157,21 +157,18 @@ describe('assertK8sResource', () => {
 describe('assertTelemetrySDKResource', () => {
   it('uses default validations', () => {
     const resource = new Resource({
-      [SEMRESATTRS_TELEMETRY_SDK_NAME]:
-        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_NAME],
-      [SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]:
-        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
-      [SEMRESATTRS_TELEMETRY_SDK_VERSION]:
-        SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_VERSION],
+      [ATTR_TELEMETRY_SDK_NAME]: SDK_INFO[ATTR_TELEMETRY_SDK_NAME],
+      [ATTR_TELEMETRY_SDK_LANGUAGE]: SDK_INFO[ATTR_TELEMETRY_SDK_LANGUAGE],
+      [ATTR_TELEMETRY_SDK_VERSION]: SDK_INFO[ATTR_TELEMETRY_SDK_VERSION],
     });
     assertTelemetrySDKResource(resource, {});
   });
 
   it('validates optional attributes', () => {
     const resource = new Resource({
-      [SEMRESATTRS_TELEMETRY_SDK_NAME]: 'opentelemetry',
-      [SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]: 'nodejs',
-      [SEMRESATTRS_TELEMETRY_SDK_VERSION]: '0.1.0',
+      [ATTR_TELEMETRY_SDK_NAME]: 'opentelemetry',
+      [ATTR_TELEMETRY_SDK_LANGUAGE]: 'nodejs',
+      [ATTR_TELEMETRY_SDK_VERSION]: '0.1.0',
     });
     assertTelemetrySDKResource(resource, {
       name: 'opentelemetry',
@@ -184,8 +181,8 @@ describe('assertTelemetrySDKResource', () => {
 describe('assertServiceResource', () => {
   it('validates required attributes', () => {
     const resource = new Resource({
-      [SEMRESATTRS_SERVICE_NAME]: 'shoppingcart',
-      [SEMRESATTRS_SERVICE_INSTANCE_ID]: '627cc493-f310-47de-96bd-71410b7dec09',
+      [ATTR_SERVICE_NAME]: 'shoppingcart',
+      [ATTR_SERVICE_INSTANCE_ID]: '627cc493-f310-47de-96bd-71410b7dec09',
     });
     assertServiceResource(resource, {
       name: 'shoppingcart',
@@ -195,10 +192,10 @@ describe('assertServiceResource', () => {
 
   it('validates optional attributes', () => {
     const resource = new Resource({
-      [SEMRESATTRS_SERVICE_NAME]: 'shoppingcart',
-      [SEMRESATTRS_SERVICE_INSTANCE_ID]: '627cc493-f310-47de-96bd-71410b7dec09',
-      [SEMRESATTRS_SERVICE_NAMESPACE]: 'shop',
-      [SEMRESATTRS_SERVICE_VERSION]: '0.1.0',
+      [ATTR_SERVICE_NAME]: 'shoppingcart',
+      [ATTR_SERVICE_INSTANCE_ID]: '627cc493-f310-47de-96bd-71410b7dec09',
+      [ATTR_SERVICE_NAMESPACE]: 'shop',
+      [ATTR_SERVICE_VERSION]: '0.1.0',
     });
     assertServiceResource(resource, {
       name: 'shoppingcart',

--- a/packages/opentelemetry-resources/test/util/resource-assertions.ts
+++ b/packages/opentelemetry-resources/test/util/resource-assertions.ts
@@ -18,45 +18,47 @@ import { SDK_INFO } from '@opentelemetry/core';
 import * as assert from 'assert';
 import { IResource } from '../../src/IResource';
 import {
-  SEMRESATTRS_CLOUD_ACCOUNT_ID,
-  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
-  SEMRESATTRS_CLOUD_PROVIDER,
-  SEMRESATTRS_CLOUD_REGION,
-  SEMRESATTRS_CONTAINER_ID,
-  SEMRESATTRS_CONTAINER_IMAGE_NAME,
-  SEMRESATTRS_CONTAINER_IMAGE_TAG,
-  SEMRESATTRS_CONTAINER_NAME,
-  SEMRESATTRS_HOST_ID,
-  SEMRESATTRS_HOST_IMAGE_ID,
-  SEMRESATTRS_HOST_IMAGE_NAME,
-  SEMRESATTRS_HOST_IMAGE_VERSION,
-  SEMRESATTRS_HOST_NAME,
-  SEMRESATTRS_HOST_TYPE,
-  SEMRESATTRS_K8S_CLUSTER_NAME,
-  SEMRESATTRS_K8S_DEPLOYMENT_NAME,
-  SEMRESATTRS_K8S_NAMESPACE_NAME,
-  SEMRESATTRS_K8S_POD_NAME,
-  SEMRESATTRS_PROCESS_COMMAND,
-  SEMRESATTRS_PROCESS_COMMAND_ARGS,
-  SEMRESATTRS_PROCESS_EXECUTABLE_NAME,
-  SEMRESATTRS_PROCESS_EXECUTABLE_PATH,
-  SEMRESATTRS_PROCESS_OWNER,
-  SEMRESATTRS_PROCESS_PID,
-  SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION,
-  SEMRESATTRS_PROCESS_RUNTIME_NAME,
-  SEMRESATTRS_PROCESS_RUNTIME_VERSION,
-  SEMRESATTRS_SERVICE_INSTANCE_ID,
-  SEMRESATTRS_SERVICE_NAME,
-  SEMRESATTRS_SERVICE_NAMESPACE,
-  SEMRESATTRS_SERVICE_VERSION,
-  SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
-  SEMRESATTRS_TELEMETRY_SDK_NAME,
-  SEMRESATTRS_TELEMETRY_SDK_VERSION,
-  SEMRESATTRS_WEBENGINE_DESCRIPTION,
-  SEMRESATTRS_WEBENGINE_NAME,
-  SEMRESATTRS_WEBENGINE_VERSION,
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+  ATTR_TELEMETRY_SDK_LANGUAGE,
+  ATTR_TELEMETRY_SDK_NAME,
+  ATTR_TELEMETRY_SDK_VERSION,
 } from '@opentelemetry/semantic-conventions';
-import * as semconv from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_CLOUD_ACCOUNT_ID,
+  ATTR_CLOUD_AVAILABILITY_ZONE,
+  ATTR_CLOUD_PROVIDER,
+  ATTR_CLOUD_REGION,
+  ATTR_CONTAINER_ID,
+  ATTR_CONTAINER_IMAGE_NAME,
+  ATTR_CONTAINER_IMAGE_TAGS,
+  ATTR_CONTAINER_NAME,
+  ATTR_HOST_ID,
+  ATTR_HOST_IMAGE_ID,
+  ATTR_HOST_IMAGE_NAME,
+  ATTR_HOST_IMAGE_VERSION,
+  ATTR_HOST_NAME,
+  ATTR_HOST_TYPE,
+  ATTR_K8S_CLUSTER_NAME,
+  ATTR_K8S_DEPLOYMENT_NAME,
+  ATTR_K8S_NAMESPACE_NAME,
+  ATTR_K8S_POD_NAME,
+  ATTR_PROCESS_COMMAND,
+  ATTR_PROCESS_COMMAND_ARGS,
+  ATTR_PROCESS_EXECUTABLE_NAME,
+  ATTR_PROCESS_EXECUTABLE_PATH,
+  ATTR_PROCESS_OWNER,
+  ATTR_PROCESS_PID,
+  ATTR_PROCESS_RUNTIME_DESCRIPTION,
+  ATTR_PROCESS_RUNTIME_NAME,
+  ATTR_PROCESS_RUNTIME_VERSION,
+  ATTR_SERVICE_INSTANCE_ID,
+  ATTR_SERVICE_NAMESPACE,
+  ATTR_WEBENGINE_DESCRIPTION,
+  ATTR_WEBENGINE_NAME,
+  ATTR_WEBENGINE_VERSION,
+} from '@opentelemetry/semantic-conventions/incubating';
+import * as semconvIncubating from '@opentelemetry/semantic-conventions/incubating';
 
 /**
  * Test utility method to validate a cloud resource
@@ -76,22 +78,22 @@ export const assertCloudResource = (
   assertHasOneLabel('CLOUD', resource);
   if (validations.provider)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CLOUD_PROVIDER],
+      resource.attributes[ATTR_CLOUD_PROVIDER],
       validations.provider
     );
   if (validations.accountId)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CLOUD_ACCOUNT_ID],
+      resource.attributes[ATTR_CLOUD_ACCOUNT_ID],
       validations.accountId
     );
   if (validations.region)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CLOUD_REGION],
+      resource.attributes[ATTR_CLOUD_REGION],
       validations.region
     );
   if (validations.zone)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CLOUD_AVAILABILITY_ZONE],
+      resource.attributes[ATTR_CLOUD_AVAILABILITY_ZONE],
       validations.zone
     );
 };
@@ -108,29 +110,26 @@ export const assertContainerResource = (
     name?: string;
     id?: string;
     imageName?: string;
-    imageTag?: string;
+    imageTags?: string[];
   }
 ) => {
   assertHasOneLabel('CONTAINER', resource);
   if (validations.name)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CONTAINER_NAME],
+      resource.attributes[ATTR_CONTAINER_NAME],
       validations.name
     );
   if (validations.id)
-    assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CONTAINER_ID],
-      validations.id
-    );
+    assert.strictEqual(resource.attributes[ATTR_CONTAINER_ID], validations.id);
   if (validations.imageName)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CONTAINER_IMAGE_NAME],
+      resource.attributes[ATTR_CONTAINER_IMAGE_NAME],
       validations.imageName
     );
-  if (validations.imageTag)
-    assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CONTAINER_IMAGE_TAG],
-      validations.imageTag
+  if (validations.imageTags)
+    assert.deepStrictEqual(
+      resource.attributes[ATTR_CONTAINER_IMAGE_TAGS],
+      validations.imageTags
     );
 };
 
@@ -154,33 +153,27 @@ export const assertHostResource = (
 ) => {
   assertHasOneLabel('HOST', resource);
   if (validations.id)
-    assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_ID],
-      validations.id
-    );
+    assert.strictEqual(resource.attributes[ATTR_HOST_ID], validations.id);
   if (validations.name)
-    assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_NAME],
-      validations.name
-    );
+    assert.strictEqual(resource.attributes[ATTR_HOST_NAME], validations.name);
   if (validations.hostType)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_TYPE],
+      resource.attributes[ATTR_HOST_TYPE],
       validations.hostType
     );
   if (validations.imageName)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_IMAGE_NAME],
+      resource.attributes[ATTR_HOST_IMAGE_NAME],
       validations.imageName
     );
   if (validations.imageId)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_IMAGE_ID],
+      resource.attributes[ATTR_HOST_IMAGE_ID],
       validations.imageId
     );
   if (validations.imageVersion)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_IMAGE_VERSION],
+      resource.attributes[ATTR_HOST_IMAGE_VERSION],
       validations.imageVersion
     );
 };
@@ -203,22 +196,22 @@ export const assertK8sResource = (
   assertHasOneLabel('K8S', resource);
   if (validations.clusterName)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_K8S_CLUSTER_NAME],
+      resource.attributes[ATTR_K8S_CLUSTER_NAME],
       validations.clusterName
     );
   if (validations.namespaceName)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_K8S_NAMESPACE_NAME],
+      resource.attributes[ATTR_K8S_NAMESPACE_NAME],
       validations.namespaceName
     );
   if (validations.podName)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_K8S_POD_NAME],
+      resource.attributes[ATTR_K8S_POD_NAME],
       validations.podName
     );
   if (validations.deploymentName)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_K8S_DEPLOYMENT_NAME],
+      resource.attributes[ATTR_K8S_DEPLOYMENT_NAME],
       validations.deploymentName
     );
 };
@@ -238,25 +231,25 @@ export const assertTelemetrySDKResource = (
   }
 ) => {
   const defaults = {
-    name: SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_NAME],
-    language: SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
-    version: SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_VERSION],
+    name: SDK_INFO[ATTR_TELEMETRY_SDK_NAME],
+    language: SDK_INFO[ATTR_TELEMETRY_SDK_LANGUAGE],
+    version: SDK_INFO[ATTR_TELEMETRY_SDK_VERSION],
   };
   validations = { ...defaults, ...validations };
 
   if (validations.name)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_NAME],
+      resource.attributes[ATTR_TELEMETRY_SDK_NAME],
       validations.name
     );
   if (validations.language)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
+      resource.attributes[ATTR_TELEMETRY_SDK_LANGUAGE],
       validations.language
     );
   if (validations.version)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_VERSION],
+      resource.attributes[ATTR_TELEMETRY_SDK_VERSION],
       validations.version
     );
 };
@@ -276,22 +269,19 @@ export const assertServiceResource = (
     version?: string;
   }
 ) => {
+  assert.strictEqual(resource.attributes[ATTR_SERVICE_NAME], validations.name);
   assert.strictEqual(
-    resource.attributes[SEMRESATTRS_SERVICE_NAME],
-    validations.name
-  );
-  assert.strictEqual(
-    resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID],
+    resource.attributes[ATTR_SERVICE_INSTANCE_ID],
     validations.instanceId
   );
   if (validations.namespace)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_SERVICE_NAMESPACE],
+      resource.attributes[ATTR_SERVICE_NAMESPACE],
       validations.namespace
     );
   if (validations.version)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_SERVICE_VERSION],
+      resource.attributes[ATTR_SERVICE_VERSION],
       validations.version
     );
 };
@@ -316,55 +306,52 @@ export const assertResource = (
     runtimeDescription?: string;
   }
 ) => {
-  assert.strictEqual(
-    resource.attributes[SEMRESATTRS_PROCESS_PID],
-    validations.pid
-  );
+  assert.strictEqual(resource.attributes[ATTR_PROCESS_PID], validations.pid);
   if (validations.name) {
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_PROCESS_EXECUTABLE_NAME],
+      resource.attributes[ATTR_PROCESS_EXECUTABLE_NAME],
       validations.name
     );
   }
   if (validations.command) {
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_PROCESS_COMMAND],
+      resource.attributes[ATTR_PROCESS_COMMAND],
       validations.command
     );
   }
   if (validations.commandArgs) {
     assert.deepStrictEqual(
-      resource.attributes[SEMRESATTRS_PROCESS_COMMAND_ARGS],
+      resource.attributes[ATTR_PROCESS_COMMAND_ARGS],
       validations.commandArgs
     );
   }
   if (validations.executablePath) {
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_PROCESS_EXECUTABLE_PATH],
+      resource.attributes[ATTR_PROCESS_EXECUTABLE_PATH],
       validations.executablePath
     );
   }
   if (validations.owner) {
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_PROCESS_OWNER],
+      resource.attributes[ATTR_PROCESS_OWNER],
       validations.owner
     );
   }
   if (validations.version) {
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_PROCESS_RUNTIME_VERSION],
+      resource.attributes[ATTR_PROCESS_RUNTIME_VERSION],
       validations.version
     );
   }
   if (validations.runtimeName) {
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_PROCESS_RUNTIME_NAME],
+      resource.attributes[ATTR_PROCESS_RUNTIME_NAME],
       validations.runtimeName
     );
   }
   if (validations.runtimeDescription) {
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION],
+      resource.attributes[ATTR_PROCESS_RUNTIME_DESCRIPTION],
       validations.runtimeDescription
     );
   }
@@ -380,19 +367,19 @@ export const assertWebEngineResource = (
 ) => {
   if (validations.name) {
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_WEBENGINE_NAME],
+      resource.attributes[ATTR_WEBENGINE_NAME],
       validations.name
     );
   }
   if (validations.version) {
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_WEBENGINE_VERSION],
+      resource.attributes[ATTR_WEBENGINE_VERSION],
       validations.version
     );
   }
   if (validations.description) {
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_WEBENGINE_DESCRIPTION],
+      resource.attributes[ATTR_WEBENGINE_DESCRIPTION],
       validations.description
     );
   }
@@ -412,9 +399,11 @@ export const assertEmptyResource = (resource: IResource) => {
  * `prefix`. By "known", we mean it is an attribute defined in semconv.
  */
 const assertHasOneLabel = (prefix: string, resource: IResource): void => {
-  const semconvModPrefix = `SEMRESATTRS_${prefix.toUpperCase()}_`;
+  const semconvModPrefix = `ATTR_${prefix.toUpperCase()}_`;
+  // Look at exports from the "incubating" entry-point because it includes both
+  // stable and unstable semconv exports.
   const knownAttrs: Set<string> = new Set(
-    Object.entries(semconv)
+    Object.entries(semconvIncubating)
       .filter(
         ([k, v]) => typeof v === 'string' && k.startsWith(semconvModPrefix)
       )
@@ -429,6 +418,6 @@ const assertHasOneLabel = (prefix: string, resource: IResource): void => {
       prefix +
       '] matching the following attributes: ' +
       Array.from(knownAttrs).join(', ') +
-      JSON.stringify(Object.keys(semconv))
+      JSON.stringify(Object.keys(semconvIncubating))
   );
 };

--- a/packages/opentelemetry-resources/test/util/sample-detector.ts
+++ b/packages/opentelemetry-resources/test/util/sample-detector.ts
@@ -15,24 +15,24 @@
  */
 
 import {
-  SEMRESATTRS_CLOUD_ACCOUNT_ID,
-  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
-  SEMRESATTRS_CLOUD_PROVIDER,
-  SEMRESATTRS_CLOUD_REGION,
-  SEMRESATTRS_HOST_ID,
-  SEMRESATTRS_HOST_TYPE,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_CLOUD_ACCOUNT_ID,
+  ATTR_CLOUD_AVAILABILITY_ZONE,
+  ATTR_CLOUD_PROVIDER,
+  ATTR_CLOUD_REGION,
+  ATTR_HOST_ID,
+  ATTR_HOST_TYPE,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { Detector, Resource } from '../../src';
 
 class SampleDetector implements Detector {
   async detect(): Promise<Resource> {
     return new Resource({
-      [SEMRESATTRS_CLOUD_PROVIDER]: 'provider',
-      [SEMRESATTRS_CLOUD_ACCOUNT_ID]: 'accountId',
-      [SEMRESATTRS_CLOUD_REGION]: 'region',
-      [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE]: 'zone',
-      [SEMRESATTRS_HOST_ID]: 'instanceId',
-      [SEMRESATTRS_HOST_TYPE]: 'instanceType',
+      [ATTR_CLOUD_PROVIDER]: 'provider',
+      [ATTR_CLOUD_ACCOUNT_ID]: 'accountId',
+      [ATTR_CLOUD_REGION]: 'region',
+      [ATTR_CLOUD_AVAILABILITY_ZONE]: 'zone',
+      [ATTR_HOST_ID]: 'instanceId',
+      [ATTR_HOST_TYPE]: 'instanceType',
     });
   }
 }


### PR DESCRIPTION
Refs: https://github.com/open-telemetry/opentelemetry-js/issues/4896

# status

This is in draft while we discuss how to handle using unstable semconv attributes: (1) use the incubating entry-point or (2) make local copies of the unstable constants. See https://github.com/open-telemetry/opentelemetry-js/issues/5182#issuecomment-2489385179

- The [first commit](https://github.com/open-telemetry/opentelemetry-js/pull/5187/commits/ddae4091653af7a098dc77499a0df56dd085bf67) on this feature branch shows option (1): using the "incubating" entry-point.
- The [third commit](https://github.com/open-telemetry/opentelemetry-js/pull/5187/commits/f89b10afcd17828fbf35dc8a7e81971c24dabced) shows changing to option (2): making a copy of unstable values (to "src/semconv.ts") and using those.