### PR TITLE
fix(docs): broken link for community contribution lifecycle and processes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Before creating a pull request, please make sure:
 - You have read the guide for contributing
   - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
 - You signed all your commits (otherwise we won't be able to merge the PR)
-  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
+  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
 - You added unit tests for the new functionality
 - You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
   the issue that your PR fixes (if such)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Reporting bugs is an important contribution. Please make sure to include:
 ### Before you start
 
 Please read project contribution
-[guide](https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md)
+[guide](https://github.com/open-telemetry/community/blob/main/guides/contributor)
 for general practices for OpenTelemetry project.
 
 #### Conventional commit
@@ -145,7 +145,7 @@ git merge upstream/main
 
 Remember to always work in a branch of your local copy, as you might otherwise have to contend with conflicts in main.
 
-Please also see [GitHub workflow](https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#github-workflow) section of general project contributing guide.
+Please also see [GitHub workflow](https://github.com/open-telemetry/community/blob/main/guides/contributor/processes.md#github-workflow) section of general project contributing guide.
 
 ## Development
 


### PR DESCRIPTION
## Which problem is this PR solving?

The current link is broken https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md

Fixes # (issue)

## Short description of the changes

Fixes the broken link for contribution processes which were moved in https://github.com/open-telemetry/community/pull/2051

## Type of change

Please delete options that are not relevant.

- [x] This change is a documentation update

## How Has This Been Tested?

- [x] View modified page https://github.com/trivikr/opentelemetry-js/blob/5c851779de309ea4b4add7214f40f2a388fa544e/CONTRIBUTING.md

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Documentation has been updated
