### PR TITLE
refactor(browser-detector): fix eslint warning

### DIFF
--- a/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
+++ b/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
@@ -63,8 +63,9 @@ class BrowserDetector implements Detector {
 // Add Browser related attributes to resources
 function getBrowserAttributes(): Attributes {
   const browserAttribs: Attributes = {};
-  const userAgentData: UserAgentData | undefined = (navigator as any)
-    .userAgentData;
+  const userAgentData = (
+    navigator as Navigator & { userAgentData?: UserAgentData }
+  ).userAgentData;
   if (userAgentData) {
     browserAttribs[BROWSER_ATTRIBUTES.PLATFORM] = userAgentData.platform;
     browserAttribs[BROWSER_ATTRIBUTES.BRANDS] = userAgentData.brands.map(


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes the following eslint warning

```
/home/runner/work/opentelemetry-js/opentelemetry-js/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
  66:66  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

Ref #5365

## Short description of the changes

Use an appropriate type for the task in place of `any`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] eslint

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
