### PR TITLE
chore: add workflow for surveys of non-members

### DIFF
--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -1,0 +1,40 @@
+name: Survey on Merged PR by Non-Member
+
+on:
+  pull_request_target:
+    types: [closed]
+
+env:
+  PR_NUM: ${{ github.event.pull_request.number }}
+  SURVEY_URL: https://docs.google.com/forms/d/e/1FAIpQLSf2FfCsW-DimeWzdQgfl0KDzT2UEAqu69_f7F2BVPSxVae1cQ/viewform?entry.1540511742=open-telemetry/opentelemetry-js
+
+jobs:
+  comment-on-pr:
+    name: Add survey to PR if author is not a member
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check if user is a member of the org
+        id: check-membership
+        run: |
+          USERNAME=$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")
+          ORG="${{ github.repository_owner }}"
+          STATUS=$(gh api "orgs/$ORG/members/$USERNAME" --silent && echo "true" || echo "false")
+          if [[ "$STATUS" == "true" ]]; then
+            echo "MEMBER_FOUND=true" >> $GITHUB_ENV
+          else
+            echo "MEMBER_FOUND=false" >> $GITHUB_ENV
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+
+      - name: Add comment to PR if author is not a member
+        if: env.MEMBER_FOUND == 'false'
+        run: |
+          gh pr comment ${PR_NUM} --repo open-telemetry/opentelemetry.io --body "Thank you for your contribution! 🎉 We would like to hear from you about your experience contributing to OpenTelemetry by taking a few minutes to fill out this [survey](${SURVEY_URL})."
+        env:
+          GH_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
As discusses on a SIG meeting a few weeks back, the Contributor Experience is adding surveys to PRs merged by non-members, to gather info about their experiences. We're starting to add to a couple of repos for testing. This PR adds to this repo.

An example of this message can be found here: https://github.com/open-telemetry/opentelemetry.io/pull/6099#issuecomment-2619960339

