### PR TITLE
refactor(sdk-trace-base): make resource private and remove getActiveSpanProcessor API

### DIFF
--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -15,6 +15,7 @@
 * feat(sdk-metrics)!: drop `View` and `Aggregation` in favor of `ViewOptions` and `AggregationOption` [#4931](https://github.com/open-telemetry/opentelemetry-js/pull/4931) @pichlermarc
 * refactor(sdk-trace-base)!: remove `new Span` constructor in favor of `Tracer.startSpan` API [#5048](https://github.com/open-telemetry/opentelemetry-js/pull/5048) @david-luna
 * refactor(sdk-trace-base)!: remove `BasicTracerProvider.addSpanProcessor` API in favor of constructor options. [#5134](https://github.com/open-telemetry/opentelemetry-js/pull/5134) @david-luna
+* refactor(sdk-trace-base)!: make `resource` property private in `BasicTracerProvider` and remove `getActiveSpanProcessor` API. [#5192](https://github.com/open-telemetry/opentelemetry-js/pull/5192) @david-luna
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -262,7 +262,7 @@ describe('Node SDK', () => {
 
       assert.ok(nodeTracerProvider instanceof NodeTracerProvider);
 
-      const spanProcessor = nodeTracerProvider.getActiveSpanProcessor() as any;
+      const spanProcessor = nodeTracerProvider['activeSpanProcessor'] as any;
 
       assert(
         spanProcessor.constructor.name === 'MultiSpanProcessor',
@@ -1117,7 +1117,7 @@ describe('setup exporter from env', () => {
 
     assert(tracerProvider instanceof NodeTracerProvider);
 
-    const activeSpanProcessor = tracerProvider.getActiveSpanProcessor();
+    const activeSpanProcessor = tracerProvider['activeSpanProcessor'];
 
     assert(activeSpanProcessor.constructor.name === 'MultiSpanProcessor');
 

--- a/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts
@@ -68,9 +68,9 @@ export class BasicTracerProvider implements TracerProvider {
 
   private readonly _config: TracerConfig;
   private readonly _tracers: Map<string, Tracer> = new Map();
+  private readonly _resource: IResource;
 
   private activeSpanProcessor: MultiSpanProcessor;
-  readonly resource: IResource;
 
   constructor(config: TracerConfig = {}) {
     const mergedConfig = merge(
@@ -78,14 +78,14 @@ export class BasicTracerProvider implements TracerProvider {
       loadDefaultConfig(),
       reconfigureLimits(config)
     );
-    this.resource = mergedConfig.resource ?? Resource.empty();
+    this._resource = mergedConfig.resource ?? Resource.empty();
 
     if (mergedConfig.mergeResourceWithDefaults) {
-      this.resource = Resource.default().merge(this.resource);
+      this._resource = Resource.default().merge(this._resource);
     }
 
     this._config = Object.assign({}, mergedConfig, {
-      resource: this.resource,
+      resource: this._resource,
     });
 
     const spanProcessors: SpanProcessor[] = [];
@@ -116,17 +116,14 @@ export class BasicTracerProvider implements TracerProvider {
         new Tracer(
           { name, version, schemaUrl: options?.schemaUrl },
           this._config,
-          this
+          this._resource,
+          this.activeSpanProcessor
         )
       );
     }
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return this._tracers.get(key)!;
-  }
-
-  getActiveSpanProcessor(): SpanProcessor {
-    return this.activeSpanProcessor;
   }
 
   /**

--- a/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
@@ -20,8 +20,6 @@ import {
   sanitizeAttributes,
   isTracingSuppressed,
 } from '@opentelemetry/core';
-import { IResource } from '@opentelemetry/resources';
-import { BasicTracerProvider } from './BasicTracerProvider';
 import { SpanImpl } from './Span';
 import { GeneralLimits, SpanLimits, TracerConfig } from './types';
 import { mergeConfig } from './utility';
@@ -29,6 +27,7 @@ import { SpanProcessor } from './SpanProcessor';
 import { Sampler } from './Sampler';
 import { IdGenerator } from './IdGenerator';
 import { RandomIdGenerator } from './platform';
+import { IResource } from '@opentelemetry/resources';
 
 /**
  * This class represents a basic tracer.
@@ -38,8 +37,10 @@ export class Tracer implements api.Tracer {
   private readonly _generalLimits: GeneralLimits;
   private readonly _spanLimits: SpanLimits;
   private readonly _idGenerator: IdGenerator;
-  readonly resource: IResource;
   readonly instrumentationLibrary: InstrumentationLibrary;
+
+  private readonly _resource: IResource;
+  private readonly _spanProcessor: SpanProcessor;
 
   /**
    * Constructs a new Tracer instance.
@@ -47,14 +48,16 @@ export class Tracer implements api.Tracer {
   constructor(
     instrumentationLibrary: InstrumentationLibrary,
     config: TracerConfig,
-    private _tracerProvider: BasicTracerProvider
+    resource: IResource,
+    spanProcessor: SpanProcessor
   ) {
     const localConfig = mergeConfig(config);
     this._sampler = localConfig.sampler;
     this._generalLimits = localConfig.generalLimits;
     this._spanLimits = localConfig.spanLimits;
     this._idGenerator = config.idGenerator || new RandomIdGenerator();
-    this.resource = _tracerProvider.resource;
+    this._resource = resource;
+    this._spanProcessor = spanProcessor;
     this.instrumentationLibrary = instrumentationLibrary;
   }
 
@@ -138,18 +141,20 @@ export class Tracer implements api.Tracer {
       Object.assign(attributes, samplingResult.attributes)
     );
 
-    const span = new SpanImpl(
-      this,
+    const span = new SpanImpl({
+      resource: this._resource,
+      scope: this.instrumentationLibrary,
       context,
-      name,
       spanContext,
-      spanKind,
-      parentSpanId,
+      name,
+      kind: spanKind,
       links,
-      options.startTime,
-      undefined,
-      initAttributes
-    );
+      parentSpanId,
+      attributes: initAttributes,
+      startTime: options.startTime,
+      spanProcessor: this._spanProcessor,
+      spanLimits: this.getSpanLimits(),
+    });
     return span;
   }
 
@@ -249,9 +254,5 @@ export class Tracer implements api.Tracer {
   /** Returns the active {@link SpanLimits}. */
   getSpanLimits(): SpanLimits {
     return this._spanLimits;
-  }
-
-  getActiveSpanProcessor(): SpanProcessor {
-    return this._tracerProvider.getActiveSpanProcessor();
   }
 }

--- a/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
@@ -153,7 +153,7 @@ export class Tracer implements api.Tracer {
       attributes: initAttributes,
       startTime: options.startTime,
       spanProcessor: this._spanProcessor,
-      spanLimits: this.getSpanLimits(),
+      spanLimits: this._spanLimits,
     });
     return span;
   }

--- a/packages/opentelemetry-sdk-trace-base/test/common/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/BasicTracerProvider.test.ts
@@ -665,8 +665,8 @@ describe('BasicTracerProvider', () => {
       const tracerProvider = new BasicTracerProvider();
       const tracer = tracerProvider.getTracer('default');
       const span = tracer.startSpan('my-span') as Span;
-      assert.strictEqual(tracer.resource, tracerProvider.resource);
-      assert.strictEqual(span.resource, tracerProvider.resource);
+      assert.strictEqual(tracer['_resource'], tracerProvider['_resource']);
+      assert.strictEqual(span.resource, tracerProvider['_resource']);
     });
 
     it('should start a span with name and options', () => {
@@ -929,7 +929,7 @@ describe('BasicTracerProvider', () => {
   describe('.resource', () => {
     it('should use the default resource when no resource is provided', function () {
       const tracerProvider = new BasicTracerProvider();
-      assert.deepStrictEqual(tracerProvider.resource, Resource.default());
+      assert.deepStrictEqual(tracerProvider['_resource'], Resource.default());
     });
 
     it('should not merge with defaults when flag is set to false', function () {
@@ -938,7 +938,7 @@ describe('BasicTracerProvider', () => {
         mergeResourceWithDefaults: false,
         resource: expectedResource,
       });
-      assert.deepStrictEqual(tracerProvider.resource, expectedResource);
+      assert.deepStrictEqual(tracerProvider['_resource'], expectedResource);
     });
 
     it('should merge with defaults when flag is set to true', function () {
@@ -948,7 +948,7 @@ describe('BasicTracerProvider', () => {
         resource: providedResource,
       });
       assert.deepStrictEqual(
-        tracerProvider.resource,
+        tracerProvider['_resource'],
         Resource.default().merge(providedResource)
       );
     });
@@ -958,7 +958,7 @@ describe('BasicTracerProvider', () => {
     it('should trigger shutdown when manually invoked', () => {
       const tracerProvider = new BasicTracerProvider();
       const shutdownStub = sinon.stub(
-        tracerProvider.getActiveSpanProcessor(),
+        tracerProvider['activeSpanProcessor'],
         'shutdown'
       );
       tracerProvider.shutdown();

--- a/packages/opentelemetry-sdk-trace-base/test/common/MultiSpanProcessor.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/MultiSpanProcessor.test.ts
@@ -63,7 +63,7 @@ describe('MultiSpanProcessor', () => {
     assert.strictEqual(processor1.spans.length, 0);
     span.end();
     assert.strictEqual(processor1.spans.length, 1);
-    tracerProvider.getActiveSpanProcessor().shutdown();
+    tracerProvider['activeSpanProcessor'].shutdown();
   });
 
   it('should handle two span processor', async () => {
@@ -81,9 +81,6 @@ describe('MultiSpanProcessor', () => {
     assert.strictEqual(processor1.spans.length, 1);
     assert.strictEqual(processor1.spans.length, processor2.spans.length);
 
-    // await tracerProvider.getActiveSpanProcessor().shutdown();
-    // assert.strictEqual(processor1.spans.length, 0);
-    // assert.strictEqual(processor1.spans.length, processor2.spans.length);
     tracerProvider.shutdown().then(() => {
       assert.strictEqual(processor1.spans.length, 0);
       assert.strictEqual(processor1.spans.length, processor2.spans.length);

--- a/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
@@ -77,25 +77,31 @@ describe('Span', () => {
   };
 
   it('should create a Span instance', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.SERVER
-    );
+      name,
+      kind: SpanKind.SERVER,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     assert.ok(span instanceof SpanImpl);
     span.end();
   });
 
   it('should have valid startTime', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.SERVER
-    );
+      name,
+      kind: SpanKind.SERVER,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     assert.ok(
       hrTimeToMilliseconds(span.startTime) >
         hrTimeToMilliseconds(performanceTimeOrigin)
@@ -103,13 +109,16 @@ describe('Span', () => {
   });
 
   it('should have valid endTime', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.SERVER
-    );
+      name,
+      kind: SpanKind.SERVER,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     span.end();
     assert.ok(
       hrTimeToNanoseconds(span.endTime) >= hrTimeToNanoseconds(span.startTime),
@@ -124,25 +133,31 @@ describe('Span', () => {
   });
 
   it('should have a duration', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.SERVER
-    );
+      name,
+      kind: SpanKind.SERVER,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     span.end();
     assert.ok(hrTimeToNanoseconds(span.duration) >= 0);
   });
 
   it('should ensure duration is never negative even if provided with inconsistent times', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.SERVER
-    );
+      name,
+      kind: SpanKind.SERVER,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     // @ts-expect-error writing readonly property. performance time origin is mocked to return ms value of [1,1]
     span['_performanceOffset'] = 0;
     span.end(hrTimeToMilliseconds(span.startTime) - 1);
@@ -150,13 +165,16 @@ describe('Span', () => {
   });
 
   it('should have valid event.time', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.SERVER
-    );
+      name,
+      kind: SpanKind.SERVER,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     span.addEvent('my-event');
     assert.ok(
       hrTimeToMilliseconds(span.events[0].time) >
@@ -166,16 +184,17 @@ describe('Span', () => {
 
   it('should have an entered time for event', () => {
     const startTime = Date.now();
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.SERVER,
-      undefined,
-      [],
-      startTime
-    );
+      name,
+      kind: SpanKind.SERVER,
+      startTime,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     const eventTimeMS = 123;
     const spanStartTime = hrTimeToMilliseconds(span.startTime);
     const eventTime = spanStartTime + eventTimeMS;
@@ -189,16 +208,17 @@ describe('Span', () => {
   describe('when 2nd param is "TimeInput" type', () => {
     it('should have an entered time for event - ', () => {
       const startTime = Date.now();
-      const span = new SpanImpl(
-        tracer,
-        ROOT_CONTEXT,
-        name,
+      const span = new SpanImpl({
+        scope: tracer.instrumentationLibrary,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
         spanContext,
-        SpanKind.SERVER,
-        undefined,
-        [],
-        startTime
-      );
+        name,
+        kind: SpanKind.SERVER,
+        startTime,
+        spanLimits: tracer.getSpanLimits(),
+        spanProcessor: tracer['_spanProcessor'],
+      });
       const eventTimeMS = 123;
       const spanStartTime = hrTimeToMilliseconds(span.startTime);
       const eventTime = spanStartTime + eventTimeMS;
@@ -211,13 +231,16 @@ describe('Span', () => {
   });
 
   it('should get the span context of span', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.CLIENT
-    );
+      name,
+      kind: SpanKind.CLIENT,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     const context = span.spanContext();
     assert.strictEqual(context.traceId, spanContext.traceId);
     assert.strictEqual(context.traceFlags, TraceFlags.SAMPLED);
@@ -229,24 +252,30 @@ describe('Span', () => {
 
   describe('isRecording', () => {
     it('should return true when span is not ended', () => {
-      const span = new SpanImpl(
-        tracer,
-        ROOT_CONTEXT,
-        name,
+      const span = new SpanImpl({
+        scope: tracer.instrumentationLibrary,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
         spanContext,
-        SpanKind.CLIENT
-      );
+        name,
+        kind: SpanKind.CLIENT,
+        spanLimits: tracer.getSpanLimits(),
+        spanProcessor: tracer['_spanProcessor'],
+      });
       assert.ok(span.isRecording());
       span.end();
     });
     it('should return false when span is ended', () => {
-      const span = new SpanImpl(
-        tracer,
-        ROOT_CONTEXT,
-        name,
+      const span = new SpanImpl({
+        scope: tracer.instrumentationLibrary,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
         spanContext,
-        SpanKind.CLIENT
-      );
+        name,
+        kind: SpanKind.CLIENT,
+        spanLimits: tracer.getSpanLimits(),
+        spanProcessor: tracer['_spanProcessor'],
+      });
       span.end();
       assert.ok(span.isRecording() === false);
     });
@@ -255,13 +284,16 @@ describe('Span', () => {
   describe('setAttribute', () => {
     describe('when default options set', () => {
       it('should set an attribute', () => {
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
 
         for (const [k, v] of Object.entries(validAttributes)) {
           span.setAttribute(k, v);
@@ -274,13 +306,16 @@ describe('Span', () => {
       });
 
       it('should be able to overwrite attributes', () => {
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
 
         span.setAttribute('overwrite', 'initial value');
         span.setAttribute('overwrite', 'overwritten value');
@@ -300,13 +335,16 @@ describe('Span', () => {
           },
         }).getTracer('default');
 
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
         for (let i = 0; i < 150; i++) {
           span.setAttribute('foo' + i, 'bar' + i);
         }
@@ -332,13 +370,16 @@ describe('Span', () => {
           },
         }).getTracer('default');
 
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
 
         it('should truncate value which length exceeds this limit', () => {
           span.setAttribute('attr-with-more-length', 'abcdefgh');
@@ -376,18 +417,17 @@ describe('Span', () => {
         });
 
         it('should truncate value when attributes are passed to the constructor', () => {
-          const span = new SpanImpl(
-            tracer,
-            ROOT_CONTEXT,
-            name,
+          const span = new SpanImpl({
+            scope: tracer.instrumentationLibrary,
+            resource: tracer['_resource'],
+            context: ROOT_CONTEXT,
             spanContext,
-            SpanKind.CLIENT,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            { 'attr-with-more-length': 'abcdefgh' }
-          );
+            name,
+            kind: SpanKind.CLIENT,
+            spanLimits: tracer.getSpanLimits(),
+            spanProcessor: tracer['_spanProcessor'],
+            attributes: { 'attr-with-more-length': 'abcdefgh' },
+          });
           assert.strictEqual(span.attributes['attr-with-more-length'], 'abcde');
         });
       });
@@ -400,13 +440,16 @@ describe('Span', () => {
           },
         }).getTracer('default');
 
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
 
         it('should not truncate any value', () => {
           span.setAttribute('attr-not-truncate', 'abcdefgh');
@@ -437,13 +480,16 @@ describe('Span', () => {
           },
         }).getTracer('default');
 
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
         for (let i = 0; i < 150; i++) {
           span.setAttribute('foo' + i, 'bar' + i);
         }
@@ -465,13 +511,16 @@ describe('Span', () => {
           },
         }).getTracer('default');
 
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
 
         it('should truncate value which length exceeds this limit', () => {
           span.setAttribute('attr-with-more-length', 'abcdefgh');
@@ -517,13 +566,16 @@ describe('Span', () => {
           },
         }).getTracer('default');
 
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
 
         it('should not truncate any value', () => {
           span.setAttribute('attr-not-truncate', 'abcdefgh');
@@ -557,13 +609,16 @@ describe('Span', () => {
           },
         }).getTracer('default');
 
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
         for (let i = 0; i < 150; i++) {
           span.setAttribute('foo' + i, 'bar' + i);
         }
@@ -589,13 +644,16 @@ describe('Span', () => {
           },
         }).getTracer('default');
 
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
         for (let i = 0; i < 150; i++) {
           span.setAttribute('foo' + i, 'bar' + i);
         }
@@ -625,13 +683,16 @@ describe('Span', () => {
           },
         }).getTracer('default');
 
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
 
         it('should truncate value which length exceeds span limit', () => {
           span.setAttribute('attr-with-more-length', 'abcdefgh');
@@ -681,13 +742,16 @@ describe('Span', () => {
           },
         }).getTracer('default');
 
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
 
         it('should not truncate value', () => {
           span.setAttribute('attr-with-more-length', 'abcdefghijklmn');
@@ -727,13 +791,16 @@ describe('Span', () => {
 
   describe('setAttributes', () => {
     it('should be able to set multiple attributes', () => {
-      const span = new SpanImpl(
-        tracer,
-        ROOT_CONTEXT,
-        name,
+      const span = new SpanImpl({
+        scope: tracer.instrumentationLibrary,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
         spanContext,
-        SpanKind.CLIENT
-      );
+        name,
+        kind: SpanKind.CLIENT,
+        spanLimits: tracer.getSpanLimits(),
+        spanProcessor: tracer['_spanProcessor'],
+      });
 
       span.setAttributes(validAttributes);
       span.setAttributes(invalidAttributes as unknown as Attributes);
@@ -744,26 +811,32 @@ describe('Span', () => {
 
   describe('addEvent', () => {
     it('should add an event', () => {
-      const span = new SpanImpl(
-        tracer,
-        ROOT_CONTEXT,
-        name,
+      const span = new SpanImpl({
+        scope: tracer.instrumentationLibrary,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
         spanContext,
-        SpanKind.CLIENT
-      );
+        name,
+        kind: SpanKind.CLIENT,
+        spanLimits: tracer.getSpanLimits(),
+        spanProcessor: tracer['_spanProcessor'],
+      });
       span.addEvent('sent');
       span.addEvent('rev', { attr1: 'value', attr2: 123, attr3: true });
       span.end();
     });
 
     it('should sanitize attribute values', () => {
-      const span = new SpanImpl(
-        tracer,
-        ROOT_CONTEXT,
-        name,
+      const span = new SpanImpl({
+        scope: tracer.instrumentationLibrary,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
         spanContext,
-        SpanKind.CLIENT
-      );
+        name,
+        kind: SpanKind.CLIENT,
+        spanLimits: tracer.getSpanLimits(),
+        spanProcessor: tracer['_spanProcessor'],
+      });
       span.addEvent('rev', {
         ...validAttributes,
         ...invalidAttributes,
@@ -777,13 +850,16 @@ describe('Span', () => {
   });
 
   it('should drop extra events', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.CLIENT
-    );
+      name,
+      kind: SpanKind.CLIENT,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
 
     const debugStub = sinon.spy(diag, 'debug');
     const warnStub = sinon.spy(diag, 'warn');
@@ -804,13 +880,16 @@ describe('Span', () => {
   });
 
   it('should store the count of dropped events in droppedEventsCount', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.CLIENT
-    );
+      name,
+      kind: SpanKind.CLIENT,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     for (let i = 0; i < 150; i++) {
       span.addEvent('sent' + i);
     }
@@ -826,13 +905,16 @@ describe('Span', () => {
       },
     }).getTracer('default');
 
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.CLIENT
-    );
+      name,
+      kind: SpanKind.CLIENT,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     for (let i = 0; i < 10; i++) {
       span.addEvent('sent' + i);
     }
@@ -842,13 +924,16 @@ describe('Span', () => {
   });
 
   it('should set an error status', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.CLIENT
-    );
+      name,
+      kind: SpanKind.CLIENT,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     span.setStatus({
       code: SpanStatusCode.ERROR,
       message: 'This is an error',
@@ -861,13 +946,16 @@ describe('Span', () => {
 
   it('should drop non-string status message', function () {
     const warnStub = sinon.spy(diag, 'warn');
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.CLIENT
-    );
+      name,
+      kind: SpanKind.CLIENT,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     span.setStatus({
       code: SpanStatusCode.ERROR,
       message: new Error('this is not a string') as any,
@@ -884,14 +972,17 @@ describe('Span', () => {
 
   it('should return ReadableSpan', () => {
     const parentId = '5c1c63257de34c67';
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      'my-span',
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.INTERNAL,
-      parentId
-    );
+      name: 'my-span',
+      kind: SpanKind.INTERNAL,
+      parentSpanId: parentId,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
 
     assert.strictEqual(span.name, 'my-span');
     assert.strictEqual(span.kind, SpanKind.INTERNAL);
@@ -911,13 +1002,16 @@ describe('Span', () => {
   });
 
   it('should return ReadableSpan with attributes', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      'my-span',
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.CLIENT
-    );
+      name: 'my-span',
+      kind: SpanKind.CLIENT,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     span.setAttribute('attr1', 'value1');
     assert.deepStrictEqual(span.attributes, { attr1: 'value1' });
 
@@ -937,21 +1031,23 @@ describe('Span', () => {
   });
 
   it('should return ReadableSpan with links', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      'my-span',
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.CLIENT,
-      undefined,
-      [
+      name: 'my-span',
+      kind: SpanKind.CLIENT,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+      links: [
         { context: linkContext },
         {
           context: linkContext,
           attributes: { attr1: 'value', attr2: 123, attr3: true },
         },
-      ]
-    );
+      ],
+    });
     assert.strictEqual(span.links.length, 2);
     assert.deepStrictEqual(span.links, [
       {
@@ -967,13 +1063,16 @@ describe('Span', () => {
   });
 
   it('should be possible to add a link after span creation', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      'my-span',
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.CONSUMER
-    );
+      name: 'my-span',
+      kind: SpanKind.CONSUMER,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
 
     span.addLink({ context: linkContext });
 
@@ -988,13 +1087,16 @@ describe('Span', () => {
   });
 
   it('should be possible to add multiple links after span creation', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      'my-span',
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.CONSUMER
-    );
+      name: 'my-span',
+      kind: SpanKind.CONSUMER,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
 
     span.addLinks([
       { context: linkContext },
@@ -1019,13 +1121,16 @@ describe('Span', () => {
   });
 
   it('should return ReadableSpan with events', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      'my-span',
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.CLIENT
-    );
+      name: 'my-span',
+      kind: SpanKind.CLIENT,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     span.addEvent('sent');
     assert.strictEqual(span.events.length, 1);
     const [event] = span.events;
@@ -1054,13 +1159,16 @@ describe('Span', () => {
   });
 
   it('should return ReadableSpan with new status', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.CLIENT
-    );
+      name,
+      kind: SpanKind.CLIENT,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     span.setStatus({
       code: SpanStatusCode.ERROR,
       message: 'This is an error',
@@ -1078,13 +1186,16 @@ describe('Span', () => {
   });
 
   it('should only end a span once', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.SERVER
-    );
+      name,
+      kind: SpanKind.SERVER,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     const endTime = Date.now();
     span.end(endTime);
     span.end(endTime + 10);
@@ -1092,13 +1203,16 @@ describe('Span', () => {
   });
 
   it('should update name', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.SERVER
-    );
+      name,
+      kind: SpanKind.SERVER,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     span.updateName('foo-span');
     span.end();
 
@@ -1108,13 +1222,16 @@ describe('Span', () => {
   });
 
   it('should have ended', () => {
-    const span = new SpanImpl(
-      tracer,
-      ROOT_CONTEXT,
-      name,
+    const span = new SpanImpl({
+      scope: tracer.instrumentationLibrary,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
       spanContext,
-      SpanKind.SERVER
-    );
+      name,
+      kind: SpanKind.SERVER,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
     assert.strictEqual(span.ended, false);
     span.end();
     assert.strictEqual(span.ended, true);
@@ -1212,13 +1329,16 @@ describe('Span', () => {
     invalidExceptions.forEach(key => {
       describe(`when exception is (${JSON.stringify(key)})`, () => {
         it('should NOT record an exception', () => {
-          const span = new SpanImpl(
-            tracer,
-            ROOT_CONTEXT,
-            name,
+          const span = new SpanImpl({
+            scope: tracer.instrumentationLibrary,
+            resource: tracer['_resource'],
+            context: ROOT_CONTEXT,
             spanContext,
-            SpanKind.CLIENT
-          );
+            name,
+            kind: SpanKind.CLIENT,
+            spanLimits: tracer.getSpanLimits(),
+            spanProcessor: tracer['_spanProcessor'],
+          });
           assert.strictEqual(span.events.length, 0);
           span.recordException(key);
           assert.strictEqual(span.events.length, 0);
@@ -1232,13 +1352,16 @@ describe('Span', () => {
         error = 'boom';
       });
       it('should record an exception', () => {
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
         assert.strictEqual(span.events.length, 0);
         span.recordException(error);
 
@@ -1265,13 +1388,16 @@ describe('Span', () => {
       describe(`when exception type is an object with ${errorObj.description}`, () => {
         const error: Exception = errorObj.obj;
         it('should record an exception', () => {
-          const span = new SpanImpl(
-            tracer,
-            ROOT_CONTEXT,
-            name,
+          const span = new SpanImpl({
+            scope: tracer.instrumentationLibrary,
+            resource: tracer['_resource'],
+            context: ROOT_CONTEXT,
             spanContext,
-            SpanKind.CLIENT
-          );
+            name,
+            kind: SpanKind.CLIENT,
+            spanLimits: tracer.getSpanLimits(),
+            spanProcessor: tracer['_spanProcessor'],
+          });
           assert.strictEqual(span.events.length, 0);
           span.recordException(error);
 
@@ -1295,13 +1421,16 @@ describe('Span', () => {
 
     describe('when time is provided', () => {
       it('should record an exception with provided time', () => {
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
         // @ts-expect-error writing readonly property. performance time origin is mocked to return ms value of [1,1]
         span['_performanceOffset'] = 0;
         assert.strictEqual(span.events.length, 0);
@@ -1313,13 +1442,16 @@ describe('Span', () => {
 
     describe('when exception code is numeric', () => {
       it('should record an exception with string value', () => {
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+        });
         assert.strictEqual(span.events.length, 0);
         span.recordException({ code: 12 });
         const event = span.events[0];
@@ -1331,18 +1463,17 @@ describe('Span', () => {
 
     describe('when attributes are specified', () => {
       it('should store specified attributes', () => {
-        const span = new SpanImpl(
-          tracer,
-          ROOT_CONTEXT,
-          name,
+        const span = new SpanImpl({
+          scope: tracer.instrumentationLibrary,
+          resource: tracer['_resource'],
+          context: ROOT_CONTEXT,
           spanContext,
-          SpanKind.CLIENT,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          { foo: 'bar' }
-        );
+          name,
+          kind: SpanKind.CLIENT,
+          spanLimits: tracer.getSpanLimits(),
+          spanProcessor: tracer['_spanProcessor'],
+          attributes: { foo: 'bar' },
+        });
         assert.deepStrictEqual(span.attributes, { foo: 'bar' });
       });
     });

--- a/packages/opentelemetry-sdk-trace-base/test/common/Tracer.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Tracer.test.ts
@@ -114,7 +114,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       {},
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
     assert.ok(tracer instanceof Tracer);
   });
@@ -123,7 +124,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       {},
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
     assert.strictEqual(
       tracer['_sampler'].toString(),
@@ -135,7 +137,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       { sampler: new AlwaysOffSampler() },
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
     const span = tracer.startSpan('span1');
     assert.ok(!span.isRecording());
@@ -146,7 +149,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       { sampler: new AlwaysOnSampler() },
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
     const span = tracer.startSpan('span2');
     assert.ok(span.isRecording());
@@ -157,7 +161,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       { sampler: new TestSampler() },
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
     const span = tracer.startSpan('span3');
     assert.strictEqual((span as Span).attributes.testAttribute, 'foobar');
@@ -169,7 +174,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       { sampler: new TestSampler(traceState) },
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
     const span = tracer.startSpan('stateSpan');
     assert.strictEqual(span.spanContext().traceState, traceState);
@@ -179,7 +185,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       {},
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
 
     const lib: InstrumentationLibrary = tracer.instrumentationLibrary;
@@ -195,7 +202,8 @@ describe('Tracer', () => {
       const tracer = new Tracer(
         { name: 'default', version: '0.0.1' },
         { sampler: new TestSampler() },
-        tracerProvider
+        tracerProvider['_resource'],
+        tracerProvider['activeSpanProcessor']
       );
 
       const span = tracer.startSpan('span3', undefined, context);
@@ -218,7 +226,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       {},
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
     const span = tracer.startSpan(
       'aSpan',
@@ -239,7 +248,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       {},
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
     const span = tracer.startSpan(
       'aSpan',
@@ -265,7 +275,12 @@ describe('Tracer', () => {
 
     const sampler: Sampler = new AlwaysOnSampler();
     const shouldSampleSpy = sinon.spy(sampler, 'shouldSample');
-    const tracer = new Tracer({ name: 'default' }, { sampler }, tp);
+    const tracer = new Tracer(
+      { name: 'default' },
+      { sampler },
+      tp['_resource'],
+      tp['activeSpanProcessor']
+    );
     const span = tracer.startSpan('a', {}, context) as Span;
     assert.strictEqual(span.parentSpanId, parent.spanId);
     sinon.assert.calledOnceWithExactly(
@@ -296,7 +311,12 @@ describe('Tracer', () => {
 
     const sampler: Sampler = new AlwaysOnSampler();
     const shouldSampleSpy = sinon.spy(sampler, 'shouldSample');
-    const tracer = new Tracer({ name: 'default' }, { sampler }, tp);
+    const tracer = new Tracer(
+      { name: 'default' },
+      { sampler },
+      tp['_resource'],
+      tp['activeSpanProcessor']
+    );
     const span = tracer.startSpan('a', { root: true }, context) as Span;
     assert.strictEqual(span.parentSpanId, undefined);
     sinon.assert.calledOnce(shouldSampleSpy);
@@ -313,7 +333,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       {},
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
     const span = tracer.startSpan('my-span');
     const context = span.spanContext();
@@ -327,7 +348,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       {},
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
     const span = tracer.startSpan('my-span');
     const context = span.spanContext();
@@ -341,7 +363,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       {},
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
     const span = tracer.startSpan('my-span');
     const context = span.spanContext();
@@ -353,7 +376,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       { sampler: new TestSampler() },
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
 
     const spy = sinon.spy(tracer, 'startSpan');
@@ -376,7 +400,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       { sampler: new TestSampler() },
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
 
     const spy = sinon.spy(tracer, 'startSpan');
@@ -403,7 +428,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       { sampler: new TestSampler() },
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
 
     const ctxKey = createContextKey('foo');
@@ -438,7 +464,8 @@ describe('Tracer', () => {
     const tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       { sampler: new TestSampler() },
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
 
     const attributes = {

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/SimpleSpanProcessor.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/SimpleSpanProcessor.test.ts
@@ -64,13 +64,17 @@ describe('SimpleSpanProcessor', () => {
         spanId: '5e0c63257de34c92',
         traceFlags: TraceFlags.SAMPLED,
       };
-      const span = new SpanImpl(
-        provider.getTracer('default'),
-        ROOT_CONTEXT,
-        'span-name',
+      const tracer = provider.getTracer('default');
+      const span = new SpanImpl({
+        scope: tracer.instrumentationLibrary,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
         spanContext,
-        SpanKind.CLIENT
-      );
+        name: 'span-name',
+        kind: SpanKind.CLIENT,
+        spanLimits: tracer.getSpanLimits(),
+        spanProcessor: tracer['_spanProcessor'],
+      });
       processor.onStart(span, ROOT_CONTEXT);
       assert.strictEqual(exporter.getFinishedSpans().length, 0);
 
@@ -88,13 +92,17 @@ describe('SimpleSpanProcessor', () => {
         spanId: '5e0c63257de34c92',
         traceFlags: TraceFlags.NONE,
       };
-      const span = new SpanImpl(
-        provider.getTracer('default'),
-        ROOT_CONTEXT,
-        'span-name',
+      const tracer = provider.getTracer('default');
+      const span = new SpanImpl({
+        scope: tracer.instrumentationLibrary,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
         spanContext,
-        SpanKind.CLIENT
-      );
+        name: 'span-name',
+        kind: SpanKind.CLIENT,
+        spanLimits: tracer.getSpanLimits(),
+        spanProcessor: tracer['_spanProcessor'],
+      });
       processor.onStart(span, ROOT_CONTEXT);
       assert.strictEqual(exporter.getFinishedSpans().length, 0);
 
@@ -113,13 +121,17 @@ describe('SimpleSpanProcessor', () => {
         spanId: '5e0c63257de34c92',
         traceFlags: TraceFlags.SAMPLED,
       };
-      const span = new SpanImpl(
-        provider.getTracer('default'),
-        ROOT_CONTEXT,
-        'span-name',
+      const tracer = provider.getTracer('default');
+      const span = new SpanImpl({
+        scope: tracer.instrumentationLibrary,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
         spanContext,
-        SpanKind.CLIENT
-      );
+        name: 'span-name',
+        kind: SpanKind.CLIENT,
+        spanLimits: tracer.getSpanLimits(),
+        spanProcessor: tracer['_spanProcessor'],
+      });
       processor.onStart(span, ROOT_CONTEXT);
 
       sinon.stub(exporter, 'export').callsFake((_, callback) => {
@@ -175,13 +187,18 @@ describe('SimpleSpanProcessor', () => {
         spanId: '5e0c63257de34c92',
         traceFlags: TraceFlags.SAMPLED,
       };
-      const span = new SpanImpl(
-        providerWithAsyncResource.getTracer('default'),
-        ROOT_CONTEXT,
-        'span-name',
+
+      const tracer = providerWithAsyncResource.getTracer('default');
+      const span = new SpanImpl({
+        scope: tracer.instrumentationLibrary,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
         spanContext,
-        SpanKind.CLIENT
-      );
+        name: 'span-name',
+        kind: SpanKind.CLIENT,
+        spanLimits: tracer.getSpanLimits(),
+        spanProcessor: tracer['_spanProcessor'],
+      });
       processor.onStart(span, ROOT_CONTEXT);
       assert.strictEqual(exporter.getFinishedSpans().length, 0);
 
@@ -216,13 +233,17 @@ describe('SimpleSpanProcessor', () => {
         spanId: '5e0c63257de34c92',
         traceFlags: TraceFlags.SAMPLED,
       };
-      const span = new SpanImpl(
-        providerWithAsyncResource.getTracer('default'),
-        ROOT_CONTEXT,
-        'span-name',
+      const tracer = providerWithAsyncResource.getTracer('default');
+      const span = new SpanImpl({
+        scope: tracer.instrumentationLibrary,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
         spanContext,
-        SpanKind.CLIENT
-      );
+        name: 'span-name',
+        kind: SpanKind.CLIENT,
+        spanLimits: tracer.getSpanLimits(),
+        spanProcessor: tracer['_spanProcessor'],
+      });
       processor.onStart(span, ROOT_CONTEXT);
       processor.onEnd(span);
 
@@ -275,13 +296,17 @@ describe('SimpleSpanProcessor', () => {
         spanId: '5e0c63257de34c92',
         traceFlags: TraceFlags.SAMPLED,
       };
-      const span = new SpanImpl(
-        provider.getTracer('default'),
-        ROOT_CONTEXT,
-        'span-name',
+      const tracer = provider.getTracer('default');
+      const span = new SpanImpl({
+        scope: tracer.instrumentationLibrary,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
         spanContext,
-        SpanKind.CLIENT
-      );
+        name: 'span-name',
+        kind: SpanKind.CLIENT,
+        spanLimits: tracer.getSpanLimits(),
+        spanProcessor: tracer['_spanProcessor'],
+      });
 
       processor.onStart(span, ROOT_CONTEXT);
       processor.onEnd(span);

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/TestTracingSpanExporter.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/TestTracingSpanExporter.ts
@@ -55,7 +55,8 @@ export class TestTracingSpanExporter extends InMemorySpanExporter {
     this._tracer = new Tracer(
       { name: 'default', version: '0.0.1' },
       { sampler: new AlwaysOnSampler() },
-      tracerProvider
+      tracerProvider['_resource'],
+      tracerProvider['activeSpanProcessor']
     );
   }
 


### PR DESCRIPTION
## Which problem is this PR solving?

Resource and active span processor should not be accessible once the tracer provider is constructed. This PR makes the necessary changes to have both as private properties and inject them into any tracer created via `getTracer` API.

Fixes #4791
Fixes #4792 


## Short description of the changes

- made `resource` private in `BasicTracerProvider`
- remove `getActiveSpanProcessor` in `BasicTracerProvider`
- refactor `SpanImpl` constructor
- update `Tracer.startSpan` to use the new constructor
- refactor `Tracer` constructor to get only necessary deps (processor & resource) instead of the provider
- update tests


### Changes in `SpanImpl` constructor

I've decided to change the constructor method signature for `SpanImpl`. This way we inject the necessary dependencies that are held in the `Tracer` class making unnecessary to have public properties or getters for span processor and resource. The class was made private (not exported) in #5048 

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [X] npm run compile && npm run test

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been updated
