### PR TITLE
feat(instrumentation-grpc): monitor error events with events.errorMonitor

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -20,10 +20,10 @@ All notable changes to experimental packages in this project will be documented 
 
 * feat(instrumentation): re-export initialize function from import-in-the-middle [#5123](https://github.com/open-telemetry/opentelemetry-js/pull/5123)
 * feat(sdk-node): lower diagnostic level [#5360](https://github.com/open-telemetry/opentelemetry-js/pull/5360) @cjihrig
-* feat(instrumentation-grpc): monitor error events with events.errorMonitor [#5369](https://github.com/open-telemetry/opentelemetry-js/pull/5369) @cjihrig
 
 ### :bug: (Bug Fix)
 
+* fix(instrumentation-grpc): monitor error events with events.errorMonitor [#5369](https://github.com/open-telemetry/opentelemetry-js/pull/5369) @cjihrig
 * fix(exporter-metrics-otlp-http): browser OTLPMetricExporter was not passing config to OTLPMetricExporterBase super class [#5331](https://github.com/open-telemetry/opentelemetry-js/pull/5331) @trentm
 
 ### :books: (Refine Doc)

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to experimental packages in this project will be documented 
 
 * feat(instrumentation): re-export initialize function from import-in-the-middle [#5123](https://github.com/open-telemetry/opentelemetry-js/pull/5123)
 * feat(sdk-node): lower diagnostic level [#5360](https://github.com/open-telemetry/opentelemetry-js/pull/5360) @cjihrig
+* feat(instrumentation-grpc): monitor error events with events.errorMonitor [#5369](https://github.com/open-telemetry/opentelemetry-js/pull/5369) @cjihrig
 
 ### :bug: (Bug Fix)
 

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/serverUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/serverUtils.ts
@@ -20,6 +20,8 @@
  * error event should be processed.
  */
 
+import { errorMonitor } from 'node:events';
+
 import type {
   ClientReadableStream,
   handleBidiStreamingCall,
@@ -86,7 +88,7 @@ function serverStreamAndBidiHandler<RequestType, ResponseType>(
     endSpan();
   });
 
-  call.on('error', (err: ServiceError) => {
+  call.on(errorMonitor, (err: ServiceError) => {
     if (call[CALL_SPAN_ENDED]) {
       return;
     }

--- a/experimental/packages/opentelemetry-instrumentation-grpc/test/helper.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/test/helper.ts
@@ -395,6 +395,7 @@ export const runTests = (
           bidiStream.write(element);
         });
 
+        assert.strictEqual(bidiStream.listenerCount('error'), 0);
         bidiStream.on('error', (err: ServiceError) => {
           reject(err);
         });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

`errorMonitor` should be preferred over `'error'` event handlers for instrumentation, as the latter alters the behavior of the server if the user has not added their own error handler.

Related to: https://github.com/open-telemetry/opentelemetry-js/issues/225. I'm not sure we want to close the issue based on this fix.

## Short description of the changes

This commit updates instrumentation-grpc to utilize `errorMonitor` instead of `'error'` event handlers. This makes the instrumented server behave more like it would without instrumentation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran the test suite.
- [x] Added an additional assertion for the `'error'` handler count of the server.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
