### PR TITLE
fix: de-confuse Nuxt build tooling by not using  'export *' in comments

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -30,6 +30,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(otlp-exporter-\*): de-confuse Nuxt build tooling by not using 'export *' in comments [#5227](https://github.com/open-telemetry/opentelemetry-js/pull/5227) @pichlermarc
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/exporter-logs-otlp-grpc/src/index.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/src/index.ts
@@ -15,6 +15,6 @@
  */
 
 /* eslint no-restricted-syntax: ["warn", "ExportAllDeclaration"] --
- * TODO: Replace export * with named exports before next major version
+ * TODO: Replace wildcard export with named exports before next major version
  */
 export * from './OTLPLogExporter';

--- a/experimental/packages/exporter-trace-otlp-grpc/src/index.ts
+++ b/experimental/packages/exporter-trace-otlp-grpc/src/index.ts
@@ -15,6 +15,6 @@
  */
 
 /* eslint no-restricted-syntax: ["warn", "ExportAllDeclaration"] --
- * TODO: Replace export * with named exports before next major version
+ * TODO: Replace wildcard export with named exports before next major version
  */
 export * from './OTLPTraceExporter';

--- a/experimental/packages/exporter-trace-otlp-http/src/index.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/index.ts
@@ -15,6 +15,6 @@
  */
 
 /* eslint no-restricted-syntax: ["warn", "ExportAllDeclaration"] --
- * TODO: Replace export * with named exports before next major version
+ * TODO: Replace wildcard export with named exports before next major version
  */
 export * from './platform';

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/browser/index.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/browser/index.ts
@@ -15,6 +15,6 @@
  */
 
 /* eslint no-restricted-syntax: ["warn", "ExportAllDeclaration"] --
- * TODO: Replace export * with named exports before next major version
+ * TODO: Replace wildcard export with named exports before next major version
  */
 export * from './OTLPTraceExporter';

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/index.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/index.ts
@@ -15,6 +15,6 @@
  */
 
 /* eslint no-restricted-syntax: ["warn", "ExportAllDeclaration"] --
- * TODO: Replace export * with named exports before next major version
+ * TODO: Replace wildcard export with named exports before next major version
  */
 export * from './node';

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/node/index.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/node/index.ts
@@ -15,6 +15,6 @@
  */
 
 /* eslint no-restricted-syntax: ["warn", "ExportAllDeclaration"] --
- * TODO: Replace export * with named exports before next major version
+ * TODO: Replace wildcard export with named exports before next major version
  */
 export * from './OTLPTraceExporter';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/index.ts
@@ -15,6 +15,6 @@
  */
 
 /* eslint no-restricted-syntax: ["warn", "ExportAllDeclaration"] --
- * TODO: Replace export * with named exports before next major version
+ * TODO: Replace wildcard export with named exports before next major version
  */
 export * from './OTLPMetricExporter';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/index.ts
@@ -15,6 +15,6 @@
  */
 
 /* eslint no-restricted-syntax: ["warn", "ExportAllDeclaration"] --
- * TODO: Replace export * with named exports before next major version
+ * TODO: Replace wildcard export with named exports before next major version
  */
 export * from './OTLPMetricExporter';

--- a/experimental/packages/opentelemetry-sdk-node/src/index.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 /* eslint no-restricted-syntax: ["warn", "ExportAllDeclaration"] --
- * TODO: Replace export * with named exports before next major version
+ * TODO: Replace wildcard export with named exports before next major version
  */
 export * as api from '@opentelemetry/api';
 export * as contextBase from '@opentelemetry/api';


### PR DESCRIPTION
## Which problem is this PR solving?

See #5218. Using `export *` in comments breaks some build tooling (specifically the tooling used by Nuxt) and breaks the build output. 

Note for reviewers: This is weird and this is difficult to test, please use the [reproducer I created](https://github.com/pichlermarc/repro-5218) for verifying that this actually fixes the problem. I also did not believe it at first when I narrowed it down to a comment. 😅 

Fixes #5218 


## Short description of the changes

changes `export *` in comments to read `wildcard export` instead

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manually tested against https://github.com/pichlermarc/repro-5218