### PR TITLE
[backport/v1.x] ci: make changelog workflow check v1.x

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,6 +9,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+      - v1.x
 jobs:
   changelog:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
 
 ### :house: (Internal)
 
+* ci: make changelog workflow check v1.x [#5338](https://github.com/open-telemetry/opentelemetry-js/pull/5338) @pichlermarc
+
 ## 1.30.0
 
 ### :rocket: (Enhancement)


### PR DESCRIPTION
## Which problem is this PR solving?

Refs https://github.com/open-telemetry/opentelemetry-js/pull/5284#discussion_r1891065431
Changelog workflow does only check `main` at the moment - this PR makes it check `v1.x` too.

Tested by adding a changelog entry - see #5337 for a PR that does have an entry, but the workflow fails.
