### PR TITLE
chore(deps): remove webpack-merge where it is not needed

### DIFF
--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -94,8 +94,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -84,8 +84,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -85,8 +85,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -83,8 +83,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -74,8 +74,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -85,8 +85,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -80,8 +80,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -80,8 +80,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -107,8 +107,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "engines": {
     "node": ">=18"

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -112,8 +112,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/sdk-events/package.json
+++ b/experimental/packages/sdk-events/package.json
@@ -88,8 +88,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "dependencies": {
     "@opentelemetry/api-events": "0.57.0",

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -93,8 +93,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "dependencies": {
     "@opentelemetry/api-logs": "0.57.0",

--- a/experimental/packages/web-common/package.json
+++ b/experimental/packages/web-common/package.json
@@ -95,7 +95,6 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -457,8 +457,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -502,8 +501,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -581,8 +579,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -624,8 +621,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -663,8 +659,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -743,8 +738,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -853,8 +847,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -900,8 +893,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -1028,8 +1020,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -1118,8 +1109,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -1311,8 +1301,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=14"
@@ -1362,8 +1351,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -1490,8 +1478,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=14"
@@ -28113,8 +28100,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -28214,8 +28200,7 @@
         "sinon": "15.1.2",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -28386,8 +28371,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -28455,8 +28439,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "engines": {
         "node": ">=18"
@@ -31718,8 +31701,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       }
     },
     "@opentelemetry/exporter-logs-otlp-proto": {
@@ -31753,8 +31735,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       }
     },
     "@opentelemetry/exporter-metrics-otlp-grpc": {
@@ -31813,8 +31794,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       }
     },
     "@opentelemetry/exporter-metrics-otlp-proto": {
@@ -31913,8 +31893,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       }
     },
     "@opentelemetry/exporter-trace-otlp-proto": {
@@ -31946,8 +31925,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       }
     },
     "@opentelemetry/exporter-zipkin": {
@@ -31981,8 +31959,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       }
     },
     "@opentelemetry/instrumentation": {
@@ -32020,8 +31997,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       }
     },
     "@opentelemetry/instrumentation-fetch": {
@@ -32057,8 +32033,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       }
     },
     "@opentelemetry/instrumentation-grpc": {
@@ -32155,8 +32130,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       }
     },
     "@opentelemetry/integration-tests-api": {
@@ -32197,8 +32171,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       }
     },
     "@opentelemetry/otlp-exporter-base": {
@@ -32227,8 +32200,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       }
     },
     "@opentelemetry/otlp-grpc-exporter-base": {
@@ -32350,8 +32322,7 @@
         "sinon": "15.1.2",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "dependencies": {
         "@opentelemetry/api": {
@@ -32461,8 +32432,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "dependencies": {
         "@types/sinon": {
@@ -32504,8 +32474,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "dependencies": {
         "@opentelemetry/api": {
@@ -32569,8 +32538,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       }
     },
     "@opentelemetry/sdk-node": {
@@ -32701,8 +32669,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       }
     },
     "@opentelemetry/selenium-tests": {
@@ -32924,8 +32891,7 @@
         "ts-loader": "9.5.1",
         "typescript": "4.4.4",
         "webpack": "5.96.1",
-        "webpack-cli": "5.1.4",
-        "webpack-merge": "5.10.0"
+        "webpack-cli": "5.1.4"
       },
       "dependencies": {
         "@types/sinon": {

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -83,8 +83,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -84,8 +84,7 @@
     "sinon": "15.1.2",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.3.0 <1.10.0"

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -83,8 +83,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0"

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -75,8 +75,7 @@
     "ts-loader": "9.5.1",
     "typescript": "4.4.4",
     "webpack": "5.96.1",
-    "webpack-cli": "5.1.4",
-    "webpack-merge": "5.10.0"
+    "webpack-cli": "5.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.9.0 <1.10.0"


### PR DESCRIPTION
## Which problem is this PR solving?

Just a quick clean-up. We don't use `webpack-merge` in these packages, so I'm removing the `devDependency`. 