### PR TITLE
chore: removed circular dependency from BasicTracerProvider

### DIFF
--- a/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts
@@ -30,7 +30,8 @@ import {
   merge,
 } from '@opentelemetry/core';
 import { IResource, Resource } from '@opentelemetry/resources';
-import { SpanProcessor, Tracer } from '.';
+import { SpanProcessor } from './SpanProcessor';
+import { Tracer } from './Tracer';
 import { loadDefaultConfig } from './config';
 import { MultiSpanProcessor } from './MultiSpanProcessor';
 import { NoopSpanProcessor } from './export/NoopSpanProcessor';


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
Removing a circular dependency in `opentelemetry-sdk-trace-base` `BasicTracerProvider.ts` which was causing an error on React Native/Babel:
`Cannot read property 'prototype' of undefined`

Simply changed it to direct import, should not be an issue on other platforms.

## Short description of the changes

Changed the import from `'.'` to `'./Tracer'` and `'./SpanProcessor'`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Retried getting a Tracer with the changes and the error was not there anymore, Tracer worked correctly.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
