### PR TITLE
refactor(sdk-trace-node): fix eslint warning

### DIFF
--- a/packages/opentelemetry-sdk-trace-node/test/registration.test.ts
+++ b/packages/opentelemetry-sdk-trace-node/test/registration.test.ts
@@ -27,10 +27,13 @@ import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-ho
 import { CompositePropagator } from '@opentelemetry/core';
 import { NodeTracerProvider } from '../src';
 
-const assertInstanceOf = (actual: object, ExpectedInstance: Function) => {
+// Here we are looking for a `AnyConstructor` type, and `Function` is a close
+// enough approximation that exists in the standard library.
+// eslint-disable-next-line @typescript-eslint/ban-types
+const assertInstanceOf = (actual: object, ExpectedConstructor: Function) => {
   assert.ok(
-    actual instanceof ExpectedInstance,
-    `Expected ${inspect(actual)} to be instance of ${ExpectedInstance.name}`
+    actual instanceof ExpectedConstructor,
+    `Expected ${inspect(actual)} to be instance of ${ExpectedConstructor.name}`
   );
 };
 


### PR DESCRIPTION
## Which problem is this PR solving?

Fix the following eslint warning:

```
/home/runner/work/opentelemetry-js/opentelemetry-js/packages/opentelemetry-sdk-trace-node/test/registration.test.ts
  30:61  warning  Don't use `Function` as a type  @typescript-eslint/ban-types
```

Ref #5365

## Short description of the changes

Here we are looking for a `AnyConstructor` type, and `Function` is a close enough approximation that exists in the standard library.

The potential foot gun of _calling_ the function resulting in an `any` value still exists, but this is a small function used in tests only, so that's probably acceptable.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] eslint

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
