### PR TITLE
chore: replace deprecated String.prototype.substr() with substring()

### DIFF
--- a/packages/opentelemetry-core/src/common/time.ts
+++ b/packages/opentelemetry-core/src/common/time.ts
@@ -111,7 +111,7 @@ export function hrTimeDuration(
 export function hrTimeToTimeStamp(time: api.HrTime): string {
   const precision = NANOSECOND_DIGITS;
   const tmp = `${'0'.repeat(precision)}${time[1]}Z`;
-  const nanoString = tmp.substr(tmp.length - precision - 1);
+  const nanoString = tmp.substring(tmp.length - precision - 1);
   const date = new Date(time[0] * 1000).toISOString();
   return date.replace('000Z', nanoString);
 }

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -377,7 +377,7 @@ export class Span implements APISpan, ReadableSpan {
     if (value.length <= limit) {
       return value;
     }
-    return value.substr(0, limit);
+    return value.substring(0, limit);
   }
 
   /**


### PR DESCRIPTION
## Which problem is this PR solving?

The [String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated.

Fixes # (issue)

## Short description of the changes

This PR replaces `String.prototype.substr()` with [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] CI

## Checklist:

- [x] Followed the style guidelines of this project