### PR TITLE
fix(exporter-logs/trace-otlp-grpc): fix error for missing dependency otlp-exporter-base

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to experimental packages in this project will be documented 
 * fix(instrumentation-grpc): monitor error events with events.errorMonitor [#5369](https://github.com/open-telemetry/opentelemetry-js/pull/5369) @cjihrig
 * fix(exporter-metrics-otlp-http): browser OTLPMetricExporter was not passing config to OTLPMetricExporterBase super class [#5331](https://github.com/open-telemetry/opentelemetry-js/pull/5331) @trentm
 * fix(instrumentation-fetch, instrumentation-xhr): Ignore network events with zero-timings [#5332](https://github.com/open-telemetry/opentelemetry-js/pull/5332) @chancancode
+* fix(exporter-logs/trace-otlp-grpc): fix error for missing dependency otlp-exporter-base [#5412](https://github.com/open-telemetry/opentelemetry-js/pull/5412) @JamieDanielson
 
 ### :books: (Refine Doc)
 

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -51,7 +51,6 @@
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/api-logs": "0.57.0",
-    "@opentelemetry/otlp-exporter-base": "0.57.0",
     "@opentelemetry/resources": "1.30.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.6.5",
@@ -70,6 +69,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
     "@opentelemetry/core": "1.30.0",
+    "@opentelemetry/otlp-exporter-base": "0.57.0",
     "@opentelemetry/otlp-grpc-exporter-base": "0.57.0",
     "@opentelemetry/otlp-transformer": "0.57.0",
     "@opentelemetry/sdk-logs": "0.57.0"

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.9.0",
-    "@opentelemetry/otlp-exporter-base": "0.57.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",
@@ -67,6 +66,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
     "@opentelemetry/core": "1.30.0",
+    "@opentelemetry/otlp-exporter-base": "0.57.0",
     "@opentelemetry/otlp-grpc-exporter-base": "0.57.0",
     "@opentelemetry/otlp-transformer": "0.57.0",
     "@opentelemetry/resources": "1.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -741,6 +741,7 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.30.0",
+        "@opentelemetry/otlp-exporter-base": "0.57.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.57.0",
         "@opentelemetry/otlp-transformer": "0.57.0",
         "@opentelemetry/sdk-logs": "0.57.0"
@@ -749,7 +750,6 @@
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/api-logs": "0.57.0",
-        "@opentelemetry/otlp-exporter-base": "0.57.0",
         "@opentelemetry/resources": "1.30.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
@@ -975,6 +975,7 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.30.0",
+        "@opentelemetry/otlp-exporter-base": "0.57.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.57.0",
         "@opentelemetry/otlp-transformer": "0.57.0",
         "@opentelemetry/resources": "1.30.0",
@@ -983,7 +984,6 @@
       "devDependencies": {
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/otlp-exporter-base": "0.57.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -28476,7 +28476,7 @@
         "typescript": "5.0.4"
       },
       "engines": {
-        "node": "^18.19.0 || >=20.6.0"
+        "node": ">=14"
       }
     },
     "semantic-conventions/node_modules/@types/node": {


### PR DESCRIPTION
## Which problem is this PR solving?

#5031 was a large refactor for OTLP exporters, and a dependency that was previously listed as a dev dependency is now required as a production dependency. Upgrading to [experimental/v0.56.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental/v0.56.0) caused an error in Yarn PnP:

```
2025-01-09T01:35:53.432Z   220 U Error: @opentelemetry/exporter-logs-otlp-grpc tried to access @opentelemetry/otlp-exporter-base, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```

## Short description of the changes

- move `@opentelemetry/otlp-exporter-base` to be production dependency

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- I am working on a separate PR to add knip to this repo (we have it on contrib already) and make the other changes suggested by knip. For this one specifically I confirmed before and after for Unlisted Dependencies by adding this `lint:deps` command to the root `package.json` and running locally.

`    "lint:deps": "npx --yes knip@5.33.3 --dependencies --production --strict",`
