### PR TITLE
chore(semantic-conventions): whitespace-only fixes in comments from weaver 0.12.0

### DIFF
--- a/scripts/semconv/generate.sh
+++ b/scripts/semconv/generate.sh
@@ -9,7 +9,7 @@ ROOT_DIR="${SCRIPT_DIR}/../../"
 # ... in git@github.com:open-telemetry/semantic-conventions.git
 SPEC_VERSION=v1.29.0
 # ... in git@github.com:open-telemetry/weaver.git
-GENERATOR_VERSION=v0.10.0
+GENERATOR_VERSION=v0.12.0
 
 # When running on windows and you are getting references to ";C" (like Telemetry;C)
 # then this is an issue with the bash shell, so first run the following in your shell:

--- a/semantic-conventions/src/experimental_attributes.ts
+++ b/semantic-conventions/src/experimental_attributes.ts
@@ -20,21 +20,21 @@
 
 /**
  * Uniquely identifies the framework API revision offered by a version (`os.version`) of the android operating system. More information can be found [here](https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels).
- * 
+ *
  * @example 33
  * @example 32
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_ANDROID_OS_API_LEVEL = 'android.os.api_level' as const;
 
 /**
  * Deprecated use the `device.app.lifecycle` event definition including `android.state` as a payload field instead.
- * 
+ *
  * @note The Android lifecycle states are defined in [Activity lifecycle callbacks](https://developer.android.com/guide/components/activities/activity-lifecycle#lc), and from which the `OS identifiers` are derived.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `device.app.lifecycle`.
  */
 export const ATTR_ANDROID_STATE = 'android.state' as const;
@@ -56,56 +56,56 @@ export const ANDROID_STATE_VALUE_FOREGROUND = "foreground" as const;
 
 /**
  * The provenance filename of the built attestation which directly relates to the build artifact filename. This filename **SHOULD** accompany the artifact at publish time. See the [SLSA Relationship](https://slsa.dev/spec/v1.0/distributing-provenance#relationship-between-artifacts-and-attestations) specification for more information.
- * 
+ *
  * @example golang-binary-amd64-v0.1.0.attestation
  * @example docker-image-amd64-v0.1.0.intoto.json1
  * @example release-1.tar.gz.attestation
  * @example file-name-package.tar.gz.intoto.json1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_ARTIFACT_ATTESTATION_FILENAME = 'artifact.attestation.filename' as const;
 
 /**
  * The full [hash value (see glossary)](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf), of the built attestation. Some envelopes in the software attestation space also refer to this as the [digest](https://github.com/in-toto/attestation/blob/main/spec/README.md#in-toto-attestation-framework-spec).
- * 
+ *
  * @example 1b31dfcd5b7f9267bf2ff47651df1cfb9147b9e4df1f335accf65b4cda498408
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_ARTIFACT_ATTESTATION_HASH = 'artifact.attestation.hash' as const;
 
 /**
  * The id of the build [software attestation](https://slsa.dev/attestation-model).
- * 
+ *
  * @example 123
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_ARTIFACT_ATTESTATION_ID = 'artifact.attestation.id' as const;
 
 /**
  * The human readable file name of the artifact, typically generated during build and release processes. Often includes the package name and version in the file name.
- * 
+ *
  * @example golang-binary-amd64-v0.1.0
  * @example docker-image-amd64-v0.1.0
  * @example release-1.tar.gz
  * @example file-name-package.tar.gz
- * 
+ *
  * @note This file name can also act as the [Package Name](https://slsa.dev/spec/v1.0/terminology#package-model)
  * in cases where the package ecosystem maps accordingly.
  * Additionally, the artifact [can be published](https://slsa.dev/spec/v1.0/terminology#software-supply-chain)
  * for others, but that is not a guarantee.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_ARTIFACT_FILENAME = 'artifact.filename' as const;
 
 /**
  * The full [hash value (see glossary)](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf), often found in checksum.txt on a release of the artifact and used to verify package integrity.
- * 
+ *
  * @example 9ff4c52759e2c4ac70b7d517bc7fcdc1cda631ca0045271ddd1b192544f8a3e9
- * 
+ *
  * @note The specific algorithm used to create the cryptographic hash value is
  * not defined. In situations where an artifact has multiple
  * cryptographic hashes, it is up to the implementer to choose which
@@ -114,253 +114,253 @@ export const ATTR_ARTIFACT_FILENAME = 'artifact.filename' as const;
  * corresponding attestation. The implementer can then provide the other
  * hash values through an additional set of attribute extensions as they
  * deem necessary.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_ARTIFACT_HASH = 'artifact.hash' as const;
 
 /**
  * The [Package URL](https://github.com/package-url/purl-spec) of the [package artifact](https://slsa.dev/spec/v1.0/terminology#package-model) provides a standard way to identify and locate the packaged artifact.
- * 
+ *
  * @example pkg:github/package-url/purl-spec@1209109710924
  * @example pkg:npm/foo@12.12.3
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_ARTIFACT_PURL = 'artifact.purl' as const;
 
 /**
  * The version of the artifact.
- * 
+ *
  * @example v0.1.0
  * @example 1.2.1
  * @example 122691-build
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_ARTIFACT_VERSION = 'artifact.version' as const;
 
 /**
  * The JSON-serialized value of each item in the `AttributeDefinitions` request field.
- * 
+ *
  * @example ["{ "AttributeName": "string", "AttributeType": "string" }"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS = 'aws.dynamodb.attribute_definitions' as const;
 
 /**
  * The value of the `AttributesToGet` request parameter.
- * 
+ *
  * @example ["lives", "id"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_ATTRIBUTES_TO_GET = 'aws.dynamodb.attributes_to_get' as const;
 
 /**
  * The value of the `ConsistentRead` request parameter.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_CONSISTENT_READ = 'aws.dynamodb.consistent_read' as const;
 
 /**
  * The JSON-serialized value of each item in the `ConsumedCapacity` response field.
- * 
+ *
  * @example ["{ "CapacityUnits": number, "GlobalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "LocalSecondaryIndexes": { "string" : { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number } }, "ReadCapacityUnits": number, "Table": { "CapacityUnits": number, "ReadCapacityUnits": number, "WriteCapacityUnits": number }, "TableName": "string", "WriteCapacityUnits": number }"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_CONSUMED_CAPACITY = 'aws.dynamodb.consumed_capacity' as const;
 
 /**
  * The value of the `Count` response parameter.
- * 
+ *
  * @example 10
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_COUNT = 'aws.dynamodb.count' as const;
 
 /**
  * The value of the `ExclusiveStartTableName` request parameter.
- * 
+ *
  * @example Users
  * @example CatsTable
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_EXCLUSIVE_START_TABLE = 'aws.dynamodb.exclusive_start_table' as const;
 
 /**
  * The JSON-serialized value of each item in the `GlobalSecondaryIndexUpdates` request field.
- * 
+ *
  * @example ["{ "Create": { "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES = 'aws.dynamodb.global_secondary_index_updates' as const;
 
 /**
  * The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field
- * 
+ *
  * @example ["{ "IndexName": "string", "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" }, "ProvisionedThroughput": { "ReadCapacityUnits": number, "WriteCapacityUnits": number } }"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES = 'aws.dynamodb.global_secondary_indexes' as const;
 
 /**
  * The value of the `IndexName` request parameter.
- * 
+ *
  * @example name_to_group
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_INDEX_NAME = 'aws.dynamodb.index_name' as const;
 
 /**
  * The JSON-serialized value of the `ItemCollectionMetrics` response field.
- * 
+ *
  * @example { "string" : [ { "ItemCollectionKey": { "string" : { "B": blob, "BOOL": boolean, "BS": [ blob ], "L": [ "AttributeValue" ], "M": { "string" : "AttributeValue" }, "N": "string", "NS": [ "string" ], "NULL": boolean, "S": "string", "SS": [ "string" ] } }, "SizeEstimateRangeGB": [ number ] } ] }
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_ITEM_COLLECTION_METRICS = 'aws.dynamodb.item_collection_metrics' as const;
 
 /**
  * The value of the `Limit` request parameter.
- * 
+ *
  * @example 10
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_LIMIT = 'aws.dynamodb.limit' as const;
 
 /**
  * The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.
- * 
+ *
  * @example ["{ "IndexArn": "string", "IndexName": "string", "IndexSizeBytes": number, "ItemCount": number, "KeySchema": [ { "AttributeName": "string", "KeyType": "string" } ], "Projection": { "NonKeyAttributes": [ "string" ], "ProjectionType": "string" } }"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES = 'aws.dynamodb.local_secondary_indexes' as const;
 
 /**
  * The value of the `ProjectionExpression` request parameter.
- * 
+ *
  * @example Title
  * @example Title, Price, Color
  * @example Title, Description, RelatedItems, ProductReviews
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_PROJECTION = 'aws.dynamodb.projection' as const;
 
 /**
  * The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.
- * 
+ *
  * @example 1.0
  * @example 2.0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY = 'aws.dynamodb.provisioned_read_capacity' as const;
 
 /**
  * The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.
- * 
+ *
  * @example 1.0
  * @example 2.0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY = 'aws.dynamodb.provisioned_write_capacity' as const;
 
 /**
  * The value of the `ScanIndexForward` request parameter.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_SCAN_FORWARD = 'aws.dynamodb.scan_forward' as const;
 
 /**
  * The value of the `ScannedCount` response parameter.
- * 
+ *
  * @example 50
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_SCANNED_COUNT = 'aws.dynamodb.scanned_count' as const;
 
 /**
  * The value of the `Segment` request parameter.
- * 
+ *
  * @example 10
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_SEGMENT = 'aws.dynamodb.segment' as const;
 
 /**
  * The value of the `Select` request parameter.
- * 
+ *
  * @example ALL_ATTRIBUTES
  * @example COUNT
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_SELECT = 'aws.dynamodb.select' as const;
 
 /**
  * The number of items in the `TableNames` response parameter.
- * 
+ *
  * @example 20
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_TABLE_COUNT = 'aws.dynamodb.table_count' as const;
 
 /**
  * The keys in the `RequestItems` object field.
- * 
+ *
  * @example ["Users", "Cats"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_TABLE_NAMES = 'aws.dynamodb.table_names' as const;
 
 /**
  * The value of the `TotalSegments` request parameter.
- * 
+ *
  * @example 100
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_DYNAMODB_TOTAL_SEGMENTS = 'aws.dynamodb.total_segments' as const;
 
 /**
  * The ARN of an [ECS cluster](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html).
- * 
+ *
  * @example arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_ECS_CLUSTER_ARN = 'aws.ecs.cluster.arn' as const;
 
 /**
  * The Amazon Resource Name (ARN) of an [ECS container instance](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html).
- * 
+ *
  * @example arn:aws:ecs:us-west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_ECS_CONTAINER_ARN = 'aws.ecs.container.arn' as const;
 
 /**
  * The [launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html) for an ECS task.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_ECS_LAUNCHTYPE = 'aws.ecs.launchtype' as const;
@@ -377,57 +377,57 @@ export const AWS_ECS_LAUNCHTYPE_VALUE_FARGATE = "fargate" as const;
 
 /**
  * The ARN of a running [ECS task](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids).
- * 
+ *
  * @example arn:aws:ecs:us-west-1:123456789123:task/10838bed-421f-43ef-870a-f43feacbbb5b
  * @example arn:aws:ecs:us-west-1:123456789123:task/my-cluster/task-id/23ebb8ac-c18f-46c6-8bbe-d55d0e37cfbd
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_ECS_TASK_ARN = 'aws.ecs.task.arn' as const;
 
 /**
  * The family name of the [ECS task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html) used to create the ECS task.
- * 
+ *
  * @example opentelemetry-family
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_ECS_TASK_FAMILY = 'aws.ecs.task.family' as const;
 
 /**
  * The ID of a running ECS task. The ID **MUST** be extracted from `task.arn`.
- * 
+ *
  * @example 10838bed-421f-43ef-870a-f43feacbbb5b
  * @example 23ebb8ac-c18f-46c6-8bbe-d55d0e37cfbd
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_ECS_TASK_ID = 'aws.ecs.task.id' as const;
 
 /**
  * The revision for the task definition used to create the ECS task.
- * 
+ *
  * @example 8
  * @example 26
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_ECS_TASK_REVISION = 'aws.ecs.task.revision' as const;
 
 /**
  * The ARN of an EKS cluster.
- * 
+ *
  * @example arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_EKS_CLUSTER_ARN = 'aws.eks.cluster.arn' as const;
 
 /**
  * The full invoked ARN as provided on the `Context` passed to the function (`Lambda-Runtime-Invoked-Function-Arn` header on the `/runtime/invocation/next` applicable).
- * 
+ *
  * @example arn:aws:lambda:us-east-1:123456:function:myfunction:myalias
- * 
+ *
  * @note This may be different from `cloud.resource_id` if an alias is involved.
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -435,105 +435,105 @@ export const ATTR_AWS_LAMBDA_INVOKED_ARN = 'aws.lambda.invoked_arn' as const;
 
 /**
  * The Amazon Resource Name(s) (ARN) of the AWS log group(s).
- * 
+ *
  * @example ["arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:*"]
- * 
+ *
  * @note See the [log group ARN format documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_LOG_GROUP_ARNS = 'aws.log.group.arns' as const;
 
 /**
  * The name(s) of the AWS log group(s) an application is writing to.
- * 
+ *
  * @example ["/aws/lambda/my-function", "opentelemetry-service"]
- * 
+ *
  * @note Multiple log groups must be supported for cases like multi-container applications, where a single application has sidecar containers, and each write to their own log group.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_LOG_GROUP_NAMES = 'aws.log.group.names' as const;
 
 /**
  * The ARN(s) of the AWS log stream(s).
- * 
+ *
  * @example ["arn:aws:logs:us-west-1:123456789012:log-group:/aws/my/group:log-stream:logs/main/10838bed-421f-43ef-870a-f43feacbbb5b"]
- * 
+ *
  * @note See the [log stream ARN format documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format). One log group can contain several log streams, so these ARNs necessarily identify both a log group and a log stream.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_LOG_STREAM_ARNS = 'aws.log.stream.arns' as const;
 
 /**
  * The name(s) of the AWS log stream(s) an application is writing to.
- * 
+ *
  * @example ["logs/main/10838bed-421f-43ef-870a-f43feacbbb5b"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_LOG_STREAM_NAMES = 'aws.log.stream.names' as const;
 
 /**
  * The AWS request ID as returned in the response headers `x-amz-request-id` or `x-amz-requestid`.
- * 
+ *
  * @example 79b9da39-b7ae-508a-a6bc-864b2829c622
  * @example C9ER4AJX75574TDJ
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_REQUEST_ID = 'aws.request_id' as const;
 
 /**
  * The S3 bucket name the request refers to. Corresponds to the `--bucket` parameter of the [S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html) operations.
- * 
+ *
  * @example some-bucket-name
- * 
+ *
  * @note The `bucket` attribute is applicable to all S3 operations that reference a bucket, i.e. that require the bucket name as a mandatory parameter.
  * This applies to almost all S3 operations except `list-buckets`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_S3_BUCKET = 'aws.s3.bucket' as const;
 
 /**
  * The source object (in the form `bucket`/`key`) for the copy operation.
- * 
+ *
  * @example someFile.yml
- * 
+ *
  * @note The `copy_source` attribute applies to S3 copy operations and corresponds to the `--copy-source` parameter
  * of the [copy-object operation within the S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html).
  * This applies in particular to the following operations:
- * 
+ *
  *   - [copy-object](https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html)
  *   - [upload-part-copy](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html)
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_S3_COPY_SOURCE = 'aws.s3.copy_source' as const;
 
 /**
  * The delete request container that specifies the objects to be deleted.
- * 
+ *
  * @example Objects=[{Key=string,VersionId=string},{Key=string,VersionId=string}],Quiet=boolean
- * 
+ *
  * @note The `delete` attribute is only applicable to the [delete-object](https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html) operation.
  * The `delete` attribute corresponds to the `--delete` parameter of the
  * [delete-objects operation within the S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-objects.html).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_S3_DELETE = 'aws.s3.delete' as const;
 
 /**
  * The S3 object key the request refers to. Corresponds to the `--key` parameter of the [S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html) operations.
- * 
+ *
  * @example someFile.yml
- * 
+ *
  * @note The `key` attribute is applicable to all object-related S3 operations, i.e. that require the object key as a mandatory parameter.
  * This applies in particular to the following operations:
- * 
+ *
  *   - [copy-object](https://docs.aws.amazon.com/cli/latest/reference/s3api/copy-object.html)
  *   - [delete-object](https://docs.aws.amazon.com/cli/latest/reference/s3api/delete-object.html)
  *   - [get-object](https://docs.aws.amazon.com/cli/latest/reference/s3api/get-object.html)
@@ -547,170 +547,170 @@ export const ATTR_AWS_S3_DELETE = 'aws.s3.delete' as const;
  *   - [list-parts](https://docs.aws.amazon.com/cli/latest/reference/s3api/list-parts.html)
  *   - [upload-part](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html)
  *   - [upload-part-copy](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html)
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_S3_KEY = 'aws.s3.key' as const;
 
 /**
  * The part number of the part being uploaded in a multipart-upload operation. This is a positive integer between 1 and 10,000.
- * 
+ *
  * @example 3456
- * 
+ *
  * @note The `part_number` attribute is only applicable to the [upload-part](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html)
  * and [upload-part-copy](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html) operations.
  * The `part_number` attribute corresponds to the `--part-number` parameter of the
  * [upload-part operation within the S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_S3_PART_NUMBER = 'aws.s3.part_number' as const;
 
 /**
  * Upload ID that identifies the multipart upload.
- * 
+ *
  * @example dfRtDYWFbkRONycy.Yxwh66Yjlx.cph0gtNBtJ
- * 
+ *
  * @note The `upload_id` attribute applies to S3 multipart-upload operations and corresponds to the `--upload-id` parameter
  * of the [S3 API](https://docs.aws.amazon.com/cli/latest/reference/s3api/index.html) multipart operations.
  * This applies in particular to the following operations:
- * 
+ *
  *   - [abort-multipart-upload](https://docs.aws.amazon.com/cli/latest/reference/s3api/abort-multipart-upload.html)
  *   - [complete-multipart-upload](https://docs.aws.amazon.com/cli/latest/reference/s3api/complete-multipart-upload.html)
  *   - [list-parts](https://docs.aws.amazon.com/cli/latest/reference/s3api/list-parts.html)
  *   - [upload-part](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part.html)
  *   - [upload-part-copy](https://docs.aws.amazon.com/cli/latest/reference/s3api/upload-part-copy.html)
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AWS_S3_UPLOAD_ID = 'aws.s3.upload_id' as const;
 
 /**
  * [Azure Resource Provider Namespace](https://learn.microsoft.com/azure/azure-resource-manager/management/azure-services-resource-providers) as recognized by the client.
- * 
+ *
  * @example Microsoft.Storage
  * @example Microsoft.KeyVault
  * @example Microsoft.ServiceBus
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AZ_NAMESPACE = 'az.namespace' as const;
 
 /**
  * The unique identifier of the service request. It's generated by the Azure service and returned with the response.
- * 
+ *
  * @example 00000000-0000-0000-0000-000000000000
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_AZ_SERVICE_REQUEST_ID = 'az.service_request_id' as const;
 
 /**
  * Array of brand name and version separated by a space
- * 
+ *
  * @example [" Not A;Brand 99", "Chromium 99", "Chrome 99"]
- * 
+ *
  * @note This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.brands`).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_BROWSER_BRANDS = 'browser.brands' as const;
 
 /**
  * Preferred language of the user using the browser
- * 
+ *
  * @example en
  * @example en-US
  * @example fr
  * @example fr-FR
- * 
+ *
  * @note This value is intended to be taken from the Navigator API `navigator.language`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_BROWSER_LANGUAGE = 'browser.language' as const;
 
 /**
  * A boolean that is true if the browser is running on a mobile device
- * 
+ *
  * @note This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.mobile`). If unavailable, this attribute **SHOULD** be left unset.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_BROWSER_MOBILE = 'browser.mobile' as const;
 
 /**
  * The platform on which the browser is running
- * 
+ *
  * @example Windows
  * @example macOS
  * @example Android
- * 
+ *
  * @note This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.platform`). If unavailable, the legacy `navigator.platform` API **SHOULD NOT** be used instead and this attribute **SHOULD** be left unset in order for the values to be consistent.
  * The list of possible values is defined in the [W3C User-Agent Client Hints specification](https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform). Note that some (but not all) of these values can overlap with values in the [`os.type` and `os.name` attributes](./os.md). However, for consistency, the values in the `browser.platform` attribute should capture the exact value that the user agent provides.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_BROWSER_PLATFORM = 'browser.platform' as const;
 
 /**
  * The human readable name of the pipeline within a CI/CD system.
- * 
+ *
  * @example Build and Test
  * @example Lint
  * @example Deploy Go Project
  * @example deploy_to_environment
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CICD_PIPELINE_NAME = 'cicd.pipeline.name' as const;
 
 /**
  * The unique identifier of a pipeline run within a CI/CD system.
- * 
+ *
  * @example 120912
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CICD_PIPELINE_RUN_ID = 'cicd.pipeline.run.id' as const;
 
 /**
  * The human readable name of a task within a pipeline. Task here most closely aligns with a [computing process](https://wikipedia.org/wiki/Pipeline_(computing)) in a pipeline. Other terms for tasks include commands, steps, and procedures.
- * 
+ *
  * @example Run GoLang Linter
  * @example Go Build
  * @example go-test
  * @example deploy_binary
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CICD_PIPELINE_TASK_NAME = 'cicd.pipeline.task.name' as const;
 
 /**
  * The unique identifier of a task run within a pipeline.
- * 
+ *
  * @example 12097
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CICD_PIPELINE_TASK_RUN_ID = 'cicd.pipeline.task.run.id' as const;
 
 /**
  * The [URL](https://wikipedia.org/wiki/URL) of the pipeline run providing the complete address in order to locate and identify the pipeline run.
- * 
+ *
  * @example https://github.com/open-telemetry/semantic-conventions/actions/runs/9753949763/job/26920038674?pr=1075
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CICD_PIPELINE_TASK_RUN_URL_FULL = 'cicd.pipeline.task.run.url.full' as const;
 
 /**
  * The type of the task within a pipeline.
- * 
+ *
  * @example build
  * @example test
  * @example deploy
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CICD_PIPELINE_TASK_TYPE = 'cicd.pipeline.task.type' as const;
@@ -732,30 +732,30 @@ export const CICD_PIPELINE_TASK_TYPE_VALUE_TEST = "test" as const;
 
 /**
  * The cloud account ID the resource is assigned to.
- * 
+ *
  * @example 111111111111
  * @example opentelemetry
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUD_ACCOUNT_ID = 'cloud.account.id' as const;
 
 /**
  * Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
- * 
+ *
  * @example us-east-1c
- * 
+ *
  * @note Availability zones are called "zones" on Alibaba Cloud and Google Cloud.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUD_AVAILABILITY_ZONE = 'cloud.availability_zone' as const;
 
 /**
  * The cloud platform in use.
- * 
+ *
  * @note The prefix of the service **SHOULD** match the one specified in `cloud.provider`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUD_PLATFORM = 'cloud.platform' as const;
@@ -902,7 +902,7 @@ export const CLOUD_PLATFORM_VALUE_TENCENT_CLOUD_SCF = "tencent_cloud_scf" as con
 
 /**
  * Name of the cloud provider.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUD_PROVIDER = 'cloud.provider' as const;
@@ -944,29 +944,29 @@ export const CLOUD_PROVIDER_VALUE_TENCENT_CLOUD = "tencent_cloud" as const;
 
 /**
  * The geographical region the resource is running.
- * 
+ *
  * @example us-central1
  * @example us-east-1
- * 
+ *
  * @note Refer to your provider's docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/global-infrastructure/geographies/), [Google Cloud regions](https://cloud.google.com/about/locations), or [Tencent Cloud regions](https://www.tencentcloud.com/document/product/213/6091).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUD_REGION = 'cloud.region' as const;
 
 /**
  * Cloud provider-specific native identifier of the monitored cloud resource (e.g. an [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) on AWS, a [fully qualified resource ID](https://learn.microsoft.com/rest/api/resources/resources/get-by-id) on Azure, a [full resource name](https://cloud.google.com/apis/design/resource_names#full_resource_name) on GCP)
- * 
+ *
  * @example arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function
  * @example //run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID
  * @example /subscriptions/<SUBSCRIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>
- * 
+ *
  * @note On some cloud providers, it may not be possible to determine the full ID at startup,
  * so it may be necessary to set `cloud.resource_id` as a span attribute instead.
- * 
+ *
  * The exact value to use for `cloud.resource_id` depends on the cloud provider.
  * The following well-known definitions **MUST** be used if you set this attribute and they apply:
- * 
+ *
  *   - **AWS Lambda:** The function [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
  *     Take care not to use the "invoked ARN" directly but replace any
  *     [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html)
@@ -978,310 +978,310 @@ export const ATTR_CLOUD_REGION = 'cloud.region' as const;
  *     `/subscriptions/<SUBSCRIPTION_GUID>/resourceGroups/<RG>/providers/Microsoft.Web/sites/<FUNCAPP>/functions/<FUNC>`.
  *     This means that a span attribute **MUST** be used, as an Azure function app can host multiple functions that would usually share
  *     a TracerProvider.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUD_RESOURCE_ID = 'cloud.resource_id' as const;
 
 /**
  * The [event_id](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id) uniquely identifies the event.
- * 
+ *
  * @example 123e4567-e89b-12d3-a456-426614174000
  * @example 0001
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDEVENTS_EVENT_ID = 'cloudevents.event_id' as const;
 
 /**
  * The [source](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#source-1) identifies the context in which an event happened.
- * 
+ *
  * @example https://github.com/cloudevents
  * @example /cloudevents/spec/pull/123
  * @example my-service
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDEVENTS_EVENT_SOURCE = 'cloudevents.event_source' as const;
 
 /**
  * The [version of the CloudEvents specification](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#specversion) which the event uses.
- * 
+ *
  * @example "1.0"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDEVENTS_EVENT_SPEC_VERSION = 'cloudevents.event_spec_version' as const;
 
 /**
  * The [subject](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#subject) of the event in the context of the event producer (identified by source).
- * 
+ *
  * @example "mynewfile.jpg"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDEVENTS_EVENT_SUBJECT = 'cloudevents.event_subject' as const;
 
 /**
  * The [event_type](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type) contains a value describing the type of event related to the originating occurrence.
- * 
+ *
  * @example com.github.pull_request.opened
  * @example com.example.object.deleted.v2
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDEVENTS_EVENT_TYPE = 'cloudevents.event_type' as const;
 
 /**
  * The guid of the application.
- * 
+ *
  * @example 218fc5a9-a5f1-4b54-aa05-46717d0ab26d
- * 
+ *
  * @note Application instrumentation should use the value from environment
  * variable `VCAP_APPLICATION.application_id`. This is the same value as
  * reported by `cf app <app-name> --guid`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDFOUNDRY_APP_ID = 'cloudfoundry.app.id' as const;
 
 /**
  * The index of the application instance. 0 when just one instance is active.
- * 
+ *
  * @example 0
  * @example 1
- * 
+ *
  * @note CloudFoundry defines the `instance_id` in the [Loggregator v2 envelope](https://github.com/cloudfoundry/loggregator-api#v2-envelope).
  * It is used for logs and metrics emitted by CloudFoundry. It is
  * supposed to contain the application instance index for applications
  * deployed on the runtime.
- * 
+ *
  * Application instrumentation should use the value from environment
  * variable `CF_INSTANCE_INDEX`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDFOUNDRY_APP_INSTANCE_ID = 'cloudfoundry.app.instance.id' as const;
 
 /**
  * The name of the application.
- * 
+ *
  * @example my-app-name
- * 
+ *
  * @note Application instrumentation should use the value from environment
  * variable `VCAP_APPLICATION.application_name`. This is the same value
  * as reported by `cf apps`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDFOUNDRY_APP_NAME = 'cloudfoundry.app.name' as const;
 
 /**
  * The guid of the CloudFoundry org the application is running in.
- * 
+ *
  * @example 218fc5a9-a5f1-4b54-aa05-46717d0ab26d
- * 
+ *
  * @note Application instrumentation should use the value from environment
  * variable `VCAP_APPLICATION.org_id`. This is the same value as
  * reported by `cf org <org-name> --guid`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDFOUNDRY_ORG_ID = 'cloudfoundry.org.id' as const;
 
 /**
  * The name of the CloudFoundry organization the app is running in.
- * 
+ *
  * @example my-org-name
- * 
+ *
  * @note Application instrumentation should use the value from environment
  * variable `VCAP_APPLICATION.org_name`. This is the same value as
  * reported by `cf orgs`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDFOUNDRY_ORG_NAME = 'cloudfoundry.org.name' as const;
 
 /**
  * The UID identifying the process.
- * 
+ *
  * @example 218fc5a9-a5f1-4b54-aa05-46717d0ab26d
- * 
+ *
  * @note Application instrumentation should use the value from environment
  * variable `VCAP_APPLICATION.process_id`. It is supposed to be equal to
  * `VCAP_APPLICATION.app_id` for applications deployed to the runtime.
  * For system components, this could be the actual PID.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDFOUNDRY_PROCESS_ID = 'cloudfoundry.process.id' as const;
 
 /**
  * The type of process.
- * 
+ *
  * @example web
- * 
+ *
  * @note CloudFoundry applications can consist of multiple jobs. Usually the
  * main process will be of type `web`. There can be additional background
  * tasks or side-cars with different process types.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDFOUNDRY_PROCESS_TYPE = 'cloudfoundry.process.type' as const;
 
 /**
  * The guid of the CloudFoundry space the application is running in.
- * 
+ *
  * @example 218fc5a9-a5f1-4b54-aa05-46717d0ab26d
- * 
+ *
  * @note Application instrumentation should use the value from environment
  * variable `VCAP_APPLICATION.space_id`. This is the same value as
  * reported by `cf space <space-name> --guid`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDFOUNDRY_SPACE_ID = 'cloudfoundry.space.id' as const;
 
 /**
  * The name of the CloudFoundry space the application is running in.
- * 
+ *
  * @example my-space-name
- * 
+ *
  * @note Application instrumentation should use the value from environment
  * variable `VCAP_APPLICATION.space_name`. This is the same value as
  * reported by `cf spaces`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDFOUNDRY_SPACE_NAME = 'cloudfoundry.space.name' as const;
 
 /**
  * A guid or another name describing the event source.
- * 
+ *
  * @example cf/gorouter
- * 
+ *
  * @note CloudFoundry defines the `source_id` in the [Loggregator v2 envelope](https://github.com/cloudfoundry/loggregator-api#v2-envelope).
  * It is used for logs and metrics emitted by CloudFoundry. It is
  * supposed to contain the component name, e.g. "gorouter", for
  * CloudFoundry components.
- * 
+ *
  * When system components are instrumented, values from the
  * [Bosh spec](https://bosh.io/docs/jobs/#properties-spec)
  * should be used. The `system.id` should be set to
  * `spec.deployment/spec.name`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDFOUNDRY_SYSTEM_ID = 'cloudfoundry.system.id' as const;
 
 /**
  * A guid describing the concrete instance of the event source.
- * 
+ *
  * @example 218fc5a9-a5f1-4b54-aa05-46717d0ab26d
- * 
+ *
  * @note CloudFoundry defines the `instance_id` in the [Loggregator v2 envelope](https://github.com/cloudfoundry/loggregator-api#v2-envelope).
  * It is used for logs and metrics emitted by CloudFoundry. It is
  * supposed to contain the vm id for CloudFoundry components.
- * 
+ *
  * When system components are instrumented, values from the
  * [Bosh spec](https://bosh.io/docs/jobs/#properties-spec)
  * should be used. The `system.instance.id` should be set to `spec.id`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CLOUDFOUNDRY_SYSTEM_INSTANCE_ID = 'cloudfoundry.system.instance.id' as const;
 
 /**
  * The column number in `code.filepath` best representing the operation. It **SHOULD** point within the code unit named in `code.function`.
- * 
+ *
  * @example 16
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CODE_COLUMN = 'code.column' as const;
 
 /**
  * The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).
- * 
+ *
  * @example "/usr/local/MyApplication/content_root/app/index.php"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CODE_FILEPATH = 'code.filepath' as const;
 
 /**
  * The method or function name, or equivalent (usually rightmost part of the code unit's name).
- * 
+ *
  * @example "serveRequest"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CODE_FUNCTION = 'code.function' as const;
 
 /**
  * The line number in `code.filepath` best representing the operation. It **SHOULD** point within the code unit named in `code.function`.
- * 
+ *
  * @example 42
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CODE_LINENO = 'code.lineno' as const;
 
 /**
  * The "namespace" within which `code.function` is defined. Usually the qualified class or module name, such that `code.namespace` + some separator + `code.function` form a unique identifier for the code unit.
- * 
+ *
  * @example "com.example.MyHttpService"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CODE_NAMESPACE = 'code.namespace' as const;
 
 /**
  * A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.
- * 
+ *
  * @example "at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\\n at com.example.GenerateTrace.main(GenerateTrace.java:5)\\n"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CODE_STACKTRACE = 'code.stacktrace' as const;
 
 /**
  * The command used to run the container (i.e. the command name).
- * 
+ *
  * @example otelcontribcol
- * 
+ *
  * @note If using embedded credentials or sensitive data, it is recommended to remove them to prevent potential leakage.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_COMMAND = 'container.command' as const;
 
 /**
  * All the command arguments (including the command/executable itself) run by the container.
- * 
+ *
  * @example ["otelcontribcol", "--config", "config.yaml"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_COMMAND_ARGS = 'container.command_args' as const;
 
 /**
  * The full command run by the container as a single string representing the full command.
- * 
+ *
  * @example otelcontribcol --config config.yaml
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_COMMAND_LINE = 'container.command_line' as const;
 
 /**
  * Deprecated, use `cpu.mode` instead.
- * 
+ *
  * @example user
  * @example kernel
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `cpu.mode`
  */
 export const ATTR_CONTAINER_CPU_STATE = 'container.cpu.state' as const;
