### PR TITLE
refactor(otlp-exporter-base): don't create blob before sending xhr

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to experimental packages in this project will be documented 
 ### :rocket: (Enhancement)
 
 * feat(otlp-exporter-base): internally accept a http header provider function only [#5179](https://github.com/open-telemetry/opentelemetry-js/pull/5179) @pichlermarc
-* refactor(otlp-exporter-base): don't create blob before sending xhr [#5193](https://github.com/open-telemetry/opentelemetry-js/pull/5193)
+* refactor(otlp-exporter-base): don't create blob before sending xhr [#5193](https://github.com/open-telemetry/opentelemetry-js/pull/5193) @pichlermarc
   * improves compatibility with some unsupported runtimes
 
 ### :bug: (Bug Fix)

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -23,11 +23,10 @@ All notable changes to experimental packages in this project will be documented 
 ### :rocket: (Enhancement)
 
 * feat(otlp-exporter-base): internally accept a http header provider function only [#5179](https://github.com/open-telemetry/opentelemetry-js/pull/5179) @pichlermarc
+* refactor(otlp-exporter-base): don't create blob before sending xhr [#5193](https://github.com/open-telemetry/opentelemetry-js/pull/5193)
+  * improves compatibility with some unsupported runtimes
 
 ### :bug: (Bug Fix)
-
-* fix(otlp-exporter-base): don't create blob before sending xhr [#5193](https://github.com/open-telemetry/opentelemetry-js/pull/5193)
-  * improves compatibility with some unsupported runtimes
 
 ### :books: (Refine Doc)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(otlp-exporter-base): don't create blob before sending xhr [#5193](https://github.com/open-telemetry/opentelemetry-js/pull/5193)
+  * improves compatibility with some unsupported runtimes
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/CollectorMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/CollectorMetricExporter.test.ts
@@ -240,77 +240,84 @@ describe('OTLPMetricExporter - web', () => {
         collectorExporter.export(metrics, () => {});
 
         queueMicrotask(async () => {
-          const request = server.requests[0];
-          assert.strictEqual(request.method, 'POST');
-          assert.strictEqual(request.url, 'http://foo.bar.com');
+          try {
+            const request = server.requests[0];
+            assert.strictEqual(request.method, 'POST');
+            assert.strictEqual(request.url, 'http://foo.bar.com');
 
-          const body = request.requestBody;
-          const decoder = new TextDecoder();
-          const json = JSON.parse(
-            decoder.decode(await body.arrayBuffer())
-          ) as IExportMetricsServiceRequest;
-          // The order of the metrics is not guaranteed.
-          const counterIndex = metrics.scopeMetrics[0].metrics.findIndex(
-            it => it.descriptor.name === 'int-counter'
-          );
-          const observableIndex = metrics.scopeMetrics[0].metrics.findIndex(
-            it => it.descriptor.name === 'double-observable-gauge2'
-          );
-          const histogramIndex = metrics.scopeMetrics[0].metrics.findIndex(
-            it => it.descriptor.name === 'int-histogram'
-          );
+            const body = request.requestBody;
+            const json = JSON.parse(
+              new TextDecoder().decode(body)
+            ) as IExportMetricsServiceRequest;
+            // The order of the metrics is not guaranteed.
+            const counterIndex = metrics.scopeMetrics[0].metrics.findIndex(
+              it => it.descriptor.name === 'int-counter'
+            );
+            const observableIndex = metrics.scopeMetrics[0].metrics.findIndex(
+              it => it.descriptor.name === 'double-observable-gauge2'
+            );
+            const histogramIndex = metrics.scopeMetrics[0].metrics.findIndex(
+              it => it.descriptor.name === 'int-histogram'
+            );
 
-          const metric1 =
-            json.resourceMetrics[0].scopeMetrics[0].metrics[counterIndex];
-          const metric2 =
-            json.resourceMetrics[0].scopeMetrics[0].metrics[observableIndex];
-          const metric3 =
-            json.resourceMetrics[0].scopeMetrics[0].metrics[histogramIndex];
+            const metric1 =
+              json.resourceMetrics[0].scopeMetrics[0].metrics[counterIndex];
+            const metric2 =
+              json.resourceMetrics[0].scopeMetrics[0].metrics[observableIndex];
+            const metric3 =
+              json.resourceMetrics[0].scopeMetrics[0].metrics[histogramIndex];
 
-          assert.ok(typeof metric1 !== 'undefined', "metric doesn't exist");
-          ensureCounterIsCorrect(
-            metric1,
-            metrics.scopeMetrics[0].metrics[counterIndex].dataPoints[0].endTime,
-            metrics.scopeMetrics[0].metrics[counterIndex].dataPoints[0]
-              .startTime
-          );
+            assert.ok(typeof metric1 !== 'undefined', "metric doesn't exist");
+            ensureCounterIsCorrect(
+              metric1,
+              metrics.scopeMetrics[0].metrics[counterIndex].dataPoints[0]
+                .endTime,
+              metrics.scopeMetrics[0].metrics[counterIndex].dataPoints[0]
+                .startTime
+            );
 
-          assert.ok(
-            typeof metric2 !== 'undefined',
-            "second metric doesn't exist"
-          );
-          ensureObservableGaugeIsCorrect(
-            metric2,
-            metrics.scopeMetrics[0].metrics[observableIndex].dataPoints[0]
-              .endTime,
-            metrics.scopeMetrics[0].metrics[observableIndex].dataPoints[0]
-              .startTime,
-            6,
-            'double-observable-gauge2'
-          );
+            assert.ok(
+              typeof metric2 !== 'undefined',
+              "second metric doesn't exist"
+            );
+            ensureObservableGaugeIsCorrect(
+              metric2,
+              metrics.scopeMetrics[0].metrics[observableIndex].dataPoints[0]
+                .endTime,
+              metrics.scopeMetrics[0].metrics[observableIndex].dataPoints[0]
+                .startTime,
+              6,
+              'double-observable-gauge2'
+            );
 
-          assert.ok(
-            typeof metric3 !== 'undefined',
-            "third metric doesn't exist"
-          );
-          ensureHistogramIsCorrect(
-            metric3,
-            metrics.scopeMetrics[0].metrics[histogramIndex].dataPoints[0]
-              .endTime,
-            metrics.scopeMetrics[0].metrics[histogramIndex].dataPoints[0]
-              .startTime,
-            [0, 100],
-            [0, 2, 0]
-          );
+            assert.ok(
+              typeof metric3 !== 'undefined',
+              "third metric doesn't exist"
+            );
+            ensureHistogramIsCorrect(
+              metric3,
+              metrics.scopeMetrics[0].metrics[histogramIndex].dataPoints[0]
+                .endTime,
+              metrics.scopeMetrics[0].metrics[histogramIndex].dataPoints[0]
+                .startTime,
+              [0, 100],
+              [0, 2, 0]
+            );
 
-          const resource = json.resourceMetrics[0].resource;
-          assert.ok(typeof resource !== 'undefined', "resource doesn't exist");
-          ensureWebResourceIsCorrect(resource);
+            const resource = json.resourceMetrics[0].resource;
+            assert.ok(
+              typeof resource !== 'undefined',
+              "resource doesn't exist"
+            );
+            ensureWebResourceIsCorrect(resource);
 
-          assert.strictEqual(stubBeacon.callCount, 0);
-          ensureExportMetricsServiceRequestIsSet(json);
+            assert.strictEqual(stubBeacon.callCount, 0);
+            ensureExportMetricsServiceRequestIsSet(json);
 
-          done();
+            done();
+          } catch (e) {
+            done(e);
+          }
         });
       });
 

--- a/experimental/packages/otlp-exporter-base/src/transport/xhr-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/xhr-transport.ts
@@ -81,7 +81,7 @@ class XhrTransport implements IExporterTransport {
         });
       };
 
