### PR TITLE
refactor(sdk-trace-web): fix eslint warning

### DIFF
--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -46,10 +46,9 @@ function getUrlNormalizingAnchor(): HTMLAnchorElement {
  * @param obj
  * @param key
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function hasKey<O extends object>(
   obj: O,
-  key: keyof any
+  key: PropertyKey
 ): key is keyof O {
   return key in obj;
 }
@@ -67,8 +66,8 @@ export function addSpanNetworkEvent(
   entries: PerformanceEntries,
   refPerfName?: string
 ): api.Span | undefined {
-  let perfTime = undefined;
-  let refTime = undefined;
+  let perfTime: number | undefined;
+  let refTime: number | undefined;
   if (
     hasKey(entries, performanceName) &&
     typeof entries[performanceName] === 'number'


### PR DESCRIPTION
## Which problem is this PR solving?

```
/home/runner/work/opentelemetry-js/opentelemetry-js/packages/opentelemetry-sdk-trace-web/src/utils.ts
  52:14  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

Ref #5365

## Short description of the changes

The eslint comment wasn't working because it was placed on the wrong line. However, it also wasn't necessary anymore – `keyof any` was used to obtain the union of all possible object key types – `string | number | symbol`. TypeScript now provides an alias for this in the standard libaray that gives exactly the same result.

Also fixed what appears to be a TypeError on an un-annotated `let` binding, not sure why it wasn't caught by the type checker, maybe it was just missed on the version of TS we are using.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] eslint
- [x] TypeScript

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