@@ -1303,123 +1303,123 @@ export const CONTAINER_CPU_STATE_VALUE_USER = "user" as const;
 
 /**
  * The name of the CSI ([Container Storage Interface](https://github.com/container-storage-interface/spec)) plugin used by the volume.
- * 
+ *
  * @example pd.csi.storage.gke.io
- * 
+ *
  * @note This can sometimes be referred to as a "driver" in CSI implementations. This should represent the `name` field of the GetPluginInfo RPC.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_CSI_PLUGIN_NAME = 'container.csi.plugin.name' as const;
 
 /**
  * The unique volume ID returned by the CSI ([Container Storage Interface](https://github.com/container-storage-interface/spec)) plugin.
- * 
+ *
  * @example projects/my-gcp-project/zones/my-gcp-zone/disks/my-gcp-disk
- * 
+ *
  * @note This can sometimes be referred to as a "volume handle" in CSI implementations. This should represent the `Volume.volume_id` field in CSI spec.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_CSI_VOLUME_ID = 'container.csi.volume.id' as const;
 
 /**
  * Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/containers/run/#container-identification). The UUID might be abbreviated.
- * 
+ *
  * @example a3bf90e006b2
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_ID = 'container.id' as const;
 
 /**
  * Runtime specific image identifier. Usually a hash algorithm followed by a UUID.
- * 
+ *
  * @example sha256:19c92d0a00d1b66d897bceaa7319bee0dd38a10a851c60bcec9474aa3f01e50f
- * 
+ *
  * @note Docker defines a sha256 of the image id; `container.image.id` corresponds to the `Image` field from the Docker container inspect [API](https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerInspect) endpoint.
  * K8s defines a link to the container registry repository with digest `"imageID": "registry.azurecr.io /namespace/service/dockerfile@sha256:bdeabd40c3a8a492eaf9e8e44d0ebbb84bac7ee25ac0cf8a7159d25f62555625"`.
  * The ID is assigned by the container runtime and can vary in different environments. Consider using `oci.manifest.digest` if it is important to identify the same image in different environments/runtimes.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_IMAGE_ID = 'container.image.id' as const;
 
 /**
  * Name of the image the container was built on.
- * 
+ *
  * @example gcr.io/opentelemetry/operator
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_IMAGE_NAME = 'container.image.name' as const;
 
 /**
  * Repo digests of the container image as provided by the container runtime.
- * 
+ *
  * @example ["example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb", "internal.registry.example.com:5000/example@sha256:b69959407d21e8a062e0416bf13405bb2b71ed7a84dde4158ebafacfa06f5578"]
- * 
+ *
  * @note [Docker](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect) and [CRI](https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238) report those under the `RepoDigests` field.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_IMAGE_REPO_DIGESTS = 'container.image.repo_digests' as const;
 
 /**
  * Container image tags. An example can be found in [Docker Image Inspect](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect). Should be only the `<tag>` section of the full name for example from `registry.example.com/my-org/my-image:<tag>`.
- * 
+ *
  * @example ["v1.27.1", "3.5.7-0"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_IMAGE_TAGS = 'container.image.tags' as const;
 
 /**
  * Container labels, `<key>` being the label name, the value being the label value.
- * 
+ *
  * @example container.label.app=nginx
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_LABEL = (key: string) => `container.label.${key}`;
 
 /**
  * Deprecated, use `container.label` instead.
- * 
+ *
  * @example container.label.app=nginx
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `container.label`.
  */
 export const ATTR_CONTAINER_LABELS = (key: string) => `container.labels.${key}`;
 
 /**
  * Container name used by container runtime.
- * 
+ *
  * @example opentelemetry-autoconf
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_NAME = 'container.name' as const;
 
 /**
  * The container runtime managing this container.
- * 
+ *
  * @example docker
  * @example containerd
  * @example rkt
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_RUNTIME = 'container.runtime' as const;
 
 /**
  * The mode of the CPU
- * 
+ *
  * @example user
  * @example system
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CPU_MODE = 'cpu.mode' as const;
@@ -1466,7 +1466,7 @@ export const CPU_MODE_VALUE_USER = "user" as const;
 
 /**
  * The consistency level of the query. Based on consistency values from [CQL](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_CASSANDRA_CONSISTENCY_LEVEL = 'db.cassandra.consistency_level' as const;
@@ -1528,73 +1528,73 @@ export const DB_CASSANDRA_CONSISTENCY_LEVEL_VALUE_TWO = "two" as const;
 
 /**
  * The data center of the coordinating node for a query.
- * 
+ *
  * @example "us-west-2"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_CASSANDRA_COORDINATOR_DC = 'db.cassandra.coordinator.dc' as const;
 
 /**
  * The ID of the coordinating node for a query.
- * 
+ *
  * @example "be13faa2-8574-4d71-926d-27f16cf8a7af"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_CASSANDRA_COORDINATOR_ID = 'db.cassandra.coordinator.id' as const;
 
 /**
  * Whether or not the query is idempotent.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_CASSANDRA_IDEMPOTENCE = 'db.cassandra.idempotence' as const;
 
 /**
  * The fetch size used for paging, i.e. how many rows will be returned at once.
- * 
+ *
  * @example 5000
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_CASSANDRA_PAGE_SIZE = 'db.cassandra.page_size' as const;
 
 /**
  * The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
- * 
+ *
  * @example 0
  * @example 2
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT = 'db.cassandra.speculative_execution_count' as const;
 
 /**
  * Deprecated, use `db.collection.name` instead.
- * 
+ *
  * @example "mytable"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.collection.name`.
  */
 export const ATTR_DB_CASSANDRA_TABLE = 'db.cassandra.table' as const;
 
 /**
  * The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation **SHOULD** use a combination of parameters that would make the name unique, for example, combining attributes `server.address`, `server.port`, and `db.namespace`, formatted as `server.address:server.port/db.namespace`. Instrumentations that generate connection pool name following different patterns **SHOULD** document it.
- * 
+ *
  * @example myDataSource
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_CLIENT_CONNECTION_POOL_NAME = 'db.client.connection.pool.name' as const;
 
 /**
  * The state of a connection in the pool
- * 
+ *
  * @example idle
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_CLIENT_CONNECTION_STATE = 'db.client.connection.state' as const;
@@ -1611,22 +1611,22 @@ export const DB_CLIENT_CONNECTION_STATE_VALUE_USED = "used" as const;
 
 /**
  * Deprecated, use `db.client.connection.pool.name` instead.
- * 
+ *
  * @example myDataSource
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.client.connection.pool.name`.
  */
 export const ATTR_DB_CLIENT_CONNECTIONS_POOL_NAME = 'db.client.connections.pool.name' as const;
 
 /**
  * Deprecated, use `db.client.connection.state` instead.
- * 
+ *
  * @example idle
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.client.connection.state`.
  */
 export const ATTR_DB_CLIENT_CONNECTIONS_STATE = 'db.client.connections.state' as const;
@@ -1643,47 +1643,47 @@ export const DB_CLIENT_CONNECTIONS_STATE_VALUE_USED = "used" as const;
 
 /**
  * The name of a collection (table, container) within the database.
- * 
+ *
  * @example public.users
  * @example customers
- * 
+ *
  * @note It is **RECOMMENDED** to capture the value as provided by the application without attempting to do any case normalization.
- * 
+ *
  * The collection name **SHOULD NOT** be extracted from `db.query.text`,
  * unless the query format is known to only ever have a single collection name present.
- * 
+ *
  * For batch operations, if the individual operations are known to have the same collection name
  * then that collection name **SHOULD** be used.
- * 
+ *
  * This attribute has stability level RELEASE CANDIDATE.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_COLLECTION_NAME = 'db.collection.name' as const;
 
 /**
  * Deprecated, use `server.address`, `server.port` attributes instead.
- * 
+ *
  * @example "Server=(localdb)\\v11.0;Integrated Security=true;"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `server.address` and `server.port`.
  */
 export const ATTR_DB_CONNECTION_STRING = 'db.connection_string' as const;
 
 /**
  * Unique Cosmos client instance id.
- * 
+ *
  * @example "3ba4827d-4422-483f-b59f-85b74211c11d"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_COSMOSDB_CLIENT_ID = 'db.cosmosdb.client_id' as const;
 
 /**
  * Cosmos client connection mode.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_COSMOSDB_CONNECTION_MODE = 'db.cosmosdb.connection_mode' as const;
@@ -1700,13 +1700,13 @@ export const DB_COSMOSDB_CONNECTION_MODE_VALUE_GATEWAY = "gateway" as const;
 
 /**
  * Account or request [consistency level](https://learn.microsoft.com/azure/cosmos-db/consistency-levels).
- * 
+ *
  * @example Eventual
  * @example ConsistentPrefix
  * @example BoundedStaleness
  * @example Strong
  * @example Session
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_COSMOSDB_CONSISTENCY_LEVEL = 'db.cosmosdb.consistency_level' as const;
@@ -1738,20 +1738,20 @@ export const DB_COSMOSDB_CONSISTENCY_LEVEL_VALUE_STRONG = "Strong" as const;
 
 /**
  * Deprecated, use `db.collection.name` instead.
- * 
+ *
  * @example "mytable"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.collection.name`.
  */
 export const ATTR_DB_COSMOSDB_CONTAINER = 'db.cosmosdb.container' as const;
 
 /**
  * Deprecated, no replacement at this time.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated No replacement at this time.
  */
 export const ATTR_DB_COSMOSDB_OPERATION_TYPE = 'db.cosmosdb.operation_type' as const;
