### PR TITLE
fix(sdk-trace-base): don't load envs top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 
 ### :bug: (Bug Fix)
 
+* fix(sdk-trace-base): do not load OTEL_ env vars on module load, but when needed [#5224](https://github.com/open-telemetry/opentelemetry-js/pull/5224)
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/packages/opentelemetry-sdk-trace-base/src/config.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/config.ts
@@ -22,7 +22,6 @@ import { AlwaysOnSampler } from './sampler/AlwaysOnSampler';
 import { ParentBasedSampler } from './sampler/ParentBasedSampler';
 import { TraceIdRatioBasedSampler } from './sampler/TraceIdRatioBasedSampler';
 
-const env = getEnv();
 const FALLBACK_OTEL_TRACES_SAMPLER = TracesSamplerValues.AlwaysOn;
 const DEFAULT_RATIO = 1;
 
@@ -36,23 +35,23 @@ const DEFAULT_RATIO = 1;
 // object needs to be wrapped in this function and called when needed otherwise
 // envs are parsed before tests are ran - causes tests using these envs to fail
 export function loadDefaultConfig() {
-  const _env = getEnv();
+  const env = getEnv();
 
   return {
     sampler: buildSamplerFromEnv(env),
     forceFlushTimeoutMillis: 30000,
     generalLimits: {
-      attributeValueLengthLimit: _env.OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT,
-      attributeCountLimit: _env.OTEL_ATTRIBUTE_COUNT_LIMIT,
+      attributeValueLengthLimit: env.OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+      attributeCountLimit: env.OTEL_ATTRIBUTE_COUNT_LIMIT,
     },
     spanLimits: {
-      attributeValueLengthLimit: _env.OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
-      attributeCountLimit: _env.OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
-      linkCountLimit: _env.OTEL_SPAN_LINK_COUNT_LIMIT,
-      eventCountLimit: _env.OTEL_SPAN_EVENT_COUNT_LIMIT,
+      attributeValueLengthLimit: env.OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+      attributeCountLimit: env.OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT,
+      linkCountLimit: env.OTEL_SPAN_LINK_COUNT_LIMIT,
+      eventCountLimit: env.OTEL_SPAN_EVENT_COUNT_LIMIT,
       attributePerEventCountLimit:
-        _env.OTEL_SPAN_ATTRIBUTE_PER_EVENT_COUNT_LIMIT,
-      attributePerLinkCountLimit: _env.OTEL_SPAN_ATTRIBUTE_PER_LINK_COUNT_LIMIT,
+        env.OTEL_SPAN_ATTRIBUTE_PER_EVENT_COUNT_LIMIT,
+      attributePerLinkCountLimit: env.OTEL_SPAN_ATTRIBUTE_PER_LINK_COUNT_LIMIT,
     },
     mergeResourceWithDefaults: true,
   };


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving? / Short description of the changes

Right now `@opentelemetry/sdk-trace-base` loads `OTEL_*` env vars when it is loaded, regardless of if `loadDefaultConfig` is ever called. In runtimes with a permission model like Deno, this may cause a bunch of permission prompts right on startup. This PR changes the env vars to all be loaded when `loadDefaultConfig` is called.

Interestingly, previously only `buildSamplerFromEnv` used the "global" env vars. For all other options the env vars are re-read on every call to `loadDefaultConfig`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have tested locally that Deno does not prompt for env vars on startup anymore when `@opentelemetry/sdk-trace-base` is loaded.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] ~Unit tests have been added~ N/A
- [ ] ~Documentation has been updated~ N/A
