### PR TITLE
chore(semantic-conventions): restore min-supported node to >=14

### DIFF
--- a/semantic-conventions/package.json
+++ b/semantic-conventions/package.json
@@ -43,7 +43,7 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=14"
   },
   "files": [
     "build/esm/**/*.js",


### PR DESCRIPTION
It had been bumped to >=18 along with most other packages in the 'next' branch. However, the semconv package (similar to the 'api' package) is staying on 1.x, so we don't want to drop support for older Node.js versions in a minor.

---

This should get merged before a next verison of the semconv package is released. The latest release (1.28.0) has `>=14`.