@@ -1833,334 +1833,334 @@ export const DB_COSMOSDB_OPERATION_TYPE_VALUE_UPSERT = "upsert" as const;
 
 /**
  * List of regions contacted during operation in the order that they were contacted. If there is more than one region listed, it indicates that the operation was performed on multiple regions i.e. cross-regional call.
- * 
+ *
  * @example ["North Central US", "Australia East", "Australia Southeast"]
- * 
+ *
  * @note Region name matches the format of `displayName` in [Azure Location API](https://learn.microsoft.com/rest/api/subscription/subscriptions/list-locations?view=rest-subscription-2021-10-01&tabs=HTTP#location)
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_COSMOSDB_REGIONS_CONTACTED = 'db.cosmosdb.regions_contacted' as const;
 
 /**
  * Request units consumed for the operation.
- * 
+ *
  * @example 46.18
  * @example 1.0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_COSMOSDB_REQUEST_CHARGE = 'db.cosmosdb.request_charge' as const;
 
 /**
  * Request payload size in bytes.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_COSMOSDB_REQUEST_CONTENT_LENGTH = 'db.cosmosdb.request_content_length' as const;
 
 /**
  * Deprecated, use `db.response.status_code` instead.
- * 
+ *
  * @example 200
  * @example 201
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.response.status_code`.
  */
 export const ATTR_DB_COSMOSDB_STATUS_CODE = 'db.cosmosdb.status_code' as const;
 
 /**
  * Cosmos DB sub status code.
- * 
+ *
  * @example 1000
  * @example 1002
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_COSMOSDB_SUB_STATUS_CODE = 'db.cosmosdb.sub_status_code' as const;
 
 /**
  * Deprecated, use `db.namespace` instead.
- * 
+ *
  * @example e9106fc68e3044f0b1475b04bf4ffd5f
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.namespace`.
  */
 export const ATTR_DB_ELASTICSEARCH_CLUSTER_NAME = 'db.elasticsearch.cluster.name' as const;
 
 /**
  * Represents the human-readable identifier of the node/instance to which a request was routed.
- * 
+ *
  * @example instance-0000000001
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_ELASTICSEARCH_NODE_NAME = 'db.elasticsearch.node.name' as const;
 
 /**
  * A dynamic value in the url path.
- * 
+ *
  * @example db.elasticsearch.path_parts.index=test-index
  * @example db.elasticsearch.path_parts.doc_id=123
- * 
+ *
  * @note Many Elasticsearch url paths allow dynamic values. These **SHOULD** be recorded in span attributes in the format `db.elasticsearch.path_parts.<key>`, where `<key>` is the url path part name. The implementation **SHOULD** reference the [elasticsearch schema](https://raw.githubusercontent.com/elastic/elasticsearch-specification/main/output/schema/schema.json) in order to map the path part values to their names.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_ELASTICSEARCH_PATH_PARTS = (key: string) => `db.elasticsearch.path_parts.${key}`;
 
 /**
  * Deprecated, no general replacement at this time. For Elasticsearch, use `db.elasticsearch.node.name` instead.
- * 
+ *
  * @example "mysql-e26b99z.example.com"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Deprecated, no general replacement at this time. For Elasticsearch, use `db.elasticsearch.node.name` instead.
  */
 export const ATTR_DB_INSTANCE_ID = 'db.instance.id' as const;
 
 /**
  * Removed, no replacement at this time.
- * 
+ *
  * @example org.postgresql.Driver
  * @example com.microsoft.sqlserver.jdbc.SQLServerDriver
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Removed as not used.
  */
 export const ATTR_DB_JDBC_DRIVER_CLASSNAME = 'db.jdbc.driver_classname' as const;
 
 /**
  * Deprecated, use `db.collection.name` instead.
- * 
+ *
  * @example "mytable"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.collection.name`.
  */
 export const ATTR_DB_MONGODB_COLLECTION = 'db.mongodb.collection' as const;
 
 /**
  * Deprecated, SQL Server instance is now populated as a part of `db.namespace` attribute.
- * 
+ *
  * @example "MSSQLSERVER"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Deprecated, no replacement at this time.
  */
 export const ATTR_DB_MSSQL_INSTANCE_NAME = 'db.mssql.instance_name' as const;
 
 /**
  * Deprecated, use `db.namespace` instead.
- * 
+ *
  * @example customers
  * @example main
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.namespace`.
  */
 export const ATTR_DB_NAME = 'db.name' as const;
 
 /**
  * The name of the database, fully qualified within the server address and port.
- * 
+ *
  * @example customers
  * @example test.users
- * 
+ *
  * @note If a database system has multiple namespace components, they **SHOULD** be concatenated (potentially using database system specific conventions) from most general to most specific namespace component, and more specific namespaces **SHOULD NOT** be captured without the more general namespaces, to ensure that "startswith" queries for the more general namespaces will be valid.
  * Semantic conventions for individual database systems **SHOULD** document what `db.namespace` means in the context of that system.
  * It is **RECOMMENDED** to capture the value as provided by the application without attempting to do any case normalization.
  * This attribute has stability level RELEASE CANDIDATE.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_NAMESPACE = 'db.namespace' as const;
 
 /**
  * Deprecated, use `db.operation.name` instead.
- * 
+ *
  * @example findAndModify
  * @example HMSET
  * @example SELECT
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.operation.name`.
  */
 export const ATTR_DB_OPERATION = 'db.operation' as const;
 
 /**
  * The number of queries included in a batch operation.
- * 
+ *
  * @example 2
  * @example 3
  * @example 4
- * 
+ *
  * @note Operations are only considered batches when they contain two or more operations, and so `db.operation.batch.size` **SHOULD** never be `1`.
  * This attribute has stability level RELEASE CANDIDATE.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_OPERATION_BATCH_SIZE = 'db.operation.batch.size' as const;
 
 /**
  * The name of the operation or command being executed.
- * 
+ *
  * @example findAndModify
  * @example HMSET
  * @example SELECT
- * 
+ *
  * @note It is **RECOMMENDED** to capture the value as provided by the application
  * without attempting to do any case normalization.
- * 
+ *
  * The operation name **SHOULD NOT** be extracted from `db.query.text`,
  * unless the query format is known to only ever have a single operation name present.
- * 
+ *
  * For batch operations, if the individual operations are known to have the same operation name
  * then that operation name **SHOULD** be used prepended by `BATCH `,
  * otherwise `db.operation.name` **SHOULD** be `BATCH` or some other database
  * system specific term if more applicable.
- * 
+ *
  * This attribute has stability level RELEASE CANDIDATE.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_OPERATION_NAME = 'db.operation.name' as const;
 
 /**
  * A database operation parameter, with `<key>` being the parameter name, and the attribute value being a string representation of the parameter value.
- * 
+ *
  * @example someval
  * @example 55
- * 
+ *
  * @note If a parameter has no name and instead is referenced only by index, then `<key>` **SHOULD** be the 0-based index.
  * If `db.query.text` is also captured, then `db.operation.parameter.<key>` **SHOULD** match up with the parameterized placeholders present in `db.query.text`.
  * This attribute has stability level RELEASE CANDIDATE.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_OPERATION_PARAMETER = (key: string) => `db.operation.parameter.${key}`;
 
 /**
  * A query parameter used in `db.query.text`, with `<key>` being the parameter name, and the attribute value being a string representation of the parameter value.
- * 
+ *
  * @example someval
  * @example 55
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.operation.parameter`.
  */
 export const ATTR_DB_QUERY_PARAMETER = (key: string) => `db.query.parameter.${key}`;
 
 /**
  * Low cardinality representation of a database query text.
- * 
+ *
  * @example SELECT wuser_table
  * @example INSERT shipping_details SELECT orders
  * @example get user by id
- * 
+ *
  * @note `db.query.summary` provides static summary of the query text. It describes a class of database queries and is useful as a grouping key, especially when analyzing telemetry for database calls involving complex queries.
  * Summary may be available to the instrumentation through instrumentation hooks or other means. If it is not available, instrumentations that support query parsing **SHOULD** generate a summary following [Generating query summary](../../docs/database/database-spans.md#generating-a-summary-of-the-query-text) section.
  * This attribute has stability level RELEASE CANDIDATE.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_QUERY_SUMMARY = 'db.query.summary' as const;
 
 /**
  * The database query being executed.
- * 
+ *
  * @example SELECT * FROM wuser_table where username = ?
  * @example SET mykey ?
- * 
+ *
  * @note For sanitization see [Sanitization of `db.query.text`](../../docs/database/database-spans.md#sanitization-of-dbquerytext).
  * For batch operations, if the individual operations are known to have the same query text then that query text **SHOULD** be used, otherwise all of the individual query texts **SHOULD** be concatenated with separator `; ` or some other database system specific separator if more applicable.
  * Even though parameterized query text can potentially have sensitive data, by using a parameterized query the user is giving a strong signal that any sensitive data will be passed as parameter values, and the benefit to observability of capturing the static part of the query text by default outweighs the risk.
  * This attribute has stability level RELEASE CANDIDATE.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_QUERY_TEXT = 'db.query.text' as const;
 
 /**
  * Deprecated, use `db.namespace` instead.
- * 
+ *
  * @example 0
  * @example 1
  * @example 15
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.namespace`.
  */
 export const ATTR_DB_REDIS_DATABASE_INDEX = 'db.redis.database_index' as const;
 
 /**
  * Number of rows returned by the operation.
- * 
+ *
  * @example 10
  * @example 30
  * @example 1000
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_RESPONSE_RETURNED_ROWS = 'db.response.returned_rows' as const;
 
 /**
  * Database response status code.
- * 
+ *
  * @example 102
  * @example ORA-17002
  * @example 08P01
  * @example 404
- * 
+ *
  * @note The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes.
  * Semantic conventions for individual database systems **SHOULD** document what `db.response.status_code` means in the context of that system.
  * This attribute has stability level RELEASE CANDIDATE.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_RESPONSE_STATUS_CODE = 'db.response.status_code' as const;
 
 /**
  * Deprecated, use `db.collection.name` instead.
- * 
+ *
  * @example "mytable"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.collection.name`.
  */
 export const ATTR_DB_SQL_TABLE = 'db.sql.table' as const;
 
 /**
  * The database statement being executed.
- * 
+ *
  * @example SELECT * FROM wuser_table
  * @example SET mykey "WuValue"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.query.text`.
  */
 export const ATTR_DB_STATEMENT = 'db.statement' as const;
 
 /**
  * The database management system (DBMS) product as identified by the client instrumentation.
- * 
+ *
  * @note The actual DBMS may differ from the one identified by the client. For example, when using PostgreSQL client libraries to connect to a CockroachDB, the `db.system` is set to `postgresql` based on the instrumentation's best knowledge.
  * This attribute has stability level RELEASE CANDIDATE.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DB_SYSTEM = 'db.system' as const;
@@ -2437,68 +2437,68 @@ export const DB_SYSTEM_VALUE_VERTICA = "vertica" as const;
 
 /**
  * Deprecated, no replacement at this time.
- * 
+ *
  * @example readonly_user
  * @example reporting_user
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated No replacement at this time.
  */
 export const ATTR_DB_USER = 'db.user' as const;
 
 /**
  * 'Deprecated, use `deployment.environment.name` instead.'
- * 
+ *
  * @example staging
  * @example production
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Deprecated, use `deployment.environment.name` instead.
  */
 export const ATTR_DEPLOYMENT_ENVIRONMENT = 'deployment.environment' as const;
 
 /**
  * Name of the [deployment environment](https://wikipedia.org/wiki/Deployment_environment) (aka deployment tier).
- * 
+ *
  * @example staging
  * @example production
- * 
+ *
  * @note `deployment.environment.name` does not affect the uniqueness constraints defined through
  * the `service.namespace`, `service.name` and `service.instance.id` resource attributes.
  * This implies that resources carrying the following attribute combinations **MUST** be
  * considered to be identifying the same service:
- * 
+ *
  *   - `service.name=frontend`, `deployment.environment.name=production`
  *   - `service.name=frontend`, `deployment.environment.name=staging`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DEPLOYMENT_ENVIRONMENT_NAME = 'deployment.environment.name' as const;
 
 /**
  * The id of the deployment.
- * 
+ *
  * @example 1208
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DEPLOYMENT_ID = 'deployment.id' as const;
 
 /**
  * The name of the deployment.
- * 
+ *
  * @example deploy my app
  * @example deploy-frontend
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DEPLOYMENT_NAME = 'deployment.name' as const;
 
 /**
  * The status of the deployment.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DEPLOYMENT_STATUS = 'deployment.status' as const;
@@ -2515,79 +2515,79 @@ export const DEPLOYMENT_STATUS_VALUE_SUCCEEDED = "succeeded" as const;
 
 /**
  * Destination address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
- * 
+ *
  * @example destination.example.com
  * @example 10.1.2.80
  * @example /tmp/my.sock
- * 
+ *
  * @note When observed from the source side, and when communicating through an intermediary, `destination.address` **SHOULD** represent the destination address behind any intermediaries, for example proxies, if it's available.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DESTINATION_ADDRESS = 'destination.address' as const;
 
 /**
  * Destination port number
- * 
+ *
  * @example 3389
  * @example 2888
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DESTINATION_PORT = 'destination.port' as const;
 
 /**
  * A unique identifier representing the device
- * 
+ *
  * @example 2ab2916d-a51f-4ac8-80ee-45ac31a28092
- * 
+ *
  * @note The device identifier **MUST** only be defined using the values outlined below. This value is not an advertising identifier and **MUST NOT** be used as such. On iOS (Swift or Objective-C), this value **MUST** be equal to the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor). On Android (Java or Kotlin), this value **MUST** be equal to the Firebase Installation ID or a globally unique UUID which is persisted across sessions in your application. More information can be found [here](https://developer.android.com/training/articles/user-data-ids) on best practices and exact implementation details. Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DEVICE_ID = 'device.id' as const;
 
 /**
  * The name of the device manufacturer
- * 
+ *
  * @example Apple
  * @example Samsung
- * 
+ *
  * @note The Android OS provides this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER). iOS apps **SHOULD** hardcode the value `Apple`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DEVICE_MANUFACTURER = 'device.manufacturer' as const;
 
 /**
  * The model identifier for the device
- * 
+ *
  * @example iPhone3,4
  * @example SM-G920F
- * 
+ *
  * @note It's recommended this value represents a machine-readable version of the model identifier rather than the market or consumer-friendly name of the device.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DEVICE_MODEL_IDENTIFIER = 'device.model.identifier' as const;
 
 /**
  * The marketing name for the device model
- * 
+ *
  * @example iPhone 6s Plus
  * @example Samsung Galaxy S6
- * 
+ *
  * @note It's recommended this value represents a human-readable version of the device model rather than a machine-readable alternative.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DEVICE_MODEL_NAME = 'device.model.name' as const;
 
 /**
  * The disk IO operation direction.
- * 
+ *
  * @example read
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DISK_IO_DIRECTION = 'disk.io.direction' as const;
@@ -2604,23 +2604,23 @@ export const DISK_IO_DIRECTION_VALUE_WRITE = "write" as const;
 
 /**
  * The name being queried.
- * 
+ *
  * @example www.example.com
  * @example opentelemetry.io
- * 
+ *
  * @note If the name field contains non-printable characters (below 32 or above 126), those characters should be represented as escaped base 10 integers (\\DDD). Back slashes and quotes should be escaped. Tabs, carriage returns, and line feeds should be converted to \\t, \\r, and \\n respectively.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DNS_QUESTION_NAME = 'dns.question.name' as const;
 
 /**
  * Name of the garbage collector managed heap generation.
- * 
+ *
  * @example gen0
  * @example gen1
  * @example gen2
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_DOTNET_GC_HEAP_GENERATION = 'dotnet.gc.heap.generation' as const;
@@ -2652,88 +2652,88 @@ export const DOTNET_GC_HEAP_GENERATION_VALUE_POH = "poh" as const;
 
 /**
  * Deprecated, use `user.id` instead.
- * 
+ *
  * @example "username"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `user.id` attribute.
  */
 export const ATTR_ENDUSER_ID = 'enduser.id' as const;
 
 /**
  * Deprecated, use `user.roles` instead.
- * 
+ *
  * @example "admin"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `user.roles` attribute.
  */
 export const ATTR_ENDUSER_ROLE = 'enduser.role' as const;
 
 /**
  * Deprecated, no replacement at this time.
- * 
+ *
  * @example "read:message, write:files"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Removed.
  */
 export const ATTR_ENDUSER_SCOPE = 'enduser.scope' as const;
 
 /**
  * Identifies the class / type of event.
- * 
+ *
  * @example browser.mouse.click
  * @example device.app.lifecycle
- * 
+ *
  * @note Event names are subject to the same rules as [attribute names](/docs/general/attribute-naming.md). Notably, event names are namespaced to avoid collisions and provide a clean separation of semantics for events in separate domains like browser, mobile, and kubernetes.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_EVENT_NAME = 'event.name' as const;
 
 /**
  * A boolean that is true if the serverless function is executed for the first time (aka cold-start).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_COLDSTART = 'faas.coldstart' as const;
 
 /**
  * A string containing the schedule period as [Cron Expression](https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm).
- * 
+ *
  * @example "0/5 * * * ? *"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_CRON = 'faas.cron' as const;
 
 /**
  * The name of the source on which the triggering operation was performed. For example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database name.
- * 
+ *
  * @example myBucketName
  * @example myDbName
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_DOCUMENT_COLLECTION = 'faas.document.collection' as const;
 
 /**
  * The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the name of the file, and in Cosmos DB the table name.
- * 
+ *
  * @example myFile.txt
  * @example myTableName
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_DOCUMENT_NAME = 'faas.document.name' as const;
 
 /**
  * Describes the type of the operation that was performed on the data.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_DOCUMENT_OPERATION = 'faas.document.operation' as const;
@@ -2755,49 +2755,49 @@ export const FAAS_DOCUMENT_OPERATION_VALUE_INSERT = "insert" as const;
 
 /**
  * A string containing the time when the data was accessed in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime).
- * 
+ *
  * @example "2020-01-23T13:47:06Z"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_DOCUMENT_TIME = 'faas.document.time' as const;
 
 /**
  * The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version.
- * 
+ *
  * @example 2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de
- * 
+ *
  * @note - **AWS Lambda:** Use the (full) log stream name.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_INSTANCE = 'faas.instance' as const;
 
 /**
  * The invocation ID of the current function invocation.
- * 
+ *
  * @example "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_INVOCATION_ID = 'faas.invocation_id' as const;
 
 /**
  * The name of the invoked function.
- * 
+ *
  * @example "my-function"
- * 
+ *
  * @note **SHOULD** be equal to the `faas.name` resource attribute of the invoked function.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_INVOKED_NAME = 'faas.invoked_name' as const;
 
 /**
  * The cloud provider of the invoked function.
- * 
+ *
  * @note **SHOULD** be equal to the `cloud.provider` resource attribute of the invoked function.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_INVOKED_PROVIDER = 'faas.invoked_provider' as const;
@@ -2829,65 +2829,65 @@ export const FAAS_INVOKED_PROVIDER_VALUE_TENCENT_CLOUD = "tencent_cloud" as cons
 
 /**
  * The cloud region of the invoked function.
- * 
+ *
  * @example "eu-central-1"
- * 
+ *
  * @note **SHOULD** be equal to the `cloud.region` resource attribute of the invoked function.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_INVOKED_REGION = 'faas.invoked_region' as const;
 
 /**
  * The amount of memory available to the serverless function converted to Bytes.
- * 
+ *
  * @example 134217728
- * 
+ *
  * @note It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information (which must be multiplied by 1,048,576).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_MAX_MEMORY = 'faas.max_memory' as const;
 
 /**
  * The name of the single function that this runtime instance executes.
- * 
+ *
  * @example my-function
  * @example myazurefunctionapp/some-function-name
- * 
+ *
  * @note This is the name of the function as configured/deployed on the FaaS
  * platform and is usually different from the name of the callback
  * function (which may be stored in the
  * [`code.namespace`/`code.function`](/docs/general/attributes.md#source-code-attributes)
  * span attributes).
- * 
+ *
  * For some cloud providers, the above definition is ambiguous. The following
  * definition of function name **MUST** be used for this attribute
  * (and consequently the span name) for the listed cloud providers/products:
- * 
+ *
  *   - **Azure:**  The full name `<FUNCAPP>/<FUNC>`, i.e., function app name
  *     followed by a forward slash followed by the function name (this form
  *     can also be seen in the resource JSON for the function).
  *     This means that a span attribute **MUST** be used, as an Azure function
  *     app can host multiple functions that would usually share
  *     a TracerProvider (see also the `cloud.resource_id` attribute).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_NAME = 'faas.name' as const;
 
 /**
  * A string containing the function invocation time in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime).
- * 
+ *
  * @example "2020-01-23T13:47:06Z"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_TIME = 'faas.time' as const;
 
 /**
  * Type of the trigger which caused this function invocation.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_TRIGGER = 'faas.trigger' as const;
@@ -2919,12 +2919,12 @@ export const FAAS_TRIGGER_VALUE_TIMER = "timer" as const;
 
 /**
  * The immutable version of the function being executed.
- * 
+ *
  * @example 26
  * @example pinkfroid-00002
- * 
+ *
  * @note Depending on the cloud provider and platform, use:
- * 
+ *
  *   - **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
  *     (an integer represented as a decimal string).
  *   - **Google Cloud Run (Services):** The [revision](https://cloud.google.com/run/docs/managing/revisions)
@@ -2932,37 +2932,37 @@ export const FAAS_TRIGGER_VALUE_TIMER = "timer" as const;
  *   - **Google Cloud Functions:** The value of the
  *     [`K_REVISION` environment variable](https://cloud.google.com/functions/docs/env-var#runtime_environment_variables_set_automatically).
  *   - **Azure Functions:** Not applicable. Do not set this attribute.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FAAS_VERSION = 'faas.version' as const;
 
 /**
  * The unique identifier for the flag evaluation context. For example, the targeting key.
- * 
+ *
  * @example 5157782b-2203-4c80-a857-dbbd5e7761db
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FEATURE_FLAG_CONTEXT_ID = 'feature_flag.context.id' as const;
 
 /**
  * A message explaining the nature of an error occurring during flag evaluation.
- * 
+ *
  * @example Flag `header-color` expected type `string` but found type `number`
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FEATURE_FLAG_EVALUATION_ERROR_MESSAGE = 'feature_flag.evaluation.error.message' as const;
 
 /**
  * The reason code which shows how a feature flag value was determined.
- * 
+ *
  * @example static
  * @example targeting_match
  * @example error
  * @example default
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FEATURE_FLAG_EVALUATION_REASON = 'feature_flag.evaluation.reason' as const;
@@ -3014,40 +3014,40 @@ export const FEATURE_FLAG_EVALUATION_REASON_VALUE_UNKNOWN = "unknown" as const;
 
 /**
  * The lookup key of the feature flag.
- * 
+ *
  * @example logo-color
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FEATURE_FLAG_KEY = 'feature_flag.key' as const;
 
 /**
  * Identifies the feature flag provider.
- * 
+ *
  * @example Flag Manager
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FEATURE_FLAG_PROVIDER_NAME = 'feature_flag.provider_name' as const;
 
 /**
  * The identifier of the [flag set](https://openfeature.dev/specification/glossary/#flag-set) to which the feature flag belongs.
- * 
+ *
  * @example proj-1
  * @example ab98sgs
  * @example service1/dev
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FEATURE_FLAG_SET_ID = 'feature_flag.set.id' as const;
 
 /**
  * A semantic identifier for an evaluated flag value.
- * 
+ *
  * @example red
  * @example true
  * @example on
- * 
+ *
  * @note A semantic identifier, commonly referred to as a variant, provides a means
  * for referring to a value without including the value itself. This can
  * provide additional context for understanding the meaning behind a value.
@@ -3058,263 +3058,263 @@ export const ATTR_FEATURE_FLAG_VARIANT = 'feature_flag.variant' as const;
 
 /**
  * The version of the ruleset used during the evaluation. This may be any stable value which uniquely identifies the ruleset.
- * 
+ *
  * @example 1
  * @example 01ABCDEF
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FEATURE_FLAG_VERSION = 'feature_flag.version' as const;
 
 /**
  * Time when the file was last accessed, in ISO 8601 format.
- * 
+ *
  * @example 2021-01-01T12:00:00Z
- * 
+ *
  * @note This attribute might not be supported by some file systems — NFS, FAT32, in embedded OS, etc.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_ACCESSED = 'file.accessed' as const;
 
 /**
  * Array of file attributes.
- * 
+ *
  * @example ["readonly", "hidden"]
- * 
+ *
  * @note Attributes names depend on the OS or file system. Here’s a non-exhaustive list of values expected for this attribute: `archive`, `compressed`, `directory`, `encrypted`, `execute`, `hidden`, `immutable`, `journaled`, `read`, `readonly`, `symbolic link`, `system`, `temporary`, `write`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_ATTRIBUTES = 'file.attributes' as const;
 
 /**
  * Time when the file attributes or metadata was last changed, in ISO 8601 format.
- * 
+ *
  * @example 2021-01-01T12:00:00Z
- * 
+ *
  * @note `file.changed` captures the time when any of the file's properties or attributes (including the content) are changed, while `file.modified` captures the timestamp when the file content is modified.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_CHANGED = 'file.changed' as const;
 
 /**
  * Time when the file was created, in ISO 8601 format.
- * 
+ *
  * @example 2021-01-01T12:00:00Z
- * 
+ *
  * @note This attribute might not be supported by some file systems — NFS, FAT32, in embedded OS, etc.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_CREATED = 'file.created' as const;
 
 /**
  * Directory where the file is located. It should include the drive letter, when appropriate.
- * 
+ *
  * @example /home/user
  * @example C:\\Program Files\\MyApp
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_DIRECTORY = 'file.directory' as const;
 
 /**
  * File extension, excluding the leading dot.
- * 
+ *
  * @example png
  * @example gz
- * 
+ *
  * @note When the file name has multiple extensions (example.tar.gz), only the last one should be captured ("gz", not "tar.gz").
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_EXTENSION = 'file.extension' as const;
 
 /**
  * Name of the fork. A fork is additional data associated with a filesystem object.
- * 
+ *
  * @example Zone.Identifer
- * 
+ *
  * @note On Linux, a resource fork is used to store additional data with a filesystem object. A file always has at least one fork for the data portion, and additional forks may exist.
  * On NTFS, this is analogous to an Alternate Data Stream (ADS), and the default data stream for a file is just called $DATA. Zone.Identifier is commonly used by Windows to track contents downloaded from the Internet. An ADS is typically of the form: C:\\path\\to\\filename.extension:some_fork_name, and some_fork_name is the value that should populate `fork_name`. `filename.extension` should populate `file.name`, and `extension` should populate `file.extension`. The full path, `file.path`, will include the fork name.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_FORK_NAME = 'file.fork_name' as const;
 
 /**
  * Primary Group ID (GID) of the file.
- * 
+ *
  * @example 1000
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_GROUP_ID = 'file.group.id' as const;
 
 /**
  * Primary group name of the file.
- * 
+ *
  * @example users
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_GROUP_NAME = 'file.group.name' as const;
 
 /**
  * Inode representing the file in the filesystem.
- * 
+ *
  * @example 256383
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_INODE = 'file.inode' as const;
 
 /**
  * Mode of the file in octal representation.
- * 
+ *
  * @example 0640
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_MODE = 'file.mode' as const;
 
 /**
  * Time when the file content was last modified, in ISO 8601 format.
- * 
+ *
  * @example 2021-01-01T12:00:00Z
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_MODIFIED = 'file.modified' as const;
 
 /**
  * Name of the file including the extension, without the directory.
- * 
+ *
  * @example example.png
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_NAME = 'file.name' as const;
 
 /**
  * The user ID (UID) or security identifier (SID) of the file owner.
- * 
+ *
  * @example 1000
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_OWNER_ID = 'file.owner.id' as const;
 
 /**
  * Username of the file owner.
- * 
+ *
  * @example root
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_OWNER_NAME = 'file.owner.name' as const;
 
 /**
  * Full path to the file, including the file name. It should include the drive letter, when appropriate.
- * 
+ *
  * @example /home/alice/example.png
  * @example C:\\Program Files\\MyApp\\myapp.exe
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_PATH = 'file.path' as const;
 
 /**
  * File size in bytes.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_SIZE = 'file.size' as const;
 
 /**
  * Path to the target of a symbolic link.
- * 
+ *
  * @example /usr/bin/python3
- * 
+ *
  * @note This attribute is only applicable to symbolic links.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_FILE_SYMBOLIC_LINK_TARGET_PATH = 'file.symbolic_link.target_path' as const;
 
 /**
  * Identifies the Google Cloud service for which the official client library is intended.
- * 
+ *
  * @example appengine
  * @example run
  * @example firestore
  * @example alloydb
  * @example spanner
- * 
+ *
  * @note Intended to be a stable identifier for Google Cloud client libraries that is uniform across implementation languages. The value should be derived from the canonical service domain for the service; for example, 'foo.googleapis.com' should result in a value of 'foo'.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GCP_CLIENT_SERVICE = 'gcp.client.service' as const;
 
 /**
  * The name of the Cloud Run [execution](https://cloud.google.com/run/docs/managing/job-executions) being run for the Job, as set by the [`CLOUD_RUN_EXECUTION`](https://cloud.google.com/run/docs/container-contract#jobs-env-vars) environment variable.
- * 
+ *
  * @example job-name-xxxx
  * @example sample-job-mdw84
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GCP_CLOUD_RUN_JOB_EXECUTION = 'gcp.cloud_run.job.execution' as const;
 
 /**
  * The index for a task within an execution as provided by the [`CLOUD_RUN_TASK_INDEX`](https://cloud.google.com/run/docs/container-contract#jobs-env-vars) environment variable.
- * 
+ *
  * @example 0
  * @example 1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GCP_CLOUD_RUN_JOB_TASK_INDEX = 'gcp.cloud_run.job.task_index' as const;
 
 /**
  * The hostname of a GCE instance. This is the full value of the default or [custom hostname](https://cloud.google.com/compute/docs/instances/custom-hostname-vm).
- * 
+ *
  * @example my-host1234.example.com
  * @example sample-vm.us-west1-b.c.my-project.internal
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GCP_GCE_INSTANCE_HOSTNAME = 'gcp.gce.instance.hostname' as const;
 
 /**
  * The instance name of a GCE instance. This is the value provided by `host.name`, the visible name of the instance in the Cloud Console UI, and the prefix for the default hostname of the instance as defined by the [default internal DNS name](https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names).
- * 
+ *
  * @example instance-1
  * @example my-vm-name
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GCP_GCE_INSTANCE_NAME = 'gcp.gce.instance.name' as const;
 
 /**
  * Deprecated, use Event API to report completions contents.
- * 
+ *
  * @example [{'role': 'assistant', 'content': 'The capital of France is Paris.'}]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Removed, no replacement at this time.
  */
 export const ATTR_GEN_AI_COMPLETION = 'gen_ai.completion' as const;
 
 /**
  * The response format that is requested.
- * 
+ *
  * @example json
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT = 'gen_ai.openai.request.response_format' as const;
@@ -3336,19 +3336,19 @@ export const GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT_VALUE_TEXT = "text" as const;
 
 /**
  * Requests with same seed value more likely to return same result.
- * 
+ *
  * @example 100
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_OPENAI_REQUEST_SEED = 'gen_ai.openai.request.seed' as const;
 
 /**
  * The service tier requested. May be a specific tier, default, or auto.
- * 
+ *
  * @example auto
  * @example default
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_OPENAI_REQUEST_SERVICE_TIER = 'gen_ai.openai.request.service_tier' as const;
@@ -3365,28 +3365,28 @@ export const GEN_AI_OPENAI_REQUEST_SERVICE_TIER_VALUE_DEFAULT = "default" as con
 
 /**
  * The service tier used for the response.
- * 
+ *
  * @example scale
  * @example default
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_OPENAI_RESPONSE_SERVICE_TIER = 'gen_ai.openai.response.service_tier' as const;
 
 /**
  * A fingerprint to track any eventual change in the Generative AI environment.
- * 
+ *
  * @example fp_44709d6fcb
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_OPENAI_RESPONSE_SYSTEM_FINGERPRINT = 'gen_ai.openai.response.system_fingerprint' as const;
 
 /**
  * The name of the operation being performed.
- * 
+ *
  * @note If one of the predefined values applies, but specific system uses a different name it's **RECOMMENDED** to document it in the semantic conventions for specific GenAI system and use system-specific name in the instrumentation. If a different name is not documented, instrumentation libraries **SHOULD** use applicable predefined value.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_OPERATION_NAME = 'gen_ai.operation.name' as const;
@@ -3408,142 +3408,142 @@ export const GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION = "text_completion" as 
 
 /**
  * Deprecated, use Event API to report prompt contents.
- * 
+ *
  * @example [{'role': 'user', 'content': 'What is the capital of France?'}]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Removed, no replacement at this time.
  */
 export const ATTR_GEN_AI_PROMPT = 'gen_ai.prompt' as const;
 
 /**
  * The encoding formats requested in an embeddings operation, if specified.
- * 
+ *
  * @example ["base64"]
  * @example ["float", "binary"]
- * 
+ *
  * @note In some GenAI systems the encoding formats are called embedding types. Also, some GenAI systems only accept a single format per request.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_REQUEST_ENCODING_FORMATS = 'gen_ai.request.encoding_formats' as const;
 
 /**
  * The frequency penalty setting for the GenAI request.
- * 
+ *
  * @example 0.1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_REQUEST_FREQUENCY_PENALTY = 'gen_ai.request.frequency_penalty' as const;
 
 /**
  * The maximum number of tokens the model generates for a request.
- * 
+ *
  * @example 100
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_REQUEST_MAX_TOKENS = 'gen_ai.request.max_tokens' as const;
 
 /**
  * The name of the GenAI model a request is being made to.
- * 
+ *
  * @example "gpt-4"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_REQUEST_MODEL = 'gen_ai.request.model' as const;
 
 /**
  * The presence penalty setting for the GenAI request.
- * 
+ *
  * @example 0.1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_REQUEST_PRESENCE_PENALTY = 'gen_ai.request.presence_penalty' as const;
 
 /**
  * List of sequences that the model will use to stop generating further tokens.
- * 
+ *
  * @example ["forest", "lived"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_REQUEST_STOP_SEQUENCES = 'gen_ai.request.stop_sequences' as const;
 
 /**
  * The temperature setting for the GenAI request.
- * 
+ *
  * @example 0.0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_REQUEST_TEMPERATURE = 'gen_ai.request.temperature' as const;
 
 /**
  * The top_k sampling setting for the GenAI request.
- * 
+ *
  * @example 1.0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_REQUEST_TOP_K = 'gen_ai.request.top_k' as const;
 
 /**
  * The top_p sampling setting for the GenAI request.
- * 
+ *
  * @example 1.0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_REQUEST_TOP_P = 'gen_ai.request.top_p' as const;
 
 /**
  * Array of reasons the model stopped generating tokens, corresponding to each generation received.
- * 
+ *
  * @example ["stop"]
  * @example ["stop", "length"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_RESPONSE_FINISH_REASONS = 'gen_ai.response.finish_reasons' as const;
 
 /**
  * The unique identifier for the completion.
- * 
+ *
  * @example chatcmpl-123
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_RESPONSE_ID = 'gen_ai.response.id' as const;
 
 /**
  * The name of the model that generated the response.
- * 
+ *
  * @example gpt-4-0613
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_RESPONSE_MODEL = 'gen_ai.response.model' as const;
 
 /**
  * The Generative AI product as identified by the client or server instrumentation.
- * 
+ *
  * @example "openai"
- * 
+ *
  * @note The `gen_ai.system` describes a family of GenAI models with specific model identified
  * by `gen_ai.request.model` and `gen_ai.response.model` attributes.
- * 
+ *
  * The actual GenAI product may differ from the one identified by the client.
  * For example, when using OpenAI client libraries to communicate with Mistral, the `gen_ai.system`
  * is set to `openai` based on the instrumentation's best knowledge.
- * 
+ *
  * For custom model, a custom friendly name **SHOULD** be used.
  * If none of these options apply, the `gen_ai.system` **SHOULD** be set to `_OTHER`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_SYSTEM = 'gen_ai.system' as const;
@@ -3585,10 +3585,10 @@ export const GEN_AI_SYSTEM_VALUE_VERTEX_AI = "vertex_ai" as const;
 
 /**
  * The type of token being counted.
- * 
+ *
  * @example input
  * @example output
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_TOKEN_TYPE = 'gen_ai.token.type' as const;
@@ -3605,47 +3605,47 @@ export const GEN_AI_TOKEN_TYPE_VALUE_COMPLETION = "output" as const;
 
 /**
  * Deprecated, use `gen_ai.usage.output_tokens` instead.
- * 
+ *
  * @example 42
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `gen_ai.usage.output_tokens` attribute.
  */
 export const ATTR_GEN_AI_USAGE_COMPLETION_TOKENS = 'gen_ai.usage.completion_tokens' as const;
 
 /**
  * The number of tokens used in the GenAI input (prompt).
- * 
+ *
  * @example 100
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_USAGE_INPUT_TOKENS = 'gen_ai.usage.input_tokens' as const;
 
 /**
  * The number of tokens used in the GenAI response (completion).
- * 
+ *
  * @example 180
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_USAGE_OUTPUT_TOKENS = 'gen_ai.usage.output_tokens' as const;
 
 /**
  * Deprecated, use `gen_ai.usage.input_tokens` instead.
- * 
+ *
  * @example 42
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `gen_ai.usage.input_tokens` attribute.
  */
 export const ATTR_GEN_AI_USAGE_PROMPT_TOKENS = 'gen_ai.usage.prompt_tokens' as const;
 
 /**
  * Two-letter code representing continent’s name.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEO_CONTINENT_CODE = 'geo.continent.code' as const;
@@ -3687,65 +3687,65 @@ export const GEO_CONTINENT_CODE_VALUE_SA = "SA" as const;
 
 /**
  * Two-letter ISO Country Code ([ISO 3166-1 alpha2](https://wikipedia.org/wiki/ISO_3166-1#Codes)).
- * 
+ *
  * @example CA
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEO_COUNTRY_ISO_CODE = 'geo.country.iso_code' as const;
 
 /**
  * Locality name. Represents the name of a city, town, village, or similar populated place.
- * 
+ *
  * @example Montreal
  * @example Berlin
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEO_LOCALITY_NAME = 'geo.locality.name' as const;
 
 /**
  * Latitude of the geo location in [WGS84](https://wikipedia.org/wiki/World_Geodetic_System#WGS84).
- * 
+ *
  * @example 45.505918
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEO_LOCATION_LAT = 'geo.location.lat' as const;
 
 /**
  * Longitude of the geo location in [WGS84](https://wikipedia.org/wiki/World_Geodetic_System#WGS84).
- * 
+ *
  * @example -73.61483
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEO_LOCATION_LON = 'geo.location.lon' as const;
 
 /**
  * Postal code associated with the location. Values appropriate for this field may also be known as a postcode or ZIP code and will vary widely from country to country.
- * 
+ *
  * @example 94040
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEO_POSTAL_CODE = 'geo.postal_code' as const;
 
 /**
  * Region ISO code ([ISO 3166-2](https://wikipedia.org/wiki/ISO_3166-2)).
- * 
+ *
  * @example CA-QC
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEO_REGION_ISO_CODE = 'geo.region.iso_code' as const;
 
 /**
  * The type of memory.
- * 
+ *
  * @example other
  * @example stack
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GO_MEMORY_TYPE = 'go.memory.type' as const;
@@ -3762,9 +3762,9 @@ export const GO_MEMORY_TYPE_VALUE_STACK = "stack" as const;
 
 /**
  * The GraphQL document being executed.
- * 
+ *
  * @example "query findBookById { bookById(id: ?) { name } }"
- * 
+ *
  * @note The value may be sanitized to exclude sensitive information.
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -3772,20 +3772,20 @@ export const ATTR_GRAPHQL_DOCUMENT = 'graphql.document' as const;
 
 /**
  * The name of the operation being executed.
- * 
+ *
  * @example "findBookById"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GRAPHQL_OPERATION_NAME = 'graphql.operation.name' as const;
 
 /**
  * The type of the operation being executed.
- * 
+ *
  * @example query
  * @example mutation
  * @example subscription
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GRAPHQL_OPERATION_TYPE = 'graphql.operation.type' as const;
@@ -3807,34 +3807,34 @@ export const GRAPHQL_OPERATION_TYPE_VALUE_SUBSCRIPTION = "subscription" as const
 
 /**
  * Unique identifier for the application
- * 
+ *
  * @example 2daa2797-e42b-4624-9322-ec3f968df4da
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HEROKU_APP_ID = 'heroku.app.id' as const;
 
 /**
  * Commit hash for the current release
- * 
+ *
  * @example e6134959463efd8966b20e75b913cafe3f5ec
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HEROKU_RELEASE_COMMIT = 'heroku.release.commit' as const;
 
 /**
  * Time and date the release was created
- * 
+ *
  * @example 2022-10-23T18:00:42Z
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HEROKU_RELEASE_CREATION_TIMESTAMP = 'heroku.release.creation_timestamp' as const;
 
 /**
  * The CPU architecture the host system is running on.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_ARCH = 'host.arch' as const;
@@ -3881,157 +3881,157 @@ export const HOST_ARCH_VALUE_X86 = "x86" as const;
 
 /**
  * The amount of level 2 memory cache available to the processor (in Bytes).
- * 
+ *
  * @example 12288000
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_CPU_CACHE_L2_SIZE = 'host.cpu.cache.l2.size' as const;
 
 /**
  * Family or generation of the CPU.
- * 
+ *
  * @example 6
  * @example PA-RISC 1.1e
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_CPU_FAMILY = 'host.cpu.family' as const;
 
 /**
  * Model identifier. It provides more granular information about the CPU, distinguishing it from other CPUs within the same family.
- * 
+ *
  * @example 6
  * @example 9000/778/B180L
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_CPU_MODEL_ID = 'host.cpu.model.id' as const;
 
 /**
  * Model designation of the processor.
- * 
+ *
  * @example 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_CPU_MODEL_NAME = 'host.cpu.model.name' as const;
 
 /**
  * Stepping or core revisions.
- * 
+ *
  * @example 1
  * @example r1p1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_CPU_STEPPING = 'host.cpu.stepping' as const;
 
 /**
  * Processor manufacturer identifier. A maximum 12-character string.
- * 
+ *
  * @example GenuineIntel
- * 
+ *
  * @note [CPUID](https://wiki.osdev.org/CPUID) command returns the vendor ID string in EBX, EDX and ECX registers. Writing these to memory in this order results in a 12-character string.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_CPU_VENDOR_ID = 'host.cpu.vendor.id' as const;
 
 /**
  * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system.
- * 
+ *
  * @example fdbf79e8af94cb7f9e8df36789187052
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_ID = 'host.id' as const;
 
 /**
  * VM image ID or host OS image ID. For Cloud, this value is from the provider.
- * 
+ *
  * @example ami-07b06b442921831e5
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_IMAGE_ID = 'host.image.id' as const;
 
 /**
  * Name of the VM image or OS install the host was instantiated from.
- * 
+ *
  * @example infra-ami-eks-worker-node-7d4ec78312
  * @example CentOS-8-x86_64-1905
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_IMAGE_NAME = 'host.image.name' as const;
 
 /**
  * The version string of the VM image or host OS as defined in [Version Attributes](/docs/resource/README.md#version-attributes).
- * 
+ *
  * @example 0.1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_IMAGE_VERSION = 'host.image.version' as const;
 
 /**
  * Available IP addresses of the host, excluding loopback interfaces.
- * 
+ *
  * @example ["192.168.1.140", "fe80::abc2:4a28:737a:609e"]
- * 
+ *
  * @note IPv4 Addresses **MUST** be specified in dotted-quad notation. IPv6 addresses **MUST** be specified in the [RFC 5952](https://www.rfc-editor.org/rfc/rfc5952.html) format.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_IP = 'host.ip' as const;
 
 /**
  * Available MAC addresses of the host, excluding loopback interfaces.
- * 
+ *
  * @example ["AC-DE-48-23-45-67", "AC-DE-48-23-45-67-01-9F"]
- * 
+ *
  * @note MAC Addresses **MUST** be represented in [IEEE RA hexadecimal form](https://standards.ieee.org/wp-content/uploads/import/documents/tutorials/eui.pdf): as hyphen-separated octets in uppercase hexadecimal form from most to least significant.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_MAC = 'host.mac' as const;
 
 /**
  * Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user.
- * 
+ *
  * @example opentelemetry-test
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_NAME = 'host.name' as const;
 
 /**
  * Type of host. For Cloud, this must be the machine type.
- * 
+ *
  * @example n1-standard-1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HOST_TYPE = 'host.type' as const;
 
 /**
  * Deprecated, use `client.address` instead.
- * 
+ *
  * @example "83.164.160.102"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `client.address`.
  */
 export const ATTR_HTTP_CLIENT_IP = 'http.client_ip' as const;
 
 /**
  * State of the HTTP connection in the HTTP connection pool.
- * 
+ *
  * @example active
  * @example idle
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HTTP_CONNECTION_STATE = 'http.connection.state' as const;
@@ -4048,9 +4048,9 @@ export const HTTP_CONNECTION_STATE_VALUE_IDLE = "idle" as const;
 
 /**
  * Deprecated, use `network.protocol.name` instead.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `network.protocol.name`.
  */
 export const ATTR_HTTP_FLAVOR = 'http.flavor' as const;
