### PR TITLE
feat(sdk-metrics)!: drop deprecated `type` field on `MetricDescriptor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 
 ### :boom: Breaking Change
 
-* feat(sdk-metrics)!: drop deprecated `InstrumentDescriptor` type; use `MetricDescriptor` instead [#5277](https://github.com/open-telemetry/opentelemetry-js/pull/5266)
+* feat(sdk-metrics)!: drop deprecated `type` field on `MetricDescriptor` [#5291](https://github.com/open-telemetry/opentelemetry-js/pull/5291) @chancancode
+* feat(sdk-metrics)!: drop deprecated `InstrumentDescriptor` type; use `MetricDescriptor` instead [#5277](https://github.com/open-telemetry/opentelemetry-js/pull/5266) @chancancode
 * feat(sdk-metrics)!: bump minimum version of `@opentelemetry/api` peer dependency to 1.9.0 [#5254](https://github.com/open-telemetry/opentelemetry-js/pull/5254) @chancancode
 * chore(shim-opentracing): replace deprecated SpanAttributes [#4430](https://github.com/open-telemetry/opentelemetry-js/pull/4430) @JamieDanielson
 * chore(otel-core): replace deprecated SpanAttributes [#4408](https://github.com/open-telemetry/opentelemetry-js/pull/4408) @JamieDanielson

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :boom: Breaking Change
 
+* feat(exporter-prometheus)!: stop the using `type` field to enforce naming conventions [#5291](https://github.com/open-telemetry/opentelemetry-js/pull/5291) @chancancode
+  * Any non-monotonic sums will now be treated as counters and will therefore include the `_total` suffix.
+* feat(shim-opencenus)!: stop mapping removed Instrument `type` to OpenTelemetry metrics [#5291](https://github.com/open-telemetry/opentelemetry-js/pull/5291) @chancancode
+  * The internal OpenTelemetry data model dropped the concept of instrument type on exported metrics, therefore mapping it is not necessary anymore.  
 * feat(instrumentation-fetch)!: passthrough original response to `applyCustomAttributes` hook [#5281](https://github.com/open-telemetry/opentelemetry-js/pull/5281) @chancancode
   * Previously, the fetch instrumentation code unconditionally clones every `fetch()` response in order to preserve the ability for the `applyCustomAttributes` hook to consume the response body. This is fundamentally unsound, as it forces the browser to buffer and retain the response body until it is fully received and read, which crates unnecessary memory pressure on large or long-running response streams. In extreme cases, this is effectively a memory leak and can cause the browser tab to crash. If your use case for `applyCustomAttributes` requires access to the response body, please chime in on [#5293](https://github.com/open-telemetry/opentelemetry-js/issues/5293).
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -389,9 +389,9 @@ describe('PrometheusExporter', () => {
 
       assert.deepStrictEqual(lines, [
         ...serializedDefaultResourceLines,
-        '# HELP metric_observable_counter a test description',
-        '# TYPE metric_observable_counter counter',
-        'metric_observable_counter{key1="attributeValue1"} 20',
+        '# HELP metric_observable_counter_total a test description',
+        '# TYPE metric_observable_counter_total counter',
+        'metric_observable_counter_total{key1="attributeValue1"} 20',
         '',
       ]);
     });

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -107,7 +107,7 @@ describe('PrometheusSerializer', () => {
 
         const result = serializer['_serializeSingularDataPoint'](
           metric.descriptor.name,
-          metric.descriptor.type,
+          metric,
           pointData[0]
         );
         return result;
@@ -162,7 +162,7 @@ describe('PrometheusSerializer', () => {
 
         const result = serializer['_serializeHistogramDataPoint'](
           metric.descriptor.name,
-          metric.descriptor.type,
+          metric,
           pointData[0]
         );
         return result;
@@ -511,7 +511,7 @@ describe('PrometheusSerializer', () => {
       } else {
         const result = serializer['_serializeSingularDataPoint'](
           metric.descriptor.name,
-          metric.descriptor.type,
+          metric,
           pointData[0]
         );
         return result;
@@ -598,7 +598,7 @@ describe('PrometheusSerializer', () => {
 
       const result = serializer['_serializeSingularDataPoint'](
         metric.descriptor.name,
-        metric.descriptor.type,
+        metric,
         pointData[0]
       );
       return result;

--- a/experimental/packages/otlp-transformer/test/metrics.test.ts
+++ b/experimental/packages/otlp-transformer/test/metrics.test.ts
@@ -18,7 +18,6 @@ import { Resource } from '@opentelemetry/resources';
 import {
   AggregationTemporality,
   DataPointType,
-  InstrumentType,
   MetricData,
   ResourceMetrics,
 } from '@opentelemetry/sdk-metrics';
@@ -110,7 +109,6 @@ describe('Metrics', () => {
     return {
       descriptor: {
         description: 'this is a description',
-        type: InstrumentType.COUNTER,
         name: 'counter',
         unit: '1',
         valueType: ValueType.INT,
@@ -136,7 +134,6 @@ describe('Metrics', () => {
     return {
       descriptor: {
         description: 'this is a description',
-        type: InstrumentType.UP_DOWN_COUNTER,
         name: 'up-down-counter',
         unit: '1',
         valueType: ValueType.INT,
@@ -162,7 +159,6 @@ describe('Metrics', () => {
     return {
       descriptor: {
         description: 'this is a description',
-        type: InstrumentType.OBSERVABLE_COUNTER,
         name: 'observable-counter',
         unit: '1',
         valueType: ValueType.INT,
@@ -188,7 +184,6 @@ describe('Metrics', () => {
     return {
       descriptor: {
         description: 'this is a description',
-        type: InstrumentType.OBSERVABLE_UP_DOWN_COUNTER,
         name: 'observable-up-down-counter',
         unit: '1',
         valueType: ValueType.INT,
@@ -211,7 +206,6 @@ describe('Metrics', () => {
     return {
       descriptor: {
         description: 'this is a description',
-        type: InstrumentType.OBSERVABLE_GAUGE,
         name: 'gauge',
         unit: '1',
         valueType: ValueType.DOUBLE,
@@ -241,7 +235,6 @@ describe('Metrics', () => {
     return {
       descriptor: {
         description: 'this is a description',
-        type: InstrumentType.HISTOGRAM,
         name: 'hist',
         unit: '1',
         valueType: ValueType.INT,
@@ -282,7 +275,6 @@ describe('Metrics', () => {
     return {
       descriptor: {
         description: 'this is a description',
-        type: InstrumentType.HISTOGRAM,
         name: 'xhist',
         unit: '1',
         valueType: ValueType.INT,

--- a/experimental/packages/shim-opencensus/src/metric-transform.ts
+++ b/experimental/packages/shim-opencensus/src/metric-transform.ts
@@ -22,14 +22,12 @@ import {
   DataPointType,
   GaugeMetricData,
   HistogramMetricData,
-  InstrumentType,
   MetricData,
   SumMetricData,
 } from '@opentelemetry/sdk-metrics';
 
 type BaseMetric = Omit<MetricData, 'dataPoints' | 'dataPointType'>;
 interface MappedType {
-  type: InstrumentType;
   valueType: ValueType;
   dataPointType:
     | DataPointType.GAUGE
@@ -51,7 +49,6 @@ export function mapOcMetric(metric: oc.Metric): MetricData | null {
       description,
       name,
       unit,
-      type: mappedType.type,
       valueType: mappedType.valueType,
     },
   };
@@ -72,33 +69,28 @@ function mapOcMetricDescriptorType(
   switch (type) {
     case oc.MetricDescriptorType.GAUGE_INT64:
       return {
-        type: InstrumentType.OBSERVABLE_GAUGE,
         valueType: ValueType.INT,
         dataPointType: DataPointType.GAUGE,
       };
     case oc.MetricDescriptorType.GAUGE_DOUBLE:
       return {
-        type: InstrumentType.OBSERVABLE_GAUGE,
         valueType: ValueType.DOUBLE,
         dataPointType: DataPointType.GAUGE,
       };
 
     case oc.MetricDescriptorType.CUMULATIVE_INT64:
       return {
-        type: InstrumentType.COUNTER,
         valueType: ValueType.INT,
         dataPointType: DataPointType.SUM,
       };
     case oc.MetricDescriptorType.CUMULATIVE_DOUBLE:
       return {
-        type: InstrumentType.COUNTER,
         valueType: ValueType.DOUBLE,
         dataPointType: DataPointType.SUM,
       };
 
     case oc.MetricDescriptorType.CUMULATIVE_DISTRIBUTION:
       return {
-        type: InstrumentType.HISTOGRAM,
         valueType: ValueType.DOUBLE,
         dataPointType: DataPointType.HISTOGRAM,
       };

--- a/experimental/packages/shim-opencensus/test/OpenCensusMetricProducer.test.ts
+++ b/experimental/packages/shim-opencensus/test/OpenCensusMetricProducer.test.ts
@@ -100,7 +100,6 @@ describe('OpenCensusMetricProducer', () => {
     assert.deepStrictEqual(ocMetric.descriptor, {
       description: 'Test OC description',
       name: 'measure',
-      type: 'COUNTER',
       unit: 'ms',
       valueType: ValueType.DOUBLE,
     });

--- a/experimental/packages/shim-opencensus/test/metric-transform.test.ts
+++ b/experimental/packages/shim-opencensus/test/metric-transform.test.ts
@@ -23,7 +23,6 @@ import {
   DataPointType,
   GaugeMetricData,
   HistogramMetricData,
-  InstrumentType,
   SumMetricData,
 } from '@opentelemetry/sdk-metrics';
 import * as assert from 'assert';
@@ -64,7 +63,6 @@ describe('metric-transform', () => {
       descriptor: {
         description: 'ocDescription',
         name: 'ocMetricName',
-        type: InstrumentType.COUNTER,
         unit: 'ocUnit',
         valueType: ValueType.INT,
       },
@@ -107,7 +105,6 @@ describe('metric-transform', () => {
       descriptor: {
         description: 'ocDescription',
         name: 'ocMetricName',
-        type: InstrumentType.COUNTER,
         unit: 'ocUnit',
         valueType: ValueType.DOUBLE,
       },
@@ -177,7 +174,6 @@ describe('metric-transform', () => {
       descriptor: {
         description: 'ocDescription',
         name: 'ocMetricName',
-        type: InstrumentType.HISTOGRAM,
         unit: 'ocUnit',
         valueType: ValueType.DOUBLE,
       },
@@ -219,7 +215,6 @@ describe('metric-transform', () => {
       descriptor: {
         description: 'ocDescription',
         name: 'ocMetricName',
-        type: InstrumentType.OBSERVABLE_GAUGE,
         unit: 'ocUnit',
         valueType: ValueType.INT,
       },
@@ -261,7 +256,6 @@ describe('metric-transform', () => {
       descriptor: {
         description: 'ocDescription',
         name: 'ocMetricName',
-        type: InstrumentType.OBSERVABLE_GAUGE,
         unit: 'ocUnit',
         valueType: ValueType.DOUBLE,
       },

--- a/packages/sdk-metrics/src/InstrumentDescriptor.ts
+++ b/packages/sdk-metrics/src/InstrumentDescriptor.ts
@@ -32,6 +32,12 @@ import { InstrumentType, MetricDescriptor } from './export/MetricData';
  */
 export interface InstrumentDescriptor extends MetricDescriptor {
   /**
+   * For internal use; exporter should avoid depending on the type of the
+   * instrument as their resulting aggregator can be re-mapped with views.
+   */
+  readonly type: InstrumentType;
+
+  /**
    * See {@link MetricAdvice}
    *
    * @experimental

--- a/packages/sdk-metrics/src/aggregator/ExponentialHistogram.ts
+++ b/packages/sdk-metrics/src/aggregator/ExponentialHistogram.ts
@@ -25,11 +25,11 @@ import {
   DataPointType,
   ExponentialHistogramMetricData,
   InstrumentType,
-  MetricDescriptor,
 } from '../export/MetricData';
 import { diag, HrTime } from '@opentelemetry/api';
 import { Maybe } from '../utils';
 import { AggregationTemporality } from '../export/AggregationTemporality';
+import { InstrumentDescriptor } from '../InstrumentDescriptor';
 import { Buckets } from './exponential-histogram/Buckets';
 import { getMapping } from './exponential-histogram/mapping/getMapping';
 import { Mapping } from './exponential-histogram/mapping/types';
@@ -566,7 +566,7 @@ export class ExponentialHistogramAggregator
   }
 
   toMetricData(
-    descriptor: MetricDescriptor,
+    descriptor: InstrumentDescriptor,
     aggregationTemporality: AggregationTemporality,
     accumulationByAttributes: AccumulationRecord<ExponentialHistogramAccumulation>[],
     endTime: HrTime

--- a/packages/sdk-metrics/src/aggregator/Histogram.ts
+++ b/packages/sdk-metrics/src/aggregator/Histogram.ts
@@ -24,11 +24,11 @@ import {
   DataPointType,
   HistogramMetricData,
   InstrumentType,
-  MetricDescriptor,
 } from '../export/MetricData';
 import { HrTime } from '@opentelemetry/api';
 import { binarySearchUB, Maybe } from '../utils';
 import { AggregationTemporality } from '../export/AggregationTemporality';
+import { InstrumentDescriptor } from '../InstrumentDescriptor';
 
 /**
  * Internal value type for HistogramAggregation.
@@ -217,7 +217,7 @@ export class HistogramAggregator implements Aggregator<HistogramAccumulation> {
   }
 
   toMetricData(
-    descriptor: MetricDescriptor,
+    descriptor: InstrumentDescriptor,
     aggregationTemporality: AggregationTemporality,
     accumulationByAttributes: AccumulationRecord<HistogramAccumulation>[],
     endTime: HrTime

--- a/packages/sdk-metrics/src/aggregator/LastValue.ts
+++ b/packages/sdk-metrics/src/aggregator/LastValue.ts
@@ -23,13 +23,10 @@ import {
 } from './types';
 import { HrTime } from '@opentelemetry/api';
 import { millisToHrTime, hrTimeToMicroseconds } from '@opentelemetry/core';
-import {
-  DataPointType,
-  GaugeMetricData,
-  MetricDescriptor,
-} from '../export/MetricData';
+import { DataPointType, GaugeMetricData } from '../export/MetricData';
 import { Maybe } from '../utils';
 import { AggregationTemporality } from '../export/AggregationTemporality';
+import { InstrumentDescriptor } from '../InstrumentDescriptor';
 
 export class LastValueAccumulation implements Accumulation {
   constructor(
@@ -106,7 +103,7 @@ export class LastValueAggregator implements Aggregator<LastValueAccumulation> {
   }
 
   toMetricData(
-    descriptor: MetricDescriptor,
+    descriptor: InstrumentDescriptor,
     aggregationTemporality: AggregationTemporality,
     accumulationByAttributes: AccumulationRecord<LastValueAccumulation>[],
     endTime: HrTime

--- a/packages/sdk-metrics/src/aggregator/Sum.ts
+++ b/packages/sdk-metrics/src/aggregator/Sum.ts
@@ -22,13 +22,10 @@ import {
   AccumulationRecord,
 } from './types';
 import { HrTime } from '@opentelemetry/api';
-import {
-  DataPointType,
-  MetricDescriptor,
-  SumMetricData,
-} from '../export/MetricData';
+import { DataPointType, SumMetricData } from '../export/MetricData';
 import { Maybe } from '../utils';
 import { AggregationTemporality } from '../export/AggregationTemporality';
+import { InstrumentDescriptor } from '../InstrumentDescriptor';
 
 export class SumAccumulation implements Accumulation {
   constructor(
@@ -112,7 +109,7 @@ export class SumAggregator implements Aggregator<SumAccumulation> {
   }
 
   toMetricData(
-    descriptor: MetricDescriptor,
+    descriptor: InstrumentDescriptor,
     aggregationTemporality: AggregationTemporality,
     accumulationByAttributes: AccumulationRecord<SumAccumulation>[],
     endTime: HrTime

--- a/packages/sdk-metrics/src/aggregator/types.ts
+++ b/packages/sdk-metrics/src/aggregator/types.ts
@@ -16,8 +16,9 @@
 
 import { HrTime, Attributes } from '@opentelemetry/api';
 import { AggregationTemporality } from '../export/AggregationTemporality';
-import { MetricData, MetricDescriptor } from '../export/MetricData';
+import { MetricData } from '../export/MetricData';
 import { Maybe } from '../utils';
+import { InstrumentDescriptor } from '../InstrumentDescriptor';
 
 /** The kind of aggregator. */
 export enum AggregatorKind {
@@ -134,7 +135,7 @@ export interface Aggregator<T> {
    * @return the {@link MetricData} that this {@link Aggregator} will produce.
    */
   toMetricData(
-    descriptor: MetricDescriptor,
+    descriptor: InstrumentDescriptor,
     aggregationTemporality: AggregationTemporality,
     accumulationByAttributes: AccumulationRecord<T>[],
     endTime: HrTime

--- a/packages/sdk-metrics/src/export/MetricData.ts
+++ b/packages/sdk-metrics/src/export/MetricData.ts
@@ -37,11 +37,6 @@ export interface MetricDescriptor {
   readonly name: string;
   readonly description: string;
   readonly unit: string;
-  /**
-   * @deprecated exporter should avoid depending on the type of the instrument
-   * as their resulting aggregator can be re-mapped with views.
-   */
-  readonly type: InstrumentType;
   readonly valueType: ValueType;
 }
 

--- a/packages/sdk-metrics/test/Instruments.test.ts
+++ b/packages/sdk-metrics/test/Instruments.test.ts
@@ -24,9 +24,9 @@ import {
   Histogram,
   InstrumentType,
   MeterProvider,
-  MetricDescriptor,
   MetricReader,
 } from '../src';
+import { InstrumentDescriptor } from '../src/InstrumentDescriptor';
 import {
   TestDeltaMetricReader,
   TestMetricReader,
@@ -63,6 +63,7 @@ describe('Instruments', () => {
           unit: 'kB',
           type: InstrumentType.COUNTER,
           valueType: ValueType.DOUBLE,
+          advice: {},
         },
       });
     });
@@ -89,6 +90,7 @@ describe('Instruments', () => {
           unit: '',
           type: InstrumentType.COUNTER,
           valueType: ValueType.INT,
+          advice: {},
         },
         dataPointType: DataPointType.SUM,
         isMonotonic: true,
@@ -191,6 +193,7 @@ describe('Instruments', () => {
           unit: 'kB',
           type: InstrumentType.UP_DOWN_COUNTER,
           valueType: ValueType.DOUBLE,
+          advice: {},
         },
       });
     });
@@ -219,6 +222,7 @@ describe('Instruments', () => {
           unit: '',
           type: InstrumentType.UP_DOWN_COUNTER,
           valueType: ValueType.INT,
+          advice: {},
         },
         dataPointType: DataPointType.SUM,
         isMonotonic: false,
@@ -286,6 +290,7 @@ describe('Instruments', () => {
           unit: 'kB',
           type: InstrumentType.HISTOGRAM,
           valueType: ValueType.DOUBLE,
+          advice: {},
         },
       });
     });
@@ -314,6 +319,7 @@ describe('Instruments', () => {
           unit: '',
           type: InstrumentType.HISTOGRAM,
           valueType: ValueType.INT,
+          advice: {},
         },
         dataPointType: DataPointType.HISTOGRAM,
         dataPoints: [
@@ -374,6 +380,9 @@ describe('Instruments', () => {
           unit: '',
           type: InstrumentType.HISTOGRAM,
           valueType: ValueType.INT,
+          advice: {
+            explicitBucketBoundaries: [1, 9, 100],
+          },
         },
         dataPointType: DataPointType.HISTOGRAM,
         dataPoints: [
@@ -443,6 +452,7 @@ describe('Instruments', () => {
           unit: '',
           type: InstrumentType.HISTOGRAM,
           valueType: ValueType.INT,
+          advice: {},
         },
         dataPointType: DataPointType.HISTOGRAM,
         dataPoints: [
@@ -473,6 +483,7 @@ describe('Instruments', () => {
           unit: '',
           type: InstrumentType.HISTOGRAM,
           valueType: ValueType.INT,
+          advice: {},
         },
         dataPointType: DataPointType.HISTOGRAM,
         dataPoints: [
@@ -827,7 +838,7 @@ function setup() {
 interface ValidateMetricData {
   resource?: Resource;
   instrumentationScope?: InstrumentationScope;
-  descriptor?: MetricDescriptor;
+  descriptor?: InstrumentDescriptor;
   dataPointType?: DataPointType;
   dataPoints?: Partial<DataPoint<number | Partial<Histogram>>>[];
   isMonotonic?: boolean;

--- a/packages/sdk-metrics/test/aggregator/ExponentialHistogram.test.ts
+++ b/packages/sdk-metrics/test/aggregator/ExponentialHistogram.test.ts
@@ -800,6 +800,7 @@ describe('ExponentialHistogramAggregation', () => {
           type: instrumentType,
           unit: '1',
           valueType: ValueType.DOUBLE,
+          advice: {},
         },
         AggregationTemporality.CUMULATIVE,
         [[{}, acc]],

--- a/packages/sdk-metrics/test/aggregator/Histogram.test.ts
+++ b/packages/sdk-metrics/test/aggregator/Histogram.test.ts
@@ -312,6 +312,7 @@ describe('HistogramAggregator', () => {
           type: instrumentType,
           unit: '1',
           valueType: ValueType.DOUBLE,
+          advice: {},
         },
         AggregationTemporality.CUMULATIVE,
         [[{}, accumulation]],

--- a/packages/sdk-metrics/test/export/MetricReader.test.ts
+++ b/packages/sdk-metrics/test/export/MetricReader.test.ts
@@ -24,7 +24,6 @@ import {
   AggregationTemporality,
   AggregationType,
   DataPointType,
-  InstrumentType,
   ScopeMetrics,
 } from '../../src';
 import {
@@ -59,7 +58,6 @@ const testScopeMetrics: ScopeMetrics[] = [
         descriptor: {
           name: 'additionalCounter',
           unit: '',
-          type: InstrumentType.COUNTER,
           description: '',
           valueType: ValueType.INT,
         },

--- a/packages/sdk-metrics/test/util.ts
+++ b/packages/sdk-metrics/test/util.ts
@@ -31,7 +31,6 @@ import {
   DataPoint,
   DataPointType,
   ScopeMetrics,
-  MetricDescriptor,
 } from '../src/export/MetricData';
 import { isNotNullish } from '../src/utils';
 import { HrTime } from '@opentelemetry/api';
@@ -103,7 +102,7 @@ export function assertScopeMetrics(
 export function assertMetricData(
   actual: unknown,
   dataPointType?: DataPointType,
-  metricDescriptor: Partial<MetricDescriptor> | null = defaultInstrumentDescriptor,
+  metricDescriptor: Partial<InstrumentDescriptor> | null = defaultInstrumentDescriptor,
   aggregationTemporality?: AggregationTemporality
 ): asserts actual is MetricData {
   const it = actual as MetricData;


### PR DESCRIPTION
## Which problem is this PR solving?

Drop deprecated `type` field on `MetricDescriptor`

Fixes #3439
Fixes https://github.com/open-telemetry/opentelemetry-js/pull/5266#pullrequestreview-2514648591 (@pichlermarc)

## Short description of the changes

Move the field to the internal `InstrumentDescriptor` type and keep it for internal use.

See also: https://github.com/open-telemetry/opentelemetry-js/pull/5266#issuecomment-2556564698

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] `npm compile`
- [x] `npm lint`
- [x] `npm test:*`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been ~~added~~ updated
- [x] Documentation has been updated
