### PR TITLE
fix(ci): adapt workflow to use supported npm versions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node_version:
-          - "18"
+          - "22"
     runs-on: self-hosted
     timeout-minutes: 10
     env:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -72,7 +72,7 @@ jobs:
           node-version: '18'
 
       # npm@11.0.0 drops support for Node.js v18
-      - run: npm install -g npm@"<11.0.0"
+      - run: npm install -g npm@<11.0.0
 
       - name: Bootstrap
         run: npm ci

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: ${{ matrix.node_version }}
 
       - run: npm install -g npm@latest
-        if: ${{ matrix.node_version == '18' || matrix.node_version == '20' || matrix.node_version == '22' }}
+        if: ${{ matrix.node_version == '20' || matrix.node_version == '22' }}
 
       # npm@10.0.0 drops support for Node.js v14 and v16
       - run: npm install -g npm@"<10.0.0"
@@ -69,9 +69,10 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: '22'
+          node-version: '18'
 
-      - run: npm install -g npm@latest
+      # npm@11.0.0 drops support for Node.js v18
+      - run: npm install -g npm@"<11.0.0"
 
       - name: Bootstrap
         run: npm ci

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -38,6 +38,10 @@ jobs:
       - run: npm install -g npm@"<10.0.0"
         if: ${{ matrix.node_version == '14' || matrix.node_version == '16' }}
 
+      # npm@11.0.0 drops support for Node.js v18
+      - run: npm install -g npm@"<11.0.0"
+        if: ${{ matrix.node_version == '18'}}
+
       - name: Bootstrap
         run: npm ci
 
@@ -65,7 +69,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: '18'
+          node-version: '22'
 
       - run: npm install -g npm@latest
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -69,10 +69,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: '18'
+          node-version: '20'
 
-      # npm@11.0.0 drops support for Node.js v18
-      - run: npm install -g npm@<11.0.0
+      - run: npm install -g npm@latest
 
       - name: Bootstrap
         run: npm ci


### PR DESCRIPTION
## Which problem is this PR solving?

- limit to npm@<11 on Node 18 as npm@11.0.0 dropped support for it via the engines field (README.md is not updated yet)
- Updates benchmark workflow to latest LTS Node.js version
- Updates Windows tests to run on Node.js v20