@@ -4087,206 +4087,206 @@ export const HTTP_FLAVOR_VALUE_SPDY = "SPDY" as const;
 
 /**
  * Deprecated, use one of `server.address`, `client.address` or `http.request.header.host` instead, depending on the usage.
- * 
+ *
  * @example www.example.org
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by one of `server.address`, `client.address` or `http.request.header.host`, depending on the usage.
  */
 export const ATTR_HTTP_HOST = 'http.host' as const;
 
 /**
  * Deprecated, use `http.request.method` instead.
- * 
+ *
  * @example GET
  * @example POST
  * @example HEAD
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `http.request.method`.
  */
 export const ATTR_HTTP_METHOD = 'http.method' as const;
 
 /**
  * The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size.
- * 
+ *
  * @example 3495
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HTTP_REQUEST_BODY_SIZE = 'http.request.body.size' as const;
 
 /**
  * The total size of the request in bytes. This should be the total number of bytes sent over the wire, including the request line (HTTP/1.1), framing (HTTP/2 and HTTP/3), headers, and request body if any.
- * 
+ *
  * @example 1437
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HTTP_REQUEST_SIZE = 'http.request.size' as const;
 
 /**
  * Deprecated, use `http.request.header.<key>` instead.
- * 
+ *
  * @example 3495
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `http.request.header.<key>`.
  */
 export const ATTR_HTTP_REQUEST_CONTENT_LENGTH = 'http.request_content_length' as const;
 
 /**
  * Deprecated, use `http.request.body.size` instead.
- * 
+ *
  * @example 5493
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `http.request.body.size`.
  */
 export const ATTR_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED = 'http.request_content_length_uncompressed' as const;
 
 /**
  * The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size.
- * 
+ *
  * @example 3495
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HTTP_RESPONSE_BODY_SIZE = 'http.response.body.size' as const;
 
 /**
  * The total size of the response in bytes. This should be the total number of bytes sent over the wire, including the status line (HTTP/1.1), framing (HTTP/2 and HTTP/3), headers, and response body and trailers if any.
- * 
+ *
  * @example 1437
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HTTP_RESPONSE_SIZE = 'http.response.size' as const;
 
 /**
  * Deprecated, use `http.response.header.<key>` instead.
- * 
+ *
  * @example 3495
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `http.response.header.<key>`.
  */
 export const ATTR_HTTP_RESPONSE_CONTENT_LENGTH = 'http.response_content_length' as const;
 
 /**
  * Deprecated, use `http.response.body.size` instead.
- * 
+ *
  * @example 5493
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replace by `http.response.body.size`.
  */
 export const ATTR_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED = 'http.response_content_length_uncompressed' as const;
 
 /**
  * Deprecated, use `url.scheme` instead.
- * 
+ *
  * @example http
  * @example https
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `url.scheme` instead.
  */
 export const ATTR_HTTP_SCHEME = 'http.scheme' as const;
 
 /**
  * Deprecated, use `server.address` instead.
- * 
+ *
  * @example example.com
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `server.address`.
  */
 export const ATTR_HTTP_SERVER_NAME = 'http.server_name' as const;
 
 /**
  * Deprecated, use `http.response.status_code` instead.
- * 
+ *
  * @example 200
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `http.response.status_code`.
  */
 export const ATTR_HTTP_STATUS_CODE = 'http.status_code' as const;
 
 /**
  * Deprecated, use `url.path` and `url.query` instead.
- * 
+ *
  * @example /search?q=OpenTelemetry#SemConv
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Split to `url.path` and `url.query.
  */
 export const ATTR_HTTP_TARGET = 'http.target' as const;
 
 /**
  * Deprecated, use `url.full` instead.
- * 
+ *
  * @example https://www.foo.bar/search?q=OpenTelemetry#SemConv
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `url.full`.
  */
 export const ATTR_HTTP_URL = 'http.url' as const;
 
 /**
  * Deprecated, use `user_agent.original` instead.
- * 
+ *
  * @example CERN-LineMode/2.15 libwww/2.17b3
  * @example Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `user_agent.original`.
  */
 export const ATTR_HTTP_USER_AGENT = 'http.user_agent' as const;
 
 /**
  * An identifier for the hardware component, unique within the monitored host
- * 
+ *
  * @example win32battery_battery_testsysa33_1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HW_ID = 'hw.id' as const;
 
 /**
  * An easily-recognizable name for the hardware component
- * 
+ *
  * @example eth0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HW_NAME = 'hw.name' as const;
 
 /**
  * Unique identifier of the parent component (typically the `hw.id` attribute of the enclosure, or disk controller)
- * 
+ *
  * @example dellStorage_perc_0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HW_PARENT = 'hw.parent' as const;
 
 /**
  * The current state of the component
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HW_STATE = 'hw.state' as const;
@@ -4308,9 +4308,9 @@ export const HW_STATE_VALUE_OK = "ok" as const;
 
 /**
  * Type of the component
- * 
+ *
  * @note Describes the category of the hardware component for which `hw.state` is being reported. For example, `hw.type=temperature` along with `hw.state=degraded` would indicate that the temperature of the hardware component has been reported as `degraded`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_HW_TYPE = 'hw.type' as const;
@@ -4387,11 +4387,11 @@ export const HW_TYPE_VALUE_VOLTAGE = "voltage" as const;
 
 /**
  * Deprecated use the `device.app.lifecycle` event definition including `ios.state` as a payload field instead.
- * 
+ *
  * @note The iOS lifecycle states are defined in the [UIApplicationDelegate documentation](https://developer.apple.com/documentation/uikit/uiapplicationdelegate#1656902), and from which the `OS terminology` column values are derived.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Moved to a payload field of `device.app.lifecycle`.
  */
 export const ATTR_IOS_STATE = 'ios.state' as const;
@@ -4423,36 +4423,36 @@ export const IOS_STATE_VALUE_TERMINATE = "terminate" as const;
 
 /**
  * Name of the buffer pool.
- * 
+ *
  * @example mapped
  * @example direct
- * 
+ *
  * @note Pool names are generally obtained via [BufferPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html#getName()).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_JVM_BUFFER_POOL_NAME = 'jvm.buffer.pool.name' as const;
 
 /**
  * The name of the cluster.
- * 
+ *
  * @example opentelemetry-cluster
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_CLUSTER_NAME = 'k8s.cluster.name' as const;
 
 /**
  * A pseudo-ID for the cluster, set to the UID of the `kube-system` namespace.
- * 
+ *
  * @example 218fc5a9-a5f1-4b54-aa05-46717d0ab26d
- * 
+ *
  * @note K8s doesn't have support for obtaining a cluster ID. If this is ever
  * added, we will recommend collecting the `k8s.cluster.uid` through the
  * official APIs. In the meantime, we are able to use the `uid` of the
  * `kube-system` namespace as a proxy for cluster ID. Read on for the
  * rationale.
- * 
+ *
  * Every object created in a K8s cluster is assigned a distinct UID. The
  * `kube-system` namespace is used by Kubernetes itself and will exist
  * for the lifetime of the cluster. Using the `uid` of the `kube-system`
@@ -4461,246 +4461,246 @@ export const ATTR_K8S_CLUSTER_NAME = 'k8s.cluster.name' as const;
  * UUIDs as standardized by
  * [ISO/IEC 9834-8 and ITU-T X.667](https://www.itu.int/ITU-T/studygroups/com17/oid.html).
  * Which states:
- * 
+ *
  * > If generated according to one of the mechanisms defined in Rec.
  * > ITU-T X.667 | ISO/IEC 9834-8, a UUID is either guaranteed to be
  * > different from all other UUIDs generated before 3603 A.D., or is
  * > extremely likely to be different (depending on the mechanism chosen).
- * 
+ *
  * Therefore, UIDs between clusters should be extremely unlikely to
  * conflict.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_CLUSTER_UID = 'k8s.cluster.uid' as const;
 
 /**
  * The name of the Container from Pod specification, must be unique within a Pod. Container runtime usually uses different globally unique name (`container.name`).
- * 
+ *
  * @example redis
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_CONTAINER_NAME = 'k8s.container.name' as const;
 
 /**
  * Number of times the container was restarted. This attribute can be used to identify a particular container (running or stopped) within a container spec.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_CONTAINER_RESTART_COUNT = 'k8s.container.restart_count' as const;
 
 /**
  * Last terminated reason of the Container.
- * 
+ *
  * @example Evicted
  * @example Error
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_CONTAINER_STATUS_LAST_TERMINATED_REASON = 'k8s.container.status.last_terminated_reason' as const;
 
 /**
  * The name of the CronJob.
- * 
+ *
  * @example opentelemetry
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_CRONJOB_NAME = 'k8s.cronjob.name' as const;
 
 /**
  * The UID of the CronJob.
- * 
+ *
  * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_CRONJOB_UID = 'k8s.cronjob.uid' as const;
 
 /**
  * The name of the DaemonSet.
- * 
+ *
  * @example opentelemetry
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_DAEMONSET_NAME = 'k8s.daemonset.name' as const;
 
 /**
  * The UID of the DaemonSet.
- * 
+ *
  * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_DAEMONSET_UID = 'k8s.daemonset.uid' as const;
 
 /**
  * The name of the Deployment.
- * 
+ *
  * @example opentelemetry
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_DEPLOYMENT_NAME = 'k8s.deployment.name' as const;
 
 /**
  * The UID of the Deployment.
- * 
+ *
  * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_DEPLOYMENT_UID = 'k8s.deployment.uid' as const;
 
 /**
  * The name of the Job.
- * 
+ *
  * @example opentelemetry
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_JOB_NAME = 'k8s.job.name' as const;
 
 /**
  * The UID of the Job.
- * 
+ *
  * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_JOB_UID = 'k8s.job.uid' as const;
 
 /**
  * The name of the namespace that the pod is running in.
- * 
+ *
  * @example default
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_NAMESPACE_NAME = 'k8s.namespace.name' as const;
 
 /**
  * The name of the Node.
- * 
+ *
  * @example node-1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_NODE_NAME = 'k8s.node.name' as const;
 
 /**
  * The UID of the Node.
- * 
+ *
  * @example 1eb3a0c6-0477-4080-a9cb-0cb7db65c6a2
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_NODE_UID = 'k8s.node.uid' as const;
 
 /**
  * The annotation key-value pairs placed on the Pod, the `<key>` being the annotation name, the value being the annotation value.
- * 
+ *
  * @example k8s.pod.annotation.kubernetes.io/enforce-mountable-secrets=true
  * @example k8s.pod.annotation.mycompany.io/arch=x64
  * @example k8s.pod.annotation.data=
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_POD_ANNOTATION = (key: string) => `k8s.pod.annotation.${key}`;
 
 /**
  * The label key-value pairs placed on the Pod, the `<key>` being the label name, the value being the label value.
- * 
+ *
  * @example k8s.pod.label.app=my-app
  * @example k8s.pod.label.mycompany.io/arch=x64
  * @example k8s.pod.label.data=
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_POD_LABEL = (key: string) => `k8s.pod.label.${key}`;
 
 /**
  * Deprecated, use `k8s.pod.label` instead.
- * 
+ *
  * @example k8s.pod.label.app=my-app
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `k8s.pod.label`.
  */
 export const ATTR_K8S_POD_LABELS = (key: string) => `k8s.pod.labels.${key}`;
 
 /**
  * The name of the Pod.
- * 
+ *
  * @example opentelemetry-pod-autoconf
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_POD_NAME = 'k8s.pod.name' as const;
 
 /**
  * The UID of the Pod.
- * 
+ *
  * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_POD_UID = 'k8s.pod.uid' as const;
 
 /**
  * The name of the ReplicaSet.
- * 
+ *
  * @example opentelemetry
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_REPLICASET_NAME = 'k8s.replicaset.name' as const;
 
 /**
  * The UID of the ReplicaSet.
- * 
+ *
  * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_REPLICASET_UID = 'k8s.replicaset.uid' as const;
 
 /**
  * The name of the StatefulSet.
- * 
+ *
  * @example opentelemetry
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_STATEFULSET_NAME = 'k8s.statefulset.name' as const;
 
 /**
  * The UID of the StatefulSet.
- * 
+ *
  * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_STATEFULSET_UID = 'k8s.statefulset.uid' as const;
 
 /**
  * The name of the K8s volume.
- * 
+ *
  * @example volume0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_VOLUME_NAME = 'k8s.volume.name' as const;
 
 /**
  * The type of the K8s volume.
- * 
+ *
  * @example emptyDir
  * @example persistentVolumeClaim
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_VOLUME_TYPE = 'k8s.volume.type' as const;
@@ -4737,10 +4737,10 @@ export const K8S_VOLUME_TYPE_VALUE_SECRET = "secret" as const;
 
 /**
  * The Linux Slab memory state
- * 
+ *
  * @example reclaimable
  * @example unreclaimable
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_LINUX_MEMORY_SLAB_STATE = 'linux.memory.slab.state' as const;
@@ -4757,43 +4757,43 @@ export const LINUX_MEMORY_SLAB_STATE_VALUE_UNRECLAIMABLE = "unreclaimable" as co
 
 /**
  * The basename of the file.
- * 
+ *
  * @example audit.log
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_LOG_FILE_NAME = 'log.file.name' as const;
 
 /**
  * The basename of the file, with symlinks resolved.
- * 
+ *
  * @example uuid.log
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_LOG_FILE_NAME_RESOLVED = 'log.file.name_resolved' as const;
 
 /**
  * The full path to the file.
- * 
+ *
  * @example /var/log/mysql/audit.log
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_LOG_FILE_PATH = 'log.file.path' as const;
 
 /**
  * The full path to the file, with symlinks resolved.
- * 
+ *
  * @example /var/lib/docker/uuid.log
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_LOG_FILE_PATH_RESOLVED = 'log.file.path_resolved' as const;
 
 /**
  * The stream associated with the log. See below for a list of well-known values.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_LOG_IOSTREAM = 'log.iostream' as const;
@@ -4810,51 +4810,51 @@ export const LOG_IOSTREAM_VALUE_STDOUT = "stdout" as const;
 
 /**
  * The complete original Log Record.
- * 
+ *
  * @example 77 <86>1 2015-08-06T21:58:59.694Z 192.168.2.133 inactive - - - Something happened
  * @example [INFO] 8/3/24 12:34:56 Something happened
- * 
+ *
  * @note This value **MAY** be added when processing a Log Record which was originally transmitted as a string or equivalent data type AND the Body field of the Log Record does not contain the same value. (e.g. a syslog or a log record read from a file.)
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_LOG_RECORD_ORIGINAL = 'log.record.original' as const;
 
 /**
  * A unique identifier for the Log Record.
- * 
+ *
  * @example 01ARZ3NDEKTSV4RRFFQ69G5FAV
- * 
+ *
  * @note If an id is provided, other log records with the same id will be considered duplicates and can be removed safely. This means, that two distinguishable log records **MUST** have different values.
  * The id **MAY** be an [Universally Unique Lexicographically Sortable Identifier (ULID)](https://github.com/ulid/spec), but other identifiers (e.g. UUID) may be used as needed.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_LOG_RECORD_UID = 'log.record.uid' as const;
 
 /**
  * Deprecated, use `rpc.message.compressed_size` instead.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `rpc.message.compressed_size`.
  */
 export const ATTR_MESSAGE_COMPRESSED_SIZE = 'message.compressed_size' as const;
 
 /**
  * Deprecated, use `rpc.message.id` instead.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `rpc.message.id`.
  */
 export const ATTR_MESSAGE_ID = 'message.id' as const;
 
 /**
  * Deprecated, use `rpc.message.type` instead.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `rpc.message.type`.
  */
 export const ATTR_MESSAGE_TYPE = 'message.type' as const;
@@ -4871,312 +4871,312 @@ export const MESSAGE_TYPE_VALUE_SENT = "SENT" as const;
 
 /**
  * Deprecated, use `rpc.message.uncompressed_size` instead.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `rpc.message.uncompressed_size`.
  */
 export const ATTR_MESSAGE_UNCOMPRESSED_SIZE = 'message.uncompressed_size' as const;
 
 /**
  * The number of messages sent, received, or processed in the scope of the batching operation.
- * 
+ *
  * @example 0
  * @example 1
  * @example 2
- * 
+ *
  * @note Instrumentations **SHOULD NOT** set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations **SHOULD** use `messaging.batch.message_count` for batching APIs and **SHOULD NOT** use it for single-message APIs.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_BATCH_MESSAGE_COUNT = 'messaging.batch.message_count' as const;
 
 /**
  * A unique identifier for the client that consumes or produces a message.
- * 
+ *
  * @example client-5
  * @example myhost@8742@s8083jm
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_CLIENT_ID = 'messaging.client.id' as const;
 
 /**
  * The name of the consumer group with which a consumer is associated.
- * 
+ *
  * @example my-group
  * @example indexer
- * 
+ *
  * @note Semantic conventions for individual messaging systems **SHOULD** document whether `messaging.consumer.group.name` is applicable and what it means in the context of that system.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_CONSUMER_GROUP_NAME = 'messaging.consumer.group.name' as const;
 
 /**
  * A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_DESTINATION_ANONYMOUS = 'messaging.destination.anonymous' as const;
 
 /**
  * The message destination name
- * 
+ *
  * @example MyQueue
  * @example MyTopic
- * 
+ *
  * @note Destination name **SHOULD** uniquely identify a specific queue, topic or other entity within the broker. If
  * the broker doesn't have such notion, the destination name **SHOULD** uniquely identify the broker.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_DESTINATION_NAME = 'messaging.destination.name' as const;
 
 /**
  * The identifier of the partition messages are sent to or received from, unique within the `messaging.destination.name`.
- * 
+ *
  * @example "1"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_DESTINATION_PARTITION_ID = 'messaging.destination.partition.id' as const;
 
 /**
  * The name of the destination subscription from which a message is consumed.
- * 
+ *
  * @example subscription-a
- * 
+ *
  * @note Semantic conventions for individual messaging systems **SHOULD** document whether `messaging.destination.subscription.name` is applicable and what it means in the context of that system.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_DESTINATION_SUBSCRIPTION_NAME = 'messaging.destination.subscription.name' as const;
 
 /**
  * Low cardinality representation of the messaging destination name
- * 
+ *
  * @example /customers/{customerId}
- * 
+ *
  * @note Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_DESTINATION_TEMPLATE = 'messaging.destination.template' as const;
 
 /**
  * A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_DESTINATION_TEMPORARY = 'messaging.destination.temporary' as const;
 
 /**
  * Deprecated, no replacement at this time.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated No replacement at this time.
  */
 export const ATTR_MESSAGING_DESTINATION_PUBLISH_ANONYMOUS = 'messaging.destination_publish.anonymous' as const;
 
 /**
  * Deprecated, no replacement at this time.
- * 
+ *
  * @example MyQueue
  * @example MyTopic
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated No replacement at this time.
  */
 export const ATTR_MESSAGING_DESTINATION_PUBLISH_NAME = 'messaging.destination_publish.name' as const;
 
 /**
  * Deprecated, use `messaging.consumer.group.name` instead.
- * 
+ *
  * @example "$Default"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `messaging.consumer.group.name`.
  */
 export const ATTR_MESSAGING_EVENTHUBS_CONSUMER_GROUP = 'messaging.eventhubs.consumer.group' as const;
 
 /**
  * The UTC epoch seconds at which the message has been accepted and stored in the entity.
- * 
+ *
  * @example 1701393730
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_EVENTHUBS_MESSAGE_ENQUEUED_TIME = 'messaging.eventhubs.message.enqueued_time' as const;
 
 /**
  * The ack deadline in seconds set for the modify ack deadline request.
- * 
+ *
  * @example 10
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_GCP_PUBSUB_MESSAGE_ACK_DEADLINE = 'messaging.gcp_pubsub.message.ack_deadline' as const;
 
 /**
  * The ack id for a given message.
- * 
+ *
  * @example "ack_id"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_GCP_PUBSUB_MESSAGE_ACK_ID = 'messaging.gcp_pubsub.message.ack_id' as const;
 
 /**
  * The delivery attempt for a given message.
- * 
+ *
  * @example 2
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_GCP_PUBSUB_MESSAGE_DELIVERY_ATTEMPT = 'messaging.gcp_pubsub.message.delivery_attempt' as const;
 
 /**
  * The ordering key for a given message. If the attribute is not present, the message does not have an ordering key.
- * 
+ *
  * @example "ordering_key"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_GCP_PUBSUB_MESSAGE_ORDERING_KEY = 'messaging.gcp_pubsub.message.ordering_key' as const;
 
 /**
  * Deprecated, use `messaging.consumer.group.name` instead.
- * 
+ *
  * @example "my-group"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `messaging.consumer.group.name`.
  */
 export const ATTR_MESSAGING_KAFKA_CONSUMER_GROUP = 'messaging.kafka.consumer.group' as const;
 
 /**
  * Deprecated, use `messaging.destination.partition.id` instead.
- * 
+ *
  * @example 2
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `messaging.destination.partition.id`.
  */
 export const ATTR_MESSAGING_KAFKA_DESTINATION_PARTITION = 'messaging.kafka.destination.partition' as const;
 
 /**
  * Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message.id` in that they're not unique. If the key is `null`, the attribute **MUST NOT** be set.
- * 
+ *
  * @example "myKey"
- * 
+ *
  * @note If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_KAFKA_MESSAGE_KEY = 'messaging.kafka.message.key' as const;
 
 /**
  * Deprecated, use `messaging.kafka.offset` instead.
- * 
+ *
  * @example 42
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `messaging.kafka.offset`.
  */
 export const ATTR_MESSAGING_KAFKA_MESSAGE_OFFSET = 'messaging.kafka.message.offset' as const;
 
 /**
  * A boolean that is true if the message is a tombstone.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_KAFKA_MESSAGE_TOMBSTONE = 'messaging.kafka.message.tombstone' as const;
 
 /**
  * The offset of a record in the corresponding Kafka partition.
- * 
+ *
  * @example 42
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_KAFKA_OFFSET = 'messaging.kafka.offset' as const;
 
 /**
  * The size of the message body in bytes.
- * 
+ *
  * @example 1439
- * 
+ *
  * @note This can refer to both the compressed or uncompressed body size. If both sizes are known, the uncompressed
  * body size should be used.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_MESSAGE_BODY_SIZE = 'messaging.message.body.size' as const;
 
 /**
  * The conversation ID identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID".
- * 
+ *
  * @example "MyConversationId"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_MESSAGE_CONVERSATION_ID = 'messaging.message.conversation_id' as const;
 
 /**
  * The size of the message body and metadata in bytes.
- * 
+ *
  * @example 2738
- * 
+ *
  * @note This can refer to both the compressed or uncompressed size. If both sizes are known, the uncompressed
  * size should be used.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_MESSAGE_ENVELOPE_SIZE = 'messaging.message.envelope.size' as const;
 
 /**
  * A value used by the messaging system as an identifier for the message, represented as a string.
- * 
+ *
  * @example "452a7c7c7c7048c2f887f61572b18fc2"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_MESSAGE_ID = 'messaging.message.id' as const;
 
 /**
  * Deprecated, use `messaging.operation.type` instead.
- * 
+ *
  * @example publish
  * @example create
  * @example process
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `messaging.operation.type`.
  */
 export const ATTR_MESSAGING_OPERATION = 'messaging.operation' as const;
 
 /**
  * The system-specific name of the messaging operation.
- * 
+ *
  * @example ack
  * @example nack
  * @example send
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_OPERATION_NAME = 'messaging.operation.name' as const;
 
 /**
  * A string identifying the type of the messaging operation.
- * 
+ *
  * @note If a custom value is used, it **MUST** be of low cardinality.
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -5219,36 +5219,36 @@ export const MESSAGING_OPERATION_TYPE_VALUE_SETTLE = "settle" as const;
 
 /**
  * RabbitMQ message routing key.
- * 
+ *
  * @example "myKey"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY = 'messaging.rabbitmq.destination.routing_key' as const;
 
 /**
  * RabbitMQ message delivery tag
- * 
+ *
  * @example 123
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG = 'messaging.rabbitmq.message.delivery_tag' as const;
 
 /**
  * Deprecated, use `messaging.consumer.group.name` instead.
- * 
+ *
  * @example "myConsumerGroup"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `messaging.consumer.group.name` on the consumer spans. No replacement for producer spans.
  */
 export const ATTR_MESSAGING_ROCKETMQ_CLIENT_GROUP = 'messaging.rocketmq.client_group' as const;
 
 /**
  * Model of message consumption. This only applies to consumer spans.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_ROCKETMQ_CONSUMPTION_MODEL = 'messaging.rocketmq.consumption_model' as const;
@@ -5265,52 +5265,52 @@ export const MESSAGING_ROCKETMQ_CONSUMPTION_MODEL_VALUE_CLUSTERING = "clustering
 
 /**
  * The delay time level for delay message, which determines the message delay time.
- * 
+ *
  * @example 3
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_ROCKETMQ_MESSAGE_DELAY_TIME_LEVEL = 'messaging.rocketmq.message.delay_time_level' as const;
 
 /**
  * The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
- * 
+ *
  * @example 1665987217045
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_ROCKETMQ_MESSAGE_DELIVERY_TIMESTAMP = 'messaging.rocketmq.message.delivery_timestamp' as const;
 
 /**
  * It is essential for FIFO message. Messages that belong to the same message group are always processed one by one within the same consumer group.
- * 
+ *
  * @example "myMessageGroup"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_ROCKETMQ_MESSAGE_GROUP = 'messaging.rocketmq.message.group' as const;
 
 /**
  * Key(s) of message, another way to mark message besides message id.
- * 
+ *
  * @example ["keyA", "keyB"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_ROCKETMQ_MESSAGE_KEYS = 'messaging.rocketmq.message.keys' as const;
 
 /**
  * The secondary classifier of message besides topic.
- * 
+ *
  * @example "tagA"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_ROCKETMQ_MESSAGE_TAG = 'messaging.rocketmq.message.tag' as const;
 
 /**
  * Type of message.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_ROCKETMQ_MESSAGE_TYPE = 'messaging.rocketmq.message.type' as const;
@@ -5337,27 +5337,27 @@ export const MESSAGING_ROCKETMQ_MESSAGE_TYPE_VALUE_TRANSACTION = "transaction" a
 
 /**
  * Namespace of RocketMQ resources, resources in different namespaces are individual.
- * 
+ *
  * @example "myNamespace"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_ROCKETMQ_NAMESPACE = 'messaging.rocketmq.namespace' as const;
 
 /**
  * Deprecated, use `messaging.destination.subscription.name` instead.
- * 
+ *
  * @example "subscription-a"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `messaging.destination.subscription.name`.
  */
 export const ATTR_MESSAGING_SERVICEBUS_DESTINATION_SUBSCRIPTION_NAME = 'messaging.servicebus.destination.subscription_name' as const;
 
 /**
  * Describes the [settlement type](https://learn.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_SERVICEBUS_DISPOSITION_STATUS = 'messaging.servicebus.disposition_status' as const;
@@ -5384,27 +5384,27 @@ export const MESSAGING_SERVICEBUS_DISPOSITION_STATUS_VALUE_DEFER = "defer" as co
 
 /**
  * Number of deliveries that have been attempted for this message.
- * 
+ *
  * @example 2
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_SERVICEBUS_MESSAGE_DELIVERY_COUNT = 'messaging.servicebus.message.delivery_count' as const;
 
 /**
  * The UTC epoch seconds at which the message has been accepted and stored in the entity.
- * 
+ *
  * @example 1701393730
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_SERVICEBUS_MESSAGE_ENQUEUED_TIME = 'messaging.servicebus.message.enqueued_time' as const;
 
 /**
  * The messaging system as identified by the client instrumentation.
- * 
+ *
  * @note The actual messaging system may differ from the one known by the client. For example, when using Kafka client libraries to communicate with Azure Event Hubs, the `messaging.system` is set to `kafka` based on the instrumentation's best knowledge.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_SYSTEM = 'messaging.system' as const;
@@ -5466,99 +5466,99 @@ export const MESSAGING_SYSTEM_VALUE_SERVICEBUS = "servicebus" as const;
 
 /**
  * Deprecated, use `network.local.address`.
- * 
+ *
  * @example "192.168.0.1"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `network.local.address`.
  */
 export const ATTR_NET_HOST_IP = 'net.host.ip' as const;
 
 /**
  * Deprecated, use `server.address`.
- * 
+ *
  * @example example.com
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `server.address`.
  */
 export const ATTR_NET_HOST_NAME = 'net.host.name' as const;
 
 /**
  * Deprecated, use `server.port`.
- * 
+ *
  * @example 8080
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `server.port`.
  */
 export const ATTR_NET_HOST_PORT = 'net.host.port' as const;
 
 /**
  * Deprecated, use `network.peer.address`.
- * 
+ *
  * @example "127.0.0.1"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `network.peer.address`.
  */
 export const ATTR_NET_PEER_IP = 'net.peer.ip' as const;
 
 /**
  * Deprecated, use `server.address` on client spans and `client.address` on server spans.
- * 
+ *
  * @example example.com
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `server.address` on client spans and `client.address` on server spans.
  */
 export const ATTR_NET_PEER_NAME = 'net.peer.name' as const;
 
 /**
  * Deprecated, use `server.port` on client spans and `client.port` on server spans.
- * 
+ *
  * @example 8080
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `server.port` on client spans and `client.port` on server spans.
  */
 export const ATTR_NET_PEER_PORT = 'net.peer.port' as const;
 
 /**
  * Deprecated, use `network.protocol.name`.
- * 
+ *
  * @example amqp
  * @example http
  * @example mqtt
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `network.protocol.name`.
  */
 export const ATTR_NET_PROTOCOL_NAME = 'net.protocol.name' as const;
 
 /**
  * Deprecated, use `network.protocol.version`.
- * 
+ *
  * @example "3.1.1"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `network.protocol.version`.
  */
 export const ATTR_NET_PROTOCOL_VERSION = 'net.protocol.version' as const;
 
 /**
  * Deprecated, use `network.transport` and `network.type`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Split to `network.transport` and `network.type`.
  */
 export const ATTR_NET_SOCK_FAMILY = 'net.sock.family' as const;
@@ -5580,64 +5580,64 @@ export const NET_SOCK_FAMILY_VALUE_UNIX = "unix" as const;
 
 /**
  * Deprecated, use `network.local.address`.
- * 
+ *
  * @example /var/my.sock
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `network.local.address`.
  */
 export const ATTR_NET_SOCK_HOST_ADDR = 'net.sock.host.addr' as const;
 
 /**
  * Deprecated, use `network.local.port`.
- * 
+ *
  * @example 8080
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `network.local.port`.
  */
 export const ATTR_NET_SOCK_HOST_PORT = 'net.sock.host.port' as const;
 
 /**
  * Deprecated, use `network.peer.address`.
- * 
+ *
  * @example 192.168.0.1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `network.peer.address`.
  */
 export const ATTR_NET_SOCK_PEER_ADDR = 'net.sock.peer.addr' as const;
 
 /**
  * Deprecated, no replacement at this time.
- * 
+ *
  * @example /var/my.sock
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Removed.
  */
 export const ATTR_NET_SOCK_PEER_NAME = 'net.sock.peer.name' as const;
 
 /**
  * Deprecated, use `network.peer.port`.
- * 
+ *
  * @example 65531
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `network.peer.port`.
  */
 export const ATTR_NET_SOCK_PEER_PORT = 'net.sock.peer.port' as const;
 
 /**
  * Deprecated, use `network.transport`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `network.transport`.
  */
 export const ATTR_NET_TRANSPORT = 'net.transport' as const;