-      xhr.send(new Blob([data], { type: headers['Content-Type'] }));
+      xhr.send(data);
     });
   }
 

--- a/experimental/packages/otlp-exporter-base/test/browser/xhr-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/xhr-transport.test.ts
@@ -65,6 +65,7 @@ describe('XhrTransport', function () {
             undefined
           );
           assert.strictEqual(request.url, testTransportParameters.url);
+          assert.strictEqual(request.requestBody, testPayload);
           ensureHeadersContain(request.requestHeaders, {
             foo: 'foo-value',
             bar: 'bar-value',

--- a/experimental/packages/otlp-exporter-base/test/browser/xhr-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/xhr-transport.test.ts
@@ -65,10 +65,6 @@ describe('XhrTransport', function () {
             undefined
           );
           assert.strictEqual(request.url, testTransportParameters.url);
-          assert.strictEqual(
-            (request.requestBody as unknown as Blob).type,
-            'application/json'
-          );
           ensureHeadersContain(request.requestHeaders, {
             foo: 'foo-value',
             bar: 'bar-value',


### PR DESCRIPTION
## Which problem is this PR solving?

Skips creating a blob and passes the `Uint8Array` directly to `request.send()`, as it was done before `0.53.0`. Both are an acceptable input according to https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send#parameters, but creating `Blob`s does not seem to work in React Native.



Fixes #5178 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manually tested with example from https://github.com/open-telemetry/opentelemetry-demo/pull/1781
- [x] Manually tested with example from `examples/opentelemetry-web` (passing empty headers to force XHR instead of sendBeacon)
- [x] Adapted unit tests 
- [x] Existing unit tests 