### PR TITLE
[backport/v1.x] ci: specify base for release-prep PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "_verify_release_kind": "echo $RELEASE_KIND | grep -oE '^(all|sdk|experimental|semconv):(minor|patch)$'",
     "_verify_release_remote": "git remote get-url $RELEASE_PR_REMOTE",
     "_github:update_release_branch": "npm run _verify_release_kind && npm run _verify_release_remote && (git checkout v1.x && git pull upstream v1.x && git branch -D release/next-v1-version; git checkout -b release/next-v1-version && npm run prepare_release:$RELEASE_KIND && git commit -am \"chore: prepare release\" && git push --set-upstream $RELEASE_PR_REMOTE --force release/next-v1-version)",
-    "github:create_or_update_release_pr": "npm run _github:update_release_branch && (gh pr create --repo open-telemetry/opentelemetry-js --title 'chore: prepare next v1.x release' --body ''; npm run _github:update_release_pr_body:$RELEASE_SCOPE)"
+    "github:create_or_update_release_pr": "npm run _github:update_release_branch && (gh pr create --repo open-telemetry/opentelemetry-js --base v1.x --title 'chore: prepare next v1.x release' --body ''; npm run _github:update_release_pr_body:$RELEASE_SCOPE)"
   },
   "repository": "open-telemetry/opentelemetry-js",
   "keywords": [


### PR DESCRIPTION
## Which problem is this PR solving?

The release prep PR for the `v1.x` branch does not open a PR towards `v1.x` but defaults to `main` at the moment. This PR fixes this by specifying a base for the PR.