### PR TITLE
refactor(sdk-base)!: Use TypeScript overload signature for `addEvent`

### DIFF
--- a/api/src/trace/NonRecordingSpan.ts
+++ b/api/src/trace/NonRecordingSpan.ts
@@ -49,7 +49,13 @@ export class NonRecordingSpan implements Span {
   }
 
   // By default does nothing
-  addEvent(_name: string, _attributes?: SpanAttributes): this {
+  addEvent(name: string, startTime?: TimeInput): this;
+  addEvent(
+    name: string,
+    attributes: SpanAttributes | undefined,
+    startTime?: TimeInput
+  ): this;
+  addEvent(): this {
     return this;
   }
 

--- a/api/src/trace/span.ts
+++ b/api/src/trace/span.ts
@@ -68,14 +68,14 @@ export interface Span {
    * Adds an event to the Span.
    *
    * @param name the name of the event.
-   * @param [attributesOrStartTime] the attributes that will be added; these are
-   *     associated with this event. Can be also a start time
-   *     if type is {@type TimeInput} and 3rd param is undefined
+   * @param [attributes] the attributes that will be added; these are
+   *                     associated with this event.
    * @param [startTime] start time of the event.
    */
+  addEvent(name: string, startTime?: TimeInput): this;
   addEvent(
     name: string,
-    attributesOrStartTime?: SpanAttributes | TimeInput,
+    attributes: SpanAttributes | undefined,
     startTime?: TimeInput
   ): this;
 

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -179,13 +179,18 @@ export class SpanImpl implements Span {
   /**
    *
    * @param name Span Name
-   * @param [attributesOrStartTime] Span attributes or start time
-   *     if type is {@type TimeInput} and 3rd param is undefined
+   * @param [attributes] Span attributes for the event
    * @param [timeStamp] Specified time stamp for the event
    */
+  addEvent(name: string, timeStamp?: TimeInput): this;
   addEvent(
     name: string,
-    attributesOrStartTime?: Attributes | TimeInput,
+    attributes: Attributes | undefined,
+    timeStamp?: TimeInput
+  ): this;
+  addEvent(
+    name: string,
+    attributesOrTimestamp?: Attributes | TimeInput,
     timeStamp?: TimeInput
   ): this {
     if (this._isSpanEnded()) return this;
@@ -202,14 +207,13 @@ export class SpanImpl implements Span {
       this._droppedEventsCount++;
     }
 
-    if (isTimeInput(attributesOrStartTime)) {
-      if (!isTimeInput(timeStamp)) {
-        timeStamp = attributesOrStartTime;
-      }
-      attributesOrStartTime = undefined;
-    }
+    let attributes: Attributes | undefined = undefined;
 
-    const attributes = sanitizeAttributes(attributesOrStartTime);
+    if (isTimeInput(attributesOrTimestamp)) {
+      timeStamp = attributesOrTimestamp;
+    } else {
+      attributes = sanitizeAttributes(attributesOrTimestamp);
+    }
 
     this.events.push({
       name,


### PR DESCRIPTION
## Which problem is this PR solving?

Stumbled upon this #5333. If it creates conflicts I'm perfectly happy with @brianphillips absorbing these into there.

This makes the intent more clear, and makes the invalid signature `addEvent(name, timeStamp1, timeStamp2)` explicitly illegal in TS.

This has always been the intent, and the textual documentation somewhat implies that already.

Technically, this is breaking change for TypeScript users. There are situations previously valid TS code will stop being accepted by the type checker, even if the code is semantically valid. It mostly arises when the caller is trying to propagate the same-ish overload signature. It can still be done safely, just requires a bit more care.

In any case, this will go into the 2.0 release so it's a great time to make this change.

That being said, the change/breakage may be too in the weeds to warrant a CHANGELOG entry? Not sure.

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] TypeScript compiles

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated
