### PR TITLE
docs(instrumenation-http): reword documentation about what is geneated

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-http/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-http/README.md
@@ -22,7 +22,7 @@ npm install --save @opentelemetry/instrumentation-http
 
 ## Usage
 
-OpenTelemetry HTTP Instrumentation allows the user to automatically collect trace data and export them to their backend of choice, to give observability to distributed systems.
+OpenTelemetry HTTP Instrumentation allows the user to automatically collect telemetry and export it to their backend of choice, to give observability to distributed systems.
 
 To load a specific instrumentation (HTTP in this case), specify it in the Node Tracer's configuration.
 


### PR DESCRIPTION
## Which problem is this PR solving?

Wording is off in the usage section and suggests that only traces are generated. This updates documentation to replace `traces` with `telemetry`.

Refs #4487

## Type of change

- [x] Documentation
