### PR TITLE
refactor(context-zone-peer-dep): fix eslint warnings

### DIFF
--- a/packages/opentelemetry-context-zone-peer-dep/src/util.ts
+++ b/packages/opentelemetry-context-zone-peer-dep/src/util.ts
@@ -15,13 +15,17 @@
  */
 
 /**
- * check if an object has addEventListener and removeEventListener functions then it will return true.
- * Generally only called with a `TargetWithEvents` but may be called with an unknown / any.
+ * check if an object has `addEventListener` and `removeEventListener` functions.
+ * Generally only called with a `TargetWithEvents` but may be called with an `unknown` value.
  * @param obj - The object to check.
  */
-export function isListenerObject(obj: any = {}): boolean {
+export function isListenerObject(obj: unknown): boolean {
   return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'addEventListener' in obj &&
     typeof obj.addEventListener === 'function' &&
+    'removeEventListener' in obj &&
     typeof obj.removeEventListener === 'function'
   );
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Fixed this eslint warning:

```
    /home/runner/work/opentelemetry-js/opentelemetry-js/packages/opentelemetry-context-zone-peer-dep/src/util.ts
      22:39  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

Ref #5365

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] eslint

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
