### PR TITLE
test(api): longer timeout for API tree-shaking tests

### DIFF
--- a/api/test/tree-shaking/tree-shaking.test.ts
+++ b/api/test/tree-shaking/tree-shaking.test.ts
@@ -28,7 +28,7 @@ import * as realFs from 'fs';
  * Webpack doesn't run in node 8 because it requires BigInt. Since we are testing
  * build tooling here, we can safely skip tooling we know can't run anyway.
  */
-describe('tree-shaking', () => {
+describe('tree-shaking', function () {
   const allowedAPIs = ['ContextAPI', 'DiagAPI'];
   const testAPIs = [
     {
@@ -50,7 +50,7 @@ describe('tree-shaking', () => {
   const outputPath = path.join(__dirname, 'output');
   const outputFilename = path.join(outputPath, 'bundle.js');
 
-  afterEach(() => {
+  afterEach(function () {
     try {
       mfs.unlinkSync(outputFilename);
     } catch {
@@ -122,6 +122,6 @@ describe('tree-shaking', () => {
       allowedAPIs.forEach(it => matches.delete(it));
 
       assert.deepStrictEqual(Array.from(matches), [testAPI.name]);
-    });
+    }).timeout(5000);
   }
 });


### PR DESCRIPTION
## Which problem is this PR solving?

I noticed that sometimes the tree-shaking tests time out when I switched to a different machine recently - some people have told me that some test times out when they run it but I was never able to figure out which tests it was. 

On my new machine it happens every once in a while, and it's always the tree-shaking tests. So I'm changing the timeout to 5 seconds (form previously 2) - if it happens to take longer than that in the future I'll have to investigate it more closely.