### PR TITLE
fix(instrumentation-fetch, instrumentation-xml-http-request) content length attributes missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 ### :bug: (Bug Fix)
 
 * fix(sdk-trace-base): do not load OTEL_ env vars on module load, but when needed [#5224](https://github.com/open-telemetry/opentelemetry-js/pull/5224)
-* fix(instrumentation-xhr, instrumentation-fetch): content length attributes no longer get removed with `ignoreNetworkEvents: true` being set [#5229](https://github.com/open-telemetry/opentelemetry-js/issues/5229)
 
 ### :books: (Refine Doc)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 ### :bug: (Bug Fix)
 
 * fix(sdk-trace-base): do not load OTEL_ env vars on module load, but when needed [#5224](https://github.com/open-telemetry/opentelemetry-js/pull/5224)
+* fix(instrumentation-xhr, instrumentation-fetch): content length attributes no longer get removed with `ignoreNetworkEvents: true` being set [#5229](https://github.com/open-telemetry/opentelemetry-js/issues/5229)
 
 ### :books: (Refine Doc)
 

--- a/CHANGELOG_NEXT.md
+++ b/CHANGELOG_NEXT.md
@@ -16,6 +16,7 @@
 * refactor(sdk-trace-base)!: remove `new Span` constructor in favor of `Tracer.startSpan` API [#5048](https://github.com/open-telemetry/opentelemetry-js/pull/5048) @david-luna
 * refactor(sdk-trace-base)!: remove `BasicTracerProvider.addSpanProcessor` API in favor of constructor options. [#5134](https://github.com/open-telemetry/opentelemetry-js/pull/5134) @david-luna
 * refactor(sdk-trace-base)!: make `resource` property private in `BasicTracerProvider` and remove `getActiveSpanProcessor` API. [#5192](https://github.com/open-telemetry/opentelemetry-js/pull/5192) @david-luna
+* feat(sdk-trace-web)!: content length attributes are no longer added in `addSpanNetworkEvents`. Logic has been moved to new method `addSpanContentLengthAttributes` [#5257](https://github.com/open-telemetry/opentelemetry-js/pull/5257) @arriIsHere
 
 ### :rocket: (Enhancement)
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -115,6 +115,7 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
     if (!this.getConfig().ignoreNetworkEvents) {
       web.addSpanNetworkEvents(childSpan, corsPreFlightRequest);
     }
+    web.addSpanContentLengthAttributes(childSpan, corsPreFlightRequest);
     childSpan.end(
       corsPreFlightRequest[web.PerformanceTimingNames.RESPONSE_END]
     );
@@ -265,6 +266,7 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
       if (!this.getConfig().ignoreNetworkEvents) {
         web.addSpanNetworkEvents(span, mainRequest);
       }
+      web.addSpanContentLengthAttributes(span, mainRequest);
     }
   }
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -1211,5 +1211,18 @@ describe('fetch', () => {
       const events = span.events;
       assert.strictEqual(events.length, 0, 'number of events is wrong');
     });
+
+    it('should still add the CONTENT_LENGTH attribute', () => {
+      const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+      const attributes = span.attributes;
+      const responseContentLength = attributes[
+        SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH
+      ] as number;
+      assert.strictEqual(
+        responseContentLength,
+        30,
+        `attributes ${SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH} is <= 0`
+      );
+    });
   });
 });

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -37,6 +37,7 @@ import {
   PerformanceTimingNames as PTN,
   shouldPropagateTraceHeaders,
   parseUrl,
+  addSpanContentLengthAttributes,
 } from '@opentelemetry/sdk-trace-web';
 import { EventNames } from './enums/EventNames';
 import {
@@ -152,6 +153,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
       if (!this.getConfig().ignoreNetworkEvents) {
         addSpanNetworkEvents(childSpan, corsPreFlightRequest);
       }
+      addSpanContentLengthAttributes(childSpan, corsPreFlightRequest);
       childSpan.end(corsPreFlightRequest[PTN.RESPONSE_END]);
     });
   }
@@ -303,6 +305,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
       if (!this.getConfig().ignoreNetworkEvents) {
         addSpanNetworkEvents(span, mainRequest);
       }
+      addSpanContentLengthAttributes(span, mainRequest);
     }
   }
 

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -859,6 +859,19 @@ describe('xhr', () => {
             const events = span.events;
             assert.strictEqual(events.length, 3, 'number of events is wrong');
           });
+
+          it('should still add the CONTENT_LENGTH attribute', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const attributes = span.attributes;
+            const responseContentLength = attributes[
+              SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH
+            ] as number;
+            assert.strictEqual(
+              responseContentLength,
+              30,
+              `attributes ${SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH} is <= 0`
+            );
+          });
         });
       });
 

--- a/packages/opentelemetry-sdk-trace-web/src/index.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/index.ts
@@ -27,6 +27,7 @@ export {
   URLLike,
   addSpanNetworkEvent,
   addSpanNetworkEvents,
+  addSpanContentLengthAttributes,
   getElementXPath,
   getResource,
   hasKey,

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -111,6 +111,17 @@ export function addSpanNetworkEvents(
   addSpanNetworkEvent(span, PTN.REQUEST_START, resource);
   addSpanNetworkEvent(span, PTN.RESPONSE_START, resource);
   addSpanNetworkEvent(span, PTN.RESPONSE_END, resource);
+}
+
+/**
+ * Helper function for adding content length attributes to a network span
+ * @param span
+ * @param resource
+ */
+export function addSpanContentLengthAttributes(
+  span: api.Span,
+  resource: PerformanceEntries
+): void {
   const encodedLength = resource[PTN.ENCODED_BODY_SIZE];
   if (encodedLength !== undefined) {
     span.setAttribute(SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH, encodedLength);


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?


`http.response_content_length` and `http.response_content_length_uncompressed` attributes are not present on network spans from `instrumentation-xml-http-request` and `instrumentation-fetch` plugins when the `ignoreNetworkEvents` configuration property is set to `true`

This PR adds the `addSpanContentLengthAttributes` utility method to `@opentelemetry/sdk-trace-web` removing the logic for adding content length related attributes from the `addSpanNetworkEvents` method.

Fixes #5229

## Short description of the changes

By skipping over the call to `addSpanNetworkEvents` the mentioned attributes were not getting added to the main and preflight network spans.  We moved the logic for adding the content length attributes to the new `addSpanContentLengthAttributes` method. This new method will be called regardless of if `ignoreNetworkEvents` is set to `true` in the config.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Automated unit tests were written as well as testing with the fetch and xhr examples to verify the attributes are being added with the proposed code.

 1. Open the examples/opentelemetry-web/examples/fetchexample
 2. Start example
 3. Note that the GET event has a http.response_content_length attribute
 4. Add the ignoreNetworkEvents: true config to the FetchInstrumentation in the index.js file
 5. Run example
 6. The http.response_content_length attribute should still be present on the GET span

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
