### PR TITLE
[backport/v1.x] ci: make v1.x release PR workflow checkout correct branch

### DIFF
--- a/.github/workflows/create-or-update-release-pr.yml
+++ b/.github/workflows/create-or-update-release-pr.yml
@@ -30,13 +30,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: opentelemetrybot/opentelemetry-js
-          ref: v1.x
+          ref: main
           token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
       - name: Sync with upstream
         run: |
           git remote show origin
           git remote add upstream https://github.com/open-telemetry/opentelemetry-js.git
           git fetch upstream
+          git checkout v1.x
           git reset --hard upstream/v1.x
           git push origin v1.x --force
 


### PR DESCRIPTION
## Which problem is this PR solving?

Release PR automation is broken as `v1.x` does not exist on the fork, so this PR fixes that by checking out main first, then changing to v1.x and pushing it once we've fetched.

See https://github.com/open-telemetry/opentelemetry-js/actions/runs/12751711772/job/35539475261