@@ -5669,45 +5669,45 @@ export const NET_TRANSPORT_VALUE_PIPE = "pipe" as const;
 
 /**
  * The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network.
- * 
+ *
  * @example "DE"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_NETWORK_CARRIER_ICC = 'network.carrier.icc' as const;
 
 /**
  * The mobile carrier country code.
- * 
+ *
  * @example "310"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_NETWORK_CARRIER_MCC = 'network.carrier.mcc' as const;
 
 /**
  * The mobile carrier network code.
- * 
+ *
  * @example "001"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_NETWORK_CARRIER_MNC = 'network.carrier.mnc' as const;
 
 /**
  * The name of the mobile carrier.
- * 
+ *
  * @example "sprint"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_NETWORK_CARRIER_NAME = 'network.carrier.name' as const;
 
 /**
  * This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection.
- * 
+ *
  * @example "LTE"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_NETWORK_CONNECTION_SUBTYPE = 'network.connection.subtype' as const;
@@ -5819,9 +5819,9 @@ export const NETWORK_CONNECTION_SUBTYPE_VALUE_UMTS = "umts" as const;
 
 /**
  * The internet connection type.
- * 
+ *
  * @example "wifi"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_NETWORK_CONNECTION_TYPE = 'network.connection.type' as const;
@@ -5853,9 +5853,9 @@ export const NETWORK_CONNECTION_TYPE_VALUE_WIRED = "wired" as const;
 
 /**
  * The network IO operation direction.
- * 
+ *
  * @example transmit
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_NETWORK_IO_DIRECTION = 'network.io.direction' as const;
@@ -5872,7 +5872,7 @@ export const NETWORK_IO_DIRECTION_VALUE_TRANSMIT = "transmit" as const;
 
 /**
  * The state of event loop time.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_NODEJS_EVENTLOOP_STATE = 'nodejs.eventloop.state' as const;
@@ -5889,21 +5889,21 @@ export const NODEJS_EVENTLOOP_STATE_VALUE_IDLE = "idle" as const;
 
 /**
  * The digest of the OCI image manifest. For container images specifically is the digest by which the container image is known.
- * 
+ *
  * @example sha256:e4ca62c0d62f3e886e684806dfe9d4e0cda60d54986898173c1083856cfda0f4
- * 
+ *
  * @note Follows [OCI Image Manifest Specification](https://github.com/opencontainers/image-spec/blob/main/manifest.md), and specifically the [Digest property](https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests).
  * An example can be found in [Example Image Manifest](https://docs.docker.com/registry/spec/manifest-v2-2/#example-image-manifest).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_OCI_MANIFEST_DIGEST = 'oci.manifest.digest' as const;
 
 /**
  * Parent-child Reference type
- * 
+ *
  * @note The causal relationship between a child Span and a parent Span.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_OPENTRACING_REF_TYPE = 'opentracing.ref_type' as const;
@@ -5920,39 +5920,39 @@ export const OPENTRACING_REF_TYPE_VALUE_FOLLOWS_FROM = "follows_from" as const;
 
 /**
  * Unique identifier for a particular build or compilation of the operating system.
- * 
+ *
  * @example TQ3C.230805.001.B2
  * @example 20E247
  * @example 22621
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_OS_BUILD_ID = 'os.build_id' as const;
 
 /**
  * Human readable (not intended to be parsed) OS version information, like e.g. reported by `ver` or `lsb_release -a` commands.
- * 
+ *
  * @example Microsoft Windows [Version 10.0.18363.778]
  * @example Ubuntu 18.04.1 LTS
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_OS_DESCRIPTION = 'os.description' as const;
 
 /**
  * Human readable operating system name.
- * 
+ *
  * @example iOS
  * @example Android
  * @example Ubuntu
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_OS_NAME = 'os.name' as const;
 
 /**
  * The operating system type.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_OS_TYPE = 'os.type' as const;
@@ -6014,97 +6014,97 @@ export const OS_TYPE_VALUE_Z_OS = "z_os" as const;
 
 /**
  * The version string of the operating system as defined in [Version Attributes](/docs/resource/README.md#version-attributes).
- * 
+ *
  * @example 14.2.1
  * @example 18.04.1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_OS_VERSION = 'os.version' as const;
 
 /**
  * Deprecated. Use the `otel.scope.name` attribute
- * 
+ *
  * @example io.opentelemetry.contrib.mongodb
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Use the `otel.scope.name` attribute.
  */
 export const ATTR_OTEL_LIBRARY_NAME = 'otel.library.name' as const;
 
 /**
  * Deprecated. Use the `otel.scope.version` attribute.
- * 
+ *
  * @example 1.0.0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Use the `otel.scope.version` attribute.
  */
 export const ATTR_OTEL_LIBRARY_VERSION = 'otel.library.version' as const;
 
 /**
  * The [`service.name`](/docs/resource/README.md#service) of the remote service. **SHOULD** be equal to the actual `service.name` resource attribute of the remote service if any.
- * 
+ *
  * @example "AuthTokenCache"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PEER_SERVICE = 'peer.service' as const;
 
 /**
  * Deprecated, use `db.client.connection.pool.name` instead.
- * 
+ *
  * @example myDataSource
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.client.connection.pool.name`.
  */
 export const ATTR_POOL_NAME = 'pool.name' as const;
 
 /**
  * Length of the process.command_args array
- * 
+ *
  * @example 4
- * 
+ *
  * @note This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_ARGS_COUNT = 'process.args_count' as const;
 
 /**
  * The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`.
- * 
+ *
  * @example cmd/otelcol
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_COMMAND = 'process.command' as const;
 
 /**
  * All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`.
- * 
+ *
  * @example ["cmd/otecol", "--config=config.yaml"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_COMMAND_ARGS = 'process.command_args' as const;
 
 /**
  * The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead.
- * 
+ *
  * @example C:\\cmd\\otecol --config="my directory\\config.yaml"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_COMMAND_LINE = 'process.command_line' as const;
 
 /**
  * Specifies whether the context switches for this data point were voluntary or involuntary.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_CONTEXT_SWITCH_TYPE = 'process.context_switch_type' as const;
@@ -6121,9 +6121,9 @@ export const PROCESS_CONTEXT_SWITCH_TYPE_VALUE_VOLUNTARY = "voluntary" as const;
 
 /**
  * Deprecated, use `cpu.mode` instead.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `cpu.mode`
  */
 export const ATTR_PROCESS_CPU_STATE = 'process.cpu.state' as const;
@@ -6145,127 +6145,127 @@ export const PROCESS_CPU_STATE_VALUE_WAIT = "wait" as const;
 
 /**
  * The date and time the process was created, in ISO 8601 format.
- * 
+ *
  * @example 2023-11-21T09:25:34.853Z
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_CREATION_TIME = 'process.creation.time' as const;
 
 /**
  * The GNU build ID as found in the `.note.gnu.build-id` ELF section (hex string).
- * 
+ *
  * @example c89b11207f6479603b0d49bf291c092c2b719293
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_EXECUTABLE_BUILD_ID_GNU = 'process.executable.build_id.gnu' as const;
 
 /**
  * The Go build ID as retrieved by `go tool buildid <go executable>`.
- * 
+ *
  * @example foh3mEXu7BLZjsN9pOwG/kATcXlYVCDEFouRMQed_/WwRFB1hPo9LBkekthSPG/x8hMC8emW2cCjXD0_1aY
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_EXECUTABLE_BUILD_ID_GO = 'process.executable.build_id.go' as const;
 
 /**
  * Profiling specific build ID for executables. See the OTel specification for Profiles for more information.
- * 
+ *
  * @example 600DCAFE4A110000F2BF38C493F5FB92
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_EXECUTABLE_BUILD_ID_HTLHASH = 'process.executable.build_id.htlhash' as const;
 
 /**
  * "Deprecated, use `process.executable.build_id.htlhash` instead."
- * 
+ *
  * @example 600DCAFE4A110000F2BF38C493F5FB92
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `process.executable.build_id.htlhash`
  */
 export const ATTR_PROCESS_EXECUTABLE_BUILD_ID_PROFILING = 'process.executable.build_id.profiling' as const;
 
 /**
  * The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`.
- * 
+ *
  * @example otelcol
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_EXECUTABLE_NAME = 'process.executable.name' as const;
 
 /**
  * The full path to the process executable. On Linux based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`.
- * 
+ *
  * @example /usr/bin/cmd/otelcol
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_EXECUTABLE_PATH = 'process.executable.path' as const;
 
 /**
  * The exit code of the process.
- * 
+ *
  * @example 127
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_EXIT_CODE = 'process.exit.code' as const;
 
 /**
  * The date and time the process exited, in ISO 8601 format.
- * 
+ *
  * @example 2023-11-21T09:26:12.315Z
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_EXIT_TIME = 'process.exit.time' as const;
 
 /**
  * The PID of the process's group leader. This is also the process group ID (PGID) of the process.
- * 
+ *
  * @example 23
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_GROUP_LEADER_PID = 'process.group_leader.pid' as const;
 
 /**
  * Whether the process is connected to an interactive shell.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_INTERACTIVE = 'process.interactive' as const;
 
 /**
  * The control group associated with the process.
- * 
+ *
  * @example 1:name=systemd:/user.slice/user-1000.slice/session-3.scope
  * @example 0::/user.slice/user-1000.slice/user@1000.service/tmux-spawn-0267755b-4639-4a27-90ed-f19f88e53748.scope
- * 
+ *
  * @note Control groups (cgroups) are a kernel feature used to organize and manage process resources. This attribute provides the path(s) to the cgroup(s) associated with the process, which should match the contents of the [/proc/<PID>/cgroup](https://man7.org/linux/man-pages/man7/cgroups.7.html) file.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_LINUX_CGROUP = 'process.linux.cgroup' as const;
 
 /**
  * The username of the user that owns the process.
- * 
+ *
  * @example root
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_OWNER = 'process.owner' as const;
 
 /**
  * The type of page fault for this data point. Type `major` is for major/hard page faults, and `minor` is for minor/soft page faults.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_PAGING_FAULT_TYPE = 'process.paging.fault_type' as const;
@@ -6282,150 +6282,150 @@ export const PROCESS_PAGING_FAULT_TYPE_VALUE_MINOR = "minor" as const;
 
 /**
  * Parent Process identifier (PPID).
- * 
+ *
  * @example 111
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_PARENT_PID = 'process.parent_pid' as const;
 
 /**
  * Process identifier (PID).
- * 
+ *
  * @example 1234
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_PID = 'process.pid' as const;
 
 /**
  * The real user ID (RUID) of the process.
- * 
+ *
  * @example 1000
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_REAL_USER_ID = 'process.real_user.id' as const;
 
 /**
  * The username of the real user of the process.
- * 
+ *
  * @example operator
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_REAL_USER_NAME = 'process.real_user.name' as const;
 
 /**
  * An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment.
- * 
+ *
  * @example "Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_RUNTIME_DESCRIPTION = 'process.runtime.description' as const;
 
 /**
  * The name of the runtime of this process.
- * 
+ *
  * @example OpenJDK Runtime Environment
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_RUNTIME_NAME = 'process.runtime.name' as const;
 
 /**
  * The version of the runtime of this process, as returned by the runtime without modification.
- * 
+ *
  * @example "14.0.2"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_RUNTIME_VERSION = 'process.runtime.version' as const;
 
 /**
  * The saved user ID (SUID) of the process.
- * 
+ *
  * @example 1002
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_SAVED_USER_ID = 'process.saved_user.id' as const;
 
 /**
  * The username of the saved user.
- * 
+ *
  * @example operator
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_SAVED_USER_NAME = 'process.saved_user.name' as const;
 
 /**
  * The PID of the process's session leader. This is also the session ID (SID) of the process.
- * 
+ *
  * @example 14
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_SESSION_LEADER_PID = 'process.session_leader.pid' as const;
 
 /**
  * Process title (proctitle)
- * 
+ *
  * @example cat /etc/hostname
  * @example xfce4-session
  * @example bash
- * 
+ *
  * @note In many Unix-like systems, process title (proctitle), is the string that represents the name or command line of a running process, displayed by system monitoring tools like ps, top, and htop.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_TITLE = 'process.title' as const;
 
 /**
  * The effective user ID (EUID) of the process.
- * 
+ *
  * @example 1001
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_USER_ID = 'process.user.id' as const;
 
 /**
  * The username of the effective user of the process.
- * 
+ *
  * @example root
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_USER_NAME = 'process.user.name' as const;
 
 /**
  * Virtual process identifier.
- * 
+ *
  * @example 12
- * 
+ *
  * @note The process ID within a PID namespace. This is not necessarily unique across all processes on the host but it is unique within the process namespace that the process exists within.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_VPID = 'process.vpid' as const;
 
 /**
  * The working directory of the process.
- * 
+ *
  * @example /root
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROCESS_WORKING_DIRECTORY = 'process.working_directory' as const;
 
 /**
  * Describes the interpreter or compiler of a single frame.
- * 
+ *
  * @example cpython
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_PROFILE_FRAME_TYPE = 'profile.frame.type' as const;
@@ -6477,7 +6477,7 @@ export const PROFILE_FRAME_TYPE_VALUE_V8JS = "v8js" as const;
 
 /**
  * The [error codes](https://connect.build/docs/protocol/#error-codes) of the Connect request. Error codes are always string values.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_CONNECT_RPC_ERROR_CODE = 'rpc.connect_rpc.error_code' as const;
@@ -6564,51 +6564,51 @@ export const RPC_CONNECT_RPC_ERROR_CODE_VALUE_UNKNOWN = "unknown" as const;
 
 /**
  * Connect request metadata, `<key>` being the normalized Connect Metadata key (lowercase), the value being the metadata values.
- * 
+ *
  * @example rpc.request.metadata.my-custom-metadata-attribute=["1.2.3.4", "1.2.3.5"]
- * 
+ *
  * @note Instrumentations **SHOULD** require an explicit configuration of which metadata values are to be captured. Including all request metadata values can be a security risk - explicit configuration helps avoid leaking sensitive information.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_CONNECT_RPC_REQUEST_METADATA = (key: string) => `rpc.connect_rpc.request.metadata.${key}`;
 
 /**
  * Connect response metadata, `<key>` being the normalized Connect Metadata key (lowercase), the value being the metadata values.
- * 
+ *
  * @example rpc.response.metadata.my-custom-metadata-attribute=["attribute_value"]
- * 
+ *
  * @note Instrumentations **SHOULD** require an explicit configuration of which metadata values are to be captured. Including all response metadata values can be a security risk - explicit configuration helps avoid leaking sensitive information.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_CONNECT_RPC_RESPONSE_METADATA = (key: string) => `rpc.connect_rpc.response.metadata.${key}`;
 
 /**
  * gRPC request metadata, `<key>` being the normalized gRPC Metadata key (lowercase), the value being the metadata values.
- * 
+ *
  * @example rpc.grpc.request.metadata.my-custom-metadata-attribute=["1.2.3.4", "1.2.3.5"]
- * 
+ *
  * @note Instrumentations **SHOULD** require an explicit configuration of which metadata values are to be captured. Including all request metadata values can be a security risk - explicit configuration helps avoid leaking sensitive information.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_GRPC_REQUEST_METADATA = (key: string) => `rpc.grpc.request.metadata.${key}`;
 
 /**
  * gRPC response metadata, `<key>` being the normalized gRPC Metadata key (lowercase), the value being the metadata values.
- * 
+ *
  * @example rpc.grpc.response.metadata.my-custom-metadata-attribute=["attribute_value"]
- * 
+ *
  * @note Instrumentations **SHOULD** require an explicit configuration of which metadata values are to be captured. Including all response metadata values can be a security risk - explicit configuration helps avoid leaking sensitive information.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_GRPC_RESPONSE_METADATA = (key: string) => `rpc.grpc.response.metadata.${key}`;
 
 /**
  * The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_GRPC_STATUS_CODE = 'rpc.grpc.status_code' as const;
@@ -6700,55 +6700,55 @@ export const RPC_GRPC_STATUS_CODE_VALUE_UNAUTHENTICATED = 16 as const;
 
 /**
  * `error.code` property of response if it is an error response.
- * 
+ *
  * @example -32700
  * @example 100
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_JSONRPC_ERROR_CODE = 'rpc.jsonrpc.error_code' as const;
 
 /**
  * `error.message` property of response if it is an error response.
- * 
+ *
  * @example Parse error
  * @example User already exists
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_JSONRPC_ERROR_MESSAGE = 'rpc.jsonrpc.error_message' as const;
 
 /**
  * `id` property of request or response. Since protocol allows id to be int, string, `null` or missing (for notifications), value is expected to be cast to string for simplicity. Use empty string in case of `null` value. Omit entirely if this is a notification.
- * 
+ *
  * @example 10
  * @example request-7
  * @example
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_JSONRPC_REQUEST_ID = 'rpc.jsonrpc.request_id' as const;
 
 /**
  * Protocol version as in `jsonrpc` property of request/response. Since JSON-RPC 1.0 doesn't specify this, the value can be omitted.
- * 
+ *
  * @example 2.0
  * @example 1.0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_JSONRPC_VERSION = 'rpc.jsonrpc.version' as const;
 
 /**
  * Compressed size of the message in bytes.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_MESSAGE_COMPRESSED_SIZE = 'rpc.message.compressed_size' as const;
 
 /**
  * **MUST** be calculated as two different counters starting from `1` one for sent messages and one for received message.
- * 
+ *
  * @note This way we guarantee that the values will be consistent between different implementations.
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -6756,7 +6756,7 @@ export const ATTR_RPC_MESSAGE_ID = 'rpc.message.id' as const;
 
 /**
  * Whether this is a received or sent message.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_MESSAGE_TYPE = 'rpc.message.type' as const;
@@ -6773,36 +6773,36 @@ export const RPC_MESSAGE_TYPE_VALUE_SENT = "SENT" as const;
 
 /**
  * Uncompressed size of the message in bytes.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_MESSAGE_UNCOMPRESSED_SIZE = 'rpc.message.uncompressed_size' as const;
 
 /**
  * The name of the (logical) method being called, must be equal to the $method part in the span name.
- * 
+ *
  * @example "exampleMethod"
- * 
+ *
  * @note This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_METHOD = 'rpc.method' as const;
 
 /**
  * The full (logical) name of the service being called, including its package name, if applicable.
- * 
+ *
  * @example "myservice.EchoService"
- * 
+ *
  * @note This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_SERVICE = 'rpc.service' as const;
 
 /**
  * A string identifying the remoting system. See below for a list of well-known identifiers.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_RPC_SYSTEM = 'rpc.system' as const;
@@ -6834,99 +6834,99 @@ export const RPC_SYSTEM_VALUE_JAVA_RMI = "java_rmi" as const;
 
 /**
  * The string ID of the service instance.
- * 
+ *
  * @example 627cc493-f310-47de-96bd-71410b7dec09
- * 
+ *
  * @note **MUST** be unique for each instance of the same `service.namespace,service.name` pair (in other words
  * `service.namespace,service.name,service.instance.id` triplet **MUST** be globally unique). The ID helps to
  * distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled
  * service).
- * 
+ *
  * Implementations, such as SDKs, are recommended to generate a random Version 1 or Version 4 [RFC
  * 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID, but are free to use an inherent unique ID as the source of
  * this value if stability is desirable. In that case, the ID **SHOULD** be used as source of a UUID Version 5 and
  * **SHOULD** use the following UUID as the namespace: `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
- * 
+ *
  * UUIDs are typically recommended, as only an opaque value for the purposes of identifying a service instance is
  * needed. Similar to what can be seen in the man page for the
  * [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/latest/machine-id.html) file, the underlying
  * data, such as pod name and namespace should be treated as confidential, being the user's choice to expose it
  * or not via another resource attribute.
- * 
+ *
  * For applications running behind an application server (like unicorn), we do not recommend using one identifier
  * for all processes participating in the application. Instead, it's recommended each division (e.g. a worker
  * thread in unicorn) to have its own instance.id.
- * 
+ *
  * It's not recommended for a Collector to set `service.instance.id` if it can't unambiguously determine the
  * service instance that is generating that telemetry. For instance, creating an UUID based on `pod.name` will
  * likely be wrong, as the Collector might not know from which container within that pod the telemetry originated.
  * However, Collectors can set the `service.instance.id` if they can unambiguously determine the service instance
  * for that telemetry. This is typically the case for scraping receivers, as they know the target address and
  * port.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SERVICE_INSTANCE_ID = 'service.instance.id' as const;
 
 /**
  * A namespace for `service.name`.
- * 
+ *
  * @example Shop
- * 
+ *
  * @note A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SERVICE_NAMESPACE = 'service.namespace' as const;
 
 /**
  * A unique id to identify a session.
- * 
+ *
  * @example "00112233-4455-6677-8899-aabbccddeeff"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SESSION_ID = 'session.id' as const;
 
 /**
  * The previous `session.id` for this user, when known.
- * 
+ *
  * @example "00112233-4455-6677-8899-aabbccddeeff"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SESSION_PREVIOUS_ID = 'session.previous_id' as const;
 
 /**
  * Source address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
- * 
+ *
  * @example source.example.com
  * @example 10.1.2.80
  * @example /tmp/my.sock
- * 
+ *
  * @note When observed from the destination side, and when communicating through an intermediary, `source.address` **SHOULD** represent the source address behind any intermediaries, for example proxies, if it's available.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SOURCE_ADDRESS = 'source.address' as const;
 
 /**
  * Source port number
- * 
+ *
  * @example 3389
  * @example 2888
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SOURCE_PORT = 'source.port' as const;
 
 /**
  * Deprecated, use `db.client.connection.state` instead.
- * 
+ *
  * @example idle
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.client.connection.state`.
  */
 export const ATTR_STATE = 'state' as const;
@@ -6943,21 +6943,21 @@ export const STATE_VALUE_USED = "used" as const;
 
 /**
  * The logical CPU number [0..n-1]
- * 
+ *
  * @example 1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SYSTEM_CPU_LOGICAL_NUMBER = 'system.cpu.logical_number' as const;
 
 /**
  * Deprecated, use `cpu.mode` instead.
- * 
+ *
  * @example idle
  * @example interrupt
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `cpu.mode`
  */
 export const ATTR_SYSTEM_CPU_STATE = 'system.cpu.state' as const;
@@ -6999,36 +6999,36 @@ export const SYSTEM_CPU_STATE_VALUE_USER = "user" as const;
 
 /**
  * The device identifier
- * 
+ *
  * @example (identifier)
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SYSTEM_DEVICE = 'system.device' as const;
 
 /**
  * The filesystem mode
- * 
+ *
  * @example rw, ro
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SYSTEM_FILESYSTEM_MODE = 'system.filesystem.mode' as const;
 
 /**
  * The filesystem mount path
- * 
+ *
  * @example /mnt/data
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SYSTEM_FILESYSTEM_MOUNTPOINT = 'system.filesystem.mountpoint' as const;
 
 /**
  * The filesystem state
- * 
+ *
  * @example used
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SYSTEM_FILESYSTEM_STATE = 'system.filesystem.state' as const;
@@ -7050,9 +7050,9 @@ export const SYSTEM_FILESYSTEM_STATE_VALUE_USED = "used" as const;
 
 /**
  * The filesystem type
- * 
+ *
  * @example ext4
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SYSTEM_FILESYSTEM_TYPE = 'system.filesystem.type' as const;
@@ -7089,10 +7089,10 @@ export const SYSTEM_FILESYSTEM_TYPE_VALUE_REFS = "refs" as const;
 
 /**
  * The memory state
- * 
+ *
  * @example free
  * @example cached
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SYSTEM_MEMORY_STATE = 'system.memory.state' as const;
@@ -7124,9 +7124,9 @@ export const SYSTEM_MEMORY_STATE_VALUE_USED = "used" as const;
 
 /**
  * A stateless protocol **MUST NOT** set this attribute
- * 
+ *
  * @example close_wait
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SYSTEM_NETWORK_STATE = 'system.network.state' as const;
@@ -7193,9 +7193,9 @@ export const SYSTEM_NETWORK_STATE_VALUE_TIME_WAIT = "time_wait" as const;
 
 /**
  * The paging access direction
- * 
+ *
  * @example in
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SYSTEM_PAGING_DIRECTION = 'system.paging.direction' as const;
@@ -7212,9 +7212,9 @@ export const SYSTEM_PAGING_DIRECTION_VALUE_OUT = "out" as const;
 
 /**
  * The memory paging state
- * 
+ *
  * @example free
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SYSTEM_PAGING_STATE = 'system.paging.state' as const;
@@ -7231,9 +7231,9 @@ export const SYSTEM_PAGING_STATE_VALUE_USED = "used" as const;
 
 /**
  * The memory paging type
- * 
+ *
  * @example minor
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SYSTEM_PAGING_TYPE = 'system.paging.type' as const;
@@ -7250,9 +7250,9 @@ export const SYSTEM_PAGING_TYPE_VALUE_MINOR = "minor" as const;
 
 /**
  * The process state, e.g., [Linux Process State Codes](https://man7.org/linux/man-pages/man1/ps.1.html#PROCESS_STATE_CODES)
- * 
+ *
  * @example running
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_SYSTEM_PROCESS_STATUS = 'system.process.status' as const;
@@ -7279,11 +7279,11 @@ export const SYSTEM_PROCESS_STATUS_VALUE_STOPPED = "stopped" as const;
 
 /**
  * Deprecated, use `system.process.status` instead.
- * 
+ *
  * @example running
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `system.process.status`.
  */
 export const ATTR_SYSTEM_PROCESSES_STATUS = 'system.processes.status' as const;
