### PR TITLE
chore: update prettier to 3.3.3

### DIFF
--- a/api/src/platform/browser/globalThis.ts
+++ b/api/src/platform/browser/globalThis.ts
@@ -30,9 +30,9 @@ export const _globalThis: typeof globalThis =
   typeof globalThis === 'object'
     ? globalThis
     : typeof self === 'object'
-    ? self
-    : typeof window === 'object'
-    ? window
-    : typeof global === 'object'
-    ? global
-    : ({} as typeof globalThis);
+      ? self
+      : typeof window === 'object'
+        ? window
+        : typeof global === 'object'
+          ? global
+          : ({} as typeof globalThis);

--- a/experimental/packages/api-events/src/platform/browser/globalThis.ts
+++ b/experimental/packages/api-events/src/platform/browser/globalThis.ts
@@ -31,9 +31,9 @@ export const _globalThis: typeof globalThis =
   typeof globalThis === 'object'
     ? globalThis
     : typeof self === 'object'
-    ? self
-    : typeof window === 'object'
-    ? window
-    : typeof global === 'object'
-    ? global
-    : ({} as typeof globalThis);
+      ? self
+      : typeof window === 'object'
+        ? window
+        : typeof global === 'object'
+          ? global
+          : ({} as typeof globalThis);

--- a/experimental/packages/api-logs/src/platform/browser/globalThis.ts
+++ b/experimental/packages/api-logs/src/platform/browser/globalThis.ts
@@ -31,9 +31,9 @@ export const _globalThis: typeof globalThis =
   typeof globalThis === 'object'
     ? globalThis
     : typeof self === 'object'
-    ? self
-    : typeof window === 'object'
-    ? window
-    : typeof global === 'object'
-    ? global
-    : ({} as typeof globalThis);
+      ? self
+      : typeof window === 'object'
+        ? window
+        : typeof global === 'object'
+          ? global
+          : ({} as typeof globalThis);

--- a/experimental/packages/opentelemetry-instrumentation-grpc/test/helper.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/test/helper.ts
@@ -106,8 +106,8 @@ const checkEqual =
     x instanceof Array && y instanceof Array
       ? arrayIsEqual(requestEqual)(x as any)(y as any)
       : !(x instanceof Array) && !(y instanceof Array)
-      ? requestEqual(x)(y)
-      : false;
+        ? requestEqual(x)(y)
+        : false;
 
 const replicate = (request: TestRequestResponse) => {
   const result: TestRequestResponse[] = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "lerna": "6.6.2",
         "linkinator": "6.1.2",
         "markdownlint-cli2": "0.15.0",
-        "prettier": "3.0.3",
+        "prettier": "3.3.3",
         "process": "0.11.10",
         "semver": "7.6.3",
         "typedoc": "0.22.18",
@@ -22117,9 +22117,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -46331,9 +46331,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "lerna": "6.6.2",
     "linkinator": "6.1.2",
     "markdownlint-cli2": "0.15.0",
-    "prettier": "3.0.3",
+    "prettier": "3.3.3",
     "process": "0.11.10",
     "semver": "7.6.3",
     "typedoc": "0.22.18",

--- a/packages/opentelemetry-core/src/platform/browser/globalThis.ts
+++ b/packages/opentelemetry-core/src/platform/browser/globalThis.ts
@@ -30,9 +30,9 @@ export const _globalThis: typeof globalThis =
   typeof globalThis === 'object'
     ? globalThis
     : typeof self === 'object'
-    ? self
-    : typeof window === 'object'
-    ? window
-    : typeof global === 'object'
-    ? global
-    : ({} as typeof globalThis);
+      ? self
+      : typeof window === 'object'
+        ? window
+        : typeof global === 'object'
+          ? global
+          : ({} as typeof globalThis);

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -333,8 +333,8 @@ export function parseUrl(url: string): URLLike {
       typeof document !== 'undefined'
         ? document.baseURI
         : typeof location !== 'undefined' // Some JS runtimes (e.g. Deno) don't define this
-        ? location.href
-        : undefined
+          ? location.href
+          : undefined
     );
   }
   const element = getUrlNormalizingAnchor();


### PR DESCRIPTION
## Which problem is this PR solving?

Has the changes from #5190, plus `npm run lint:fix` to apply the new rules.

Supersedes #5190

## Short description of the changes

- updates prettier to 3.3.3
- applies `lint:fix`