### PR TITLE
feat: ParentSpanContext Should be Available on Span/ReadableSpan

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -293,12 +293,164 @@ describe('fetch', () => {
       exportedSpans = [];
     });
 
+<<<<<<< Updated upstream
     const assertPropagationHeaders = async (
       response: Response
     ): Promise<Record<string, string>> => {
       const { request } = await response.json();
 
       const span: tracing.ReadableSpan = exportedSpans[0];
+=======
+    it('should create a span with correct root span', () => {
+      const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+      assert.strictEqual(
+        span.parentSpanContext,
+        rootSpan.spanContext(),
+        'parent span is not root span'
+      );
+    });
+
+    it('span should have correct name', () => {
+      const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+      assert.strictEqual(span.name, 'HTTP GET', 'span has wrong name');
+    });
+
+    it('span should have correct kind', () => {
+      const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+      assert.strictEqual(span.kind, api.SpanKind.CLIENT, 'span has wrong kind');
+    });
+
+    it('span should have correct attributes', () => {
+      const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+      const attributes = span.attributes;
+      const keys = Object.keys(attributes);
+      assert.notStrictEqual(
+        attributes[AttributeNames.COMPONENT],
+        '',
+        `attributes ${AttributeNames.COMPONENT} is not defined`
+      );
+
+      assert.strictEqual(
+        attributes[SEMATTRS_HTTP_METHOD],
+        'GET',
+        `attributes ${SEMATTRS_HTTP_METHOD} is wrong`
+      );
+      assert.strictEqual(
+        attributes[SEMATTRS_HTTP_URL],
+        url,
+        `attributes ${SEMATTRS_HTTP_URL} is wrong`
+      );
+      assert.strictEqual(
+        attributes[SEMATTRS_HTTP_STATUS_CODE],
+        200,
+        `attributes ${SEMATTRS_HTTP_STATUS_CODE} is wrong`
+      );
+      const statusText = attributes[AttributeNames.HTTP_STATUS_TEXT];
+      assert.ok(
+        statusText === 'OK' || statusText === '',
+        `attributes ${AttributeNames.HTTP_STATUS_TEXT} is wrong`
+      );
+      assert.ok(
+        (attributes[SEMATTRS_HTTP_HOST] as string).indexOf('localhost') === 0,
+        `attributes ${SEMATTRS_HTTP_HOST} is wrong`
+      );
+
+      const httpScheme = attributes[SEMATTRS_HTTP_SCHEME];
+      assert.ok(
+        httpScheme === 'http' || httpScheme === 'https',
+        `attributes ${SEMATTRS_HTTP_SCHEME} is wrong`
+      );
+      assert.notStrictEqual(
+        attributes[SEMATTRS_HTTP_USER_AGENT],
+        '',
+        `attributes ${SEMATTRS_HTTP_USER_AGENT} is not defined`
+      );
+      const requestContentLength = attributes[
+        SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED
+      ] as number;
+      assert.strictEqual(
+        requestContentLength,
+        undefined,
+        `attributes ${SEMATTRS_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED} is defined`
+      );
+      const responseContentLength = attributes[
+        SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH
+      ] as number;
+      assert.strictEqual(
+        responseContentLength,
+        30,
+        `attributes ${SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH} is <= 0`
+      );
+
+      assert.strictEqual(keys.length, 9, 'number of attributes is wrong');
+    });
+
+    it('span should have correct events', () => {
+      const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+      const events = span.events;
+      assert.strictEqual(events.length, 8, 'number of events is wrong');
+      testForCorrectEvents(events, [
+        PTN.FETCH_START,
+        PTN.DOMAIN_LOOKUP_START,
+        PTN.DOMAIN_LOOKUP_END,
+        PTN.CONNECT_START,
+        PTN.CONNECT_END,
+        PTN.REQUEST_START,
+        PTN.RESPONSE_START,
+        PTN.RESPONSE_END,
+      ]);
+    });
+
+    it('should create a span for preflight request', () => {
+      const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+      const parentSpan: tracing.ReadableSpan = exportSpy.args[1][0][0];
+      assert.strictEqual(
+        span.parentSpanContext,
+        parentSpan.spanContext(),
+        'parent span is not root span'
+      );
+    });
+
+    it('preflight request span should have correct name', () => {
+      const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+      assert.strictEqual(
+        span.name,
+        'CORS Preflight',
+        'preflight request span has wrong name'
+      );
+    });
+
+    it('preflight request span should have correct kind', () => {
+      const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+      assert.strictEqual(
+        span.kind,
+        api.SpanKind.INTERNAL,
+        'span has wrong kind'
+      );
+    });
+
+    it('preflight request span should have correct events', () => {
+      const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+      const events = span.events;
+      assert.strictEqual(events.length, 8, 'number of events is wrong');
+      testForCorrectEvents(events, [
+        PTN.FETCH_START,
+        PTN.DOMAIN_LOOKUP_START,
+        PTN.DOMAIN_LOOKUP_END,
+        PTN.CONNECT_START,
+        PTN.CONNECT_END,
+        PTN.REQUEST_START,
+        PTN.RESPONSE_START,
+        PTN.RESPONSE_END,
+      ]);
+    });
+
+    it('should set trace headers', async () => {
+      const span: api.Span = exportSpy.args[1][0][0];
+      assert.ok(lastResponse instanceof Response);
+
+      const { request } = await lastResponse.json();
+>>>>>>> Stashed changes
 
       assert.strictEqual(
         request.headers[X_B3_TRACE_ID],
@@ -1156,6 +1308,21 @@ describe('fetch', () => {
         });
       });
     });
