### PR TITLE
refactor(otlp-exporter-base): remove unnecessary `isNaN()` checks

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :house: (Internal)
 
+* refactor(otlp-exporter-base): remove unnecessary isNaN() checks [#5374](https://github.com/open-telemetry/opentelemetry-js/pull/5374) @cjihrig
+
 ## 0.57.0
 
 ### :rocket: (Enhancement)

--- a/experimental/packages/otlp-exporter-base/src/configuration/shared-configuration.ts
+++ b/experimental/packages/otlp-exporter-base/src/configuration/shared-configuration.ts
@@ -29,11 +29,7 @@ export interface OtlpSharedConfiguration {
 }
 
 export function validateTimeoutMillis(timeoutMillis: number) {
-  if (
-    !Number.isNaN(timeoutMillis) &&
-    Number.isFinite(timeoutMillis) &&
-    timeoutMillis > 0
-  ) {
+  if (Number.isFinite(timeoutMillis) && timeoutMillis > 0) {
     return timeoutMillis;
   }
   throw new Error(

--- a/experimental/packages/otlp-exporter-base/src/configuration/shared-env-configuration.ts
+++ b/experimental/packages/otlp-exporter-base/src/configuration/shared-env-configuration.ts
@@ -22,11 +22,7 @@ function parseAndValidateTimeoutFromEnv(
   const envTimeout = process.env[timeoutEnvVar]?.trim();
   if (envTimeout != null && envTimeout !== '') {
     const definedTimeout = Number(envTimeout);
-    if (
-      !Number.isNaN(definedTimeout) &&
-      Number.isFinite(definedTimeout) &&
-      definedTimeout > 0
-    ) {
+    if (Number.isFinite(definedTimeout) && definedTimeout > 0) {
       return definedTimeout;
     }
     diag.warn(

--- a/experimental/packages/otlp-exporter-base/test/common/configuration/shared-configuration.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/common/configuration/shared-configuration.test.ts
@@ -19,6 +19,7 @@ import {
   mergeOtlpSharedConfigurationWithDefaults,
   OtlpSharedConfiguration,
 } from '../../../src';
+import { validateTimeoutMillis } from '../../../src/configuration/shared-configuration';
 
 export function testSharedConfigBehavior<T extends OtlpSharedConfiguration>(
   sut: (
@@ -132,5 +133,17 @@ describe('mergeOtlpSharedConfigurationWithDefaults', function () {
     timeoutMillis: 1,
     compression: 'none',
     concurrencyLimit: 2,
+  });
+});
+
+describe('validateTimeoutMillis', function () {
+  it('throws if timeout is not a positive number', () => {
+    const values = [null, '1', true, NaN, Infinity, -Infinity, -1, 0];
+
+    for (let i = 0; i < values.length; ++i) {
+      assert.throws(() => {
+        validateTimeoutMillis(values[i] as any);
+      }, /Configuration: timeoutMillis is invalid/);
+    }
   });
 });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This PR removes validation code that is not needed.

Fixes N/A

## Short description of the changes

This commit removes two `Number.isNaN()` checks. These checks are not needed because the `Number.isFinite()` checks they are paired with also detect `NaN` values.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ran the existing test suite which includes NaN tests for one of the checks.
- [x] Added unit tests for the other NaN check that did not appear to be tested.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