@@ -7310,42 +7310,42 @@ export const SYSTEM_PROCESSES_STATUS_VALUE_STOPPED = "stopped" as const;
 
 /**
  * The name of the auto instrumentation agent or distribution, if used.
- * 
+ *
  * @example parts-unlimited-java
- * 
+ *
  * @note Official auto instrumentation agents and distributions **SHOULD** set the `telemetry.distro.name` attribute to
  * a string starting with `opentelemetry-`, e.g. `opentelemetry-java-instrumentation`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TELEMETRY_DISTRO_NAME = 'telemetry.distro.name' as const;
 
 /**
  * The version string of the auto instrumentation agent or distribution, if used.
- * 
+ *
  * @example 1.2.3
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TELEMETRY_DISTRO_VERSION = 'telemetry.distro.version' as const;
 
 /**
  * The fully qualified human readable name of the [test case](https://wikipedia.org/wiki/Test_case).
- * 
+ *
  * @example org.example.TestCase1.test1
  * @example example/tests/TestCase1.test1
  * @example ExampleTestCase1_test1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TEST_CASE_NAME = 'test.case.name' as const;
 
 /**
  * The status of the actual test case result from test execution.
- * 
+ *
  * @example pass
  * @example fail
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TEST_CASE_RESULT_STATUS = 'test.case.result.status' as const;
@@ -7362,23 +7362,23 @@ export const TEST_CASE_RESULT_STATUS_VALUE_PASS = "pass" as const;
 
 /**
  * The human readable name of a [test suite](https://wikipedia.org/wiki/Test_suite).
- * 
+ *
  * @example TestSuite1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TEST_SUITE_NAME = 'test.suite.name' as const;
 
 /**
  * The status of the test suite run.
- * 
+ *
  * @example success
  * @example failure
  * @example skipped
  * @example aborted
  * @example timed_out
  * @example in_progress
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TEST_SUITE_RUN_STATUS = 'test.suite.run.status' as const;
@@ -7415,174 +7415,174 @@ export const TEST_SUITE_RUN_STATUS_VALUE_TIMED_OUT = "timed_out" as const;
 
 /**
  * Current "managed" thread ID (as opposed to OS thread ID).
- * 
+ *
  * @example 42
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_THREAD_ID = 'thread.id' as const;
 
 /**
  * Current thread name.
- * 
+ *
  * @example "main"
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_THREAD_NAME = 'thread.name' as const;
 
 /**
  * String indicating the [cipher](https://datatracker.ietf.org/doc/html/rfc5246#appendix-A.5) used during the current connection.
- * 
+ *
  * @example TLS_RSA_WITH_3DES_EDE_CBC_SHA
  * @example TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
- * 
+ *
  * @note The values allowed for `tls.cipher` **MUST** be one of the `Descriptions` of the [registered TLS Cipher Suits](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#table-tls-parameters-4).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_CIPHER = 'tls.cipher' as const;
 
 /**
  * PEM-encoded stand-alone certificate offered by the client. This is usually mutually-exclusive of `client.certificate_chain` since this value also exists in that list.
- * 
+ *
  * @example MII...
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_CLIENT_CERTIFICATE = 'tls.client.certificate' as const;
 
 /**
  * Array of PEM-encoded certificates that make up the certificate chain offered by the client. This is usually mutually-exclusive of `client.certificate` since that value should be the first certificate in the chain.
- * 
+ *
  * @example ["MII...", "MI..."]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_CLIENT_CERTIFICATE_CHAIN = 'tls.client.certificate_chain' as const;
 
 /**
  * Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash.
- * 
+ *
  * @example 0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_CLIENT_HASH_MD5 = 'tls.client.hash.md5' as const;
 
 /**
  * Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash.
- * 
+ *
  * @example 9E393D93138888D288266C2D915214D1D1CCEB2A
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_CLIENT_HASH_SHA1 = 'tls.client.hash.sha1' as const;
 
 /**
  * Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash.
- * 
+ *
  * @example 0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_CLIENT_HASH_SHA256 = 'tls.client.hash.sha256' as const;
 
 /**
  * Distinguished name of [subject](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6) of the issuer of the x.509 certificate presented by the client.
- * 
+ *
  * @example CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_CLIENT_ISSUER = 'tls.client.issuer' as const;
 
 /**
  * A hash that identifies clients based on how they perform an SSL/TLS handshake.
- * 
+ *
  * @example d4e5b18d6b55c71272893221c96ba240
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_CLIENT_JA3 = 'tls.client.ja3' as const;
 
 /**
  * Date/Time indicating when client certificate is no longer considered valid.
- * 
+ *
  * @example 2021-01-01T00:00:00.000Z
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_CLIENT_NOT_AFTER = 'tls.client.not_after' as const;
 
 /**
  * Date/Time indicating when client certificate is first considered valid.
- * 
+ *
  * @example 1970-01-01T00:00:00.000Z
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_CLIENT_NOT_BEFORE = 'tls.client.not_before' as const;
 
 /**
  * Deprecated, use `server.address` instead.
- * 
+ *
  * @example opentelemetry.io
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `server.address`.
  */
 export const ATTR_TLS_CLIENT_SERVER_NAME = 'tls.client.server_name' as const;
 
 /**
  * Distinguished name of subject of the x.509 certificate presented by the client.
- * 
+ *
  * @example CN=myclient, OU=Documentation Team, DC=example, DC=com
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_CLIENT_SUBJECT = 'tls.client.subject' as const;
 
 /**
  * Array of ciphers offered by the client during the client hello.
- * 
+ *
  * @example ["TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_CLIENT_SUPPORTED_CIPHERS = 'tls.client.supported_ciphers' as const;
 
 /**
  * String indicating the curve used for the given cipher, when applicable
- * 
+ *
  * @example secp256r1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_CURVE = 'tls.curve' as const;
 
 /**
  * Boolean flag indicating if the TLS negotiation was successful and transitioned to an encrypted tunnel.
- * 
+ *
  * @example true
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_ESTABLISHED = 'tls.established' as const;
 
 /**
  * String indicating the protocol being tunneled. Per the values in the [IANA registry](https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids), this string should be lower case.
- * 
+ *
  * @example http/1.1
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_NEXT_PROTOCOL = 'tls.next_protocol' as const;
 
 /**
  * Normalized lowercase protocol name parsed from original string of the negotiated [SSL/TLS protocol version](https://www.openssl.org/docs/man1.1.1/man3/SSL_get_version.html#RETURN-VALUES)
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_PROTOCOL_NAME = 'tls.protocol.name' as const;
@@ -7599,281 +7599,281 @@ export const TLS_PROTOCOL_NAME_VALUE_TLS = "tls" as const;
 
 /**
  * Numeric part of the version parsed from the original string of the negotiated [SSL/TLS protocol version](https://www.openssl.org/docs/man1.1.1/man3/SSL_get_version.html#RETURN-VALUES)
- * 
+ *
  * @example 1.2
  * @example 3
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_PROTOCOL_VERSION = 'tls.protocol.version' as const;
 
 /**
  * Boolean flag indicating if this TLS connection was resumed from an existing TLS negotiation.
- * 
+ *
  * @example true
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_RESUMED = 'tls.resumed' as const;
 
 /**
  * PEM-encoded stand-alone certificate offered by the server. This is usually mutually-exclusive of `server.certificate_chain` since this value also exists in that list.
- * 
+ *
  * @example MII...
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_SERVER_CERTIFICATE = 'tls.server.certificate' as const;
 
 /**
  * Array of PEM-encoded certificates that make up the certificate chain offered by the server. This is usually mutually-exclusive of `server.certificate` since that value should be the first certificate in the chain.
- * 
+ *
  * @example ["MII...", "MI..."]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_SERVER_CERTIFICATE_CHAIN = 'tls.server.certificate_chain' as const;
 
 /**
  * Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash.
- * 
+ *
  * @example 0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_SERVER_HASH_MD5 = 'tls.server.hash.md5' as const;
 
 /**
  * Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash.
- * 
+ *
  * @example 9E393D93138888D288266C2D915214D1D1CCEB2A
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_SERVER_HASH_SHA1 = 'tls.server.hash.sha1' as const;
 
 /**
  * Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash.
- * 
+ *
  * @example 0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_SERVER_HASH_SHA256 = 'tls.server.hash.sha256' as const;
 
 /**
  * Distinguished name of [subject](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6) of the issuer of the x.509 certificate presented by the client.
- * 
+ *
  * @example CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_SERVER_ISSUER = 'tls.server.issuer' as const;
 
 /**
  * A hash that identifies servers based on how they perform an SSL/TLS handshake.
- * 
+ *
  * @example d4e5b18d6b55c71272893221c96ba240
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_SERVER_JA3S = 'tls.server.ja3s' as const;
 
 /**
  * Date/Time indicating when server certificate is no longer considered valid.
- * 
+ *
  * @example 2021-01-01T00:00:00.000Z
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_SERVER_NOT_AFTER = 'tls.server.not_after' as const;
 
 /**
  * Date/Time indicating when server certificate is first considered valid.
- * 
+ *
  * @example 1970-01-01T00:00:00.000Z
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_SERVER_NOT_BEFORE = 'tls.server.not_before' as const;
 
 /**
  * Distinguished name of subject of the x.509 certificate presented by the server.
- * 
+ *
  * @example CN=myserver, OU=Documentation Team, DC=example, DC=com
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_TLS_SERVER_SUBJECT = 'tls.server.subject' as const;
 
 /**
  * Domain extracted from the `url.full`, such as "opentelemetry.io".
- * 
+ *
  * @example www.foo.bar
  * @example opentelemetry.io
  * @example 3.12.167.2
  * @example [1080:0:0:0:8:800:200C:417A]
- * 
+ *
  * @note In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the domain field. If the URL contains a [literal IPv6 address](https://www.rfc-editor.org/rfc/rfc2732#section-2) enclosed by `[` and `]`, the `[` and `]` characters should also be captured in the domain field.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_URL_DOMAIN = 'url.domain' as const;
 
 /**
  * The file extension extracted from the `url.full`, excluding the leading dot.
- * 
+ *
  * @example png
  * @example gz
- * 
+ *
  * @note The file extension is only set if it exists, as not every url has a file extension. When the file name has multiple extensions `example.tar.gz`, only the last one should be captured `gz`, not `tar.gz`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_URL_EXTENSION = 'url.extension' as const;
 
 /**
  * Unmodified original URL as seen in the event source.
- * 
+ *
  * @example https://www.foo.bar/search?q=OpenTelemetry#SemConv
  * @example search?q=OpenTelemetry
- * 
+ *
  * @note In network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path. This field is meant to represent the URL as it was observed, complete or not.
  * `url.original` might contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case password and username **SHOULD NOT** be redacted and attribute's value **SHOULD** remain the same.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_URL_ORIGINAL = 'url.original' as const;
 
 /**
  * Port extracted from the `url.full`
- * 
+ *
  * @example 443
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_URL_PORT = 'url.port' as const;
 
 /**
  * The highest registered url domain, stripped of the subdomain.
- * 
+ *
  * @example example.com
  * @example foo.co.uk
- * 
+ *
  * @note This value can be determined precisely with the [public suffix list](http://publicsuffix.org). For example, the registered domain for `foo.example.com` is `example.com`. Trying to approximate this by simply taking the last two labels will not work well for TLDs such as `co.uk`.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_URL_REGISTERED_DOMAIN = 'url.registered_domain' as const;
 
 /**
  * The subdomain portion of a fully qualified domain name includes all of the names except the host name under the registered_domain. In a partially qualified domain, or if the qualification level of the full name cannot be determined, subdomain contains all of the names below the registered domain.
- * 
+ *
  * @example east
  * @example sub2.sub1
- * 
+ *
  * @note The subdomain portion of `www.east.mydomain.co.uk` is `east`. If the domain has multiple levels of subdomain, such as `sub2.sub1.example.com`, the subdomain field should contain `sub2.sub1`, with no trailing period.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_URL_SUBDOMAIN = 'url.subdomain' as const;
 
 /**
  * The low-cardinality template of an [absolute path reference](https://www.rfc-editor.org/rfc/rfc3986#section-4.2).
- * 
+ *
  * @example /users/{id}
  * @example /users/:id
  * @example /users?id={id}
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_URL_TEMPLATE = 'url.template' as const;
 
 /**
  * The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is `com`.
- * 
+ *
  * @example com
  * @example co.uk
- * 
+ *
  * @note This value can be determined precisely with the [public suffix list](http://publicsuffix.org).
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_URL_TOP_LEVEL_DOMAIN = 'url.top_level_domain' as const;
 
 /**
  * User email address.
- * 
+ *
  * @example a.einstein@example.com
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_USER_EMAIL = 'user.email' as const;
 
 /**
  * User's full name
- * 
+ *
  * @example Albert Einstein
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_USER_FULL_NAME = 'user.full_name' as const;
 
 /**
  * Unique user hash to correlate information for a user in anonymized form.
- * 
+ *
  * @example 364fc68eaf4c8acec74a4e52d7d1feaa
- * 
+ *
  * @note Useful if `user.id` or `user.name` contain confidential information and cannot be used.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_USER_HASH = 'user.hash' as const;
 
 /**
  * Unique identifier of the user.
- * 
+ *
  * @example S-1-5-21-202424912787-2692429404-2351956786-1000
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_USER_ID = 'user.id' as const;
 
 /**
  * Short name or login/username of the user.
- * 
+ *
  * @example a.einstein
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_USER_NAME = 'user.name' as const;
 
 /**
  * Array of user roles at the time of the event.
- * 
+ *
  * @example ["admin", "reporting_user"]
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_USER_ROLES = 'user.roles' as const;
 
 /**
  * Name of the user-agent extracted from original. Usually refers to the browser's name.
- * 
+ *
  * @example Safari
  * @example YourApp
- * 
+ *
  * @note [Example](https://www.whatsmyua.info) of extracting browser's name from original string. In the case of using a user-agent for non-browser products, such as microservices with multiple names/versions inside the `user_agent.original`, the most significant name **SHOULD** be selected. In such a scenario it should align with `user_agent.version`
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_USER_AGENT_NAME = 'user_agent.name' as const;
 
 /**
  * Specifies the category of synthetic traffic, such as tests or bots.
- * 
+ *
  * @note This attribute **MAY** be derived from the contents of the `user_agent.original` attribute. Components that populate the attribute are responsible for determining what they consider to be synthetic bot or test traffic. This attribute can either be set for self-identification purposes, or on telemetry detected to be generated as a result of a synthetic request. This attribute is useful for distinguishing between genuine client traffic and synthetic traffic generated by bots or tests.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_USER_AGENT_SYNTHETIC_TYPE = 'user_agent.synthetic.type' as const;
@@ -7890,19 +7890,19 @@ export const USER_AGENT_SYNTHETIC_TYPE_VALUE_TEST = "test" as const;
 
 /**
  * Version of the user-agent extracted from original. Usually refers to the browser's version
- * 
+ *
  * @example 14.1.2
  * @example 1.0.0
- * 
+ *
  * @note [Example](https://www.whatsmyua.info) of extracting browser's version from original string. In the case of using a user-agent for non-browser products, such as microservices with multiple names/versions inside the `user_agent.original`, the most significant version **SHOULD** be selected. In such a scenario it should align with `user_agent.name`
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_USER_AGENT_VERSION = 'user_agent.version' as const;
 
 /**
  * The type of garbage collection.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_V8JS_GC_TYPE = 'v8js.gc.type' as const;
@@ -7929,9 +7929,9 @@ export const V8JS_GC_TYPE_VALUE_WEAKCB = "weakcb" as const;
 
 /**
  * The name of the space type of heap memory.
- * 
+ *
  * @note Value can be retrieved from value `space_name` of [`v8.getHeapSpaceStatistics()`](https://nodejs.org/api/v8.html#v8getheapspacestatistics)
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_V8JS_HEAP_SPACE_NAME = 'v8js.heap.space.name' as const;
@@ -7963,20 +7963,20 @@ export const V8JS_HEAP_SPACE_NAME_VALUE_OLD_SPACE = "old_space" as const;
 
 /**
  * The ID of the change (pull request/merge request/changelist) if applicable. This is usually a unique (within repository) identifier generated by the VCS system.
- * 
+ *
  * @example 123
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_VCS_CHANGE_ID = 'vcs.change.id' as const;
 
 /**
  * The state of the change (pull request/merge request/changelist).
- * 
+ *
  * @example open
  * @example closed
  * @example merged
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_VCS_CHANGE_STATE = 'vcs.change.state' as const;
@@ -8003,21 +8003,21 @@ export const VCS_CHANGE_STATE_VALUE_WIP = "wip" as const;
 
 /**
  * The human readable title of the change (pull request/merge request/changelist). This title is often a brief summary of the change and may get merged in to a ref as the commit summary.
- * 
+ *
  * @example Fixes broken thing
  * @example feat: add my new feature
  * @example [chore] update dependency
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_VCS_CHANGE_TITLE = 'vcs.change.title' as const;
 
 /**
  * The type of line change being measured on a branch or change.
- * 
+ *
  * @example added
  * @example removed
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_VCS_LINE_CHANGE_TYPE = 'vcs.line_change.type' as const;
@@ -8034,22 +8034,22 @@ export const VCS_LINE_CHANGE_TYPE_VALUE_REMOVED = "removed" as const;
 
 /**
  * The name of the [reference](https://git-scm.com/docs/gitglossary#def_ref) such as **branch** or **tag** in the repository.
- * 
+ *
  * @example my-feature-branch
  * @example tag-1-test
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_VCS_REF_BASE_NAME = 'vcs.ref.base.name' as const;
 
 /**
  * The revision, literally [revised version](https://www.merriam-webster.com/dictionary/revision), The revision most often refers to a commit object in Git, or a revision number in SVN.
- * 
+ *
  * @example 9d59409acf479dfa0df1aa568182e43e43df8bbe28d60fcf2bc52e30068802cc
  * @example main
  * @example 123
  * @example HEAD
- * 
+ *
  * @note The revision can be a full [hash value (see glossary)](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf),
  * of the recorded change to a ref within a repository pointing to a
  * commit [commit](https://git-scm.com/docs/git-commit) object. It does
@@ -8059,17 +8059,17 @@ export const ATTR_VCS_REF_BASE_NAME = 'vcs.ref.base.name' as const;
  * it is identical to the `ref.base.name`, it **SHOULD** still be included. It is
  * up to the implementer to decide which value to set as the revision
  * based on the VCS system and situational context.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_VCS_REF_BASE_REVISION = 'vcs.ref.base.revision' as const;
 
 /**
  * The type of the [reference](https://git-scm.com/docs/gitglossary#def_ref) in the repository.
- * 
+ *
  * @example branch
  * @example tag
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_VCS_REF_BASE_TYPE = 'vcs.ref.base.type' as const;
@@ -8086,22 +8086,22 @@ export const VCS_REF_BASE_TYPE_VALUE_TAG = "tag" as const;
 
 /**
  * The name of the [reference](https://git-scm.com/docs/gitglossary#def_ref) such as **branch** or **tag** in the repository.
- * 
+ *
  * @example my-feature-branch
  * @example tag-1-test
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_VCS_REF_HEAD_NAME = 'vcs.ref.head.name' as const;
 
 /**
  * The revision, literally [revised version](https://www.merriam-webster.com/dictionary/revision), The revision most often refers to a commit object in Git, or a revision number in SVN.
- * 
+ *
  * @example 9d59409acf479dfa0df1aa568182e43e43df8bbe28d60fcf2bc52e30068802cc
  * @example main
  * @example 123
  * @example HEAD
- * 
+ *
  * @note The revision can be a full [hash value (see glossary)](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf),
  * of the recorded change to a ref within a repository pointing to a
  * commit [commit](https://git-scm.com/docs/git-commit) object. It does
@@ -8111,17 +8111,17 @@ export const ATTR_VCS_REF_HEAD_NAME = 'vcs.ref.head.name' as const;
  * it is identical to the `ref.head.name`, it **SHOULD** still be included. It is
  * up to the implementer to decide which value to set as the revision
  * based on the VCS system and situational context.
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_VCS_REF_HEAD_REVISION = 'vcs.ref.head.revision' as const;
 
 /**
  * The type of the [reference](https://git-scm.com/docs/gitglossary#def_ref) in the repository.
- * 
+ *
  * @example branch
  * @example tag
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_VCS_REF_HEAD_TYPE = 'vcs.ref.head.type' as const;
@@ -8138,10 +8138,10 @@ export const VCS_REF_HEAD_TYPE_VALUE_TAG = "tag" as const;
 
 /**
  * The type of the [reference](https://git-scm.com/docs/gitglossary#def_ref) in the repository.
- * 
+ *
  * @example branch
  * @example tag
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_VCS_REF_TYPE = 'vcs.ref.type' as const;
@@ -8158,62 +8158,62 @@ export const VCS_REF_TYPE_VALUE_TAG = "tag" as const;
 
 /**
  * Deprecated, use `vcs.change.id` instead.
- * 
+ *
  * @example 123
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Deprecated, use `vcs.change.id` instead.
  */
 export const ATTR_VCS_REPOSITORY_CHANGE_ID = 'vcs.repository.change.id' as const;
 
 /**
  * Deprecated, use `vcs.change.title` instead.
- * 
+ *
  * @example Fixes broken thing
  * @example feat: add my new feature
  * @example [chore] update dependency
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Deprecated, use `vcs.change.title` instead.
  */
 export const ATTR_VCS_REPOSITORY_CHANGE_TITLE = 'vcs.repository.change.title' as const;
 
 /**
  * Deprecated, use `vcs.ref.head.name` instead.
- * 
+ *
  * @example my-feature-branch
  * @example tag-1-test
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Deprecated, use `vcs.ref.head.name` instead.
  */
 export const ATTR_VCS_REPOSITORY_REF_NAME = 'vcs.repository.ref.name' as const;
 
 /**
  * Deprecated, use `vcs.ref.head.revision` instead.
- * 
+ *
  * @example 9d59409acf479dfa0df1aa568182e43e43df8bbe28d60fcf2bc52e30068802cc
  * @example main
  * @example 123
  * @example HEAD
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Deprecated, use `vcs.ref.head.revision` instead.
  */
 export const ATTR_VCS_REPOSITORY_REF_REVISION = 'vcs.repository.ref.revision' as const;
 
 /**
  * Deprecated, use `vcs.ref.head.type` instead.
- * 
+ *
  * @example branch
  * @example tag
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Deprecated, use `vcs.ref.head.type` instead.
  */
 export const ATTR_VCS_REPOSITORY_REF_TYPE = 'vcs.repository.ref.type' as const;
