### PR TITLE
ci: run browser and worker tests on Node.js 22

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -92,7 +92,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: 16
+          node-version: 22
 
       - name: Bootstrap
         run: npm ci
@@ -120,7 +120,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: 16
+          node-version: 22
 
       - name: Bootstrap
         run: npm ci


### PR DESCRIPTION
## Which problem is this PR solving?

Some devDependencies for browser/webworker tests require Node.js 18+. Since Node.js Version for web tests only affects development, we can bump the version we use for testing browser/workers to Node.js 22. This will unblock some Renovate updates.

## How Has This Been Tested?

- [x] Unit tests
