### PR TITLE
refactor(core): fix eslint warning

### DIFF
--- a/packages/opentelemetry-core/src/utils/lodash.merge.ts
+++ b/packages/opentelemetry-core/src/utils/lodash.merge.ts
@@ -27,25 +27,11 @@ const undefinedTag = '[object Undefined]';
 const funcProto = Function.prototype;
 const funcToString = funcProto.toString;
 const objectCtorString = funcToString.call(Object);
-const getPrototype = overArg(Object.getPrototypeOf, Object);
+const getPrototypeOf = Object.getPrototypeOf;
 const objectProto = Object.prototype;
 const hasOwnProperty = objectProto.hasOwnProperty;
 const symToStringTag = Symbol ? Symbol.toStringTag : undefined;
 const nativeObjectToString = objectProto.toString;
-
-/**
- * Creates a unary function that invokes `func` with its argument transformed.
- *
- * @private
- * @param {Function} func The function to wrap.
- * @param {Function} transform The argument transform.
- * @returns {Function} Returns the new function.
- */
-function overArg(func: Function, transform: any): any {
-  return function (arg: any) {
-    return func(transform(arg));
-  };
-}
 
 /**
  * Checks if `value` is a plain object, that is, an object created by the
@@ -79,7 +65,7 @@ export function isPlainObject(value: any) {
   if (!isObjectLike(value) || baseGetTag(value) !== objectTag) {
     return false;
   }
-  const proto = getPrototype(value);
+  const proto = getPrototypeOf(value);
   if (proto === null) {
     return true;
   }


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes the following eslint warning in the `core` pacakge:

```
/home/runner/work/opentelemetry-js/opentelemetry-js/packages/opentelemetry-core/src/utils/lodash.merge.ts
  44:24  warning  Don't use `Function` as a type  @typescript-eslint/ban-types
```

Ref #5365

## Short description of the changes

This could have been addressed in various ways with no change to the code, but upon further inspection, we can probably shed some weight here.

This code was inherited from lodash, which defines:

```js
const getPrototype = overArg(Object.getPrototypeOf, Object);
```

`overArg` allows each argument of the passed in function to be transformed by a mapper function, in this case, effective it amounts to:

```js
const getPrototypeOf = Object.getPrototype;

function getPrototype(value) {
  return getPrototypeOf(Object(value));
}
```

So at minimum, we can just inline _that_ and get rid of `overArg`, since that's the only place we use that function.

The intent here appears to be making a "safe" version of `Object.getPrototypeOf` that can be called with primitive values.

For example, `Object.getPrototypeOf(null)` would throw, but `Object.getPrototypeOf(Object(null))` wouldn't, and same for `1`, `true`, etc.

Essentially, `Object(value)` will box the primitive value and the function will return the prototype of the boxed primitive object.

I suppose this is useful in the rest of the lodash codebase. However, it's unclear that it is necessary in our stripped down version.

`getPrototype` is only used in `isPlainObject`. The first thing that function does is reject any non-object values which would necessarily exclude all primitive values.

So I am pretty sure the `Object()` does nothing for us and we can just call `Object.getPrototypeOf` directly and shed all the extra stuff.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] eslint

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
