### PR TITLE
refactor(instrumentation): fix eslint warnings

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/types.ts
@@ -135,15 +135,12 @@ export interface InstrumentationModuleDefinition {
   includePrerelease?: boolean;
 
   /** Method to patch the instrumentation  */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  patch?:
-    | ((moduleExports: any, moduleVersion?: string | undefined) => any)
-    | undefined;
+  patch?: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ((moduleExports: any, moduleVersion?: string | undefined) => any) | undefined;
 
   /** Method to unpatch the instrumentation  */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  unpatch?:
-    | ((moduleExports: any, moduleVersion?: string | undefined) => void)
+  unpatch?: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  | ((moduleExports: any, moduleVersion?: string | undefined) => void)
     | undefined;
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes the following eslint warning:

```
/home/runner/work/opentelemetry-js/opentelemetry-js/experimental/packages/opentelemetry-instrumentation/src/types.ts
  140:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  140:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  146:24  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

Ref #5365

## Short description of the changes

The annotations weren't working because they were placed on the wrong lines.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] eslint

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
