### PR TITLE
[backport/v1.x] fix(exporter-metrics-otlp-http): browser OTLPMetricExporter was not passing config to OTLPMetricExporterBase super class [#5331]

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(exporter-metrics-otlp-http): browser OTLPMetricExporter was not passing config to OTLPMetricExporterBase super class [#5331](https://github.com/open-telemetry/opentelemetry-js/pull/5331) @trentm
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/browser/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/browser/OTLPMetricExporter.ts
@@ -31,7 +31,8 @@ export class OTLPMetricExporter extends OTLPMetricExporterBase {
         JsonMetricsSerializer,
         'v1/metrics',
         { 'Content-Type': 'application/json' }
-      )
+      ),
+      config
     );
   }
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/OTLPMetricExporter.test.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
+import { AggregationTemporalityPreference } from '../../src';
 import {
+  AggregationOption,
+  AggregationTemporality,
+  AggregationType,
+  InstrumentType,
   MeterProvider,
   PeriodicExportingMetricReader,
 } from '@opentelemetry/sdk-metrics';
@@ -103,6 +108,148 @@ describe('OTLPMetricExporter', function () {
           'expected requestBody to be in JSON format, but parsing failed'
         );
       });
+    });
+  });
+
+  describe('temporality', () => {
+    it('should use the right temporality when Cumulative preference is selected', () => {
+      const exporter = new OTLPMetricExporter({
+        temporalityPreference: AggregationTemporalityPreference.CUMULATIVE,
+      });
+
+      assert.equal(
+        exporter.selectAggregationTemporality(InstrumentType.COUNTER),
+        AggregationTemporality.CUMULATIVE,
+        'Counter'
+      );
+      assert.equal(
+        exporter.selectAggregationTemporality(InstrumentType.HISTOGRAM),
+        AggregationTemporality.CUMULATIVE,
+        'Histogram'
+      );
+      assert.equal(
+        exporter.selectAggregationTemporality(InstrumentType.UP_DOWN_COUNTER),
+        AggregationTemporality.CUMULATIVE,
+        'UpDownCounter'
+      );
+      assert.equal(
+        exporter.selectAggregationTemporality(
+          InstrumentType.OBSERVABLE_COUNTER
+        ),
+        AggregationTemporality.CUMULATIVE,
+        'Asynchronous Counter'
+      );
+      assert.equal(
+        exporter.selectAggregationTemporality(
+          InstrumentType.OBSERVABLE_UP_DOWN_COUNTER
+        ),
+        AggregationTemporality.CUMULATIVE,
+        'Asynchronous UpDownCounter'
+      );
+    });
+
+    it('should use the right temporality when Delta preference is selected', () => {
+      const exporter = new OTLPMetricExporter({
+        temporalityPreference: AggregationTemporalityPreference.DELTA,
+      });
+
+      assert.equal(
+        exporter.selectAggregationTemporality(InstrumentType.COUNTER),
+        AggregationTemporality.DELTA,
+        'Counter'
+      );
+      assert.equal(
+        exporter.selectAggregationTemporality(InstrumentType.HISTOGRAM),
+        AggregationTemporality.DELTA,
+        'Histogram'
+      );
+      assert.equal(
+        exporter.selectAggregationTemporality(InstrumentType.UP_DOWN_COUNTER),
+        AggregationTemporality.CUMULATIVE,
+        'UpDownCounter'
+      );
+      assert.equal(
+        exporter.selectAggregationTemporality(
+          InstrumentType.OBSERVABLE_COUNTER
+        ),
+        AggregationTemporality.DELTA,
+        'Asynchronous Counter'
+      );
+      assert.equal(
+        exporter.selectAggregationTemporality(
+          InstrumentType.OBSERVABLE_UP_DOWN_COUNTER
+        ),
+        AggregationTemporality.CUMULATIVE,
+        'Asynchronous UpDownCounter'
+      );
+    });
+
+    it('should use the right temporality when LowMemory preference is selected', () => {
+      const exporter = new OTLPMetricExporter({
+        temporalityPreference: AggregationTemporalityPreference.LOWMEMORY,
+      });
+
+      assert.equal(
+        exporter.selectAggregationTemporality(InstrumentType.COUNTER),
+        AggregationTemporality.DELTA,
+        'Counter'
+      );
+      assert.equal(
+        exporter.selectAggregationTemporality(InstrumentType.HISTOGRAM),
+        AggregationTemporality.DELTA,
+        'Histogram'
+      );
+      assert.equal(
+        exporter.selectAggregationTemporality(InstrumentType.UP_DOWN_COUNTER),
+        AggregationTemporality.CUMULATIVE,
+        'UpDownCounter'
+      );
+      assert.equal(
+        exporter.selectAggregationTemporality(
+          InstrumentType.OBSERVABLE_COUNTER
+        ),
+        AggregationTemporality.CUMULATIVE,
+        'Asynchronous Counter'
+      );
+      assert.equal(
+        exporter.selectAggregationTemporality(
+          InstrumentType.OBSERVABLE_UP_DOWN_COUNTER
+        ),
+        AggregationTemporality.CUMULATIVE,
+        'Asynchronous UpDownCounter'
+      );
+    });
+  });
+
+  describe('aggregation', () => {
+    it('aggregationSelector calls the selector supplied to the constructor', () => {
+      const aggregation: AggregationOption = {
+        type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,
+        options: {
+          boundaries: [0, 100, 100000],
+        },
+      };
+      const exporter = new OTLPMetricExporter({
+        aggregationPreference: _instrumentType => aggregation,
+      });
+      assert.equal(
+        exporter.selectAggregation(InstrumentType.COUNTER),
+        aggregation
+      );
+    });
+
+    it('aggregationSelector returns the default aggregation preference when nothing is supplied', () => {
+      const exporter = new OTLPMetricExporter({
+        aggregationPreference: _instrumentType => ({
+          type: AggregationType.DEFAULT,
+        }),
+      });
+      assert.deepStrictEqual(
+        exporter.selectAggregation(InstrumentType.COUNTER),
+        {
+          type: AggregationType.DEFAULT,
+        }
+      );
     });
   });
 });

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/OTLPMetricExporter.test.ts
@@ -16,9 +16,9 @@
 
 import { AggregationTemporalityPreference } from '../../src';
 import {
-  AggregationOption,
+  Aggregation,
   AggregationTemporality,
-  AggregationType,
+  ExplicitBucketHistogramAggregation,
   InstrumentType,
   MeterProvider,
   PeriodicExportingMetricReader,
@@ -223,12 +223,9 @@ describe('OTLPMetricExporter', function () {
 
   describe('aggregation', () => {
     it('aggregationSelector calls the selector supplied to the constructor', () => {
-      const aggregation: AggregationOption = {
-        type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,
-        options: {
-          boundaries: [0, 100, 100000],
-        },
-      };
+      const aggregation: Aggregation = new ExplicitBucketHistogramAggregation([
+        0, 100, 100000,
+      ]);
       const exporter = new OTLPMetricExporter({
         aggregationPreference: _instrumentType => aggregation,
       });
@@ -240,15 +237,11 @@ describe('OTLPMetricExporter', function () {
 
     it('aggregationSelector returns the default aggregation preference when nothing is supplied', () => {
       const exporter = new OTLPMetricExporter({
-        aggregationPreference: _instrumentType => ({
-          type: AggregationType.DEFAULT,
-        }),
+        aggregationPreference: _instrumentType => Aggregation.Default(),
       });
       assert.deepStrictEqual(
         exporter.selectAggregation(InstrumentType.COUNTER),
-        {
-          type: AggregationType.DEFAULT,
-        }
+        Aggregation.Default()
       );
     });
   });


### PR DESCRIPTION
Backports #5331 to v1.x