@@ -8230,20 +8230,20 @@ export const VCS_REPOSITORY_REF_TYPE_VALUE_TAG = "tag" as const;
 
 /**
  * The [URL](https://wikipedia.org/wiki/URL) of the repository providing the complete address in order to locate and identify the repository.
- * 
+ *
  * @example https://github.com/opentelemetry/open-telemetry-collector-contrib
  * @example https://gitlab.com/my-org/my-project/my-projects-project/repo
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_VCS_REPOSITORY_URL_FULL = 'vcs.repository.url.full' as const;
 
 /**
  * The type of revision comparison.
- * 
+ *
  * @example ahead
  * @example behind
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_VCS_REVISION_DELTA_DIRECTION = 'vcs.revision_delta.direction' as const;
@@ -8260,27 +8260,27 @@ export const VCS_REVISION_DELTA_DIRECTION_VALUE_BEHIND = "behind" as const;
 
 /**
  * Additional description of the web engine (e.g. detailed version and edition information).
- * 
+ *
  * @example WildFly Full 21.0.0.Final (WildFly Core 13.0.1.Final) - 2.2.2.Final
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_WEBENGINE_DESCRIPTION = 'webengine.description' as const;
 
 /**
  * The name of the web engine.
- * 
+ *
  * @example WildFly
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_WEBENGINE_NAME = 'webengine.name' as const;
 
 /**
  * The version of the web engine.
- * 
+ *
  * @example 21.0.0
- * 
+ *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_WEBENGINE_VERSION = 'webengine.version' as const;

--- a/semantic-conventions/src/experimental_metrics.ts
+++ b/semantic-conventions/src/experimental_metrics.ts
@@ -20,1249 +20,1249 @@
 
 /**
  * Total CPU time consumed
- * 
+ *
  * @note Total CPU time consumed by the specific container on all available CPU cores
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_CONTAINER_CPU_TIME = 'container.cpu.time' as const;
 
 /**
  * Container's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs
- * 
+ *
  * @note CPU usage of the specific container on all available CPU cores, averaged over the sample window
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_CONTAINER_CPU_USAGE = 'container.cpu.usage' as const;
 
 /**
  * Disk bytes for the container.
- * 
+ *
  * @note The total number of bytes read/written successfully (aggregated from all disks).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_CONTAINER_DISK_IO = 'container.disk.io' as const;
 
 /**
  * Memory usage of the container.
- * 
+ *
  * @note Memory usage of the container.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_CONTAINER_MEMORY_USAGE = 'container.memory.usage' as const;
 
 /**
  * Network bytes for the container.
- * 
+ *
  * @note The number of bytes sent/received on all network interfaces by the container.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_CONTAINER_NETWORK_IO = 'container.network.io' as const;
 
 /**
  * The time the container has been running
- * 
+ *
  * @note Instrumentations **SHOULD** use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
  * The actual accuracy would depend on the instrumentation and operating system.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_CONTAINER_UPTIME = 'container.uptime' as const;
 
 /**
  * The number of connections that are currently in state described by the `state` attribute
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DB_CLIENT_CONNECTION_COUNT = 'db.client.connection.count' as const;
 
 /**
  * The time it took to create a new connection
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DB_CLIENT_CONNECTION_CREATE_TIME = 'db.client.connection.create_time' as const;
 
 /**
  * The maximum number of idle open connections allowed
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DB_CLIENT_CONNECTION_IDLE_MAX = 'db.client.connection.idle.max' as const;
 
 /**
  * The minimum number of idle open connections allowed
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DB_CLIENT_CONNECTION_IDLE_MIN = 'db.client.connection.idle.min' as const;
 
 /**
  * The maximum number of open connections allowed
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DB_CLIENT_CONNECTION_MAX = 'db.client.connection.max' as const;
 
 /**
  * The number of current pending requests for an open connection
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DB_CLIENT_CONNECTION_PENDING_REQUESTS = 'db.client.connection.pending_requests' as const;
 
 /**
  * The number of connection timeouts that have occurred trying to obtain a connection from the pool
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DB_CLIENT_CONNECTION_TIMEOUTS = 'db.client.connection.timeouts' as const;
 
 /**
  * The time between borrowing a connection and returning it to the pool
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DB_CLIENT_CONNECTION_USE_TIME = 'db.client.connection.use_time' as const;
 
 /**
  * The time it took to obtain an open connection from the pool
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DB_CLIENT_CONNECTION_WAIT_TIME = 'db.client.connection.wait_time' as const;
 
 /**
  * Deprecated, use `db.client.connection.create_time` instead. Note: the unit also changed from `ms` to `s`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.client.connection.create_time`. Note: the unit also changed from `ms` to `s`.
  */
 export const METRIC_DB_CLIENT_CONNECTIONS_CREATE_TIME = 'db.client.connections.create_time' as const;
 
 /**
  * Deprecated, use `db.client.connection.idle.max` instead.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.client.connection.idle.max`.
  */
 export const METRIC_DB_CLIENT_CONNECTIONS_IDLE_MAX = 'db.client.connections.idle.max' as const;
 
 /**
  * Deprecated, use `db.client.connection.idle.min` instead.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.client.connection.idle.min`.
  */
 export const METRIC_DB_CLIENT_CONNECTIONS_IDLE_MIN = 'db.client.connections.idle.min' as const;
 
 /**
  * Deprecated, use `db.client.connection.max` instead.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.client.connection.max`.
  */
 export const METRIC_DB_CLIENT_CONNECTIONS_MAX = 'db.client.connections.max' as const;
 
 /**
  * Deprecated, use `db.client.connection.pending_requests` instead.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.client.connection.pending_requests`.
  */
 export const METRIC_DB_CLIENT_CONNECTIONS_PENDING_REQUESTS = 'db.client.connections.pending_requests' as const;
 
 /**
  * Deprecated, use `db.client.connection.timeouts` instead.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.client.connection.timeouts`.
  */
 export const METRIC_DB_CLIENT_CONNECTIONS_TIMEOUTS = 'db.client.connections.timeouts' as const;
 
 /**
  * Deprecated, use `db.client.connection.count` instead.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.client.connection.count`.
  */
 export const METRIC_DB_CLIENT_CONNECTIONS_USAGE = 'db.client.connections.usage' as const;
 
 /**
  * Deprecated, use `db.client.connection.use_time` instead. Note: the unit also changed from `ms` to `s`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.client.connection.use_time`. Note: the unit also changed from `ms` to `s`.
  */
 export const METRIC_DB_CLIENT_CONNECTIONS_USE_TIME = 'db.client.connections.use_time' as const;
 
 /**
  * Deprecated, use `db.client.connection.wait_time` instead. Note: the unit also changed from `ms` to `s`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `db.client.connection.wait_time`. Note: the unit also changed from `ms` to `s`.
  */
 export const METRIC_DB_CLIENT_CONNECTIONS_WAIT_TIME = 'db.client.connections.wait_time' as const;
 
 /**
  * Number of active client instances
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DB_CLIENT_COSMOSDB_ACTIVE_INSTANCE_COUNT = 'db.client.cosmosdb.active_instance.count' as const;
 
 /**
  * [Request charge](https://learn.microsoft.com/azure/cosmos-db/request-units) consumed by the operation
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DB_CLIENT_COSMOSDB_OPERATION_REQUEST_CHARGE = 'db.client.cosmosdb.operation.request_charge' as const;
 
 /**
  * Duration of database client operations.
- * 
+ *
  * @note Batch operations **SHOULD** be recorded as a single operation.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DB_CLIENT_OPERATION_DURATION = 'db.client.operation.duration' as const;
 
 /**
  * The actual number of records returned by the database operation.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DB_CLIENT_RESPONSE_RETURNED_ROWS = 'db.client.response.returned_rows' as const;
 
 /**
  * Measures the time taken to perform a DNS lookup.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DNS_LOOKUP_DURATION = 'dns.lookup.duration' as const;
 
 /**
  * The number of .NET assemblies that are currently loaded.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`AppDomain.CurrentDomain.GetAssemblies().Length`](https://learn.microsoft.com/dotnet/api/system.appdomain.getassemblies).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_ASSEMBLY_COUNT = 'dotnet.assembly.count' as const;
 
 /**
  * The number of exceptions that have been thrown in managed code.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as counting calls to [`AppDomain.CurrentDomain.FirstChanceException`](https://learn.microsoft.com/dotnet/api/system.appdomain.firstchanceexception).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_EXCEPTIONS = 'dotnet.exceptions' as const;
 
 /**
  * The number of garbage collections that have occurred since the process has started.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric uses the [`GC.CollectionCount(int generation)`](https://learn.microsoft.com/dotnet/api/system.gc.collectioncount) API to calculate exclusive collections per generation.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_GC_COLLECTIONS = 'dotnet.gc.collections' as const;
 
 /**
  * The *approximate* number of bytes allocated on the managed GC heap since the process has started. The returned value does not include any native allocations.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`GC.GetTotalAllocatedBytes()`](https://learn.microsoft.com/dotnet/api/system.gc.gettotalallocatedbytes).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_GC_HEAP_TOTAL_ALLOCATED = 'dotnet.gc.heap.total_allocated' as const;
 
 /**
  * The heap fragmentation, as observed during the latest garbage collection.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`GC.GetGCMemoryInfo().GenerationInfo.FragmentationAfterBytes`](https://learn.microsoft.com/dotnet/api/system.gcgenerationinfo.fragmentationafterbytes).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_GC_LAST_COLLECTION_HEAP_FRAGMENTATION_SIZE = 'dotnet.gc.last_collection.heap.fragmentation.size' as const;
 
 /**
  * The managed GC heap size (including fragmentation), as observed during the latest garbage collection.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`GC.GetGCMemoryInfo().GenerationInfo.SizeAfterBytes`](https://learn.microsoft.com/dotnet/api/system.gcgenerationinfo.sizeafterbytes).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_GC_LAST_COLLECTION_HEAP_SIZE = 'dotnet.gc.last_collection.heap.size' as const;
 
 /**
  * The amount of committed virtual memory in use by the .NET GC, as observed during the latest garbage collection.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`GC.GetGCMemoryInfo().TotalCommittedBytes`](https://learn.microsoft.com/dotnet/api/system.gcmemoryinfo.totalcommittedbytes). Committed virtual memory may be larger than the heap size because it includes both memory for storing existing objects (the heap size) and some extra memory that is ready to handle newly allocated objects in the future.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_GC_LAST_COLLECTION_MEMORY_COMMITTED_SIZE = 'dotnet.gc.last_collection.memory.committed_size' as const;
 
 /**
  * The total amount of time paused in GC since the process has started.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`GC.GetTotalPauseDuration()`](https://learn.microsoft.com/dotnet/api/system.gc.gettotalpauseduration).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_GC_PAUSE_TIME = 'dotnet.gc.pause.time' as const;
 
 /**
  * The amount of time the JIT compiler has spent compiling methods since the process has started.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`JitInfo.GetCompilationTime()`](https://learn.microsoft.com/dotnet/api/system.runtime.jitinfo.getcompilationtime).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_JIT_COMPILATION_TIME = 'dotnet.jit.compilation.time' as const;
 
 /**
  * Count of bytes of intermediate language that have been compiled since the process has started.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`JitInfo.GetCompiledILBytes()`](https://learn.microsoft.com/dotnet/api/system.runtime.jitinfo.getcompiledilbytes).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_JIT_COMPILED_IL_SIZE = 'dotnet.jit.compiled_il.size' as const;
 
 /**
  * The number of times the JIT compiler (re)compiled methods since the process has started.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`JitInfo.GetCompiledMethodCount()`](https://learn.microsoft.com/dotnet/api/system.runtime.jitinfo.getcompiledmethodcount).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_JIT_COMPILED_METHODS = 'dotnet.jit.compiled_methods' as const;
 
 /**
  * The number of times there was contention when trying to acquire a monitor lock since the process has started.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`Monitor.LockContentionCount`](https://learn.microsoft.com/dotnet/api/system.threading.monitor.lockcontentioncount).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_MONITOR_LOCK_CONTENTIONS = 'dotnet.monitor.lock_contentions' as const;
 
 /**
  * The number of processors available to the process.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as accessing [`Environment.ProcessorCount`](https://learn.microsoft.com/dotnet/api/system.environment.processorcount).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_PROCESS_CPU_COUNT = 'dotnet.process.cpu.count' as const;
 
 /**
  * CPU time used by the process.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as accessing the corresponding processor time properties on [`System.Diagnostics.Process`](https://learn.microsoft.com/dotnet/api/system.diagnostics.process).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_PROCESS_CPU_TIME = 'dotnet.process.cpu.time' as const;
 
 /**
  * The number of bytes of physical memory mapped to the process context.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`Environment.WorkingSet`](https://learn.microsoft.com/dotnet/api/system.environment.workingset).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_PROCESS_MEMORY_WORKING_SET = 'dotnet.process.memory.working_set' as const;
 
 /**
  * The number of work items that are currently queued to be processed by the thread pool.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`ThreadPool.PendingWorkItemCount`](https://learn.microsoft.com/dotnet/api/system.threading.threadpool.pendingworkitemcount).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_THREAD_POOL_QUEUE_LENGTH = 'dotnet.thread_pool.queue.length' as const;
 
 /**
  * The number of thread pool threads that currently exist.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`ThreadPool.ThreadCount`](https://learn.microsoft.com/dotnet/api/system.threading.threadpool.threadcount).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_THREAD_POOL_THREAD_COUNT = 'dotnet.thread_pool.thread.count' as const;
 
 /**
  * The number of work items that the thread pool has completed since the process has started.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`ThreadPool.CompletedWorkItemCount`](https://learn.microsoft.com/dotnet/api/system.threading.threadpool.completedworkitemcount).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_THREAD_POOL_WORK_ITEM_COUNT = 'dotnet.thread_pool.work_item.count' as const;
 
 /**
  * The number of timer instances that are currently active.
- * 
+ *
  * @note Meter name: `System.Runtime`; Added in: .NET 9.0.
  * This metric reports the same values as calling [`Timer.ActiveCount`](https://learn.microsoft.com/dotnet/api/system.threading.timer.activecount).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_DOTNET_TIMER_COUNT = 'dotnet.timer.count' as const;
 
 /**
  * Number of invocation cold starts
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_FAAS_COLDSTARTS = 'faas.coldstarts' as const;
 
 /**
  * Distribution of CPU usage per invocation
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_FAAS_CPU_USAGE = 'faas.cpu_usage' as const;
 
 /**
  * Number of invocation errors
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_FAAS_ERRORS = 'faas.errors' as const;
 
 /**
  * Measures the duration of the function's initialization, such as a cold start
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_FAAS_INIT_DURATION = 'faas.init_duration' as const;
 
 /**
  * Number of successful invocations
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_FAAS_INVOCATIONS = 'faas.invocations' as const;
 
 /**
  * Measures the duration of the function's logic execution
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_FAAS_INVOKE_DURATION = 'faas.invoke_duration' as const;
 
 /**
  * Distribution of max memory usage per invocation
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_FAAS_MEM_USAGE = 'faas.mem_usage' as const;
 
 /**
  * Distribution of net I/O usage per invocation
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_FAAS_NET_IO = 'faas.net_io' as const;
 
 /**
  * Number of invocation timeouts
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_FAAS_TIMEOUTS = 'faas.timeouts' as const;
 
 /**
  * GenAI operation duration
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GEN_AI_CLIENT_OPERATION_DURATION = 'gen_ai.client.operation.duration' as const;
 
 /**
  * Measures number of input and output tokens used
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GEN_AI_CLIENT_TOKEN_USAGE = 'gen_ai.client.token.usage' as const;
 
 /**
  * Generative AI server request duration such as time-to-last byte or last output token
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GEN_AI_SERVER_REQUEST_DURATION = 'gen_ai.server.request.duration' as const;
 
 /**
  * Time per output token generated after the first token for successful responses
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GEN_AI_SERVER_TIME_PER_OUTPUT_TOKEN = 'gen_ai.server.time_per_output_token' as const;
 
 /**
  * Time to generate first token for successful responses
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GEN_AI_SERVER_TIME_TO_FIRST_TOKEN = 'gen_ai.server.time_to_first_token' as const;
 
 /**
  * Heap size target percentage configured by the user, otherwise 100.
- * 
+ *
  * @note The value range is [0.0,100.0]. Computed from `/gc/gogc:percent`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GO_CONFIG_GOGC = 'go.config.gogc' as const;
 
 /**
  * Count of live goroutines.
- * 
+ *
  * @note Computed from `/sched/goroutines:goroutines`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GO_GOROUTINE_COUNT = 'go.goroutine.count' as const;
 
 /**
  * Memory allocated to the heap by the application.
- * 
+ *
  * @note Computed from `/gc/heap/allocs:bytes`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GO_MEMORY_ALLOCATED = 'go.memory.allocated' as const;
 
 /**
  * Count of allocations to the heap by the application.
- * 
+ *
  * @note Computed from `/gc/heap/allocs:objects`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GO_MEMORY_ALLOCATIONS = 'go.memory.allocations' as const;
 
 /**
  * Heap size target for the end of the GC cycle.
- * 
+ *
  * @note Computed from `/gc/heap/goal:bytes`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GO_MEMORY_GC_GOAL = 'go.memory.gc.goal' as const;
 
 /**
  * Go runtime memory limit configured by the user, if a limit exists.
- * 
+ *
  * @note Computed from `/gc/gomemlimit:bytes`. This metric is excluded if the limit obtained from the Go runtime is math.MaxInt64.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GO_MEMORY_LIMIT = 'go.memory.limit' as const;
 
 /**
  * Memory used by the Go runtime.
- * 
+ *
  * @note Computed from `(/memory/classes/total:bytes - /memory/classes/heap/released:bytes)`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GO_MEMORY_USED = 'go.memory.used' as const;
 
 /**
  * The number of OS threads that can execute user-level Go code simultaneously.
- * 
+ *
  * @note Computed from `/sched/gomaxprocs:threads`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GO_PROCESSOR_LIMIT = 'go.processor.limit' as const;
 
 /**
  * The time goroutines have spent in the scheduler in a runnable state before actually running.
- * 
+ *
  * @note Computed from `/sched/latencies:seconds`. Bucket boundaries are provided by the runtime, and are subject to change.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_GO_SCHEDULE_DURATION = 'go.schedule.duration' as const;
 
 /**
  * Number of active HTTP requests.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_HTTP_CLIENT_ACTIVE_REQUESTS = 'http.client.active_requests' as const;
 
 /**
  * The duration of the successfully established outbound HTTP connections.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_HTTP_CLIENT_CONNECTION_DURATION = 'http.client.connection.duration' as const;
 
 /**
  * Number of outbound HTTP connections that are currently active or idle on the client.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_HTTP_CLIENT_OPEN_CONNECTIONS = 'http.client.open_connections' as const;
 
 /**
  * Size of HTTP client request bodies.
- * 
+ *
  * @note The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_HTTP_CLIENT_REQUEST_BODY_SIZE = 'http.client.request.body.size' as const;
 
 /**
  * Size of HTTP client response bodies.
- * 
+ *
  * @note The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_HTTP_CLIENT_RESPONSE_BODY_SIZE = 'http.client.response.body.size' as const;
 
 /**
  * Number of active HTTP server requests.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_HTTP_SERVER_ACTIVE_REQUESTS = 'http.server.active_requests' as const;
 
 /**
  * Size of HTTP server request bodies.
- * 
+ *
  * @note The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_HTTP_SERVER_REQUEST_BODY_SIZE = 'http.server.request.body.size' as const;
 
 /**
  * Size of HTTP server response bodies.
- * 
+ *
  * @note The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length) header. For requests using transport encoding, this should be the compressed size.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_HTTP_SERVER_RESPONSE_BODY_SIZE = 'http.server.response.body.size' as const;
 
 /**
  * Energy consumed by the component
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_HW_ENERGY = 'hw.energy' as const;
 
 /**
  * Number of errors encountered by the component
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_HW_ERRORS = 'hw.errors' as const;
 
 /**
  * Instantaneous power consumed by the component
- * 
+ *
  * @note It is recommended to report `hw.energy` instead of `hw.power` when possible.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_HW_POWER = 'hw.power' as const;
 
 /**
  * Operational status: `1` (true) or `0` (false) for each of the possible states
- * 
+ *
  * @note `hw.status` is currently specified as an *UpDownCounter* but would ideally be represented using a [*StateSet* as defined in OpenMetrics](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#stateset). This semantic convention will be updated once *StateSet* is specified in OpenTelemetry. This planned change is not expected to have any consequence on the way users query their timeseries backend to retrieve the values of `hw.status` over time.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_HW_STATUS = 'hw.status' as const;
 
 /**
  * Number of buffers in the pool.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_JVM_BUFFER_COUNT = 'jvm.buffer.count' as const;
 
 /**
  * Measure of total memory capacity of buffers.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_JVM_BUFFER_MEMORY_LIMIT = 'jvm.buffer.memory.limit' as const;
 
 /**
  * Deprecated, use `jvm.buffer.memory.used` instead.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `jvm.buffer.memory.used`.
  */
 export const METRIC_JVM_BUFFER_MEMORY_USAGE = 'jvm.buffer.memory.usage' as const;
 
 /**
  * Measure of memory used by buffers.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_JVM_BUFFER_MEMORY_USED = 'jvm.buffer.memory.used' as const;
 
 /**
  * Measure of initial memory requested.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_JVM_MEMORY_INIT = 'jvm.memory.init' as const;
 
 /**
  * Average CPU load of the whole system for the last minute as reported by the JVM.
- * 
+ *
  * @note The value range is [0,n], where n is the number of CPU cores - or a negative number if the value is not available. This utilization is not defined as being for the specific interval since last measurement (unlike `system.cpu.utilization`). [Reference](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/OperatingSystemMXBean.html#getSystemLoadAverage()).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_JVM_SYSTEM_CPU_LOAD_1M = 'jvm.system.cpu.load_1m' as const;
 
 /**
  * Recent CPU utilization for the whole system as reported by the JVM.
- * 
+ *
  * @note The value range is [0.0,1.0]. This utilization is not defined as being for the specific interval since last measurement (unlike `system.cpu.utilization`). [Reference](https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getCpuLoad()).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_JVM_SYSTEM_CPU_UTILIZATION = 'jvm.system.cpu.utilization' as const;
 
 /**
  * Total CPU time consumed
- * 
+ *
  * @note Total CPU time consumed by the specific Node on all available CPU cores
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_NODE_CPU_TIME = 'k8s.node.cpu.time' as const;
 
 /**
  * Node's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs
- * 
+ *
  * @note CPU usage of the specific Node on all available CPU cores, averaged over the sample window
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_NODE_CPU_USAGE = 'k8s.node.cpu.usage' as const;
 
 /**
  * Memory usage of the Node
- * 
+ *
  * @note Total memory usage of the Node
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_NODE_MEMORY_USAGE = 'k8s.node.memory.usage' as const;
 
 /**
  * Node network errors
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_NODE_NETWORK_ERRORS = 'k8s.node.network.errors' as const;
 
 /**
  * Network bytes for the Node
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_NODE_NETWORK_IO = 'k8s.node.network.io' as const;
 
 /**
  * The time the Node has been running
- * 
+ *
  * @note Instrumentations **SHOULD** use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
  * The actual accuracy would depend on the instrumentation and operating system.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_NODE_UPTIME = 'k8s.node.uptime' as const;
 
 /**
  * Total CPU time consumed
- * 
+ *
  * @note Total CPU time consumed by the specific Pod on all available CPU cores
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_POD_CPU_TIME = 'k8s.pod.cpu.time' as const;
 
 /**
  * Pod's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs
- * 
+ *
  * @note CPU usage of the specific Pod on all available CPU cores, averaged over the sample window
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_POD_CPU_USAGE = 'k8s.pod.cpu.usage' as const;
 
 /**
  * Memory usage of the Pod
- * 
+ *
  * @note Total memory usage of the Pod
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_POD_MEMORY_USAGE = 'k8s.pod.memory.usage' as const;
 
 /**
  * Pod network errors
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_POD_NETWORK_ERRORS = 'k8s.pod.network.errors' as const;
 
 /**
  * Network bytes for the Pod
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_POD_NETWORK_IO = 'k8s.pod.network.io' as const;
 
 /**
  * The time the Pod has been running
- * 
+ *
  * @note Instrumentations **SHOULD** use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
  * The actual accuracy would depend on the instrumentation and operating system.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_POD_UPTIME = 'k8s.pod.uptime' as const;
 
 /**
  * Number of messages that were delivered to the application.
- * 
+ *
  * @note Records the number of messages pulled from the broker or number of messages dispatched to the application in push-based scenarios.
  * The metric **SHOULD** be reported once per message delivery. For example, if receiving and processing operations are both instrumented for a single message delivery, this counter is incremented when the message is received and not reported when it is processed.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_MESSAGING_CLIENT_CONSUMED_MESSAGES = 'messaging.client.consumed.messages' as const;
 
 /**
  * Duration of messaging operation initiated by a producer or consumer client.
- * 
+ *
  * @note This metric **SHOULD NOT** be used to report processing duration - processing duration is reported in `messaging.process.duration` metric.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_MESSAGING_CLIENT_OPERATION_DURATION = 'messaging.client.operation.duration' as const;
 
 /**
  * Deprecated. Use `messaging.client.sent.messages` instead.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `messaging.client.sent.messages`.
  */
 export const METRIC_MESSAGING_CLIENT_PUBLISHED_MESSAGES = 'messaging.client.published.messages' as const;
 
 /**
  * Number of messages producer attempted to send to the broker.
- * 
+ *
  * @note This metric **MUST NOT** count messages that were created but haven't yet been sent.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_MESSAGING_CLIENT_SENT_MESSAGES = 'messaging.client.sent.messages' as const;
 
 /**
  * Duration of processing operation.
- * 
+ *
  * @note This metric **MUST** be reported for operations with `messaging.operation.type` that matches `process`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_MESSAGING_PROCESS_DURATION = 'messaging.process.duration' as const;
 
 /**
  * Deprecated. Use `messaging.client.consumed.messages` instead.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `messaging.client.consumed.messages`.
  */
 export const METRIC_MESSAGING_PROCESS_MESSAGES = 'messaging.process.messages' as const;
 
 /**
  * Deprecated. Use `messaging.client.operation.duration` instead.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `messaging.client.operation.duration`.
  */
 export const METRIC_MESSAGING_PUBLISH_DURATION = 'messaging.publish.duration' as const;
 
 /**
  * Deprecated. Use `messaging.client.produced.messages` instead.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `messaging.client.produced.messages`.
  */
 export const METRIC_MESSAGING_PUBLISH_MESSAGES = 'messaging.publish.messages' as const;
 
 /**
  * Deprecated. Use `messaging.client.operation.duration` instead.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `messaging.client.operation.duration`.
  */
 export const METRIC_MESSAGING_RECEIVE_DURATION = 'messaging.receive.duration' as const;
 
 /**
  * Deprecated. Use `messaging.client.consumed.messages` instead.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- * 
+ *
  * @deprecated Replaced by `messaging.client.consumed.messages`.
  */
 export const METRIC_MESSAGING_RECEIVE_MESSAGES = 'messaging.receive.messages' as const;
 
 /**
  * Event loop maximum delay.
- * 
+ *
  * @note Value can be retrieved from value `histogram.max` of [`perf_hooks.monitorEventLoopDelay([options])`](https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_NODEJS_EVENTLOOP_DELAY_MAX = 'nodejs.eventloop.delay.max' as const;
 
 /**
  * Event loop mean delay.
- * 
+ *
  * @note Value can be retrieved from value `histogram.mean` of [`perf_hooks.monitorEventLoopDelay([options])`](https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_NODEJS_EVENTLOOP_DELAY_MEAN = 'nodejs.eventloop.delay.mean' as const;
 
 /**
  * Event loop minimum delay.
- * 
+ *
  * @note Value can be retrieved from value `histogram.min` of [`perf_hooks.monitorEventLoopDelay([options])`](https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_NODEJS_EVENTLOOP_DELAY_MIN = 'nodejs.eventloop.delay.min' as const;
 
 /**
  * Event loop 50 percentile delay.
- * 
+ *
  * @note Value can be retrieved from value `histogram.percentile(50)` of [`perf_hooks.monitorEventLoopDelay([options])`](https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_NODEJS_EVENTLOOP_DELAY_P50 = 'nodejs.eventloop.delay.p50' as const;
 
 /**
  * Event loop 90 percentile delay.
- * 
+ *
  * @note Value can be retrieved from value `histogram.percentile(90)` of [`perf_hooks.monitorEventLoopDelay([options])`](https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_NODEJS_EVENTLOOP_DELAY_P90 = 'nodejs.eventloop.delay.p90' as const;
 
 /**
  * Event loop 99 percentile delay.
- * 
+ *
  * @note Value can be retrieved from value `histogram.percentile(99)` of [`perf_hooks.monitorEventLoopDelay([options])`](https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_NODEJS_EVENTLOOP_DELAY_P99 = 'nodejs.eventloop.delay.p99' as const;
 
 /**
  * Event loop standard deviation delay.
- * 
+ *
  * @note Value can be retrieved from value `histogram.stddev` of [`perf_hooks.monitorEventLoopDelay([options])`](https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_NODEJS_EVENTLOOP_DELAY_STDDEV = 'nodejs.eventloop.delay.stddev' as const;
 
 /**
  * Cumulative duration of time the event loop has been in each state.
- * 
+ *
  * @note Value can be retrieved from [`performance.eventLoopUtilization([utilization1[, utilization2]])`](https://nodejs.org/api/perf_hooks.html#performanceeventlooputilizationutilization1-utilization2)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_NODEJS_EVENTLOOP_TIME = 'nodejs.eventloop.time' as const;
 
 /**
  * Event loop utilization.
- * 
+ *
  * @note The value range is [0.0, 1.0] and can be retrieved from [`performance.eventLoopUtilization([utilization1[, utilization2]])`](https://nodejs.org/api/perf_hooks.html#performanceeventlooputilizationutilization1-utilization2)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_NODEJS_EVENTLOOP_UTILIZATION = 'nodejs.eventloop.utilization' as const;
 
 /**
  * Number of times the process has been context switched.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_PROCESS_CONTEXT_SWITCHES = 'process.context_switches' as const;
 
 /**
  * Total CPU seconds broken down by different states.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_PROCESS_CPU_TIME = 'process.cpu.time' as const;
 
 /**
  * Difference in process.cpu.time since the last measurement, divided by the elapsed time and number of CPUs available to the process.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_PROCESS_CPU_UTILIZATION = 'process.cpu.utilization' as const;
 
 /**
  * Disk bytes transferred.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_PROCESS_DISK_IO = 'process.disk.io' as const;
 
 /**
  * The amount of physical memory in use.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_PROCESS_MEMORY_USAGE = 'process.memory.usage' as const;
 
 /**
  * The amount of committed virtual memory.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_PROCESS_MEMORY_VIRTUAL = 'process.memory.virtual' as const;
 
 /**
  * Network bytes transferred.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_PROCESS_NETWORK_IO = 'process.network.io' as const;
 
 /**
  * Number of file descriptors in use by the process.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_PROCESS_OPEN_FILE_DESCRIPTOR_COUNT = 'process.open_file_descriptor.count' as const;
 
 /**
  * Number of page faults the process has made.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_PROCESS_PAGING_FAULTS = 'process.paging.faults' as const;
 
 /**
  * Process threads count.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_PROCESS_THREAD_COUNT = 'process.thread.count' as const;
 
 /**
  * The time the process has been running.
- * 
+ *
  * @note Instrumentations **SHOULD** use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
  * The actual accuracy would depend on the instrumentation and operating system.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_PROCESS_UPTIME = 'process.uptime' as const;
 
 /**
  * Measures the duration of outbound RPC.
- * 
+ *
  * @note While streaming RPCs may record this metric as start-of-batch
  * to end-of-batch, it's hard to interpret in practice.
- * 
+ *
  * **Streaming**: N/A.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_RPC_CLIENT_DURATION = 'rpc.client.duration' as const;
 
 /**
  * Measures the size of RPC request messages (uncompressed).
- * 
+ *
  * @note **Streaming**: Recorded per message in a streaming batch
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_RPC_CLIENT_REQUEST_SIZE = 'rpc.client.request.size' as const;
 
 /**
  * Measures the number of messages received per RPC.
- * 
+ *
  * @note Should be 1 for all non-streaming RPCs.
- * 
+ *
  * **Streaming**: This metric is required for server and client streaming RPCs
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_RPC_CLIENT_REQUESTS_PER_RPC = 'rpc.client.requests_per_rpc' as const;
 
 /**
  * Measures the size of RPC response messages (uncompressed).
- * 
+ *
  * @note **Streaming**: Recorded per response in a streaming batch
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_RPC_CLIENT_RESPONSE_SIZE = 'rpc.client.response.size' as const;
 
 /**
  * Measures the number of messages sent per RPC.
- * 
+ *
  * @note Should be 1 for all non-streaming RPCs.
- * 
+ *
  * **Streaming**: This metric is required for server and client streaming RPCs
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_RPC_CLIENT_RESPONSES_PER_RPC = 'rpc.client.responses_per_rpc' as const;
 
 /**
  * Measures the duration of inbound RPC.
- * 
+ *
  * @note While streaming RPCs may record this metric as start-of-batch
  * to end-of-batch, it's hard to interpret in practice.
- * 
+ *
  * **Streaming**: N/A.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_RPC_SERVER_DURATION = 'rpc.server.duration' as const;
 
 /**
  * Measures the size of RPC request messages (uncompressed).
- * 
+ *
  * @note **Streaming**: Recorded per message in a streaming batch
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_RPC_SERVER_REQUEST_SIZE = 'rpc.server.request.size' as const;
 
 /**
  * Measures the number of messages received per RPC.
- * 
+ *
  * @note Should be 1 for all non-streaming RPCs.
- * 
+ *
  * **Streaming** : This metric is required for server and client streaming RPCs
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_RPC_SERVER_REQUESTS_PER_RPC = 'rpc.server.requests_per_rpc' as const;
 
 /**
  * Measures the size of RPC response messages (uncompressed).
- * 
+ *
  * @note **Streaming**: Recorded per response in a streaming batch
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_RPC_SERVER_RESPONSE_SIZE = 'rpc.server.response.size' as const;
 
 /**
  * Measures the number of messages sent per RPC.
- * 
+ *
  * @note Should be 1 for all non-streaming RPCs.
- * 
+ *
  * **Streaming**: This metric is required for server and client streaming RPCs
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_RPC_SERVER_RESPONSES_PER_RPC = 'rpc.server.responses_per_rpc' as const;
 
 /**
  * Reports the current frequency of the CPU in Hz
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_CPU_FREQUENCY = 'system.cpu.frequency' as const;
 
 /**
  * Reports the number of logical (virtual) processor cores created by the operating system to manage multitasking
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_CPU_LOGICAL_COUNT = 'system.cpu.logical.count' as const;
 
 /**
  * Reports the number of actual physical processor cores on the hardware
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_CPU_PHYSICAL_COUNT = 'system.cpu.physical.count' as const;
 
 /**
  * Seconds each logical CPU spent on each mode
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_CPU_TIME = 'system.cpu.time' as const;
 
 /**
  * Difference in system.cpu.time since the last measurement, divided by the elapsed time and number of logical CPUs
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_CPU_UTILIZATION = 'system.cpu.utilization' as const;
@@ -1274,21 +1274,21 @@ export const METRIC_SYSTEM_DISK_IO = 'system.disk.io' as const;
 
 /**
  * Time disk spent activated
- * 
+ *
  * @note The real elapsed time ("wall clock") used in the I/O path (time from operations running in parallel are not counted). Measured as:
- * 
+ *
  *   - Linux: Field 13 from [procfs-diskstats](https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats)
  *   - Windows: The complement of
  *     ["Disk% Idle Time"](https://learn.microsoft.com/archive/blogs/askcore/windows-performance-monitor-disk-counters-explained#windows-performance-monitor-disk-counters-explained)
  *     performance counter: `uptime * (100 - "Disk\% Idle Time") / 100`
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_DISK_IO_TIME = 'system.disk.io_time' as const;
 
 /**
  * The total storage capacity of the disk
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_DISK_LIMIT = 'system.disk.limit' as const;
@@ -1300,12 +1300,12 @@ export const METRIC_SYSTEM_DISK_MERGED = 'system.disk.merged' as const;
 
 /**
  * Sum of the time each operation took to complete
- * 
+ *
  * @note Because it is the sum of time each request took, parallel-issued requests each contribute to make the count grow. Measured as:
- * 
+ *
  *   - Linux: Fields 7 & 11 from [procfs-diskstats](https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats)
  *   - Windows: "Avg. Disk sec/Read" perf counter multiplied by "Disk Reads/sec" perf counter (similar for Writes)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_DISK_OPERATION_TIME = 'system.disk.operation_time' as const;
@@ -1317,17 +1317,17 @@ export const METRIC_SYSTEM_DISK_OPERATIONS = 'system.disk.operations' as const;
 
 /**
  * The total storage capacity of the filesystem
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_FILESYSTEM_LIMIT = 'system.filesystem.limit' as const;
 
 /**
  * Reports a filesystem's space usage across different states.
- * 
+ *
  * @note The sum of all `system.filesystem.usage` values over the different `system.filesystem.state` attributes
  * **SHOULD** equal the total storage capacity of the filesystem, that is `system.filesystem.limit`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_FILESYSTEM_USAGE = 'system.filesystem.usage' as const;
@@ -1339,53 +1339,53 @@ export const METRIC_SYSTEM_FILESYSTEM_UTILIZATION = 'system.filesystem.utilizati
 
 /**
  * An estimate of how much memory is available for starting new applications, without causing swapping
- * 
+ *
  * @note This is an alternative to `system.memory.usage` metric with `state=free`.
  * Linux starting from 3.14 exports "available" memory. It takes "free" memory as a baseline, and then factors in kernel-specific values.
  * This is supposed to be more accurate than just "free" memory.
  * For reference, see the calculations [here](https://superuser.com/a/980821).
  * See also `MemAvailable` in [/proc/meminfo](https://man7.org/linux/man-pages/man5/proc.5.html).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_LINUX_MEMORY_AVAILABLE = 'system.linux.memory.available' as const;
 
 /**
  * Reports the memory used by the Linux kernel for managing caches of frequently used objects.
- * 
+ *
  * @note The sum over the `reclaimable` and `unreclaimable` state values in `linux.memory.slab.usage` **SHOULD** be equal to the total slab memory available on the system.
  * Note that the total slab memory is not constant and may vary over time.
  * See also the [Slab allocator](https://blogs.oracle.com/linux/post/understanding-linux-kernel-memory-statistics) and `Slab` in [/proc/meminfo](https://man7.org/linux/man-pages/man5/proc.5.html).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_LINUX_MEMORY_SLAB_USAGE = 'system.linux.memory.slab.usage' as const;
 
 /**
  * Total memory available in the system.
- * 
+ *
  * @note Its value **SHOULD** equal the sum of `system.memory.state` over all states.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_MEMORY_LIMIT = 'system.memory.limit' as const;
 
 /**
  * Shared memory used (mostly by tmpfs).
- * 
+ *
  * @note Equivalent of `shared` from [`free` command](https://man7.org/linux/man-pages/man1/free.1.html) or
  * `Shmem` from [`/proc/meminfo`](https://man7.org/linux/man-pages/man5/proc.5.html)"
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_MEMORY_SHARED = 'system.memory.shared' as const;
 
 /**
  * Reports memory in use by state.
- * 
+ *
  * @note The sum over all `system.memory.state` values **SHOULD** equal the total memory
  * available on the system, that is `system.memory.limit`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_MEMORY_USAGE = 'system.memory.usage' as const;
@@ -1402,26 +1402,26 @@ export const METRIC_SYSTEM_NETWORK_CONNECTIONS = 'system.network.connections' as
 
 /**
  * Count of packets that are dropped or discarded even though there was no error
- * 
+ *
  * @note Measured as:
- * 
+ *
  *   - Linux: the `drop` column in `/proc/dev/net` ([source](https://web.archive.org/web/20180321091318/http://www.onlamp.com/pub/a/linux/2000/11/16/LinuxAdmin.html))
  *   - Windows: [`InDiscards`/`OutDiscards`](https://docs.microsoft.com/windows/win32/api/netioapi/ns-netioapi-mib_if_row2)
  *     from [`GetIfEntry2`](https://docs.microsoft.com/windows/win32/api/netioapi/nf-netioapi-getifentry2)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_NETWORK_DROPPED = 'system.network.dropped' as const;
 
 /**
  * Count of network errors detected
- * 
+ *
  * @note Measured as:
- * 
+ *
  *   - Linux: the `errs` column in `/proc/dev/net` ([source](https://web.archive.org/web/20180321091318/http://www.onlamp.com/pub/a/linux/2000/11/16/LinuxAdmin.html)).
  *   - Windows: [`InErrors`/`OutErrors`](https://docs.microsoft.com/windows/win32/api/netioapi/ns-netioapi-mib_if_row2)
  *     from [`GetIfEntry2`](https://docs.microsoft.com/windows/win32/api/netioapi/nf-netioapi-getifentry2).
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_NETWORK_ERRORS = 'system.network.errors' as const;
@@ -1448,7 +1448,7 @@ export const METRIC_SYSTEM_PAGING_OPERATIONS = 'system.paging.operations' as con
 
 /**
  * Unix swap or windows pagefile usage
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_PAGING_USAGE = 'system.paging.usage' as const;
@@ -1460,139 +1460,139 @@ export const METRIC_SYSTEM_PAGING_UTILIZATION = 'system.paging.utilization' as c
 
 /**
  * Total number of processes in each state
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_PROCESS_COUNT = 'system.process.count' as const;
 
 /**
  * Total number of processes created over uptime of the host
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_PROCESS_CREATED = 'system.process.created' as const;
 
 /**
  * The time the system has been running
- * 
+ *
  * @note Instrumentations **SHOULD** use a gauge with type `double` and measure uptime in seconds as a floating point number with the highest precision available.
  * The actual accuracy would depend on the instrumentation and operating system.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_SYSTEM_UPTIME = 'system.uptime' as const;
 
 /**
  * Garbage collection duration.
- * 
+ *
  * @note The values can be retrieve from [`perf_hooks.PerformanceObserver(...).observe({ entryTypes: ['gc'] })`](https://nodejs.org/api/perf_hooks.html#performanceobserverobserveoptions)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_V8JS_GC_DURATION = 'v8js.gc.duration' as const;
 
 /**
  * Heap space available size.
- * 
+ *
  * @note Value can be retrieved from value `space_available_size` of [`v8.getHeapSpaceStatistics()`](https://nodejs.org/api/v8.html#v8getheapspacestatistics)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_V8JS_HEAP_SPACE_AVAILABLE_SIZE = 'v8js.heap.space.available_size' as const;
 
 /**
  * Committed size of a heap space.
- * 
+ *
  * @note Value can be retrieved from value `physical_space_size` of [`v8.getHeapSpaceStatistics()`](https://nodejs.org/api/v8.html#v8getheapspacestatistics)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_V8JS_HEAP_SPACE_PHYSICAL_SIZE = 'v8js.heap.space.physical_size' as const;
 
 /**
  * Total heap memory size pre-allocated.
- * 
+ *
  * @note The value can be retrieved from value `space_size` of [`v8.getHeapSpaceStatistics()`](https://nodejs.org/api/v8.html#v8getheapspacestatistics)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_V8JS_MEMORY_HEAP_LIMIT = 'v8js.memory.heap.limit' as const;
 
 /**
  * Heap Memory size allocated.
- * 
+ *
  * @note The value can be retrieved from value `space_used_size` of [`v8.getHeapSpaceStatistics()`](https://nodejs.org/api/v8.html#v8getheapspacestatistics)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_V8JS_MEMORY_HEAP_USED = 'v8js.memory.heap.used' as const;
 
 /**
  * The number of changes (pull requests/merge requests/changelists) in a repository, categorized by their state (e.g. open or merged)
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_VCS_CHANGE_COUNT = 'vcs.change.count' as const;
 
 /**
  * The time duration a change (pull request/merge request/changelist) has been in a given state.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_VCS_CHANGE_DURATION = 'vcs.change.duration' as const;
 
 /**
  * The amount of time since its creation it took a change (pull request/merge request/changelist) to get the first approval
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_VCS_CHANGE_TIME_TO_APPROVAL = 'vcs.change.time_to_approval' as const;
 
 /**
  * The number of unique contributors to a repository
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_VCS_CONTRIBUTOR_COUNT = 'vcs.contributor.count' as const;
 
 /**
  * The number of refs of type branch or tag in a repository
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_VCS_REF_COUNT = 'vcs.ref.count' as const;
 
 /**
  * The number of lines added/removed in a ref (branch) relative to the ref from the `vcs.ref.base.name` attribute
- * 
+ *
  * @note This metric should be reported for each `vcs.line_change.type` value. For example if a ref added 3 lines and removed 2 lines,
  * instrumentation **SHOULD** report two measurements: 3 and 2 (both positive numbers).
  * If number of lines added/removed should be calculated from the start of time, then `vcs.ref.base.name` **SHOULD** be set to an empty string.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_VCS_REF_LINES_DELTA = 'vcs.ref.lines_delta' as const;
 
 /**
  * The number of revisions (commits) a ref (branch) is ahead/behind the branch from the `vcs.ref.base.name` attribute
- * 
+ *
  * @note This metric should be reported for each `vcs.revision_delta.direction` value. For example if branch `a` is 3 commits behind and 2 commits ahead of `trunk`,
  * instrumentation **SHOULD** report two measurements: 3 and 2 (both positive numbers) and `vcs.ref.base.name` is set to `trunk`.
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_VCS_REF_REVISIONS_DELTA = 'vcs.ref.revisions_delta' as const;
 
 /**
  * Time a ref (branch) created from the default branch (trunk) has existed. The `ref.type` attribute will always be `branch`
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_VCS_REF_TIME = 'vcs.ref.time' as const;
 
 /**
  * The number of repositories in an organization
- * 
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_VCS_REPOSITORY_COUNT = 'vcs.repository.count' as const;

--- a/semantic-conventions/src/stable_attributes.ts
+++ b/semantic-conventions/src/stable_attributes.ts
@@ -20,7 +20,7 @@
 
 /**
  * ASP.NET Core exception middleware handling result
- * 
+ *
  * @example handled
  * @example unhandled
  */
