### PR TITLE
feat: add support to dynamic header on legacy config

### DIFF
--- a/experimental/packages/otlp-exporter-base/src/configuration/legacy-base-configuration.ts
+++ b/experimental/packages/otlp-exporter-base/src/configuration/legacy-base-configuration.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 export interface OTLPExporterConfigBase {
-  headers?: Record<string, string>;
+  headers?: Record<string, string> | (() => Record<string, string>);
   url?: string;
   concurrencyLimit?: number;
   /** Maximum time the OTLP exporter will wait for each batch export.

--- a/experimental/packages/otlp-exporter-base/src/configuration/shared-configuration.ts
+++ b/experimental/packages/otlp-exporter-base/src/configuration/shared-configuration.ts
@@ -42,10 +42,14 @@ export function validateTimeoutMillis(timeoutMillis: number) {
 }
 
 export function wrapStaticHeadersInFunction(
-  headers: Record<string, string> | undefined
+  headers: Record<string, string> | (() => Record<string, string>) | undefined
 ): (() => Record<string, string>) | undefined {
   if (headers == null) {
     return undefined;
+  }
+
+  if (headers instanceof Function) {
+    return headers;
   }
 
   return () => headers;


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Follow up of pr: #5179 , introducing dynamic header support also for legacy base config, to be albe to use it also for logs/traces/metrics exporters which extends `OTLPExporterNodeBase` class.



## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested with locally instrumentation over nodejs and nextjs applications

## Checklist:

- [X] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
