### PR TITLE
feat(sdk-metrics): PeriodicExportingMetricReader now flushes pending tasks at shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 
 ### :rocket: (Enhancement)
 
+* feat(sdk-metrics): PeriodicExportingMetricReader now flushes pending tasks at shutdown [#5242](https://github.com/open-telemetry/opentelemetry-js/pull/5242)
+
 ### :bug: (Bug Fix)
 
 * fix(sdk-trace-base): do not load OTEL_ env vars on module load, but when needed [#5224](https://github.com/open-telemetry/opentelemetry-js/pull/5224)

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/OTLPMetricExporter.test.ts
@@ -214,8 +214,9 @@ describe('OTLPMetricExporter', () => {
       meterProvider.getMeter('test-meter').createCounter('test-counter').add(1);
 
       // act
-      meterProvider.forceFlush();
-      meterProvider.shutdown();
+      meterProvider.forceFlush().then(() => {
+        return meterProvider.shutdown();
+      });
     });
   });
 });

--- a/packages/sdk-metrics/src/MeterProvider.ts
+++ b/packages/sdk-metrics/src/MeterProvider.ts
@@ -122,7 +122,7 @@ export class MeterProvider implements IMeterProvider {
   }
 
   /**
-   * Flush all buffered data and shut down the MeterProvider and all registered
+   * Shut down the MeterProvider and all registered
    * MetricReaders.
    *
    * Returns a promise which is resolved when all flushes are complete.
@@ -131,13 +131,6 @@ export class MeterProvider implements IMeterProvider {
     if (this._shutdown) {
       diag.warn('shutdown may only be called once per MeterProvider');
       return;
-    }
-
-    try {
-      await this.forceFlush();
-    } catch (e) {
-      // log the error and continue with shutdown
-      diag.warn('error flushing data during shutdown', e);
     }
 
     this._shutdown = true;

--- a/packages/sdk-metrics/src/MeterProvider.ts
+++ b/packages/sdk-metrics/src/MeterProvider.ts
@@ -133,6 +133,13 @@ export class MeterProvider implements IMeterProvider {
       return;
     }
 
+    try {
+      await this.forceFlush();
+    } catch (e) {
+      // log the error and continue with shutdown
+      diag.warn('error flushing data during shutdown', e);
+    }
+
     this._shutdown = true;
 
     await Promise.all(

--- a/packages/sdk-metrics/src/export/PeriodicExportingMetricReader.ts
+++ b/packages/sdk-metrics/src/export/PeriodicExportingMetricReader.ts
@@ -161,7 +161,7 @@ export class PeriodicExportingMetricReader extends MetricReader {
     if (this._interval) {
       clearInterval(this._interval);
     }
-
+    await this.onForceFlush();
     await this._exporter.shutdown();
   }
 }

--- a/packages/sdk-metrics/test/MeterProvider.test.ts
+++ b/packages/sdk-metrics/test/MeterProvider.test.ts
@@ -126,9 +126,9 @@ describe('MeterProvider', () => {
       assert.strictEqual(meter1, meter2);
     });
 
-    it('get a noop meter on shutdown', () => {
+    it('get a noop meter on shutdown', async () => {
       const meterProvider = new MeterProvider();
-      meterProvider.shutdown();
+      await meterProvider.shutdown();
       const meter = meterProvider.getMeter('meter1', '1.0.0');
       // returned tracer should be no-op, not instance of Meter (from SDK)
       assert.ok(!(meter instanceof Meter));

--- a/packages/sdk-metrics/test/MeterProvider.test.ts
+++ b/packages/sdk-metrics/test/MeterProvider.test.ts
@@ -835,11 +835,10 @@ describe('MeterProvider', () => {
         timeoutMillis: 5678,
       });
 
-      await meterProvider.shutdown(); // <-- this will call forceFlush() internally
+      await meterProvider.shutdown();
       await meterProvider.forceFlush();
-      assert.strictEqual(reader1ForceFlushSpy.callCount, 3);
-      assert.strictEqual(reader2ForceFlushSpy.callCount, 3);
-
+      assert.strictEqual(reader1ForceFlushSpy.callCount, 2);
+      assert.strictEqual(reader2ForceFlushSpy.callCount, 2);
     });
   });
 });

--- a/packages/sdk-metrics/test/MeterProvider.test.ts
+++ b/packages/sdk-metrics/test/MeterProvider.test.ts
@@ -835,10 +835,11 @@ describe('MeterProvider', () => {
         timeoutMillis: 5678,
       });
 
-      await meterProvider.shutdown();
+      await meterProvider.shutdown(); // <-- this will call forceFlush() internally
       await meterProvider.forceFlush();
-      assert.strictEqual(reader1ForceFlushSpy.callCount, 2);
-      assert.strictEqual(reader2ForceFlushSpy.callCount, 2);
+      assert.strictEqual(reader1ForceFlushSpy.callCount, 3);
+      assert.strictEqual(reader2ForceFlushSpy.callCount, 3);
+
     });
   });
 });

--- a/packages/sdk-metrics/test/export/PeriodicExportingMetricReader.test.ts
+++ b/packages/sdk-metrics/test/export/PeriodicExportingMetricReader.test.ts
@@ -77,9 +77,7 @@ class TestMetricExporter implements PushMetricExporter {
 
   async shutdown(): Promise<void> {
     if (this._shutdown) return;
-    const flushPromise = this.forceFlush();
     this._shutdown = true;
-    await flushPromise;
   }
 
   async forceFlush(): Promise<void> {


### PR DESCRIPTION
## Which problem is this PR solving?

Metric provider behave differently from traces and logs providers during shutdown process, being the only one that does not flush pending tasks.

Although it's not explicitly required ([yet](https://github.com/open-telemetry/opentelemetry-specification/issues/2983)) by the specs for [metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#shutdown-1) and [logs](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/sdk.md#shutdown) as it is for [traces](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#shutdown-1), this PR adds flushing metrics on shutdown, with the intent of eliminating a not infrequent confusion and wrong assumption among users.  
This way we consistently ensure the flush for all supported signals upon shutdown.

The same approach has already been taken by [java and python](https://github.com/open-telemetry/opentelemetry-specification/issues/2983#issuecomment-1458303448) SDKs.

## Short description of the changes

now `MeterProvider#shutdown()` calls `MeterProvider#forceFlush()`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been ~added~ updated
