### PR TITLE
refactor(instrumentation-grpc): fix eslint warnings

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/clientUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/clientUtils.ts
@@ -102,7 +102,7 @@ export function patchResponseMetadataEvent(
   call: EventEmitter,
   metadataCapture: metadataCaptureType
 ) {
-  call.on('metadata', (responseMetadata: any) => {
+  call.on('metadata', (responseMetadata: Metadata) => {
     metadataCapture.client.captureResponseMetadata(span, responseMetadata);
   });
 }

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
@@ -126,22 +126,22 @@ export class GrpcInstrumentation extends InstrumentationBase<GrpcInstrumentation
           this._wrap(
             moduleExports.Client.prototype,
             'makeUnaryRequest',
-            this._patchClientRequestMethod(moduleExports, false) as any
+            this._patchClientRequestMethod(moduleExports, false)
           );
           this._wrap(
             moduleExports.Client.prototype,
             'makeClientStreamRequest',
-            this._patchClientRequestMethod(moduleExports, false) as any
+            this._patchClientRequestMethod(moduleExports, false)
           );
           this._wrap(
             moduleExports.Client.prototype,
             'makeServerStreamRequest',
-            this._patchClientRequestMethod(moduleExports, true) as any
+            this._patchClientRequestMethod(moduleExports, true)
           );
           this._wrap(
             moduleExports.Client.prototype,
             'makeBidiStreamRequest',
-            this._patchClientRequestMethod(moduleExports, true) as any
+            this._patchClientRequestMethod(moduleExports, true)
           );
           return moduleExports;
         },

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/serverUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/serverUtils.ts
@@ -108,7 +108,10 @@ function serverStreamAndBidiHandler<RequestType, ResponseType>(
     endSpan();
   });
 
-  // Types of parameters 'call' and 'call' are incompatible.
+  // TODO: Investigate this call/signature – it was inherited from very old
+  // code and the `this: {}` is highly suspicious, and likely isn't doing
+  // anything useful. There is probably a more precise cast we can do here.
+  // eslint-disable-next-line @typescript-eslint/ban-types
   return (original as Function).call({}, call);
 }
 
@@ -149,6 +152,11 @@ function clientStreamAndUnaryHandler<RequestType, ResponseType>(
   };
 
   context.bind(context.active(), call);
+
+  // TODO: Investigate this call/signature – it was inherited from very old
+  // code and the `this: {}` is highly suspicious, and likely isn't doing
+  // anything useful. There is probably a more precise cast we can do here.
+  // eslint-disable-next-line @typescript-eslint/ban-types
   return (original as Function).call({}, call, patchedCallback);
 }
 
@@ -204,10 +212,18 @@ export function handleUntracedServerFunction<RequestType, ResponseType>(
     case 'unary':
     case 'clientStream':
     case 'client_stream':
+      // TODO: Investigate this call/signature – it was inherited from very old
+      // code and the `this: {}` is highly suspicious, and likely isn't doing
+      // anything useful. There is probably a more precise cast we can do here.
+      // eslint-disable-next-line @typescript-eslint/ban-types
       return (originalFunc as Function).call({}, call, callback);
     case 'serverStream':
     case 'server_stream':
     case 'bidi':
+      // TODO: Investigate this call/signature – it was inherited from very old
+      // code and the `this: {}` is highly suspicious, and likely isn't doing
+      // anything useful. There is probably a more precise cast we can do here.
+      // eslint-disable-next-line @typescript-eslint/ban-types
       return (originalFunc as Function).call({}, call);
     default:
       break;

--- a/experimental/packages/opentelemetry-instrumentation-grpc/test/helper.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/test/helper.ts
@@ -80,7 +80,7 @@ type TestGrpcClient = Client & {
 interface TestGrpcCall {
   description: string;
   methodName: string;
-  method: Function;
+  method: (...args: any[]) => unknown;
   request: TestRequestResponse | TestRequestResponse[];
   result: TestRequestResponse | TestRequestResponse[];
   metadata?: Metadata;


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes the following eslint warnings in the instrumentation-grpc package:

```
/home/runner/work/opentelemetry-js/opentelemetry-js/experimental/packages/opentelemetry-instrumentation-grpc/src/clientUtils.ts
  105:42  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/opentelemetry-js/opentelemetry-js/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
  129:69  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  134:69  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  139:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  144:68  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/home/runner/work/opentelemetry-js/opentelemetry-js/experimental/packages/opentelemetry-instrumentation-grpc/src/serverUtils.ts
  112:23  warning  Don't use `Function` as a type  @typescript-eslint/ban-types
  152:23  warning  Don't use `Function` as a type  @typescript-eslint/ban-types
  207:31  warning  Don't use `Function` as a type  @typescript-eslint/ban-types
  211:31  warning  Don't use `Function` as a type  @typescript-eslint/ban-types

/home/runner/work/opentelemetry-js/opentelemetry-js/experimental/packages/opentelemetry-instrumentation-grpc/test/helper.ts
  83:11  warning  Don't use `Function` as a type  @typescript-eslint/ban-types
```

Ref #5365

## Short description of the changes

**This commit does not involve any changes to runtime code and can be safely merged without any concerns about changing behavior.**

The first can be replaced with the more precise type that we are expecting.

The second just wansn't needed anymore.

**The third is highly unusual. After spending significant amount of time reading and stepping through the code – I am quite confident that the `.call({}, ...)` (and `.apply({}, ...)` elsewhere in the tests) are a mistake that we inherited from very old code. However I don't feel confident enough that I can *explain* what is going on here to make a change to the runtime code, so in the meantime, I think the best course of action is to leave it as-is, document the issue and have someone with more expertise untangle this down the road.**

The last one was a change in test code to use a more precise call signature.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] eslint

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
