### PR TITLE
chore(deps): remove unused 'semver' deps from some packages

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to experimental packages in this project will be documented 
 * feat(exporter-prometheus)!: stop the using `type` field to enforce naming conventions [#5291](https://github.com/open-telemetry/opentelemetry-js/pull/5291) @chancancode
   * Any non-monotonic sums will now be treated as counters and will therefore include the `_total` suffix.
 * feat(shim-opencenus)!: stop mapping removed Instrument `type` to OpenTelemetry metrics [#5291](https://github.com/open-telemetry/opentelemetry-js/pull/5291) @chancancode
-  * The internal OpenTelemetry data model dropped the concept of instrument type on exported metrics, therefore mapping it is not necessary anymore.  
+  * The internal OpenTelemetry data model dropped the concept of instrument type on exported metrics, therefore mapping it is not necessary anymore.
 * feat(instrumentation-fetch)!: passthrough original response to `applyCustomAttributes` hook [#5281](https://github.com/open-telemetry/opentelemetry-js/pull/5281) @chancancode
   * Previously, the fetch instrumentation code unconditionally clones every `fetch()` response in order to preserve the ability for the `applyCustomAttributes` hook to consume the response body. This is fundamentally unsound, as it forces the browser to buffer and retain the response body until it is fully received and read, which crates unnecessary memory pressure on large or long-running response streams. In extreme cases, this is effectively a memory leak and can cause the browser tab to crash. If your use case for `applyCustomAttributes` requires access to the response body, please chime in on [#5293](https://github.com/open-telemetry/opentelemetry-js/issues/5293).
 

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -59,13 +59,11 @@
     "@protobuf-ts/runtime-rpc": "2.9.4",
     "@types/mocha": "10.0.10",
     "@types/node": "18.6.5",
-    "@types/semver": "7.5.8",
     "@types/sinon": "17.0.3",
     "cross-var": "1.1.0",
     "lerna": "6.6.2",
     "mocha": "10.8.2",
     "nyc": "15.1.0",
-    "semver": "7.6.3",
     "sinon": "15.1.2",
     "typescript": "4.4.4"
   },

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -56,7 +56,6 @@
     "@types/mocha": "10.0.10",
     "@types/node": "18.6.5",
     "@types/request-promise-native": "1.0.21",
-    "@types/semver": "7.5.8",
     "@types/sinon": "17.0.3",
     "@types/superagent": "8.1.9",
     "axios": "1.7.9",
@@ -78,8 +77,7 @@
     "@opentelemetry/core": "1.30.0",
     "@opentelemetry/instrumentation": "0.57.0",
     "@opentelemetry/semantic-conventions": "1.28.0",
-    "forwarded-parse": "2.1.2",
-    "semver": "^7.5.2"
+    "forwarded-parse": "2.1.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -88,7 +88,7 @@ Detect resources automatically from the environment using the default resource d
 
 ### contextManager
 
-Use a custom context manager. Default: [AsyncHooksContextManager](../../../packages/opentelemetry-context-async-hooks/README.md)
+Use a custom context manager. Default: [AsyncLocalStorageContextManager](../../../packages/opentelemetry-context-async-hooks/README.md)
 
 ### textMapPropagator
 

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -74,13 +74,11 @@
     "@opentelemetry/exporter-jaeger": "1.30.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.6.5",
-    "@types/semver": "7.5.8",
     "@types/sinon": "17.0.3",
     "cross-var": "1.1.0",
     "lerna": "6.6.2",
     "mocha": "10.8.2",
     "nyc": "15.1.0",
-    "semver": "7.6.3",
     "sinon": "15.1.2",
     "ts-loader": "9.5.1",
     "typescript": "4.4.4"

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -57,7 +57,6 @@ import {
   SpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
-import * as semver from 'semver';
 import * as Sinon from 'sinon';
 import { NodeSDK } from '../src';
 import { env } from 'process';
@@ -88,10 +87,6 @@ import {
   SEMRESATTRS_PROCESS_PID,
 } from '@opentelemetry/semantic-conventions';
 import { ZipkinExporter } from '@opentelemetry/exporter-zipkin';
-
-const DefaultContextManager = semver.gte(process.version, '14.8.0')
-  ? AsyncLocalStorageContextManager
-  : AsyncHooksContextManager;
 
 describe('Node SDK', () => {
   let ctxManager: any;
@@ -257,7 +252,7 @@ describe('Node SDK', () => {
 
       assert.ok(
         context['_getContextManager']().constructor.name ===
-          DefaultContextManager.name
+          AsyncLocalStorageContextManager.name
       );
       assert.ok(
         propagation['_getGlobalPropagator']() instanceof CompositePropagator

--- a/experimental/packages/shim-opencensus/package.json
+++ b/experimental/packages/shim-opencensus/package.json
@@ -70,8 +70,7 @@
     "@opentelemetry/core": "1.30.0",
     "@opentelemetry/resources": "1.30.0",
     "@opentelemetry/sdk-metrics": "1.30.0",
-    "require-in-the-middle": "^7.1.1",
-    "semver": "^7.5.2"
+    "require-in-the-middle": "^7.1.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/shim-opencensus",
   "sideEffects": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -955,7 +955,7 @@
       "version": "0.57.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.12.5",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.30.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.57.0",
         "@opentelemetry/otlp-transformer": "0.57.0",
@@ -1510,7 +1510,7 @@
       "version": "0.57.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.12.5",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.30.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.57.0",
         "@opentelemetry/otlp-transformer": "0.57.0",
@@ -2287,7 +2287,7 @@
       "version": "0.57.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.12.5",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.30.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.57.0",
         "@opentelemetry/otlp-exporter-base": "0.57.0",
@@ -3067,7 +3067,7 @@
       },
       "devDependencies": {
         "@bufbuild/buf": "1.47.2",
-        "@grpc/grpc-js": "^1.12.5",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/context-async-hooks": "1.30.0",
@@ -3079,13 +3079,11 @@
         "@protobuf-ts/runtime-rpc": "2.9.4",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
-        "@types/semver": "7.5.8",
         "@types/sinon": "17.0.3",
         "cross-var": "1.1.0",
         "lerna": "6.6.2",
         "mocha": "10.8.2",
         "nyc": "15.1.0",
-        "semver": "7.6.3",
         "sinon": "15.1.2",
         "typescript": "4.4.4"
       },
@@ -3159,8 +3157,7 @@
         "@opentelemetry/core": "1.30.0",
         "@opentelemetry/instrumentation": "0.57.0",
         "@opentelemetry/semantic-conventions": "1.28.0",
-        "forwarded-parse": "2.1.2",
-        "semver": "^7.5.2"
+        "forwarded-parse": "2.1.2"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.9.0",
@@ -3171,7 +3168,6 @@
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
-        "@types/semver": "7.5.8",
         "@types/sinon": "17.0.3",
         "@types/superagent": "8.1.9",
         "axios": "1.7.9",
@@ -3702,13 +3698,11 @@
         "@opentelemetry/exporter-jaeger": "1.30.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
-        "@types/semver": "7.5.8",
         "@types/sinon": "17.0.3",
         "cross-var": "1.1.0",
         "lerna": "6.6.2",
         "mocha": "10.8.2",
         "nyc": "15.1.0",
-        "semver": "7.6.3",
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4"
@@ -4007,7 +4001,7 @@
       "version": "0.57.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.12.5",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.30.0",
         "@opentelemetry/otlp-exporter-base": "0.57.0",
         "@opentelemetry/otlp-transformer": "0.57.0"
@@ -4999,8 +4993,7 @@
         "@opentelemetry/core": "1.30.0",
         "@opentelemetry/resources": "1.30.0",
         "@opentelemetry/sdk-metrics": "1.30.0",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2"
+        "require-in-the-middle": "^7.1.1"
       },
       "devDependencies": {
         "@opencensus/core": "0.1.0",
@@ -33862,8 +33855,7 @@
         "@opentelemetry/core": "1.30.0",
         "@opentelemetry/propagator-b3": "1.30.0",
         "@opentelemetry/propagator-jaeger": "1.30.0",
-        "@opentelemetry/sdk-trace-base": "1.30.0",
-        "semver": "^7.5.2"
+        "@opentelemetry/sdk-trace-base": "1.30.0"
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
@@ -33871,7 +33863,6 @@
         "@opentelemetry/semantic-conventions": "1.28.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
-        "@types/semver": "7.5.8",
         "@types/sinon": "17.0.3",
         "cross-var": "1.1.0",
         "lerna": "6.6.2",
@@ -38556,7 +38547,7 @@
     "@opentelemetry/exporter-logs-otlp-grpc": {
       "version": "file:experimental/packages/exporter-logs-otlp-grpc",
       "requires": {
-        "@grpc/grpc-js": "1.12.5",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/api-logs": "0.57.0",
@@ -38949,7 +38940,7 @@
     "@opentelemetry/exporter-metrics-otlp-grpc": {
       "version": "file:experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
       "requires": {
-        "@grpc/grpc-js": "^1.12.5",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/core": "1.30.0",
@@ -39306,7 +39297,7 @@
     "@opentelemetry/exporter-trace-otlp-grpc": {
       "version": "file:experimental/packages/exporter-trace-otlp-grpc",
       "requires": {
-        "@grpc/grpc-js": "^1.12.5",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/core": "1.30.0",
@@ -40188,7 +40179,7 @@
       "version": "file:experimental/packages/opentelemetry-instrumentation-grpc",
       "requires": {
         "@bufbuild/buf": "1.47.2",
-        "@grpc/grpc-js": "^1.12.5",
+        "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/context-async-hooks": "1.30.0",
@@ -40202,13 +40193,11 @@
         "@protobuf-ts/runtime-rpc": "2.9.4",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
-        "@types/semver": "7.5.8",
         "@types/sinon": "17.0.3",
         "cross-var": "1.1.0",
         "lerna": "6.6.2",
         "mocha": "10.8.2",
         "nyc": "15.1.0",
-        "semver": "7.6.3",
         "sinon": "15.1.2",
         "typescript": "4.4.4"
       },
@@ -40270,7 +40259,6 @@
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
         "@types/request-promise-native": "1.0.21",
-        "@types/semver": "7.5.8",
         "@types/sinon": "17.0.3",
         "@types/superagent": "8.1.9",
         "axios": "1.7.9",
@@ -40282,7 +40270,6 @@
         "nyc": "15.1.0",
         "request": "2.88.2",
         "request-promise-native": "1.0.9",
-        "semver": "^7.5.2",
         "sinon": "15.1.2",
         "superagent": "10.0.2",
         "typescript": "4.4.4"
@@ -40867,7 +40854,7 @@
     "@opentelemetry/otlp-grpc-exporter-base": {
       "version": "file:experimental/packages/otlp-grpc-exporter-base",
       "requires": {
-        "@grpc/grpc-js": "^1.12.5",
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/core": "1.30.0",
         "@opentelemetry/otlp-exporter-base": "0.57.0",
@@ -42136,13 +42123,11 @@
         "@opentelemetry/semantic-conventions": "1.28.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
-        "@types/semver": "7.5.8",
         "@types/sinon": "17.0.3",
         "cross-var": "1.1.0",
         "lerna": "6.6.2",
         "mocha": "10.8.2",
         "nyc": "15.1.0",
-        "semver": "7.6.3",
         "sinon": "15.1.2",
         "ts-loader": "9.5.1",
         "typescript": "4.4.4"
@@ -42361,13 +42346,11 @@
         "@opentelemetry/semantic-conventions": "1.28.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
-        "@types/semver": "7.5.8",
         "@types/sinon": "17.0.3",
         "cross-var": "1.1.0",
         "lerna": "6.6.2",
         "mocha": "10.8.2",
         "nyc": "15.1.0",
-        "semver": "^7.5.2",
         "sinon": "15.1.2",
         "typescript": "4.4.4"
       },
@@ -42798,7 +42781,6 @@
         "mocha": "10.8.2",
         "nyc": "15.1.0",
         "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
         "sinon": "15.1.2",
         "typescript": "4.4.4"
       },

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -50,7 +50,6 @@
     "@opentelemetry/semantic-conventions": "1.28.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.6.5",
-    "@types/semver": "7.5.8",
     "@types/sinon": "17.0.3",
     "cross-var": "1.1.0",
     "lerna": "6.6.2",
@@ -67,8 +66,7 @@
     "@opentelemetry/core": "1.30.0",
     "@opentelemetry/propagator-b3": "1.30.0",
     "@opentelemetry/propagator-jaeger": "1.30.0",
-    "@opentelemetry/sdk-trace-base": "1.30.0",
-    "semver": "^7.5.2"
+    "@opentelemetry/sdk-trace-base": "1.30.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node",
   "sideEffects": false


### PR DESCRIPTION
This re-applies some changes from #4341 that were dropped in
the merge from 'next' back to 'main'.

As a rider, it also corrects the sdk-node/README to indicate
the default context-manager is now the one based on AsyncLocalStorage.