@@ -48,14 +48,14 @@ export const ASPNETCORE_DIAGNOSTICS_EXCEPTION_RESULT_VALUE_UNHANDLED = "unhandle
 
 /**
  * Full type name of the [`IExceptionHandler`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.diagnostics.iexceptionhandler) implementation that handled the exception.
- * 
+ *
  * @example Contoso.MyHandler
  */
 export const ATTR_ASPNETCORE_DIAGNOSTICS_HANDLER_TYPE = 'aspnetcore.diagnostics.handler.type' as const;
 
 /**
  * Rate limiting policy name.
- * 
+ *
  * @example fixed
  * @example sliding
  * @example token
@@ -64,7 +64,7 @@ export const ATTR_ASPNETCORE_RATE_LIMITING_POLICY = 'aspnetcore.rate_limiting.po
 
 /**
  * Rate-limiting result, shows whether the lease was acquired or contains a rejection reason
- * 
+ *
  * @example acquired
  * @example request_canceled
  */
@@ -92,21 +92,21 @@ export const ASPNETCORE_RATE_LIMITING_RESULT_VALUE_REQUEST_CANCELED = "request_c
 
 /**
  * Flag indicating if request was handled by the application pipeline.
- * 
+ *
  * @example true
  */
 export const ATTR_ASPNETCORE_REQUEST_IS_UNHANDLED = 'aspnetcore.request.is_unhandled' as const;
 
 /**
  * A value that indicates whether the matched route is a fallback route.
- * 
+ *
  * @example true
  */
 export const ATTR_ASPNETCORE_ROUTING_IS_FALLBACK = 'aspnetcore.routing.is_fallback' as const;
 
 /**
  * Match result - success or failure
- * 
+ *
  * @example success
  * @example failure
  */
@@ -124,49 +124,49 @@ export const ASPNETCORE_ROUTING_MATCH_STATUS_VALUE_SUCCESS = "success" as const;
 
 /**
  * Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
- * 
+ *
  * @example client.example.com
  * @example 10.1.2.80
  * @example /tmp/my.sock
- * 
+ *
  * @note When observed from the server side, and when communicating through an intermediary, `client.address` **SHOULD** represent the client address behind any intermediaries,  for example proxies, if it's available.
  */
 export const ATTR_CLIENT_ADDRESS = 'client.address' as const;
 
 /**
  * Client port number.
- * 
+ *
  * @example 65123
- * 
+ *
  * @note When observed from the server side, and when communicating through an intermediary, `client.port` **SHOULD** represent the client port behind any intermediaries,  for example proxies, if it's available.
  */
 export const ATTR_CLIENT_PORT = 'client.port' as const;
 
 /**
  * Describes a class of error the operation ended with.
- * 
+ *
  * @example timeout
  * @example java.net.UnknownHostException
  * @example server_certificate_invalid
  * @example 500
- * 
+ *
  * @note The `error.type` **SHOULD** be predictable, and **SHOULD** have low cardinality.
- * 
+ *
  * When `error.type` is set to a type (e.g., an exception type), its
  * canonical class name identifying the type within the artifact **SHOULD** be used.
- * 
+ *
  * Instrumentations **SHOULD** document the list of errors they report.
- * 
+ *
  * The cardinality of `error.type` within one instrumentation library **SHOULD** be low.
  * Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
  * should be prepared for `error.type` to have high cardinality at query time when no
  * additional filters are applied.
- * 
+ *
  * If the operation has completed successfully, instrumentations **SHOULD NOT** set `error.type`.
- * 
+ *
  * If a specific domain defines its own set of error identifiers (such as HTTP or gRPC status codes),
  * it's **RECOMMENDED** to:
- * 
+ *
  *   - Use a domain-specific attribute
  *   - Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
  */
@@ -179,19 +179,19 @@ export const ERROR_TYPE_VALUE_OTHER = "_OTHER" as const;
 
 /**
  * **SHOULD** be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span.
- * 
+ *
  * @note An exception is considered to have escaped (or left) the scope of a span,
  * if that span is ended while the exception is still logically "in flight".
  * This may be actually "in flight" in some languages (e.g. if the exception
  * is passed to a Context manager's `__exit__` method in Python) but will
  * usually be caught at the point of recording the exception in most languages.
- * 
+ *
  * It is usually not possible to determine at the point where an exception is thrown
  * whether it will escape the scope of a span.
  * However, it is trivial to know that an exception
  * will escape, if one checks for an active exception just before ending the span,
  * as done in the [example for recording span exceptions](https://opentelemetry.io/docs/specs/semconv/exceptions/exceptions-spans/#recording-an-exception).
- * 
+ *
  * It follows that an exception may still escape the scope of the span
  * even if the `exception.escaped` attribute was not set or set to false,
  * since the event might have been recorded at a time where it was not
@@ -201,7 +201,7 @@ export const ATTR_EXCEPTION_ESCAPED = 'exception.escaped' as const;
 
 /**
  * The exception message.
- * 
+ *
  * @example Division by zero
  * @example Can't convert 'int' object to str implicitly
  */
@@ -209,14 +209,14 @@ export const ATTR_EXCEPTION_MESSAGE = 'exception.message' as const;
 
 /**
  * A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.
- * 
+ *
  * @example "Exception in thread "main" java.lang.RuntimeException: Test exception\\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\\n at com.example.GenerateTrace.main(GenerateTrace.java:5)\\n"
  */
 export const ATTR_EXCEPTION_STACKTRACE = 'exception.stacktrace' as const;
 
 /**
  * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
- * 
+ *
  * @example java.net.ConnectException
  * @example OSError
  */
@@ -224,10 +224,10 @@ export const ATTR_EXCEPTION_TYPE = 'exception.type' as const;
 
 /**
  * HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values.
- * 
+ *
  * @example http.request.header.content-type=["application/json"]
  * @example http.request.header.x-forwarded-for=["1.2.3.4", "1.2.3.5"]
- * 
+ *
  * @note Instrumentations **SHOULD** require an explicit configuration of which headers are to be captured. Including all request headers can be a security risk - explicit configuration helps avoid leaking sensitive information.
  * The `User-Agent` header is already captured in the `user_agent.original` attribute. Users **MAY** explicitly configure instrumentations to capture them even though it is not recommended.
  * The attribute value **MUST** consist of either multiple header values as an array of strings or a single-item array containing a possibly comma-concatenated string, depending on the way the HTTP library provides access to headers.
@@ -236,22 +236,22 @@ export const ATTR_HTTP_REQUEST_HEADER = (key: string) => `http.request.header.${
 
 /**
  * HTTP request method.
- * 
+ *
  * @example GET
  * @example POST
  * @example HEAD
- * 
+ *
  * @note HTTP request method value **SHOULD** be "known" to the instrumentation.
  * By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
  * and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
- * 
+ *
  * If the HTTP request method is not known to instrumentation, it **MUST** set the `http.request.method` attribute to `_OTHER`.
- * 
+ *
  * If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it **MUST** provide a way to override
  * the list of known HTTP methods. If this override is done via environment variable, then the environment variable **MUST** be named
  * OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
  * (this list **MUST** be a full override of the default known method, it is not a list of known methods in addition to the defaults).
- * 
+ *
  * HTTP method names are case-sensitive and `http.request.method` attribute value **MUST** match a known HTTP method name exactly.
  * Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, **SHOULD** populate a canonical equivalent.
  * Tracing instrumentations that do so, **MUST** also set `http.request.method_original` to the original value.
@@ -310,7 +310,7 @@ export const HTTP_REQUEST_METHOD_VALUE_TRACE = "TRACE" as const;
 
 /**
  * Original HTTP method sent by the client in the request line.
- * 
+ *
  * @example GeT
  * @example ACL
  * @example foo
@@ -319,19 +319,19 @@ export const ATTR_HTTP_REQUEST_METHOD_ORIGINAL = 'http.request.method_original' 
 
 /**
  * The ordinal number of request resending attempt (for any reason, including redirects).
- * 
+ *
  * @example 3
- * 
+ *
  * @note The resend count **SHOULD** be updated each time an HTTP request gets resent by the client, regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues, or any other).
  */
 export const ATTR_HTTP_REQUEST_RESEND_COUNT = 'http.request.resend_count' as const;
 
 /**
  * HTTP response headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values.
- * 
+ *
  * @example http.response.header.content-type=["application/json"]
  * @example http.response.header.my-custom-header=["abc", "def"]
- * 
+ *
  * @note Instrumentations **SHOULD** require an explicit configuration of which headers are to be captured. Including all response headers can be a security risk - explicit configuration helps avoid leaking sensitive information.
  * Users **MAY** explicitly configure instrumentations to capture them even though it is not recommended.
  * The attribute value **MUST** consist of either multiple header values as an array of strings or a single-item array containing a possibly comma-concatenated string, depending on the way the HTTP library provides access to headers.
@@ -340,17 +340,17 @@ export const ATTR_HTTP_RESPONSE_HEADER = (key: string) => `http.response.header.
 
 /**
  * [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).
- * 
+ *
  * @example 200
  */
 export const ATTR_HTTP_RESPONSE_STATUS_CODE = 'http.response.status_code' as const;
 
 /**
  * The matched route, that is, the path template in the format used by the respective server framework.
- * 
+ *
  * @example /users/:userID?
  * @example {controller}/{action}/{id?}
- * 
+ *
  * @note **MUST NOT** be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
  * **SHOULD** include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
  */
@@ -358,38 +358,38 @@ export const ATTR_HTTP_ROUTE = 'http.route' as const;
 
 /**
  * Name of the garbage collector action.
- * 
+ *
  * @example end of minor GC
  * @example end of major GC
- * 
+ *
  * @note Garbage collector action is generally obtained via [GarbageCollectionNotificationInfo#getGcAction()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcAction()).
  */
 export const ATTR_JVM_GC_ACTION = 'jvm.gc.action' as const;
 
 /**
  * Name of the garbage collector.
- * 
+ *
  * @example G1 Young Generation
  * @example G1 Old Generation
- * 
+ *
  * @note Garbage collector name is generally obtained via [GarbageCollectionNotificationInfo#getGcName()](https://docs.oracle.com/en/java/javase/11/docs/api/jdk.management/com/sun/management/GarbageCollectionNotificationInfo.html#getGcName()).
  */
 export const ATTR_JVM_GC_NAME = 'jvm.gc.name' as const;
 
 /**
  * Name of the memory pool.
- * 
+ *
  * @example G1 Old Gen
  * @example G1 Eden space
  * @example G1 Survivor Space
- * 
+ *
  * @note Pool names are generally obtained via [MemoryPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName()).
  */
 export const ATTR_JVM_MEMORY_POOL_NAME = 'jvm.memory.pool.name' as const;
 
 /**
  * The type of memory.
- * 
+ *
  * @example heap
  * @example non_heap
  */
@@ -412,7 +412,7 @@ export const ATTR_JVM_THREAD_DAEMON = 'jvm.thread.daemon' as const;
 
 /**
  * State of the thread.
- * 
+ *
  * @example runnable
  * @example blocked
  */
@@ -450,7 +450,7 @@ export const JVM_THREAD_STATE_VALUE_WAITING = "waiting" as const;
 
 /**
  * Local address of the network connection - IP address or Unix domain socket name.
- * 
+ *
  * @example 10.1.2.80
  * @example /tmp/my.sock
  */
@@ -458,14 +458,14 @@ export const ATTR_NETWORK_LOCAL_ADDRESS = 'network.local.address' as const;
 
 /**
  * Local port number of the network connection.
- * 
+ *
  * @example 65123
  */
 export const ATTR_NETWORK_LOCAL_PORT = 'network.local.port' as const;
 
 /**
  * Peer address of the network connection - IP address or Unix domain socket name.
- * 
+ *
  * @example 10.1.2.80
  * @example /tmp/my.sock
  */
@@ -473,40 +473,40 @@ export const ATTR_NETWORK_PEER_ADDRESS = 'network.peer.address' as const;
 
 /**
  * Peer port number of the network connection.
- * 
+ *
  * @example 65123
  */
 export const ATTR_NETWORK_PEER_PORT = 'network.peer.port' as const;
 
 /**
  * [OSI application layer](https://wikipedia.org/wiki/Application_layer) or non-OSI equivalent.
- * 
+ *
  * @example amqp
  * @example http
  * @example mqtt
- * 
+ *
  * @note The value **SHOULD** be normalized to lowercase.
  */
 export const ATTR_NETWORK_PROTOCOL_NAME = 'network.protocol.name' as const;
 
 /**
  * The actual version of the protocol used for network communication.
- * 
+ *
  * @example 1.1
  * @example 2
- * 
+ *
  * @note If protocol version is subject to negotiation (for example using [ALPN](https://www.rfc-editor.org/rfc/rfc7301.html)), this attribute **SHOULD** be set to the negotiated version. If the actual protocol version is not known, this attribute **SHOULD NOT** be set.
  */
 export const ATTR_NETWORK_PROTOCOL_VERSION = 'network.protocol.version' as const;
 
 /**
  * [OSI transport layer](https://wikipedia.org/wiki/Transport_layer) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication).
- * 
+ *
  * @example tcp
  * @example udp
- * 
+ *
  * @note The value **SHOULD** be normalized to lowercase.
- * 
+ *
  * Consider always setting the transport when setting a port number, since
  * a port number is ambiguous without knowing the transport. For example
  * different processes could be listening on TCP port 12345 and UDP port 12345.
@@ -540,10 +540,10 @@ export const NETWORK_TRANSPORT_VALUE_UNIX = "unix" as const;
 
 /**
  * [OSI network layer](https://wikipedia.org/wiki/Network_layer) or non-OSI equivalent.
- * 
+ *
  * @example ipv4
  * @example ipv6
- * 
+ *
  * @note The value **SHOULD** be normalized to lowercase.
  */
 export const ATTR_NETWORK_TYPE = 'network.type' as const;
@@ -560,14 +560,14 @@ export const NETWORK_TYPE_VALUE_IPV6 = "ipv6" as const;
 
 /**
  * The name of the instrumentation scope - (`InstrumentationScope.Name` in OTLP).
- * 
+ *
  * @example io.opentelemetry.contrib.mongodb
  */
 export const ATTR_OTEL_SCOPE_NAME = 'otel.scope.name' as const;
 
 /**
  * The version of the instrumentation scope - (`InstrumentationScope.Version` in OTLP).
- * 
+ *
  * @example 1.0.0
  */
 export const ATTR_OTEL_SCOPE_VERSION = 'otel.scope.version' as const;
@@ -589,45 +589,45 @@ export const OTEL_STATUS_CODE_VALUE_OK = "OK" as const;
 
 /**
  * Description of the Status if it has a value, otherwise not set.
- * 
+ *
  * @example resource not found
  */
 export const ATTR_OTEL_STATUS_DESCRIPTION = 'otel.status_description' as const;
 
 /**
  * Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
- * 
+ *
  * @example example.com
  * @example 10.1.2.80
  * @example /tmp/my.sock
- * 
+ *
  * @note When observed from the client side, and when communicating through an intermediary, `server.address` **SHOULD** represent the server address behind any intermediaries, for example proxies, if it's available.
  */
 export const ATTR_SERVER_ADDRESS = 'server.address' as const;
 
 /**
  * Server port number.
- * 
+ *
  * @example 80
  * @example 8080
  * @example 443
- * 
+ *
  * @note When observed from the client side, and when communicating through an intermediary, `server.port` **SHOULD** represent the server port behind any intermediaries, for example proxies, if it's available.
  */
 export const ATTR_SERVER_PORT = 'server.port' as const;
 
 /**
  * Logical name of the service.
- * 
+ *
  * @example shoppingcart
- * 
+ *
  * @note **MUST** be the same for all instances of horizontally scaled services. If the value was not specified, SDKs **MUST** fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value **MUST** be set to `unknown_service`.
  */
 export const ATTR_SERVICE_NAME = 'service.name' as const;
 
 /**
  * The version string of the service API or implementation. The format is not defined by these conventions.
- * 
+ *
  * @example 2.0.0
  * @example a01dbef8a
  */
@@ -635,7 +635,7 @@ export const ATTR_SERVICE_VERSION = 'service.version' as const;
 
 /**
  * SignalR HTTP connection closure status.
- * 
+ *
  * @example app_shutdown
  * @example timeout
  */
@@ -658,7 +658,7 @@ export const SIGNALR_CONNECTION_STATUS_VALUE_TIMEOUT = "timeout" as const;
 
 /**
  * [SignalR transport type](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md)
- * 
+ *
  * @example web_sockets
  * @example long_polling
  */
@@ -746,9 +746,9 @@ export const TELEMETRY_SDK_LANGUAGE_VALUE_WEBJS = "webjs" as const;
 
 /**
  * The name of the telemetry SDK as defined above.
- * 
+ *
  * @example opentelemetry
- * 
+ *
  * @note The OpenTelemetry SDK **MUST** set the `telemetry.sdk.name` attribute to `opentelemetry`.
  * If another SDK, like a fork or a vendor-provided implementation, is used, this SDK **MUST** set the
  * `telemetry.sdk.name` attribute to the fully-qualified class or module name of this SDK's main entry point
@@ -760,45 +760,45 @@ export const ATTR_TELEMETRY_SDK_NAME = 'telemetry.sdk.name' as const;
 
 /**
  * The version string of the telemetry SDK.
- * 
+ *
  * @example 1.2.3
  */
 export const ATTR_TELEMETRY_SDK_VERSION = 'telemetry.sdk.version' as const;
 
 /**
  * The [URI fragment](https://www.rfc-editor.org/rfc/rfc3986#section-3.5) component
- * 
+ *
  * @example SemConv
  */
 export const ATTR_URL_FRAGMENT = 'url.fragment' as const;
 
 /**
  * Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986)
- * 
+ *
  * @example https://www.foo.bar/search?q=OpenTelemetry#SemConv
  * @example //localhost
- * 
+ *
  * @note For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment
  * is not transmitted over HTTP, but if it is known, it **SHOULD** be included nevertheless.
- * 
+ *
  * `url.full` **MUST NOT** contain credentials passed via URL in form of `https://username:password@www.example.com/`.
  * In such case username and password **SHOULD** be redacted and attribute's value **SHOULD** be `https://REDACTED:REDACTED@www.example.com/`.
- * 
+ *
  * `url.full` **SHOULD** capture the absolute URL when it is available (or can be reconstructed).
- * 
+ *
  * Sensitive content provided in `url.full` **SHOULD** be scrubbed when instrumentations can identify it.
- * 
- * 
+ *
+ *
  * Query string values for the following keys **SHOULD** be redacted by default and replaced by the
  * value `REDACTED`:
- * 
+ *
  *   - [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
  *   - [`Signature`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
  *   - [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token)
  *   - [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)
- * 
+ *
  * This list is subject to change over time.
- * 
+ *
  * When a query string value is redacted, the query string key **SHOULD** still be preserved, e.g.
  * `https://www.example.com/path?color=blue&sig=REDACTED`.
  */
@@ -806,30 +806,30 @@ export const ATTR_URL_FULL = 'url.full' as const;
 
 /**
  * The [URI path](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) component
- * 
+ *
  * @example /search
- * 
+ *
  * @note Sensitive content provided in `url.path` **SHOULD** be scrubbed when instrumentations can identify it.
  */
 export const ATTR_URL_PATH = 'url.path' as const;
 
 /**
  * The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component
- * 
+ *
  * @example q=OpenTelemetry
- * 
+ *
  * @note Sensitive content provided in `url.query` **SHOULD** be scrubbed when instrumentations can identify it.
- * 
- * 
+ *
+ *
  * Query string values for the following keys **SHOULD** be redacted by default and replaced by the value `REDACTED`:
- * 
+ *
  *   - [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
  *   - [`Signature`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
  *   - [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token)
  *   - [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)
- * 
+ *
  * This list is subject to change over time.
- * 
+ *
  * When a query string value is redacted, the query string key **SHOULD** still be preserved, e.g.
  * `q=OpenTelemetry&sig=REDACTED`.
  */
@@ -837,7 +837,7 @@ export const ATTR_URL_QUERY = 'url.query' as const;
 
 /**
  * The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol.
- * 
+ *
  * @example https
  * @example ftp
  * @example telnet
@@ -846,7 +846,7 @@ export const ATTR_URL_SCHEME = 'url.scheme' as const;
 
 /**
  * Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client.
- * 
+ *
  * @example CERN-LineMode/2.15 libwww/2.17b3
  * @example Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1
  * @example YourApp/1.0.0 grpc-java-okhttp/1.27.2

--- a/semantic-conventions/src/stable_metrics.ts
+++ b/semantic-conventions/src/stable_metrics.ts
@@ -20,54 +20,54 @@
 
 /**
  * Number of exceptions caught by exception handling middleware.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.Diagnostics`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_ASPNETCORE_DIAGNOSTICS_EXCEPTIONS = 'aspnetcore.diagnostics.exceptions' as const;
 
 /**
  * Number of requests that are currently active on the server that hold a rate limiting lease.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.RateLimiting`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_ASPNETCORE_RATE_LIMITING_ACTIVE_REQUEST_LEASES = 'aspnetcore.rate_limiting.active_request_leases' as const;
 
 /**
  * Number of requests that are currently queued, waiting to acquire a rate limiting lease.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.RateLimiting`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_ASPNETCORE_RATE_LIMITING_QUEUED_REQUESTS = 'aspnetcore.rate_limiting.queued_requests' as const;
 
 /**
  * The time the request spent in a queue waiting to acquire a rate limiting lease.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.RateLimiting`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_ASPNETCORE_RATE_LIMITING_REQUEST_TIME_IN_QUEUE = 'aspnetcore.rate_limiting.request.time_in_queue' as const;
 
 /**
  * The duration of rate limiting lease held by requests on the server.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.RateLimiting`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_ASPNETCORE_RATE_LIMITING_REQUEST_LEASE_DURATION = 'aspnetcore.rate_limiting.request_lease.duration' as const;
 
 /**
  * Number of requests that tried to acquire a rate limiting lease.
- * 
+ *
  * @note Requests could be:
- * 
+ *
  *   - Rejected by global or endpoint rate limiting policies
  *   - Canceled while waiting for the lease.
- * 
+ *
  * Meter name: `Microsoft.AspNetCore.RateLimiting`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_ASPNETCORE_RATE_LIMITING_REQUESTS = 'aspnetcore.rate_limiting.requests' as const;
 
 /**
  * Number of requests that were attempted to be matched to an endpoint.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.Routing`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_ASPNETCORE_ROUTING_MATCH_ATTEMPTS = 'aspnetcore.routing.match_attempts' as const;
@@ -104,7 +104,7 @@ export const METRIC_JVM_CPU_COUNT = 'jvm.cpu.count' as const;
 
 /**
  * Recent CPU utilization for the process as reported by the JVM.
- * 
+ *
  * @note The value range is [0.0,1.0]. This utilization is not defined as being for the specific interval since last measurement (unlike `system.cpu.utilization`). [Reference](https://docs.oracle.com/en/java/javase/17/docs/api/jdk.management/com/sun/management/OperatingSystemMXBean.html#getProcessCpuLoad()).
  */
 export const METRIC_JVM_CPU_RECENT_UTILIZATION = 'jvm.cpu.recent_utilization' as const;
@@ -146,42 +146,42 @@ export const METRIC_JVM_THREAD_COUNT = 'jvm.thread.count' as const;
 
 /**
  * Number of connections that are currently active on the server.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.Server.Kestrel`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_KESTREL_ACTIVE_CONNECTIONS = 'kestrel.active_connections' as const;
 
 /**
  * Number of TLS handshakes that are currently in progress on the server.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.Server.Kestrel`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_KESTREL_ACTIVE_TLS_HANDSHAKES = 'kestrel.active_tls_handshakes' as const;
 
 /**
  * The duration of connections on the server.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.Server.Kestrel`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_KESTREL_CONNECTION_DURATION = 'kestrel.connection.duration' as const;
 
 /**
  * Number of connections that are currently queued and are waiting to start.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.Server.Kestrel`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_KESTREL_QUEUED_CONNECTIONS = 'kestrel.queued_connections' as const;
 
 /**
  * Number of HTTP requests on multiplexed connections (HTTP/2 and HTTP/3) that are currently queued and are waiting to start.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.Server.Kestrel`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_KESTREL_QUEUED_REQUESTS = 'kestrel.queued_requests' as const;
 
 /**
  * Number of connections rejected by the server.
- * 
+ *
  * @note Connections are rejected when the currently active count exceeds the value configured with `MaxConcurrentConnections`.
  * Meter name: `Microsoft.AspNetCore.Server.Kestrel`; Added in: ASP.NET Core 8.0
  */
@@ -189,30 +189,30 @@ export const METRIC_KESTREL_REJECTED_CONNECTIONS = 'kestrel.rejected_connections
 
 /**
  * The duration of TLS handshakes on the server.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.Server.Kestrel`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_KESTREL_TLS_HANDSHAKE_DURATION = 'kestrel.tls_handshake.duration' as const;
 
 /**
  * Number of connections that are currently upgraded (WebSockets). .
- * 
+ *
  * @note The counter only tracks HTTP/1.1 connections.
- * 
+ *
  * Meter name: `Microsoft.AspNetCore.Server.Kestrel`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_KESTREL_UPGRADED_CONNECTIONS = 'kestrel.upgraded_connections' as const;
 
 /**
  * Number of connections that are currently active on the server.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.Http.Connections`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_SIGNALR_SERVER_ACTIVE_CONNECTIONS = 'signalr.server.active_connections' as const;
 
 /**
  * The duration of connections on the server.
- * 
+ *
  * @note Meter name: `Microsoft.AspNetCore.Http.Connections`; Added in: ASP.NET Core 8.0
  */
 export const METRIC_SIGNALR_SERVER_CONNECTION_DURATION = 'signalr.server.connection.duration' as const;


### PR DESCRIPTION
This updates the version of weaver used for semconv file generation to 0.12.0.
This includes fixes for trailing whitespace in multi-line comments.

---

Note: if you look at the diff ignoring whitespace, you can see the diff is tiny: https://github.com/open-telemetry/opentelemetry-js/pull/5427/files?w=1
