### PR TITLE
docs: add 'Contrib Triagers' section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,12 +246,12 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 - [David Luna](https://github.com/david-luna), Elastic
 - [Hector Hernandez](https://github.com/hectorhdzg), Microsoft
 - [Martin Kuba](https://github.com/martinkuba), Lightstep
+- [Marylia Gutierrez](https://github.com/maryliag), Grafana Labs
 - [Matthew Wear](https://github.com/mwear), LightStep
 - [Naseem K. Ullah](https://github.com/naseemkullah), Transit
 - [Neville Wylie](https://github.com/MSNev), Microsoft
 - [Purvi Kanal](https://github.com/pkanal), Honeycomb
 - [Svetlana Brennan](https://github.com/svetlanabrennan), New Relic
-- [Marylia Gutierrez](https://github.com/maryliag), Grafana Labs
 
 *Find more about the approver role in the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).*
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 - [Marc Pichler](https://github.com/pichlermarc), Dynatrace
 - [Trent Mick](https://github.com/trentm), Elastic
 
-*Find more about the maintainer role in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).*
+*Find more about the maintainer role in the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).*
 
 #### Approvers ([@open-telemetry/javascript-approvers](https://github.com/orgs/open-telemetry/teams/javascript-approvers))
 
@@ -253,13 +253,24 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 - [Svetlana Brennan](https://github.com/svetlanabrennan), New Relic
 - [Marylia Gutierrez](https://github.com/maryliag), Grafana Labs
 
-*Find more about the approver role in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).*
+*Find more about the approver role in the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).*
 
-#### Triager ([@open-telemetry/javascript-triagers](https://github.com/orgs/open-telemetry/teams/javascript-triagers))
+#### Triagers ([@open-telemetry/javascript-triagers](https://github.com/orgs/open-telemetry/teams/javascript-triagers))
 
-- N/A
+Members of this team have triager permissions for opentelemetry-js.git and opentelemetry-js-contrib.git.
 
-*Find more about the triager role in the [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#triager).*
+- (none currently)
+
+*Find more about the triager role in the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#triager).*
+
+#### Contrib Triagers ([@open-telemetry/javascript-contrib-triagers](https://github.com/orgs/open-telemetry/teams/javascript-contrib-triagers))
+
+Members of this team have triager permissions for opentelemetry-js-contrib.git.
+
+- [Jonathan Munz](https://github.com/jpmunz), Embrace
+- [Florencia Acosta](https://github.com/facostaembrace), Embrace
+
+*Find more about the triager role in the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#triager).*
 
 #### Emeriti
 
@@ -276,7 +287,7 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 - [Gerhard Stöbich](https://github.com/Flarna), Dynatrace, Approver
 - [Haddas Bronfman](https://github.com/haddasbronfman), Cisco, Approver
 
-*Find more about the emeritus role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#emeritus-maintainerapprovertriager).*
+*Find more about the emeritus role in [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#emeritus-maintainerapprovertriager).*
 
 #### Thanks to all the people who already contributed
 


### PR DESCRIPTION
This adds the section next to the existing 'Triagers' section
These are separate 'teams', the new one just provides permissions
on the contrib repo.

This adds Jon and Florencia for now. There are others to add, but
I will follow-up separately.

Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2600
