### PR TITLE
chore(instrumentation-grpc): remove unused `findIndex()` function

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :house: (Internal)
 
+* chore(instrumentation-grpc): remove unused findIndex() function [#5372](https://github.com/open-telemetry/opentelemetry-js/pull/5372) @cjihrig
+
 ## 0.57.0
 
 ### :rocket: (Enhancement)

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/utils.ts
@@ -23,21 +23,6 @@ import type { IgnoreMatcher } from './types';
 export const URI_REGEX =
   /(?:([A-Za-z0-9+.-]+):(?:\/\/)?)?(?<name>[A-Za-z0-9+.-]+):(?<port>[0-9+.-]+)$/;
 
-// Equivalent to lodash _.findIndex
-export const findIndex: <T>(args: T[], fn: (arg: T) => boolean) => number = (
-  args,
-  fn
-) => {
-  let index = -1;
-  for (const arg of args) {
-    index++;
-    if (fn(arg)) {
-      return index;
-    }
-  }
-  return -1;
-};
-
 /**
  * Convert a grpc status code to an opentelemetry SpanStatus code.
  * @param status


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

There is not a problem, but this appears to be unused code.

Fixes N/A

## Short description of the changes

This commit removes the `findIndex()` function. This function appears to be unused and `findIndex()` is part of the language now.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran the test suite

## Checklist:

- [x] Followed the style guidelines of this project
