### PR TITLE
fix(opentelemetry-sdk-trace-base): always wait on pending export in SimpleSpanProcessor

### DIFF
--- a/packages/opentelemetry-sdk-trace-base/test/common/export/SimpleSpanProcessor.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/SimpleSpanProcessor.test.ts
@@ -216,7 +216,40 @@ describe('SimpleSpanProcessor', () => {
       );
     });
 
-    it('should await doExport() and delete from _unresolvedExports', async () => {
+    it('should await doExport() and delete from _pendingExports', async () => {
+      const testExporterWithDelay = new TestExporterWithDelay();
+      const processor = new SimpleSpanProcessor(testExporterWithDelay);
+      const spanContext: SpanContext = {
+        traceId: 'a3cda95b652f4a1592b449d5929fda1b',
+        spanId: '5e0c63257de34c92',
+        traceFlags: TraceFlags.SAMPLED,
+      };
+      const tracer = provider.getTracer('default');
+      const span = new SpanImpl({
+        scope: tracer.instrumentationLibrary,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
+        spanContext,
+        name: 'span-name',
+        kind: SpanKind.CLIENT,
+        spanLimits: tracer.getSpanLimits(),
+        spanProcessor: tracer['_spanProcessor'],
+      });
+      processor.onStart(span, ROOT_CONTEXT);
+      processor.onEnd(span);
+
+      assert.strictEqual(processor['_pendingExports'].size, 1);
+
+      await processor.forceFlush();
+
+      assert.strictEqual(processor['_pendingExports'].size, 0);
+
+      const exportedSpans = testExporterWithDelay.getFinishedSpans();
+
+      assert.strictEqual(exportedSpans.length, 1);
+    });
+
+    it('should await doExport() and delete from _pendingExports with async resource', async () => {
       const testExporterWithDelay = new TestExporterWithDelay();
       const processor = new SimpleSpanProcessor(testExporterWithDelay);
 
@@ -247,11 +280,11 @@ describe('SimpleSpanProcessor', () => {
       processor.onStart(span, ROOT_CONTEXT);
       processor.onEnd(span);
 
-      assert.strictEqual(processor['_unresolvedExports'].size, 1);
+      assert.strictEqual(processor['_pendingExports'].size, 1);
 
       await processor.forceFlush();
 
-      assert.strictEqual(processor['_unresolvedExports'].size, 0);
+      assert.strictEqual(processor['_pendingExports'].size, 0);
 
       const exportedSpans = testExporterWithDelay.getFinishedSpans();
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

It isn't possible to know when a `SimpleSpanProcessor` has finished exporting spans, e.g. before asserting on spans in a unit test.

Fixes #1841

## Short description of the changes

Tracks pending exports always in `SimpleSpanProcessor`, not only when async resource is used. This is because export itself is async and has the same need for tracking as the async resource path. There isn't a way to avoid "scheduling a promise" if export itself is a promise.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit test

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been added
- [ ] Documentation has been updated
