### PR TITLE
feat(sdk-metrics)!: Drop deprecated `InstrumentDescriptor` export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 
 ### :boom: Breaking Change
 
+* feat(sdk-metrics)!: drop deprecated `InstrumentDescriptor` type; use `MetricDescriptor` instead [#5277](https://github.com/open-telemetry/opentelemetry-js/pull/5266)
 * feat(sdk-metrics)!: bump minimum version of `@opentelemetry/api` peer dependency to 1.9.0 [#5254](https://github.com/open-telemetry/opentelemetry-js/pull/5254) @chancancode
 * chore(shim-opentracing): replace deprecated SpanAttributes [#4430](https://github.com/open-telemetry/opentelemetry-js/pull/4430) @JamieDanielson
 * chore(otel-core): replace deprecated SpanAttributes [#4408](https://github.com/open-telemetry/opentelemetry-js/pull/4408) @JamieDanielson
@@ -33,6 +34,7 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 
 ### :house: (Internal)
 
+* refactor(sdk-metrics): the internal `InstrumentDescriptor` type now extends `MetricDescriptor`; moved public `InstrumentType` type enum into `./src/export/MetricData.ts` [#5277](https://github.com/open-telemetry/opentelemetry-js/pull/5266)
 * refactor(sdk-metrics): remove `Gauge` and `MetricAdvice` workaround types in favor of the upstream `@opentelemetry/api` types [#5254](https://github.com/open-telemetry/opentelemetry-js/pull/5254) @chancancode
 * chore: remove checks for unsupported node versions [#4341](https://github.com/open-telemetry/opentelemetry-js/pull/4341) @dyladan
 * refactor(sdk-trace-base): remove `BasicTracerProvider._registeredSpanProcessors` private property. [#5134](https://github.com/open-telemetry/opentelemetry-js/pull/5134) @david-luna

--- a/packages/sdk-metrics/src/InstrumentDescriptor.ts
+++ b/packages/sdk-metrics/src/InstrumentDescriptor.ts
@@ -22,19 +22,7 @@ import {
 } from '@opentelemetry/api';
 import { View } from './view/View';
 import { equalsCaseInsensitive } from './utils';
-
-/**
- * Supported types of metric instruments.
- */
-export enum InstrumentType {
-  COUNTER = 'COUNTER',
-  GAUGE = 'GAUGE',
-  HISTOGRAM = 'HISTOGRAM',
-  UP_DOWN_COUNTER = 'UP_DOWN_COUNTER',
-  OBSERVABLE_COUNTER = 'OBSERVABLE_COUNTER',
-  OBSERVABLE_GAUGE = 'OBSERVABLE_GAUGE',
-  OBSERVABLE_UP_DOWN_COUNTER = 'OBSERVABLE_UP_DOWN_COUNTER',
-}
+import { InstrumentType, MetricDescriptor } from './export/MetricData';
 
 /**
  * An internal interface describing the instrument.
@@ -42,12 +30,7 @@ export enum InstrumentType {
  * This is intentionally distinguished from the public MetricDescriptor (a.k.a. InstrumentDescriptor)
  * which may not contains internal fields like metric advice.
  */
-export interface InstrumentDescriptor {
-  readonly name: string;
-  readonly description: string;
-  readonly unit: string;
-  readonly type: InstrumentType;
-  readonly valueType: ValueType;
+export interface InstrumentDescriptor extends MetricDescriptor {
   /**
    * See {@link MetricAdvice}
    *

--- a/packages/sdk-metrics/src/Meter.ts
+++ b/packages/sdk-metrics/src/Meter.ts
@@ -27,10 +27,7 @@ import {
   BatchObservableCallback,
   Observable,
 } from '@opentelemetry/api';
-import {
-  createInstrumentDescriptor,
-  InstrumentType,
-} from './InstrumentDescriptor';
+import { createInstrumentDescriptor } from './InstrumentDescriptor';
 import {
   CounterInstrument,
   GaugeInstrument,
@@ -41,6 +38,7 @@ import {
   UpDownCounterInstrument,
 } from './Instruments';
 import { MeterSharedState } from './state/MeterSharedState';
+import { InstrumentType } from './export/MetricData';
 
 /**
  * This class implements the {@link IMeter} interface.

--- a/packages/sdk-metrics/src/aggregator/ExponentialHistogram.ts
+++ b/packages/sdk-metrics/src/aggregator/ExponentialHistogram.ts
@@ -24,10 +24,10 @@ import {
 import {
   DataPointType,
   ExponentialHistogramMetricData,
+  InstrumentType,
   MetricDescriptor,
 } from '../export/MetricData';
 import { diag, HrTime } from '@opentelemetry/api';
-import { InstrumentType } from '../InstrumentDescriptor';
 import { Maybe } from '../utils';
 import { AggregationTemporality } from '../export/AggregationTemporality';
 import { Buckets } from './exponential-histogram/Buckets';

--- a/packages/sdk-metrics/src/aggregator/Histogram.ts
+++ b/packages/sdk-metrics/src/aggregator/Histogram.ts
@@ -23,10 +23,10 @@ import {
 import {
   DataPointType,
   HistogramMetricData,
+  InstrumentType,
   MetricDescriptor,
 } from '../export/MetricData';
 import { HrTime } from '@opentelemetry/api';
-import { InstrumentType } from '../InstrumentDescriptor';
 import { binarySearchUB, Maybe } from '../utils';
 import { AggregationTemporality } from '../export/AggregationTemporality';
 

--- a/packages/sdk-metrics/src/export/AggregationSelector.ts
+++ b/packages/sdk-metrics/src/export/AggregationSelector.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { InstrumentType } from '../InstrumentDescriptor';
 import { AggregationTemporality } from './AggregationTemporality';
+import { InstrumentType } from './MetricData';
 import { AggregationOption, AggregationType } from '../view/AggregationOption';
 
 /**

--- a/packages/sdk-metrics/src/export/CardinalitySelector.ts
+++ b/packages/sdk-metrics/src/export/CardinalitySelector.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { InstrumentType } from '../InstrumentDescriptor';
+import { InstrumentType } from './MetricData';
+
 /**
  * Cardinality Limit selector based on metric instrument types.
  */

--- a/packages/sdk-metrics/src/export/ConsoleMetricExporter.ts
+++ b/packages/sdk-metrics/src/export/ConsoleMetricExporter.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 import { ExportResult, ExportResultCode } from '@opentelemetry/core';
-import { InstrumentType } from '../InstrumentDescriptor';
 import { AggregationTemporality } from './AggregationTemporality';
-import { ResourceMetrics } from './MetricData';
+import { ResourceMetrics, InstrumentType } from './MetricData';
 import { PushMetricExporter } from './MetricExporter';
 import {
   AggregationTemporalitySelector,

--- a/packages/sdk-metrics/src/export/InMemoryMetricExporter.ts
+++ b/packages/sdk-metrics/src/export/InMemoryMetricExporter.ts
@@ -16,9 +16,8 @@
 
 import { ExportResultCode } from '@opentelemetry/core';
 import { ExportResult } from '@opentelemetry/core';
-import { InstrumentType } from '../InstrumentDescriptor';
 import { AggregationTemporality } from './AggregationTemporality';
-import { ResourceMetrics } from './MetricData';
+import { InstrumentType, ResourceMetrics } from './MetricData';
 import { PushMetricExporter } from './MetricExporter';
 
 /**

--- a/packages/sdk-metrics/src/export/MetricData.ts
+++ b/packages/sdk-metrics/src/export/MetricData.ts
@@ -17,9 +17,21 @@
 import { HrTime, Attributes, ValueType } from '@opentelemetry/api';
 import { InstrumentationScope } from '@opentelemetry/core';
 import { IResource } from '@opentelemetry/resources';
-import { InstrumentType } from '../InstrumentDescriptor';
 import { AggregationTemporality } from './AggregationTemporality';
 import { Histogram, ExponentialHistogram } from '../aggregator/types';
+
+/**
+ * Supported types of metric instruments.
+ */
+export enum InstrumentType {
+  COUNTER = 'COUNTER',
+  GAUGE = 'GAUGE',
+  HISTOGRAM = 'HISTOGRAM',
+  UP_DOWN_COUNTER = 'UP_DOWN_COUNTER',
+  OBSERVABLE_COUNTER = 'OBSERVABLE_COUNTER',
+  OBSERVABLE_GAUGE = 'OBSERVABLE_GAUGE',
+  OBSERVABLE_UP_DOWN_COUNTER = 'OBSERVABLE_UP_DOWN_COUNTER',
+}
 
 export interface MetricDescriptor {
   readonly name: string;

--- a/packages/sdk-metrics/src/export/MetricExporter.ts
+++ b/packages/sdk-metrics/src/export/MetricExporter.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { AggregationTemporality } from './AggregationTemporality';
-import { ResourceMetrics } from './MetricData';
 import { ExportResult } from '@opentelemetry/core';
-import { InstrumentType } from '../InstrumentDescriptor';
+import { AggregationTemporality } from './AggregationTemporality';
+import { InstrumentType, ResourceMetrics } from './MetricData';
 import { AggregationOption } from '../view/AggregationOption';
 
 /**

--- a/packages/sdk-metrics/src/export/MetricReader.ts
+++ b/packages/sdk-metrics/src/export/MetricReader.ts
@@ -17,9 +17,8 @@
 import * as api from '@opentelemetry/api';
 import { AggregationTemporality } from './AggregationTemporality';
 import { MetricProducer } from './MetricProducer';
-import { CollectionResult } from './MetricData';
+import { CollectionResult, InstrumentType } from './MetricData';
 import { FlatMap, callWithTimeout } from '../utils';
-import { InstrumentType } from '../InstrumentDescriptor';
 import {
   CollectionOptions,
   ForceFlushOptions,

--- a/packages/sdk-metrics/src/index.ts
+++ b/packages/sdk-metrics/src/index.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { MetricDescriptor } from './export/MetricData';
-
 export {
   Sum,
   LastValue,
@@ -36,6 +34,7 @@ export {
   SumMetricData,
   GaugeMetricData,
   HistogramMetricData,
+  InstrumentType,
   ExponentialHistogramMetricData,
   ResourceMetrics,
   ScopeMetrics,
@@ -58,12 +57,6 @@ export { InMemoryMetricExporter } from './export/InMemoryMetricExporter';
 export { ConsoleMetricExporter } from './export/ConsoleMetricExporter';
 
 export { MetricCollectOptions, MetricProducer } from './export/MetricProducer';
-
-export { InstrumentType } from './InstrumentDescriptor';
-/**
- * @deprecated Use {@link MetricDescriptor} instead.
- */
-export type InstrumentDescriptor = MetricDescriptor;
 
 export { MeterProvider, MeterProviderOptions } from './MeterProvider';
 

--- a/packages/sdk-metrics/src/state/MeterProviderSharedState.ts
+++ b/packages/sdk-metrics/src/state/MeterProviderSharedState.ts
@@ -16,13 +16,13 @@
 
 import { InstrumentationScope } from '@opentelemetry/core';
 import { IResource } from '@opentelemetry/resources';
-import { InstrumentType } from '..';
 import { instrumentationScopeId } from '../utils';
 import { ViewRegistry } from '../view/ViewRegistry';
 import { MeterSharedState } from './MeterSharedState';
 import { MetricCollector, MetricCollectorHandle } from './MetricCollector';
 import { toAggregation } from '../view/AggregationOption';
 import { Aggregation } from '../view/Aggregation';
+import { InstrumentType } from '../export/MetricData';
 
 /**
  * An internal record for shared meter provider states.

--- a/packages/sdk-metrics/src/state/MetricCollector.ts
+++ b/packages/sdk-metrics/src/state/MetricCollector.ts
@@ -16,10 +16,13 @@
 
 import { millisToHrTime } from '@opentelemetry/core';
 import { AggregationTemporalitySelector } from '../export/AggregationSelector';
-import { CollectionResult, ScopeMetrics } from '../export/MetricData';
+import {
+  CollectionResult,
+  InstrumentType,
+  ScopeMetrics,
+} from '../export/MetricData';
 import { MetricProducer, MetricCollectOptions } from '../export/MetricProducer';
 import { MetricReader } from '../export/MetricReader';
-import { InstrumentType } from '../InstrumentDescriptor';
 import { ForceFlushOptions, ShutdownOptions } from '../types';
 import { MeterProviderSharedState } from './MeterProviderSharedState';
 

--- a/packages/sdk-metrics/src/view/Aggregation.ts
+++ b/packages/sdk-metrics/src/view/Aggregation.ts
@@ -24,8 +24,9 @@ import {
   ExponentialHistogramAggregator,
 } from '../aggregator';
 import { Accumulation } from '../aggregator/types';
-import { InstrumentDescriptor, InstrumentType } from '../InstrumentDescriptor';
+import { InstrumentDescriptor } from '../InstrumentDescriptor';
 import { Maybe } from '../utils';
+import { InstrumentType } from '../export/MetricData';
 
 /**
  * Configures how measurements are combined into metrics for views.

--- a/packages/sdk-metrics/src/view/InstrumentSelector.ts
+++ b/packages/sdk-metrics/src/view/InstrumentSelector.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { InstrumentType } from '../InstrumentDescriptor';
 import { ExactPredicate, PatternPredicate, Predicate } from './Predicate';
+import { InstrumentType } from '../export/MetricData';
 
 export interface InstrumentSelectorCriteria {
   name?: string;

--- a/packages/sdk-metrics/src/view/View.ts
+++ b/packages/sdk-metrics/src/view/View.ts
@@ -23,12 +23,12 @@ import {
 import { InstrumentSelector } from './InstrumentSelector';
 import { MeterSelector } from './MeterSelector';
 import { Aggregation } from './Aggregation';
-import { InstrumentType } from '../InstrumentDescriptor';
 import {
   AggregationOption,
   AggregationType,
   toAggregation,
 } from './AggregationOption';
+import { InstrumentType } from '../export/MetricData';
 
 export type ViewOptions = {
   /**

--- a/packages/sdk-metrics/test/InstrumentDescriptor.test.ts
+++ b/packages/sdk-metrics/test/InstrumentDescriptor.test.ts
@@ -18,10 +18,10 @@ import * as assert from 'assert';
 import {
   createInstrumentDescriptor,
   InstrumentDescriptor,
-  InstrumentType,
   isValidName,
   isDescriptorCompatibleWith,
 } from '../src/InstrumentDescriptor';
+import { InstrumentType } from '../src';
 import { invalidNames, validNames } from './util';
 import { ValueType } from '@opentelemetry/api';
 

--- a/packages/sdk-metrics/test/util.ts
+++ b/packages/sdk-metrics/test/util.ts
@@ -24,11 +24,9 @@ import {
 import { InstrumentationScope } from '@opentelemetry/core';
 import { Resource } from '@opentelemetry/resources';
 import * as assert from 'assert';
+import { InstrumentDescriptor } from '../src/InstrumentDescriptor';
 import {
-  InstrumentDescriptor,
   InstrumentType,
-} from '../src/InstrumentDescriptor';
-import {
   MetricData,
   DataPoint,
   DataPointType,

--- a/packages/sdk-metrics/test/view/Aggregation.test.ts
+++ b/packages/sdk-metrics/test/view/Aggregation.test.ts
@@ -15,6 +15,7 @@
  */
 
 import * as assert from 'assert';
+import { InstrumentType } from '../../src';
 import {
   Aggregator,
   DropAggregator,
@@ -22,10 +23,7 @@ import {
   LastValueAggregator,
   SumAggregator,
 } from '../../src/aggregator';
-import {
-  InstrumentDescriptor,
-  InstrumentType,
-} from '../../src/InstrumentDescriptor';
+import { InstrumentDescriptor } from '../../src/InstrumentDescriptor';
 import {
   DefaultAggregation,
   ExplicitBucketHistogramAggregation,


### PR DESCRIPTION
## Which problem is this PR solving?

Drop the `@deprecated` `InstrumentDescriptor` type export 

## Short description of the changes

Note that this public `InstrumentDescriptor` has always been just an alias of `MetricDescriptor`, and does not actually point to the internal type with the same name.

Separately:

* Refactor the internal `InstrumentDescriptor` type to extend from the public `MetricDescriptor`, adding only the `advice` field

* Move the `InstrumentType` enum into `./src/export/MetricData.ts` as it is a public export, plus to avoid a circular dependency after the refactor (hence the big diff)

Fixes https://github.com/open-telemetry/opentelemetry-js/pull/5254#issuecomment-2541202896 (cc @pichlermarc)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Internal refactor

## How Has This Been Tested?

- [x] `npm run compile`
- [x] `npm run lint`
- [x] `npm run test:*`

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] ~~Unit tests have been added~~
- [ ] ~~Documentation has been updated~~
