### PR TITLE
refactor(otlp-transformer): json schema based validation

### DIFF
--- a/api/test/common/diag/logLevel.test.ts
+++ b/api/test/common/diag/logLevel.test.ts
@@ -77,7 +77,7 @@ describe('LogLevelFilter DiagLogger', () => {
 
   const levelMap: Array<{
     message: string;
-    level: DiagLogLevel;
+    level: number | DiagLogLevel;
     ignoreFuncs: Array<keyof DiagLogger>;
   }> = [
     { message: 'ALL', level: DiagLogLevel.ALL, ignoreFuncs: [] },

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -19,6 +19,10 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+* feat(otlp-transformer)!: add new entrypoints for non-core features [#5259](https://github.com/open-telemetry/opentelemetry-js/pull/5259/)
+  * (user-facing): OTLP (binary protobuf) utilities now located at `@opentelemetry/otlp-transformer/proto`
+  * (user-facing): OTLP (json) utilities now located at `@opentelemetry/otlp-transformer/json`
+  * (internal): features to remain experimental post-stabilization now located at `@opentelemetry/otlp-transformer/experimental` (empty for now)
 * feat(otlp-exporter-base)!: collapse base classes into one [#5031](https://github.com/open-telemetry/opentelemetry-js/pull/5031) @pichlermarc
   * `OTLPExporterNodeBase` has been removed in favor of a platform-agnostic implementation (`OTLPExporterBase`)
   * `OTLPExporterBrowserBase` has been removed in favor of a platform-agnostic implementation (`OTLPExporterBase`)

--- a/experimental/packages/exporter-logs-otlp-grpc/src/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/src/OTLPLogExporter.ts
@@ -20,7 +20,7 @@ import {
   createOtlpGrpcExportDelegate,
   OTLPGRPCExporterConfigNode,
 } from '@opentelemetry/otlp-grpc-exporter-base';
-import { ProtobufLogsSerializer } from '@opentelemetry/otlp-transformer';
+import { ProtobufLogsSerializer } from '@opentelemetry/otlp-transformer/protobuf';
 import { OTLPExporterBase } from '@opentelemetry/otlp-exporter-base';
 
 /**

--- a/experimental/packages/exporter-logs-otlp-http/src/platform/browser/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-http/src/platform/browser/OTLPLogExporter.ts
@@ -20,7 +20,7 @@ import type {
 } from '@opentelemetry/sdk-logs';
 import type { OTLPExporterConfigBase } from '@opentelemetry/otlp-exporter-base';
 import { OTLPExporterBase } from '@opentelemetry/otlp-exporter-base';
-import { JsonLogsSerializer } from '@opentelemetry/otlp-transformer';
+import { JsonLogsSerializer } from '@opentelemetry/otlp-transformer/json';
 import { createLegacyOtlpBrowserExportDelegate } from '@opentelemetry/otlp-exporter-base/browser-http';
 
 /**

--- a/experimental/packages/exporter-logs-otlp-http/src/platform/node/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-http/src/platform/node/OTLPLogExporter.ts
@@ -20,7 +20,7 @@ import type {
 } from '@opentelemetry/sdk-logs';
 import type { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
 import { OTLPExporterBase } from '@opentelemetry/otlp-exporter-base';
-import { JsonLogsSerializer } from '@opentelemetry/otlp-transformer';
+import { JsonLogsSerializer } from '@opentelemetry/otlp-transformer/json';
 import { VERSION } from '../../version';
 import {
   convertLegacyHttpOptions,

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/OTLPLogExporter.ts
@@ -18,7 +18,7 @@ import {
   OTLPExporterConfigBase,
   OTLPExporterBase,
 } from '@opentelemetry/otlp-exporter-base';
-import { ProtobufLogsSerializer } from '@opentelemetry/otlp-transformer';
+import { ProtobufLogsSerializer } from '@opentelemetry/otlp-transformer/protobuf';
 
 import { ReadableLogRecord, LogRecordExporter } from '@opentelemetry/sdk-logs';
 import { createLegacyOtlpBrowserExportDelegate } from '@opentelemetry/otlp-exporter-base/browser-http';

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
@@ -18,7 +18,7 @@ import {
   OTLPExporterBase,
   OTLPExporterNodeConfigBase,
 } from '@opentelemetry/otlp-exporter-base';
-import { ProtobufLogsSerializer } from '@opentelemetry/otlp-transformer';
+import { ProtobufLogsSerializer } from '@opentelemetry/otlp-transformer/protobuf';
 import {
   convertLegacyHttpOptions,
   createOtlpHttpExportDelegate,

--- a/experimental/packages/exporter-trace-otlp-grpc/src/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-grpc/src/OTLPTraceExporter.ts
@@ -20,7 +20,7 @@ import {
   createOtlpGrpcExportDelegate,
   OTLPGRPCExporterConfigNode,
 } from '@opentelemetry/otlp-grpc-exporter-base';
-import { ProtobufTraceSerializer } from '@opentelemetry/otlp-transformer';
+import { ProtobufTraceSerializer } from '@opentelemetry/otlp-transformer/protobuf';
 import { OTLPExporterBase } from '@opentelemetry/otlp-exporter-base';
 
 /**

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/browser/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/browser/OTLPTraceExporter.ts
@@ -19,7 +19,7 @@ import {
   OTLPExporterConfigBase,
   OTLPExporterBase,
 } from '@opentelemetry/otlp-exporter-base';
-import { JsonTraceSerializer } from '@opentelemetry/otlp-transformer';
+import { JsonTraceSerializer } from '@opentelemetry/otlp-transformer/json';
 import { createLegacyOtlpBrowserExportDelegate } from '@opentelemetry/otlp-exporter-base/browser-http';
 
 /**

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/node/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/node/OTLPTraceExporter.ts
@@ -20,7 +20,7 @@ import {
   OTLPExporterBase,
 } from '@opentelemetry/otlp-exporter-base';
 import { VERSION } from '../../version';
-import { JsonTraceSerializer } from '@opentelemetry/otlp-transformer';
+import { JsonTraceSerializer } from '@opentelemetry/otlp-transformer/json';
 import {
   convertLegacyHttpOptions,
   createOtlpHttpExportDelegate,

--- a/experimental/packages/exporter-trace-otlp-proto/src/platform/browser/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/src/platform/browser/OTLPTraceExporter.ts
@@ -19,7 +19,7 @@ import {
   OTLPExporterConfigBase,
   OTLPExporterBase,
 } from '@opentelemetry/otlp-exporter-base';
-import { ProtobufTraceSerializer } from '@opentelemetry/otlp-transformer';
+import { ProtobufTraceSerializer } from '@opentelemetry/otlp-transformer/protobuf';
 import { createLegacyOtlpBrowserExportDelegate } from '@opentelemetry/otlp-exporter-base/browser-http';
 
 const DEFAULT_COLLECTOR_RESOURCE_PATH = 'v1/traces';

--- a/experimental/packages/exporter-trace-otlp-proto/src/platform/node/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/src/platform/node/OTLPTraceExporter.ts
@@ -19,7 +19,7 @@ import {
   OTLPExporterNodeConfigBase,
   OTLPExporterBase,
 } from '@opentelemetry/otlp-exporter-base';
-import { ProtobufTraceSerializer } from '@opentelemetry/otlp-transformer';
+import { ProtobufTraceSerializer } from '@opentelemetry/otlp-transformer/protobuf';
 import { VERSION } from '../../version';
 import {
   createOtlpHttpExportDelegate,

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/OTLPMetricExporter.ts
@@ -23,7 +23,7 @@ import {
   createOtlpGrpcExportDelegate,
   OTLPGRPCExporterConfigNode,
 } from '@opentelemetry/otlp-grpc-exporter-base';
-import { ProtobufMetricsSerializer } from '@opentelemetry/otlp-transformer';
+import { ProtobufMetricsSerializer } from '@opentelemetry/otlp-transformer/protobuf';
 
 /**
  * OTLP-gRPC metric exporter

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/browser/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/browser/OTLPMetricExporter.ts
@@ -17,7 +17,7 @@
 import { OTLPMetricExporterOptions } from '../../OTLPMetricExporterOptions';
 import { OTLPMetricExporterBase } from '../../OTLPMetricExporterBase';
 import { OTLPExporterConfigBase } from '@opentelemetry/otlp-exporter-base';
-import { JsonMetricsSerializer } from '@opentelemetry/otlp-transformer';
+import { JsonMetricsSerializer } from '@opentelemetry/otlp-transformer/json';
 import { createLegacyOtlpBrowserExportDelegate } from '@opentelemetry/otlp-exporter-base/browser-http';
 
 /**

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/OTLPMetricExporter.ts
@@ -17,7 +17,7 @@
 import { OTLPMetricExporterOptions } from '../../OTLPMetricExporterOptions';
 import { OTLPMetricExporterBase } from '../../OTLPMetricExporterBase';
 import { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
-import { JsonMetricsSerializer } from '@opentelemetry/otlp-transformer';
+import { JsonMetricsSerializer } from '@opentelemetry/otlp-transformer/json';
 import { VERSION } from '../../version';
 import {
   convertLegacyHttpOptions,

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/OTLPMetricExporter.ts
@@ -17,7 +17,7 @@
 import { OTLPMetricExporterOptions } from '@opentelemetry/exporter-metrics-otlp-http';
 import { OTLPMetricExporterBase } from '@opentelemetry/exporter-metrics-otlp-http';
 import { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
-import { ProtobufMetricsSerializer } from '@opentelemetry/otlp-transformer';
+import { ProtobufMetricsSerializer } from '@opentelemetry/otlp-transformer/protobuf';
 import { VERSION } from './version';
 import {
   convertLegacyHttpOptions,

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -115,10 +115,11 @@
     "nyc": "15.1.0",
     "protobufjs-cli": "1.1.3",
     "ts-loader": "9.5.1",
-    "typescript": "4.4.4",
+    "typescript": "5.7.2",
     "webpack": "5.96.1"
   },
   "dependencies": {
+    "@sinclair/typebox": "0.34.11",
     "@opentelemetry/api-logs": "0.56.0",
     "@opentelemetry/core": "1.29.0",
     "@opentelemetry/resources": "1.29.0",

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -6,10 +6,48 @@
   },
   "version": "0.56.0",
   "description": "Transform OpenTelemetry SDK data into OTLP",
-  "module": "build/esm/index.js",
-  "esnext": "build/esnext/index.js",
-  "types": "build/src/index.d.ts",
-  "main": "build/src/index.js",
+  "exports": {
+    ".": {
+      "module": "./build/esm/index.js",
+      "esnext": "./build/esnext/index.js",
+      "types": "./build/src/index.d.ts",
+      "default": "./build/src/index.js"
+    },
+    "./experimental": {
+      "module": "./build/esm/experimental/index.js",
+      "esnext": "./build/esnext/experimental/index.js",
+      "types": "./build/src/experimental/index.d.ts",
+      "default": "./build/src/experimental/index.js"
+    },
+    "./json": {
+      "module": "./build/esm/json/index.js",
+      "esnext": "./build/esnext/json/index.js",
+      "types": "./build/src/json/index.d.ts",
+      "default": "./build/src/json/index.js"
+    },
+    "./protobuf": {
+      "module": "./build/esm/protobuf/index.js",
+      "esnext": "./build/esnext/protobuf/index.js",
+      "types": "./build/src/protobuf/index.d.ts",
+      "default": "./build/src/protobuf/index.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./build/src/index.d.ts"
+      ],
+      "experimental": [
+        "./build/src/experimental/index.d.ts"
+      ],
+      "json": [
+        "./build/src/json/index.d.ts"
+      ],
+      "protobuf": [
+        "./build/src/protobuf/index.d.ts"
+      ]
+    }
+  },
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "prepublishOnly": "npm run compile",

--- a/experimental/packages/otlp-transformer/src/common/types.ts
+++ b/experimental/packages/otlp-transformer/src/common/types.ts
@@ -14,72 +14,71 @@
  * limitations under the License.
  */
 
-/** Properties of an InstrumentationScope. */
-export interface IInstrumentationScope {
-  /** InstrumentationScope name */
-  name: string;
+import { Type, type Static } from "@sinclair/typebox";
 
-  /** InstrumentationScope version */
-  version?: string;
+export const OtelCommonTypes = Type.Module({
+  ResourceAttributes: Type.Object({
+    key: Type.String(),
+    value: Type.Any(),
+  }),
+  IResource: Type.Object({
+    attributes: Type.Array(Type.Ref("ResourceAttributes")),
+  }),
+  IKeyValue: Type.Object({
+    key: Type.String(),
+    value: Type.Ref("IAnyValue"),
+  }),
+  IKeyValueList: Type.Object({
+    values: Type.Array(Type.Ref("IKeyValue")),
+  }),
+  IArrayValue: Type.Object({
+    values: Type.Array(Type.Ref("IAnyValue")),
+  }),
+  IAnyValue: Type.Object({
+    stringValue: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    boolValue: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
+    intValue: Type.Optional(Type.Union([Type.Number(), Type.Null()])),
+    doubleValue: Type.Optional(Type.Union([Type.Number(), Type.Null()])),
+    arrayValue: Type.Optional(Type.Ref("IArrayValue")),
+    kvlistValue: Type.Optional(Type.Ref("IKeyValueList")),
+    bytesValue: Type.Optional(Type.Uint8Array()),
+  }),
+  IInstrumentationScope: Type.Object({
+    name: Type.String(),
+    version: Type.Optional(Type.String()),
+    attributes: Type.Optional(Type.Array(Type.Ref("IKeyValue"))),
+    droppedAttributesCount: Type.Optional(Type.Number()),
+  }),
+  LongBits: Type.Object({
+    low: Type.Number(),
+    high: Type.Number(),
+  }),
+  Fixed64: Type.Union([Type.Ref("LongBits"), Type.String(), Type.Number()]),
+});
 
-  /** InstrumentationScope attributes */
-  attributes?: IKeyValue[];
+export const TResourceAttributes = OtelCommonTypes.Import("ResourceAttributes");
+export type ResourceAttributes = Static<typeof TResourceAttributes>;
 
-  /** InstrumentationScope droppedAttributesCount */
-  droppedAttributesCount?: number;
-}
+export const TKeyValue = OtelCommonTypes.Import("IKeyValue");
+export type IKeyValue = Static<typeof TKeyValue>;
 
-/** Properties of a KeyValue. */
-export interface IKeyValue {
-  /** KeyValue key */
-  key: string;
+export const TKeyValueList = OtelCommonTypes.Import("IKeyValueList");
+export type IKeyValueList = Static<typeof TKeyValueList>;
 
-  /** KeyValue value */
-  value: IAnyValue;
-}
+export const TArrayValue = OtelCommonTypes.Import("IArrayValue");
+export type IArrayValue = Static<typeof TArrayValue>;
 
-/** Properties of an AnyValue. */
-export interface IAnyValue {
-  /** AnyValue stringValue */
-  stringValue?: string | null;
+export const TAnyValue = OtelCommonTypes.Import("IAnyValue");
+export type IAnyValue = Static<typeof TAnyValue>;
 
-  /** AnyValue boolValue */
-  boolValue?: boolean | null;
+export const TInstrumentationScope = OtelCommonTypes.Import("IInstrumentationScope");
+export type IInstrumentationScope = Static<typeof TInstrumentationScope>;
 
-  /** AnyValue intValue */
-  intValue?: number | null;
+export const TLongBits = OtelCommonTypes.Import("LongBits");
+export type LongBits = Static<typeof TLongBits>;
 
-  /** AnyValue doubleValue */
-  doubleValue?: number | null;
-
-  /** AnyValue arrayValue */
-  arrayValue?: IArrayValue;
-
-  /** AnyValue kvlistValue */
-  kvlistValue?: IKeyValueList;
-
-  /** AnyValue bytesValue */
-  bytesValue?: Uint8Array;
-}
-
-/** Properties of an ArrayValue. */
-export interface IArrayValue {
-  /** ArrayValue values */
-  values: IAnyValue[];
-}
-
-/** Properties of a KeyValueList. */
-export interface IKeyValueList {
-  /** KeyValueList values */
-  values: IKeyValue[];
-}
-
-export interface LongBits {
-  low: number;
-  high: number;
-}
-
-export type Fixed64 = LongBits | string | number;
+export const TFixed64 = OtelCommonTypes.Import("Fixed64");
+export type Fixed64 = Static<typeof TFixed64>;
 
 export interface OtlpEncodingOptions {
   /** Convert trace and span IDs to hex strings. */

--- a/experimental/packages/otlp-transformer/src/experimental/index.ts
+++ b/experimental/packages/otlp-transformer/src/experimental/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default {};

--- a/experimental/packages/otlp-transformer/src/index.ts
+++ b/experimental/packages/otlp-transformer/src/index.ts
@@ -84,16 +84,4 @@ export { createExportTraceServiceRequest } from './trace';
 export { createExportMetricsServiceRequest } from './metrics';
 export { createExportLogsServiceRequest } from './logs';
 
-export {
-  ProtobufLogsSerializer,
-  ProtobufMetricsSerializer,
-  ProtobufTraceSerializer,
-} from './protobuf/serializers';
-
-export {
-  JsonTraceSerializer,
-  JsonLogsSerializer,
-  JsonMetricsSerializer,
-} from './json/serializers';
-
 export { ISerializer } from './common/i-serializer';

--- a/experimental/packages/otlp-transformer/src/json/index.ts
+++ b/experimental/packages/otlp-transformer/src/json/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {
+  JsonTraceSerializer,
+  JsonMetricsSerializer,
+  JsonLogsSerializer,
+} from './serializers';

--- a/experimental/packages/otlp-transformer/src/logs/types.ts
+++ b/experimental/packages/otlp-transformer/src/logs/types.ts
@@ -14,19 +14,9 @@
  * limitations under the License.
  */
 
-import type {
-  Fixed64,
-  IAnyValue,
-  IInstrumentationScope,
-  IKeyValue,
-} from '../common/types';
-import type { IResource } from '../resource/types';
-
-/** Properties of an ExportLogsServiceRequest. */
-export interface IExportLogsServiceRequest {
-  /** ExportLogsServiceRequest resourceLogs */
-  resourceLogs?: IResourceLogs[];
-}
+import { Type, type Static } from "@sinclair/typebox";
+import { TKeyValue, TFixed64, TAnyValue, TInstrumentationScope } from "../common/types";
+import { TResource } from '../resource/types';
 
 export interface IExportLogsServiceResponse {
   /** ExportLogsServiceResponse partialSuccess */
@@ -41,67 +31,10 @@ export interface IExportLogsPartialSuccess {
   errorMessage?: string;
 }
 
-/** Properties of a ResourceLogs. */
-export interface IResourceLogs {
-  /** ResourceLogs resource */
-  resource?: IResource;
-
-  /** ResourceLogs scopeLogs */
-  scopeLogs: IScopeLogs[];
-
-  /** ResourceLogs schemaUrl */
-  schemaUrl?: string;
-}
-
-/** Properties of an ScopeLogs. */
-export interface IScopeLogs {
-  /** IScopeLogs scope */
-  scope?: IInstrumentationScope;
-
-  /** IScopeLogs logRecords */
-  logRecords?: ILogRecord[];
-
-  /** IScopeLogs schemaUrl */
-  schemaUrl?: string | null;
-}
-
-/** Properties of a LogRecord. */
-export interface ILogRecord {
-  /** LogRecord timeUnixNano */
-  timeUnixNano: Fixed64;
-
-  /** LogRecord observedTimeUnixNano */
-  observedTimeUnixNano: Fixed64;
-
-  /** LogRecord severityNumber */
-  severityNumber?: ESeverityNumber;
-
-  /** LogRecord severityText */
-  severityText?: string;
-
-  /** LogRecord body */
-  body?: IAnyValue;
-
-  /** LogRecord attributes */
-  attributes: IKeyValue[];
-
-  /** LogRecord droppedAttributesCount */
-  droppedAttributesCount: number;
-
-  /** LogRecord flags */
-  flags?: number;
-
-  /** LogRecord traceId */
-  traceId?: string | Uint8Array;
-
-  /** LogRecord spanId */
-  spanId?: string | Uint8Array;
-}
-
 /**
  * Numerical value of the severity, normalized to values described in Log Data Model.
  */
-export const enum ESeverityNumber {
+export enum ESeverityNumber {
   /** Unspecified. Do NOT use as default */
   SEVERITY_NUMBER_UNSPECIFIED = 0,
   SEVERITY_NUMBER_TRACE = 1,
@@ -129,3 +62,43 @@ export const enum ESeverityNumber {
   SEVERITY_NUMBER_FATAL3 = 23,
   SEVERITY_NUMBER_FATAL4 = 24,
 }
+
+export const OtelLogTypes = Type.Module({
+  ILogRecord: Type.Object({
+    timeUnixNano: TFixed64,
+    observedTimeUnixNano: TFixed64,
+    severityNumber: Type.Optional(Type.Enum(ESeverityNumber)),
+    severityText: Type.Optional(Type.String()),
+    body: Type.Optional(TAnyValue),
+    attributes: Type.Array(TKeyValue),
+    droppedAttributesCount: Type.Number(),
+    flags: Type.Optional(Type.Number()),
+    traceId: Type.Optional(Type.Union([Type.String(), Type.Uint8Array()])),
+    spanId: Type.Optional(Type.Union([Type.String(), Type.Uint8Array()])),
+  }),
+  IScopeLogs: Type.Object({
+    scope: Type.Optional(TInstrumentationScope),
+    logRecords: Type.Optional(Type.Array(Type.Ref("ILogRecord"))),
+    schemaUrl: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  }),
+  IResourceLogs: Type.Object({
+    resource: Type.Optional(TResource),
+    scopeLogs: Type.Array(Type.Ref("IScopeLogs")),
+    schemaUrl: Type.Optional(Type.String()),
+  }),
+  IExportLogsServiceRequest: Type.Object({
+    resourceLogs: Type.Optional(Type.Array(Type.Ref("IResourceLogs"))),
+  }),
+});
+
+export const TLogRecord = OtelLogTypes.Import("ILogRecord");
+export type ILogRecord = Static<typeof TLogRecord>;
+
+export const TScopeLogs = OtelLogTypes.Import("IScopeLogs");
+export type IScopeLogs = Static<typeof TScopeLogs>;
+
+export const TResourceLogs = OtelLogTypes.Import("IResourceLogs");
+export type IResourceLogs = Static<typeof TResourceLogs>;
+
+export const TExportLogsServiceRequest = OtelLogTypes.Import("IExportLogsServiceRequest");
+export type IExportLogsServiceRequest = Static<typeof TExportLogsServiceRequest>;

--- a/experimental/packages/otlp-transformer/src/metrics/types.ts
+++ b/experimental/packages/otlp-transformer/src/metrics/types.ts
@@ -13,14 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Fixed64, IInstrumentationScope, IKeyValue } from '../common/types';
-import { IResource } from '../resource/types';
-
-/** Properties of an ExportMetricsServiceRequest. */
-export interface IExportMetricsServiceRequest {
-  /** ExportMetricsServiceRequest resourceMetrics */
-  resourceMetrics: IResourceMetrics[];
-}
+import { TFixed64, TInstrumentationScope, TKeyValue } from '../common/types';
+import { TResource } from '../resource/types';
+import { Type, type Static } from "@sinclair/typebox";
 
 export interface IExportMetricsServiceResponse {
   /** ExportMetricsServiceResponse partialSuccess */
@@ -35,270 +30,12 @@ export interface IExportMetricsPartialSuccess {
   errorMessage?: string;
 }
 
-/** Properties of a ResourceMetrics. */
-export interface IResourceMetrics {
-  /** ResourceMetrics resource */
-  resource?: IResource;
-
-  /** ResourceMetrics scopeMetrics */
-  scopeMetrics: IScopeMetrics[];
-
-  /** ResourceMetrics schemaUrl */
-  schemaUrl?: string;
-}
-
-/** Properties of an IScopeMetrics. */
-export interface IScopeMetrics {
-  /** ScopeMetrics scope */
-  scope?: IInstrumentationScope;
-
-  /** ScopeMetrics metrics */
-  metrics: IMetric[];
-
-  /** ScopeMetrics schemaUrl */
-  schemaUrl?: string;
-}
-
-/** Properties of a Metric. */
-export interface IMetric {
-  /** Metric name */
-  name: string;
-
-  /** Metric description */
-  description?: string;
-
-  /** Metric unit */
-  unit?: string;
-
-  /** Metric gauge */
-  gauge?: IGauge;
-
-  /** Metric sum */
-  sum?: ISum;
-
-  /** Metric histogram */
-  histogram?: IHistogram;
-
-  /** Metric exponentialHistogram */
-  exponentialHistogram?: IExponentialHistogram;
-
-  /** Metric summary */
-  summary?: ISummary;
-}
-
-/** Properties of a Gauge. */
-export interface IGauge {
-  /** Gauge dataPoints */
-  dataPoints: INumberDataPoint[];
-}
-
-/** Properties of a Sum. */
-export interface ISum {
-  /** Sum dataPoints */
-  dataPoints: INumberDataPoint[];
-
-  /** Sum aggregationTemporality */
-  aggregationTemporality: EAggregationTemporality;
-
-  /** Sum isMonotonic */
-  isMonotonic?: boolean | null;
-}
-
-/** Properties of a Histogram. */
-export interface IHistogram {
-  /** Histogram dataPoints */
-  dataPoints: IHistogramDataPoint[];
-
-  /** Histogram aggregationTemporality */
-  aggregationTemporality?: EAggregationTemporality;
-}
-
-/** Properties of an ExponentialHistogram. */
-export interface IExponentialHistogram {
-  /** ExponentialHistogram dataPoints */
-  dataPoints: IExponentialHistogramDataPoint[];
-
-  /** ExponentialHistogram aggregationTemporality */
-  aggregationTemporality?: EAggregationTemporality;
-}
-
-/** Properties of a Summary. */
-export interface ISummary {
-  /** Summary dataPoints */
-  dataPoints: ISummaryDataPoint[];
-}
-
-/** Properties of a NumberDataPoint. */
-export interface INumberDataPoint {
-  /** NumberDataPoint attributes */
-  attributes: IKeyValue[];
-
-  /** NumberDataPoint startTimeUnixNano */
-  startTimeUnixNano?: Fixed64;
-
-  /** NumberDataPoint timeUnixNano */
-  timeUnixNano?: Fixed64;
-
-  /** NumberDataPoint asDouble */
-  asDouble?: number | null;
-
-  /** NumberDataPoint asInt */
-  asInt?: number;
-
-  /** NumberDataPoint exemplars */
-  exemplars?: IExemplar[];
-
-  /** NumberDataPoint flags */
-  flags?: number;
-}
-
-/** Properties of a HistogramDataPoint. */
-export interface IHistogramDataPoint {
-  /** HistogramDataPoint attributes */
-  attributes?: IKeyValue[];
-
-  /** HistogramDataPoint startTimeUnixNano */
-  startTimeUnixNano?: Fixed64;
-
-  /** HistogramDataPoint timeUnixNano */
-  timeUnixNano?: Fixed64;
-
-  /** HistogramDataPoint count */
-  count?: number;
-
-  /** HistogramDataPoint sum */
-  sum?: number;
-
-  /** HistogramDataPoint bucketCounts */
-  bucketCounts?: number[];
-
-  /** HistogramDataPoint explicitBounds */
-  explicitBounds?: number[];
-
-  /** HistogramDataPoint exemplars */
-  exemplars?: IExemplar[];
-
-  /** HistogramDataPoint flags */
-  flags?: number;
-
-  /** HistogramDataPoint min */
-  min?: number;
-
-  /** HistogramDataPoint max */
-  max?: number;
-}
-
-/** Properties of an ExponentialHistogramDataPoint. */
-export interface IExponentialHistogramDataPoint {
-  /** ExponentialHistogramDataPoint attributes */
-  attributes?: IKeyValue[];
-
-  /** ExponentialHistogramDataPoint startTimeUnixNano */
-  startTimeUnixNano?: Fixed64;
-
-  /** ExponentialHistogramDataPoint timeUnixNano */
-  timeUnixNano?: Fixed64;
-
-  /** ExponentialHistogramDataPoint count */
-  count?: number;
-
-  /** ExponentialHistogramDataPoint sum */
-  sum?: number;
-
-  /** ExponentialHistogramDataPoint scale */
-  scale?: number;
-
-  /** ExponentialHistogramDataPoint zeroCount */
-  zeroCount?: number;
-
-  /** ExponentialHistogramDataPoint positive */
-  positive?: IBuckets;
-
-  /** ExponentialHistogramDataPoint negative */
-  negative?: IBuckets;
-
-  /** ExponentialHistogramDataPoint flags */
-  flags?: number;
-
-  /** ExponentialHistogramDataPoint exemplars */
-  exemplars?: IExemplar[];
-
-  /** ExponentialHistogramDataPoint min */
-  min?: number;
-
-  /** ExponentialHistogramDataPoint max */
-  max?: number;
-}
-
-/** Properties of a SummaryDataPoint. */
-export interface ISummaryDataPoint {
-  /** SummaryDataPoint attributes */
-  attributes?: IKeyValue[];
-
-  /** SummaryDataPoint startTimeUnixNano */
-  startTimeUnixNano?: number;
-
-  /** SummaryDataPoint timeUnixNano */
-  timeUnixNano?: string;
-
-  /** SummaryDataPoint count */
-  count?: number;
-
-  /** SummaryDataPoint sum */
-  sum?: number;
-
-  /** SummaryDataPoint quantileValues */
-  quantileValues?: IValueAtQuantile[];
-
-  /** SummaryDataPoint flags */
-  flags?: number;
-}
-
-/** Properties of a ValueAtQuantile. */
-export interface IValueAtQuantile {
-  /** ValueAtQuantile quantile */
-  quantile?: number;
-
-  /** ValueAtQuantile value */
-  value?: number;
-}
-
-/** Properties of a Buckets. */
-export interface IBuckets {
-  /** Buckets offset */
-  offset?: number;
-
-  /** Buckets bucketCounts */
-  bucketCounts?: number[];
-}
-
-/** Properties of an Exemplar. */
-export interface IExemplar {
-  /** Exemplar filteredAttributes */
-  filteredAttributes?: IKeyValue[];
-
-  /** Exemplar timeUnixNano */
-  timeUnixNano?: string;
-
-  /** Exemplar asDouble */
-  asDouble?: number;
-
-  /** Exemplar asInt */
-  asInt?: number;
-
-  /** Exemplar spanId */
-  spanId?: string | Uint8Array;
-
-  /** Exemplar traceId */
-  traceId?: string | Uint8Array;
-}
-
 /**
  * AggregationTemporality defines how a metric aggregator reports aggregated
  * values. It describes how those values relate to the time interval over
  * which they are aggregated.
  */
-export const enum EAggregationTemporality {
+export enum EAggregationTemporality {
   /* UNSPECIFIED is the default AggregationTemporality, it MUST not be used. */
   AGGREGATION_TEMPORALITY_UNSPECIFIED = 0,
 
@@ -365,3 +102,158 @@ export const enum EAggregationTemporality {
   value was reset (e.g. Prometheus). */
   AGGREGATION_TEMPORALITY_CUMULATIVE = 2,
 }
+
+export const OtelMetricTypes = Type.Module({
+  IExportMetricsServiceRequest: Type.Object({
+    resourceMetrics: Type.Array(Type.Ref("IResourceMetrics")),
+  }),
+  IResourceMetrics: Type.Object({
+    resource: Type.Optional(TResource),
+    scopeMetrics: Type.Array(Type.Ref("IScopeMetrics")),
+    schemaUrl: Type.Optional(Type.String()),
+  }),
+  IScopeMetrics: Type.Object({
+    scope: Type.Optional(TInstrumentationScope),
+    metrics: Type.Array(Type.Ref("IMetric")),
+    schemaUrl: Type.Optional(Type.String()),
+  }),
+  IMetric: Type.Object({
+    name: Type.String(),
+    description: Type.Optional(Type.String()),
+    unit: Type.Optional(Type.String()),
+    gauge: Type.Optional(Type.Ref("IGauge")),
+    sum: Type.Optional(Type.Ref("ISum")),
+    histogram: Type.Optional(Type.Ref("IHistogram")),
+    exponentialHistogram: Type.Optional(Type.Ref("IExponentialHistogram")),
+    summary: Type.Optional(Type.Ref("ISummary")),
+  }),
+  IGauge: Type.Object({
+    dataPoints: Type.Array(Type.Ref("INumberDataPoint")),
+  }),
+  ISum: Type.Object({
+    dataPoints: Type.Array(Type.Ref("INumberDataPoint")),
+    aggregationTemporality: Type.Enum(EAggregationTemporality),
+    isMonotonic: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
+  }),
+  IHistogram: Type.Object({
+    dataPoints: Type.Array(Type.Ref("IHistogramDataPoint")),
+    aggregationTemporality: Type.Optional(Type.Enum(EAggregationTemporality)),
+  }),
+  IExponentialHistogram: Type.Object({
+    dataPoints: Type.Array(Type.Ref("IExponentialHistogramDataPoint")),
+    aggregationTemporality: Type.Optional(Type.Enum(EAggregationTemporality)),
+  }),
+  ISummary: Type.Object({
+    dataPoints: Type.Array(Type.Ref("ISummaryDataPoint")),
+  }),
+  INumberDataPoint: Type.Object({
+    attributes: Type.Array(TKeyValue),
+    startTimeUnixNano: Type.Optional(TFixed64),
+    timeUnixNano: Type.Optional(TFixed64),
+    asDouble: Type.Optional(Type.Union([Type.Number(), Type.Null()])),
+    asInt: Type.Optional(Type.Number()),
+    exemplars: Type.Optional(Type.Array(Type.Ref("IExemplar"))),
+    flags: Type.Optional(Type.Number()),
+  }),
+  IHistogramDataPoint: Type.Object({
+    attributes: Type.Optional(Type.Array(TKeyValue)),
+    startTimeUnixNano: Type.Optional(TFixed64),
+    timeUnixNano: Type.Optional(TFixed64),
+    count: Type.Optional(Type.Number()),
+    sum: Type.Optional(Type.Number()),
+    bucketCounts: Type.Optional(Type.Array(Type.Number())),
+    explicitBounds: Type.Optional(Type.Array(Type.Number())),
+    exemplars: Type.Optional(Type.Array(Type.Ref("IExemplar"))),
+    flags: Type.Optional(Type.Number()),
+    min: Type.Optional(Type.Number()),
+    max: Type.Optional(Type.Number()),
+  }),
+  IExponentialHistogramDataPoint: Type.Object({
+    attributes: Type.Optional(Type.Array(TKeyValue)),
+    startTimeUnixNano: Type.Optional(TFixed64),
+    timeUnixNano: Type.Optional(TFixed64),
+    count: Type.Optional(Type.Number()),
+    sum: Type.Optional(Type.Number()),
+    scale: Type.Optional(Type.Number()),
+    zeroCount: Type.Optional(Type.Number()),
+    positive: Type.Optional(Type.Ref("IBuckets")),
+    negative: Type.Optional(Type.Ref("IBuckets")),
+    flags: Type.Optional(Type.Number()),
+    exemplars: Type.Optional(Type.Array(Type.Ref("IExemplar"))),
+    min: Type.Optional(Type.Number()),
+    max: Type.Optional(Type.Number()),
+  }),
+  ISummaryDataPoint: Type.Object({
+    attributes: Type.Optional(Type.Array(TKeyValue)),
+    startTimeUnixNano: Type.Optional(Type.Number()),
+    timeUnixNano: Type.Optional(Type.String()),
+    count: Type.Optional(Type.Number()),
+    sum: Type.Optional(Type.Number()),
+    quantileValues: Type.Optional(Type.Array(Type.Ref("IValueAtQuantile"))),
+    flags: Type.Optional(Type.Number()),
+  }),
+  IValueAtQuantile: Type.Object({
+    quantile: Type.Optional(Type.Number()),
+    value: Type.Optional(Type.Number()),
+  }),
+  IBuckets: Type.Object({
+    offset: Type.Optional(Type.Number()),
+    bucketCounts: Type.Optional(Type.Array(Type.Number())),
+  }),
+  IExemplar: Type.Object({
+    filteredAttributes: Type.Optional(Type.Array(TKeyValue)),
+    timeUnixNano: Type.Optional(Type.String()),
+    asDouble: Type.Optional(Type.Number()),
+    asInt: Type.Optional(Type.Number()),
+    spanId: Type.Optional(Type.Union([Type.String(), Type.Uint8Array()])),
+    traceId: Type.Optional(Type.Union([Type.String(), Type.Uint8Array()])),
+  }),
+});
+
+export const TExportMetricsServiceRequest = OtelMetricTypes.Import("IExportMetricsServiceRequest");
+export type IExportMetricsServiceRequest = Static<typeof TExportMetricsServiceRequest>;
+
+export const TResourceMetrics = OtelMetricTypes.Import("IResourceMetrics");
+export type IResourceMetrics = Static<typeof TResourceMetrics>;
+
+export const TScopeMetrics = OtelMetricTypes.Import("IScopeMetrics");
+export type IScopeMetrics = Static<typeof TScopeMetrics>;
+
+export const TMetric = OtelMetricTypes.Import("IMetric");
+export type IMetric = Static<typeof TMetric>;
+
+export const TGauge = OtelMetricTypes.Import("IGauge");
+export type IGauge = Static<typeof TGauge>;
+
+export const TSum = OtelMetricTypes.Import("ISum");
+export type ISum = Static<typeof TSum>;
+
+export const THistogram = OtelMetricTypes.Import("IHistogram");
+export type IHistogram = Static<typeof THistogram>;
+
+export const TExponentialHistogram = OtelMetricTypes.Import("IExponentialHistogram");
+export type IExponentialHistogram = Static<typeof TExponentialHistogram>;
+
+export const TSummary = OtelMetricTypes.Import("ISummary");
+export type ISummary = Static<typeof TSummary>;
+
+export const TNumberDataPoint = OtelMetricTypes.Import("INumberDataPoint");
+export type INumberDataPoint = Static<typeof TNumberDataPoint>;
+
+export const THistogramDataPoint = OtelMetricTypes.Import("IHistogramDataPoint");
+export type IHistogramDataPoint = Static<typeof THistogramDataPoint>;
+
+export const TExponentialHistogramDataPoint = OtelMetricTypes.Import("IExponentialHistogramDataPoint");
+export type IExponentialHistogramDataPoint = Static<typeof TExponentialHistogramDataPoint>;
+
+export const TSummaryDataPoint = OtelMetricTypes.Import("ISummaryDataPoint");
+export type ISummaryDataPoint = Static<typeof TSummaryDataPoint>;
+
+export const TValueAtQuantile = OtelMetricTypes.Import("IValueAtQuantile");
+export type IValueAtQuantile = Static<typeof TValueAtQuantile>;
+
+export const TBuckets = OtelMetricTypes.Import("IBuckets");
+export type IBuckets = Static<typeof TBuckets>;
+
+export const TExemplar = OtelMetricTypes.Import("IExemplar");
+export type IExemplar = Static<typeof TExemplar>;

--- a/experimental/packages/otlp-transformer/src/protobuf/index.ts
+++ b/experimental/packages/otlp-transformer/src/protobuf/index.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {
+  ProtobufTraceSerializer,
+  ProtobufMetricsSerializer,
+  ProtobufLogsSerializer,
+} from './serializers';

--- a/experimental/packages/otlp-transformer/src/resource/types.ts
+++ b/experimental/packages/otlp-transformer/src/resource/types.ts
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-import { IKeyValue } from '../common/types';
+import { TKeyValue } from '../common/types';
+import { Type, type Static } from "@sinclair/typebox";
 
-/** Properties of a Resource. */
-export interface IResource {
-  /** Resource attributes */
-  attributes: IKeyValue[];
+export const OtelResourceTypes = Type.Module({
+  IResource: Type.Object({
+    attributes: Type.Array(TKeyValue),
+    droppedAttributesCount: Type.Number(),
+  }),
+});
 
-  /** Resource droppedAttributesCount */
-  droppedAttributesCount: number;
-}
+export const TResource = OtelResourceTypes.Import("IResource");
+export type IResource = Static<typeof TResource>;

--- a/experimental/packages/otlp-transformer/src/trace/types.ts
+++ b/experimental/packages/otlp-transformer/src/trace/types.ts
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-import { Fixed64, IInstrumentationScope, IKeyValue } from '../common/types';
-import { IResource } from '../resource/types';
 
-/** Properties of an ExportTraceServiceRequest. */
-export interface IExportTraceServiceRequest {
-  /** ExportTraceServiceRequest resourceSpans */
-  resourceSpans?: IResourceSpans[];
-}
+import { TFixed64, TInstrumentationScope, TKeyValue } from '../common/types';
+import { Type, type Static } from "@sinclair/typebox";
+import { TResource } from '../resource/types';
 
 export interface IExportTraceServiceResponse {
   /** ExportTraceServiceResponse partialSuccess */
@@ -34,78 +30,6 @@ export interface IExportTracePartialSuccess {
 
   /** ExportLogsServiceResponse errorMessage */
   errorMessage?: string;
-}
-
-/** Properties of a ResourceSpans. */
-export interface IResourceSpans {
-  /** ResourceSpans resource */
-  resource?: IResource;
-
-  /** ResourceSpans scopeSpans */
-  scopeSpans: IScopeSpans[];
-
-  /** ResourceSpans schemaUrl */
-  schemaUrl?: string;
-}
-
-/** Properties of an ScopeSpans. */
-export interface IScopeSpans {
-  /** IScopeSpans scope */
-  scope?: IInstrumentationScope;
-
-  /** IScopeSpans spans */
-  spans?: ISpan[];
-
-  /** IScopeSpans schemaUrl */
-  schemaUrl?: string | null;
-}
-
-/** Properties of a Span. */
-export interface ISpan {
-  /** Span traceId */
-  traceId: string | Uint8Array;
-
-  /** Span spanId */
-  spanId: string | Uint8Array;
-
-  /** Span traceState */
-  traceState?: string | null;
-
-  /** Span parentSpanId */
-  parentSpanId?: string | Uint8Array;
-
-  /** Span name */
-  name: string;
-
-  /** Span kind */
-  kind: ESpanKind;
-
-  /** Span startTimeUnixNano */
-  startTimeUnixNano: Fixed64;
-
-  /** Span endTimeUnixNano */
-  endTimeUnixNano: Fixed64;
-
-  /** Span attributes */
-  attributes: IKeyValue[];
-
-  /** Span droppedAttributesCount */
-  droppedAttributesCount: number;
-
-  /** Span events */
-  events: IEvent[];
-
-  /** Span droppedEventsCount */
-  droppedEventsCount: number;
-
-  /** Span links */
-  links: ILink[];
-
-  /** Span droppedLinksCount */
-  droppedLinksCount: number;
-
-  /** Span status */
-  status: IStatus;
 }
 
 /**
@@ -144,17 +68,8 @@ export enum ESpanKind {
   SPAN_KIND_CONSUMER = 5,
 }
 
-/** Properties of a Status. */
-export interface IStatus {
-  /** Status message */
-  message?: string;
-
-  /** Status code */
-  code: EStatusCode;
-}
-
 /** StatusCode enum. */
-export const enum EStatusCode {
+export enum EStatusCode {
   /** The default status. */
   STATUS_CODE_UNSET = 0,
   /** The Span has been evaluated by an Application developers or Operator to have completed successfully. */
@@ -163,35 +78,73 @@ export const enum EStatusCode {
   STATUS_CODE_ERROR = 2,
 }
 
-/** Properties of an Event. */
-export interface IEvent {
-  /** Event timeUnixNano */
-  timeUnixNano: Fixed64;
+export const OtelTraceTypes = Type.Module({
+  IExportTraceServiceRequest: Type.Object({
+    resourceSpans: Type.Optional(Type.Array(Type.Ref("IResourceSpans"))),
+  }),
+  IResourceSpans: Type.Object({
+    resource: Type.Optional(TResource),
+    scopeSpans: Type.Array(Type.Ref("IScopeSpans")),
+    schemaUrl: Type.Optional(Type.String()),
+  }),
+  IScopeSpans: Type.Object({
+    scope: Type.Optional(TInstrumentationScope),
+    spans: Type.Optional(Type.Array(Type.Ref("ISpan"))),
+    schemaUrl: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+  }),
+  ISpan: Type.Object({
+    traceId: Type.Union([Type.String(), Type.Uint8Array()]),
+    spanId: Type.Union([Type.String(), Type.Uint8Array()]),
+    traceState: Type.Optional(Type.Union([Type.String(), Type.Null()])),
+    parentSpanId: Type.Optional(Type.Union([Type.String(), Type.Uint8Array()])),
+    name: Type.String(),
+    kind: Type.Enum(ESpanKind),
+    startTimeUnixNano: TFixed64,
+    endTimeUnixNano: TFixed64,
+    attributes: Type.Array(TKeyValue),
+    droppedAttributesCount: Type.Number(),
+    events: Type.Array(Type.Ref("IEvent")),
+    droppedEventsCount: Type.Number(),
+    links: Type.Array(Type.Ref("ILink")),
+    droppedLinksCount: Type.Number(),
+    status: Type.Ref("IStatus"),
+  }),
+  IStatus: Type.Object({
+    message: Type.Optional(Type.String()),
+    code: Type.Enum(EStatusCode),
+  }),
+  IEvent: Type.Object({
+    timeUnixNano: TFixed64,
+    name: Type.String(),
+    attributes: Type.Array(TKeyValue),
+    droppedAttributesCount: Type.Number(),
+  }),
+  ILink: Type.Object({
+    traceId: Type.Union([Type.String(), Type.Uint8Array()]),
+    spanId: Type.Union([Type.String(), Type.Uint8Array()]),
+    traceState: Type.Optional(Type.String()),
+    attributes: Type.Array(TKeyValue),
+    droppedAttributesCount: Type.Number(),
+  }),
+});
 
-  /** Event name */
-  name: string;
+export const TExportTraceServiceRequest = OtelTraceTypes.Import("IExportTraceServiceRequest");
+export type IExportTraceServiceRequest = Static<typeof TExportTraceServiceRequest>;
 
-  /** Event attributes */
-  attributes: IKeyValue[];
+export const TResourceSpans = OtelTraceTypes.Import("IResourceSpans");
+export type IResourceSpans = Static<typeof TResourceSpans>;
 
-  /** Event droppedAttributesCount */
-  droppedAttributesCount: number;
-}
+export const TScopeSpans = OtelTraceTypes.Import("IScopeSpans");
+export type IScopeSpans = Static<typeof TScopeSpans>;
 
-/** Properties of a Link. */
-export interface ILink {
-  /** Link traceId */
-  traceId: string | Uint8Array;
+export const TSpan = OtelTraceTypes.Import("ISpan");
+export type ISpan = Static<typeof TSpan>;
 
-  /** Link spanId */
-  spanId: string | Uint8Array;
+export const TStatus = OtelTraceTypes.Import("IStatus");
+export type IStatus = Static<typeof TStatus>;
 
-  /** Link traceState */
-  traceState?: string;
+export const TEvent = OtelTraceTypes.Import("IEvent");
+export type IEvent = Static<typeof TEvent>;
 
-  /** Link attributes */
-  attributes: IKeyValue[];
-
-  /** Link droppedAttributesCount */
-  droppedAttributesCount: number;
-}
+export const TLink = OtelTraceTypes.Import("ILink");
+export type ILink = Static<typeof TLink>;

--- a/experimental/packages/otlp-transformer/test/logs.test.ts
+++ b/experimental/packages/otlp-transformer/test/logs.test.ts
@@ -21,10 +21,10 @@ import {
   createExportLogsServiceRequest,
   ESeverityNumber,
   IExportLogsServiceRequest,
-  ProtobufLogsSerializer,
-  JsonLogsSerializer,
   OtlpEncodingOptions,
 } from '../src';
+import { JsonLogsSerializer } from '../src/json';
+import { ProtobufLogsSerializer } from '../src/protobuf';
 import { ReadableLogRecord } from '@opentelemetry/sdk-logs';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import { toBase64 } from './utils';

--- a/experimental/packages/otlp-transformer/test/metrics.test.ts
+++ b/experimental/packages/otlp-transformer/test/metrics.test.ts
@@ -26,12 +26,9 @@ import * as assert from 'assert';
 import { createExportMetricsServiceRequest } from '../src/metrics';
 import { EAggregationTemporality } from '../src/metrics/types';
 import { hrTime, hrTimeToNanoseconds } from '@opentelemetry/core';
-import {
-  encodeAsString,
-  encodeAsLongBits,
-  ProtobufMetricsSerializer,
-  JsonMetricsSerializer,
-} from '../src';
+import { encodeAsString, encodeAsLongBits } from '../src';
+import { JsonMetricsSerializer } from '../src/json';
+import { ProtobufMetricsSerializer } from '../src/protobuf';
 import * as root from '../src/generated/root';
 
 const START_TIME = hrTime();

--- a/experimental/packages/otlp-transformer/test/trace.test.ts
+++ b/experimental/packages/otlp-transformer/test/trace.test.ts
@@ -24,9 +24,9 @@ import {
   createExportTraceServiceRequest,
   ESpanKind,
   EStatusCode,
-  ProtobufTraceSerializer,
-  JsonTraceSerializer,
 } from '../src';
+import { JsonTraceSerializer } from '../src/json';
+import { ProtobufTraceSerializer } from '../src/protobuf';
 import { toBase64 } from './utils';
 
 function createExpectedSpanJson(options: OtlpEncodingOptions) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1167,6 +1167,7 @@
         "@opentelemetry/sdk-logs": "0.56.0",
         "@opentelemetry/sdk-metrics": "1.29.0",
         "@opentelemetry/sdk-trace-base": "1.29.0",
+        "@sinclair/typebox": "0.34.11",
         "protobufjs": "^7.3.0"
       },
       "devDependencies": {
@@ -1186,7 +1187,7 @@
         "nyc": "15.1.0",
         "protobufjs-cli": "1.1.3",
         "ts-loader": "9.5.1",
-        "typescript": "4.4.4",
+        "typescript": "5.7.2",
         "webpack": "5.96.1"
       },
       "engines": {
@@ -1194,6 +1195,26 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "experimental/packages/otlp-transformer/node_modules/@sinclair/typebox": {
+      "version": "0.34.11",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.11.tgz",
+      "integrity": "sha512-zE9pWGVSG82z+sFO+oUmqmqRVm8Wg5sVhmljYi1fDhLOSphBBy939QmC/qXcKFWqTiRJ6keyG4y75bIoTPRBAw==",
+      "license": "MIT"
+    },
+    "experimental/packages/otlp-transformer/node_modules/typescript": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "experimental/packages/sampler-jaeger-remote": {
@@ -32466,6 +32487,7 @@
         "@opentelemetry/sdk-logs": "0.56.0",
         "@opentelemetry/sdk-metrics": "1.29.0",
         "@opentelemetry/sdk-trace-base": "1.29.0",
+        "@sinclair/typebox": "0.34.11",
         "@types/mocha": "10.0.10",
         "@types/webpack-env": "1.16.3",
         "babel-plugin-istanbul": "7.0.0",
@@ -32482,8 +32504,21 @@
         "protobufjs": "^7.3.0",
         "protobufjs-cli": "1.1.3",
         "ts-loader": "9.5.1",
-        "typescript": "4.4.4",
+        "typescript": "5.7.2",
         "webpack": "5.96.1"
+      },
+      "dependencies": {
+        "@sinclair/typebox": {
+          "version": "0.34.11",
+          "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.11.tgz",
+          "integrity": "sha512-zE9pWGVSG82z+sFO+oUmqmqRVm8Wg5sVhmljYi1fDhLOSphBBy939QmC/qXcKFWqTiRJ6keyG4y75bIoTPRBAw=="
+        },
+        "typescript": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+          "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+          "dev": true
+        }
       }
     },
     "@opentelemetry/propagator-b3": {


### PR DESCRIPTION
## Which problem is this PR solving?

The goal of `oltp-transformer` is to provide JS-friendly (de)serialization logic for traces, metrics and logs

However, currently, there is no deserialization logic (mostly equivalent to a no-op) for JSON and there are only placeholder types given.

This PR aims to make a big step towards providing proper deserialization by defining a JSON schema for the various formats (defined using Typebox)

This means you can now deserialize a trace for example with the following code

```ts
import { Value } from '@sinclair/typebox/value';

const requestBody = ...; // some raw data you got from somewhere
const parsed = Value.Parse(TExportLogsServiceRequest, request.body);
//        ^? this now has the proper type definition
```

## Short description of the changes

Introduce JSON Schema types for log, trace and metrics in `otlp-transformer` as a setup for proper deserialization

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The previous tests all still pass with the new refactoring. 

You can verify yourself with `npm run test` inside `experimental/packages/otlp-transformer

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
