### PR TITLE
refactor(sdk-metrics): fix eslint warning

### DIFF
--- a/packages/sdk-metrics/src/state/DeltaMetricProcessor.ts
+++ b/packages/sdk-metrics/src/state/DeltaMetricProcessor.ts
@@ -93,6 +93,8 @@ export class DeltaMetricProcessor<T extends Maybe<Accumulation>> {
             attributes = this._overflowAttributes;
             hashCode = this._overflowHashCode;
             if (this._cumulativeMemoStorage.has(attributes, hashCode)) {
+              // has() returned true, previous is present.
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               const previous = this._cumulativeMemoStorage.get(
                 attributes,
                 hashCode
@@ -103,7 +105,7 @@ export class DeltaMetricProcessor<T extends Maybe<Accumulation>> {
         }
         // Merge with uncollected active delta.
         if (this._activeCollectionStorage.has(attributes, hashCode)) {
-          // has() returned true, previous is present.
+          // has() returned true, active is present.
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const active = this._activeCollectionStorage.get(
             attributes,


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes the following eslint warning in the sdk-metrics package:

```
/home/runner/work/opentelemetry-js/opentelemetry-js/packages/sdk-metrics/src/state/DeltaMetricProcessor.ts
  96:32  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
```

Ref #5365

## Short description of the changes

The assertion was intentional, base on the `.has()` check with the same inputs immediately prior. The surrounding code has the same patterns and used the eslint magic comment to disable the warning, this one was just missed.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] eslint

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated
