### PR TITLE
[sdk-metrics] Switch workaround types to official @otel/api types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28665,7 +28665,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
     "packages/template": {

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -79,7 +79,7 @@
     "webpack-merge": "5.10.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": ">=1.3.0 <1.10.0"
+    "@opentelemetry/api": ">=1.9.0 <1.10.0"
   },
   "dependencies": {
     "@opentelemetry/core": "1.29.0",

--- a/packages/sdk-metrics/src/InstrumentDescriptor.ts
+++ b/packages/sdk-metrics/src/InstrumentDescriptor.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { MetricOptions, ValueType, diag } from '@opentelemetry/api';
+import {
+  MetricAdvice,
+  MetricOptions,
+  ValueType,
+  diag,
+} from '@opentelemetry/api';
 import { View } from './view/View';
 import { equalsCaseInsensitive } from './utils';
 
@@ -44,18 +49,11 @@ export interface InstrumentDescriptor {
   readonly type: InstrumentType;
   readonly valueType: ValueType;
   /**
-   * @experimental
+   * See {@link MetricAdvice}
    *
-   * This is intentionally not using the API's type as it's only available from @opentelemetry/api 1.7.0 and up.
-   * In SDK 2.0 we'll be able to bump the minimum API version and remove this workaround.
+   * @experimental
    */
-  readonly advice: {
-    /**
-     * Hint the explicit bucket boundaries for SDK if the metric has been
-     * aggregated with a HistogramAggregator.
-     */
-    explicitBucketBoundaries?: number[];
-  };
+  readonly advice: MetricAdvice;
 }
 
 export function createInstrumentDescriptor(

--- a/packages/sdk-metrics/src/Instruments.ts
+++ b/packages/sdk-metrics/src/Instruments.ts
@@ -22,6 +22,7 @@ import {
   ValueType,
   UpDownCounter,
   Counter,
+  Gauge,
   Histogram,
   Observable,
   ObservableCallback,
@@ -36,7 +37,6 @@ import {
   AsyncWritableMetricStorage,
   WritableMetricStorage,
 } from './state/WritableMetricStorage';
-import { Gauge } from './types';
 
 export class SyncInstrument {
   constructor(

--- a/packages/sdk-metrics/src/Meter.ts
+++ b/packages/sdk-metrics/src/Meter.ts
@@ -17,6 +17,7 @@
 import {
   Meter as IMeter,
   MetricOptions,
+  Gauge,
   Histogram,
   Counter,
   UpDownCounter,
@@ -40,7 +41,6 @@ import {
   UpDownCounterInstrument,
 } from './Instruments';
 import { MeterSharedState } from './state/MeterSharedState';
-import { Gauge } from './types';
 
 /**
  * This class implements the {@link IMeter} interface.

--- a/packages/sdk-metrics/src/types.ts
+++ b/packages/sdk-metrics/src/types.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Context, Attributes } from '@opentelemetry/api';
 
 export type CommonReaderOptions = {
   timeoutMillis?: number;
@@ -24,14 +23,3 @@ export type CollectionOptions = CommonReaderOptions;
 export type ShutdownOptions = CommonReaderOptions;
 
 export type ForceFlushOptions = CommonReaderOptions;
-
-/**
- * This is intentionally not using the API's type as it's only available from @opentelemetry/api 1.9.0 and up.
- * In SDK 2.0 we'll be able to bump the minimum API version and remove this workaround.
- */
-export interface Gauge<AttributesTypes extends Attributes = Attributes> {
-  /**
-   * Records a measurement. Value of the measurement must not be negative.
-   */
-  record(value: number, attributes?: AttributesTypes, context?: Context): void;
-}


### PR DESCRIPTION
## Which problem is this PR solving?

Remove workaround types in favor of official `@opentelemetry/api` types (in the `next` branch for SDK 2.0).

These types were introduced in the 1.0 series when the metrics package depended on an older version of the api package that didn't come with those types, so the interfaces were essentially vendored into the package for internal use.

Now with the 2.0 release on the horrizon, we can bump the required version of @otel/api and is now safe to unvendor these types in favor of the official ones.

Fixes #5223
Fixes #5224

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] TypeScript compiles

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] ~~Unit tests have been added~~ N/A – type-only changes
- [x] Documentation has been updated