+<<<<<<< Updated upstream
+=======
+    afterEach(() => {
+      clearData();
+    });
+    it('should create a span with correct root span', () => {
+      const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+      assert.strictEqual(
+        span.parentSpanContext,
+        rootSpan.spanContext(),
+        'parent span is not root span'
+      );
+    });
+  });
+>>>>>>> Stashed changes
 
     describe('secure origin requests', () => {
       const tracedFetch = async ({
@@ -1208,11 +1375,23 @@ describe('fetch', () => {
       });
     });
 
+<<<<<<< Updated upstream
     describe('`applyCustomAttributesOnSpan` hook', () => {
       const tracedFetch = async ({
         handlers = [
           msw.http.get('/api/project-headers.json', ({ request }) => {
             const headers = new Headers();
+=======
+    it('should create a span with correct root span', () => {
+      const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+      assert.strictEqual(
+        span.parentSpanContext,
+        rootSpan.spanContext(),
+        'parent span is not root span'
+      );
+    });
+  });
+>>>>>>> Stashed changes
 
             for (const [key, value] of request.headers) {
               headers.set(`x-request-${key}`, value);

--- a/experimental/packages/opentelemetry-instrumentation-http/test/utils/assertSpan.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/utils/assertSpan.ts
@@ -185,8 +185,8 @@ export const assertSpan = (
       validations.component,
       ' must have http.scheme attribute'
     );
-    assert.ok(typeof span.parentSpanId === 'string');
-    assert.ok(isValidSpanId(span.parentSpanId));
+    assert.ok(typeof span.parentSpanContext?.spanId === 'string');
+    assert.ok(isValidSpanId(span.parentSpanContext.spanId));
   } else if (validations.reqHeaders) {
     assert.ok(validations.reqHeaders[DummyPropagation.TRACE_CONTEXT_KEY]);
     assert.ok(validations.reqHeaders[DummyPropagation.SPAN_CONTEXT_KEY]);

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -385,7 +385,7 @@ describe('xhr', () => {
         it('should create a span with correct root span', () => {
           const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
           assert.strictEqual(
-            span.parentSpanId,
+            span.parentSpanContext?.spanId,
             rootSpan.spanContext().spanId,
             'parent span is not root span'
           );
@@ -489,7 +489,7 @@ describe('xhr', () => {
           const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
           const parentSpan: tracing.ReadableSpan = exportSpy.args[1][0][0];
           assert.strictEqual(
-            span.parentSpanId,
+            span.parentSpanContext?.spanId,
             parentSpan.spanContext().spanId,
             'parent span is not root span'
           );
@@ -1583,7 +1583,7 @@ describe('xhr', () => {
         it('should create a span with correct root span', () => {
           const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
           assert.strictEqual(
-            span.parentSpanId,
+            span.parentSpanContext?.spanId,
             rootSpan.spanContext().spanId,
             'parent span is not root span'
           );
@@ -1687,7 +1687,7 @@ describe('xhr', () => {
           const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
           const parentSpan: tracing.ReadableSpan = exportSpy.args[1][0][0];
           assert.strictEqual(
-            span.parentSpanId,
+            span.parentSpanContext?.spanId,
             parentSpan.spanContext().spanId,
             'parent span is not root span'
           );

--- a/experimental/packages/otlp-transformer/src/trace/internal-types.ts
+++ b/experimental/packages/otlp-transformer/src/trace/internal-types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { SpanContext } from '@opentelemetry/api';
 import {
   Fixed64,
   IInstrumentationScope,
@@ -64,6 +65,9 @@ export interface ISpan {
 
   /** Span parentSpanId */
   parentSpanId?: string | Uint8Array;
+
+  /** Span parentSpanContext */
+  parentSpanContext?: SpanContext;
 
   /** Span name */
   name: string;

--- a/experimental/packages/otlp-transformer/test/trace.test.ts
+++ b/experimental/packages/otlp-transformer/test/trace.test.ts
@@ -336,7 +336,7 @@ describe('Trace', () => {
       });
       assert.ok(exportRequest);
       assert.strictEqual(
-        exportRequest.resourceSpans?.[0].scopeSpans[0].spans?.[0].parentSpanId,
+        exportRequest.resourceSpans?.[0].scopeSpans[0].spans?.[0].parentSpanContext?.spanId,
         undefined
       );
     });
@@ -348,7 +348,7 @@ describe('Trace', () => {
       });
       assert.ok(exportRequest);
       assert.strictEqual(
-        exportRequest.resourceSpans?.[0].scopeSpans[0].spans?.[0].parentSpanId,
+        exportRequest.resourceSpans?.[0].scopeSpans[0].spans?.[0].parentSpanContext?.spanId,
         undefined
       );
     });

--- a/experimental/packages/shim-opencensus/src/ShimSpan.ts
+++ b/experimental/packages/shim-opencensus/src/ShimSpan.ts
@@ -16,7 +16,7 @@
 
 import * as oc from '@opencensus/core';
 import { ShimTracer } from './ShimTracer';
-import { AttributeValue, Span, SpanStatusCode, diag } from '@opentelemetry/api';
+import { AttributeValue, Span, SpanContext, SpanStatusCode, diag } from '@opentelemetry/api';
 import { mapMessageEvent, reverseMapSpanContext } from './trace-transform';
 
 // Copied from
@@ -33,6 +33,7 @@ interface Options {
   isRootSpan?: boolean | undefined;
   kind?: oc.SpanKind | undefined;
   parentSpanId?: string | undefined;
+  parentSpanContext?: SpanContext;
 }
 
 export class ShimSpan implements oc.Span {
@@ -71,6 +72,7 @@ export class ShimSpan implements oc.Span {
 
   readonly kind: oc.SpanKind;
   readonly parentSpanId: string;
+  readonly parentSpanContext: SpanContext;
 
   get remoteParent(): boolean {
     return this.otelSpan.spanContext().isRemote ?? false;
@@ -83,12 +85,18 @@ export class ShimSpan implements oc.Span {
     isRootSpan = false,
     kind = oc.SpanKind.UNSPECIFIED,
     parentSpanId = '',
+    parentSpanContext = {
+      spanId: '',
+      traceId: '',
+      traceFlags: 0,
+    },
   }: Options) {
     this._shimTracer = shimTracer;
     this.otelSpan = otelSpan;
     this._isRootSpan = isRootSpan;
     this.kind = kind;
     this.parentSpanId = parentSpanId;
+    this.parentSpanContext = parentSpanContext;
   }
 
   /** Returns whether a span is root or not. */

--- a/experimental/packages/shim-opencensus/src/ShimTracer.ts
+++ b/experimental/packages/shim-opencensus/src/ShimTracer.ts
@@ -117,6 +117,7 @@ export class ShimTracer implements oc.Tracer {
       isRootSpan: true,
       kind,
       parentSpanId: trace.getSpanContext(parentCtx)?.spanId,
+      parentSpanContext: trace.getSpanContext(parentCtx),
     });
 
     let ctx = trace.setSpan(parentCtx, otelSpan);
@@ -148,6 +149,7 @@ export class ShimTracer implements oc.Tracer {
       isRootSpan: false,
       kind,
       parentSpanId: trace.getSpanContext(ctx)?.spanId,
+      parentSpanContext: trace.getSpanContext(ctx),
     });
   }
 

--- a/experimental/packages/shim-opencensus/test/ShimSpan.test.ts
+++ b/experimental/packages/shim-opencensus/test/ShimSpan.test.ts
@@ -107,7 +107,7 @@ describe('ShimSpan', () => {
 
       assert.strictEqual(childSpan.name, 'span');
       assert.deepStrictEqual(
-        childSpan.parentSpanId,
+        childSpan.parentSpanContext?.spanId,
         parentSpan.spanContext().spanId
       );
     });
@@ -120,7 +120,7 @@ describe('ShimSpan', () => {
 
       assert.strictEqual(childSpan.name, 'child');
       assert.deepStrictEqual(
-        childSpan.parentSpanId,
+        childSpan.parentSpanContext?.spanId,
         parentSpan.spanContext().spanId
       );
     });

--- a/experimental/packages/shim-opencensus/test/ShimTracer.test.ts
+++ b/experimental/packages/shim-opencensus/test/ShimTracer.test.ts
@@ -92,7 +92,7 @@ describe('ShimTracer', () => {
         otelSpans[0].spanContext().traceId,
         '9e7ecdc193765065fee1efe757fdd874'
       );
-      assert.strictEqual(otelSpans[0].parentSpanId, '4bf6239d37d8b0f0');
+      assert.strictEqual(otelSpans[0].parentSpanContext?.spanId, '4bf6239d37d8b0f0');
     });
 
     it('should set the span as root span in context', async () => {
@@ -154,7 +154,7 @@ describe('ShimTracer', () => {
         parent.end();
       });
       assert.strictEqual(
-        childSpan.parentSpanId,
+        childSpan.parentSpanContext?.spanId,
         parentSpan.spanContext().spanId
       );
     });
@@ -171,7 +171,7 @@ describe('ShimTracer', () => {
           }
         );
       });
-      assert.strictEqual(childSpan.parentSpanId, rootSpan.spanContext().spanId);
+      assert.strictEqual(childSpan.parentSpanContext?.spanId, rootSpan.spanContext().spanId);
     });
   });
 

--- a/experimental/packages/shim-opencensus/test/otel-sandwich.test.ts
+++ b/experimental/packages/shim-opencensus/test/otel-sandwich.test.ts
@@ -38,7 +38,7 @@ describe('OpenTelemetry sandwich', () => {
       childSpan.spanContext().traceId,
       parentSpan.spanContext().traceId
     );
-    assert.strictEqual(childSpan.parentSpanId, parentSpan.spanContext().spanId);
+    assert.strictEqual(childSpan.parentSpanContext?.spanId, parentSpan.spanContext().spanId);
   });
 
   it('should maintain parent-child relationship for OC -> OTel', async () => {
@@ -55,7 +55,7 @@ describe('OpenTelemetry sandwich', () => {
       childSpan.spanContext().traceId,
       parentSpan.spanContext().traceId
     );
-    assert.strictEqual(childSpan.parentSpanId, parentSpan.spanContext().spanId);
+    assert.strictEqual(childSpan.parentSpanContext?.spanId, parentSpan.spanContext().spanId);
   });
 
   it('should maintain structure for OTel -> OC -> OTel', async () => {
@@ -80,9 +80,9 @@ describe('OpenTelemetry sandwich', () => {
       parentSpan.spanContext().traceId
     );
     assert.strictEqual(
-      middleSpan.parentSpanId,
+      middleSpan.parentSpanContext?.spanId,
       parentSpan.spanContext().spanId
     );
-    assert.strictEqual(childSpan.parentSpanId, middleSpan.spanContext().spanId);
+    assert.strictEqual(childSpan.parentSpanContext?.spanId, middleSpan.spanContext().spanId);
   });
 });

--- a/packages/opentelemetry-exporter-jaeger/src/transform.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/transform.ts
@@ -43,9 +43,10 @@ export function spanToThrift(span: ReadableSpan): ThriftSpan {
   const traceId = span.spanContext().traceId.padStart(32, '0');
   const traceIdHigh = traceId.slice(0, 16);
   const traceIdLow = traceId.slice(16);
-  const parentSpan = span.parentSpanId
+  const parentSpanId = span.parentSpanId
     ? Utils.encodeInt64(span.parentSpanId)
     : ThriftUtils.emptyBuffer;
+  const parentSpan = span.parentSpanContext || ThriftUtils.emptySpanContext;
 
   const tags = Object.keys(span.attributes).map(
     (name): Tag => ({ key: name, value: toTagValue(span.attributes[name]) })
@@ -134,7 +135,8 @@ export function spanToThrift(span: ReadableSpan): ThriftSpan {
     traceIdLow: Utils.encodeInt64(traceIdLow),
     traceIdHigh: Utils.encodeInt64(traceIdHigh),
     spanId: Utils.encodeInt64(span.spanContext().spanId),
-    parentSpanId: parentSpan,
+    parentSpanId: parentSpanId,
+    parentSpanContext: parentSpan,
     operationName: span.name,
     references: spanLinksToThriftRefs(span.links),
     flags: span.spanContext().traceFlags || DEFAULT_FLAGS,

--- a/packages/opentelemetry-exporter-jaeger/src/types.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/types.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { SpanContext } from "@opentelemetry/api";
+
 /**
  * Options for Jaeger configuration
  */
@@ -95,6 +97,7 @@ export interface ThriftSpan {
   traceIdHigh: Buffer;
   spanId: Buffer;
   parentSpanId: string | Buffer;
+  parentSpanContext: SpanContext;
   operationName: string;
   references: ThriftReference[];
   flags: number;

--- a/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
@@ -238,6 +238,11 @@ describe('transform', () => {
         },
         attributes: {},
         parentSpanId: '3e0c63257de34c92',
+        parentSpanContext: {
+          traceId: 'a4cda95b652f4a1592b449d5929fda1b',
+          spanId: '3e0c63257de34c92',
+          traceFlags: TraceFlags.SAMPLED,
+        },
         links: [
           {
             context: {

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -68,6 +68,7 @@ interface SpanOptions {
   name: string;
   kind: SpanKind;
   parentSpanId?: string;
+  parentSpanContext?: SpanContext;
   links?: Link[];
   startTime?: TimeInput;
   attributes?: Attributes;
@@ -84,6 +85,7 @@ export class SpanImpl implements Span {
   private readonly _spanContext: SpanContext;
   readonly kind: SpanKind;
   readonly parentSpanId?: string;
+  readonly parentSpanContext?: SpanContext;
   readonly attributes: Attributes = {};
   readonly links: Link[] = [];
   readonly events: TimedEvent[] = [];
@@ -128,6 +130,7 @@ export class SpanImpl implements Span {
 
     this.name = opts.name;
     this.parentSpanId = opts.parentSpanId;
+    this.parentSpanContext = opts.parentSpanContext;
     this.kind = opts.kind;
     this.links = opts.links || [];
     this.startTime = this._getTime(opts.startTime ?? now);

--- a/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
@@ -150,6 +150,7 @@ export class Tracer implements api.Tracer {
       kind: spanKind,
       links,
       parentSpanId,
+      parentSpanContext,
       attributes: initAttributes,
       startTime: options.startTime,
       spanProcessor: this._spanProcessor,

--- a/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
@@ -70,6 +70,7 @@ export class ConsoleSpanExporter implements SpanExporter {
       instrumentationScope: span.instrumentationScope,
       traceId: span.spanContext().traceId,
       parentId: span.parentSpanId,
+      parentSpanContext: span.parentSpanContext,
       traceState: span.spanContext().traceState?.serialize(),
       name: span.name,
       id: span.spanContext().spanId,

--- a/packages/opentelemetry-sdk-trace-base/src/export/ReadableSpan.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/ReadableSpan.ts
@@ -31,6 +31,7 @@ export interface ReadableSpan {
   readonly kind: SpanKind;
   readonly spanContext: () => SpanContext;
   readonly parentSpanId?: string;
+  readonly parentSpanContext?: SpanContext;
   readonly startTime: HrTime;
   readonly endTime: HrTime;
   readonly status: SpanStatus;

--- a/packages/opentelemetry-sdk-trace-base/test/common/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/BasicTracerProvider.test.ts
@@ -588,7 +588,7 @@ describe('BasicTracerProvider', () => {
         )
       );
       assert.ok(span instanceof SpanImpl);
-      assert.deepStrictEqual((span as Span).parentSpanId, undefined);
+      assert.deepStrictEqual((span as Span).parentSpanContext?.spanId, undefined);
     });
 
     it('should start a span with name and with invalid spancontext', () => {

--- a/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
@@ -1006,13 +1006,18 @@ describe('Span', () => {
       name: 'my-span',
       kind: SpanKind.INTERNAL,
       parentSpanId: parentId,
+      parentSpanContext: {
+        spanId: parentId,
+        traceId: spanContext.traceId,
+        traceFlags: spanContext.traceFlags,
+      },
       spanLimits: tracer.getSpanLimits(),
       spanProcessor: tracer['_spanProcessor'],
     });
 
     assert.strictEqual(span.name, 'my-span');
     assert.strictEqual(span.kind, SpanKind.INTERNAL);
-    assert.strictEqual(span.parentSpanId, parentId);
+    assert.strictEqual(span.parentSpanContext?.spanId, parentId);
     assert.strictEqual(span.spanContext().traceId, spanContext.traceId);
     assert.deepStrictEqual(span.status, {
       code: SpanStatusCode.UNSET,

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/ConsoleSpanExporter.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/ConsoleSpanExporter.test.ts
@@ -87,6 +87,7 @@ describe('ConsoleSpanExporter', () => {
           'links',
           'name',
           'parentId',
+          'parentSpanContext',
           'resource',
           'status',
           'timestamp',

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/InMemorySpanExporter.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/InMemorySpanExporter.test.ts
@@ -63,8 +63,8 @@ describe('InMemorySpanExporter', () => {
       span2.spanContext().traceId,
       span3.spanContext().traceId
     );
-    assert.strictEqual(span1.parentSpanId, span2.spanContext().spanId);
-    assert.strictEqual(span2.parentSpanId, span3.spanContext().spanId);
+    assert.strictEqual(span1.parentSpanContext?.spanId, span2.spanContext().spanId);
+    assert.strictEqual(span2.parentSpanContext?.spanId, span3.spanContext().spanId);
   });
 
   it('should shutdown the exporter', () => {

--- a/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
+++ b/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
@@ -226,7 +226,7 @@ describe('OpenTracing Shim', () => {
           childOf: span,
         }) as SpanShim;
         assert.strictEqual(
-          (childSpan.getSpan() as Span).parentSpanId,
+          (childSpan.getSpan() as Span).parentSpanContext?.spanId,
           context.toSpanId()
         );
         assert.strictEqual(
@@ -240,7 +240,7 @@ describe('OpenTracing Shim', () => {
           childOf: context,
         }) as SpanShim;
         assert.strictEqual(
-          (childSpan.getSpan() as Span).parentSpanId,
+          (childSpan.getSpan() as Span).parentSpanContext?.spanId,
           context.toSpanId()
         );
         assert.strictEqual(


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #5345

## Short description of the changes
Adds the `parentSpanContext` attribute to the `Span` and `ReadableSpan` classes. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Updated span tests to include checks for the `parentSpanContext` attributes to ensure they is set on newly created spans using the values from the parent span.

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
