### PR TITLE
refactor(exporter-metrics-otlp-http): fix eslint warning

### DIFF
--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/OTLPMetricExporterBase.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/OTLPMetricExporterBase.ts
@@ -111,18 +111,14 @@ function chooseTemporalitySelector(
   return chooseTemporalitySelectorFromEnvironment();
 }
 
+const DEFAULT_AGGREGATION = Object.freeze({
+  type: AggregationType.DEFAULT,
+});
+
 function chooseAggregationSelector(
   config: OTLPMetricExporterOptions | undefined
-) {
-  if (config?.aggregationPreference) {
-    return config.aggregationPreference;
-  } else {
-    return (_instrumentType: any) => {
-      return {
-        type: AggregationType.DEFAULT,
-      };
-    };
-  }
+): AggregationSelector {
+  return config?.aggregationPreference ?? (() => DEFAULT_AGGREGATION);
 }
 
 export class OTLPMetricExporterBase


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes the following eslint warning in exporter-metrics-otlp-http:

```
/home/runner/work/opentelemetry-js/opentelemetry-js/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/OTLPMetricExporterBase.ts
  120:30  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```

Ref #5365

## Short description of the changes

The unused parameter can be explicitly typed as `InstrumentType`, but since this default selector doesn't actually care about it, it can also just be elided.

By adding an explicit return type, if someone in the future added the wrong parameter to the default selector function, TypeScript would reject it.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] eslint

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
