### PR TITLE
docs: re-categoize misplaced changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 
 ## 1.29.0
 
-### :boom: Breaking Change
+### :rocket: (Enhancement)
 
 * feat(sdk-metrics): Add support for aggregation cardinality limit with a default limit of 2000. This limit can be customized via views [#5182](https://github.com/open-telemetry/opentelemetry-js/pull/5128)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 
 ### :rocket: (Enhancement)
 
-* feat(sdk-metrics): Add support for aggregation cardinality limit with a default limit of 2000. This limit can be customized via views [#5182](https://github.com/open-telemetry/opentelemetry-js/pull/5128)
+* feat(sdk-metrics): Add support for aggregation cardinality limit with a default limit of 2000. This limit can be customized via views [#5128](https://github.com/open-telemetry/opentelemetry-js/pull/5128)
 
 ## 1.28.0
 


### PR DESCRIPTION
## Which problem is this PR solving?

Changelog entry was misplaced in #5128, updating it to fit the correct category (I also edited the release before publishing 1.29.0 to avoid confusion) 