### PR TITLE
chore: tweak the section titles for changelogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "test:webworker": "lerna run test:webworker",
     "test:backcompat": "lerna run test:backcompat",
     "test:bench": "lerna run test:bench",
-    "changelog": "lerna-changelog",
     "predocs-test": "npm run docs",
     "docs": "typedoc --readme none && touch docs/.nojekyll",
     "docs-deploy": "gh-pages --dotfiles --dist docs",

--- a/package.json
+++ b/package.json
@@ -115,19 +115,6 @@
     "typescript": "5.0.4",
     "util": "0.12.5"
   },
-  "changelog": {
-    "repo": "open-telemetry/opentelemetry-js",
-    "labels": {
-      "breaking": ":boom: Breaking Change",
-      "enhancement": ":rocket: (Enhancement)",
-      "bug": ":bug: (Bug Fix)",
-      "core": ":wrench: Core",
-      "document": ":books: (Refine Doc)",
-      "feature-request": ":sparkles: (Feature)",
-      "internal": ":house: (Internal)"
-    },
-    "cacheDir": ".changelog"
-  },
   "workspaces": [
     "api",
     "packages/*",

--- a/scripts/update-changelog.js
+++ b/scripts/update-changelog.js
@@ -16,15 +16,15 @@ const path = require("path");
 
 const EMPTY_UNRELEASED_SECTION = `## Unreleased
 
-### :boom: Breaking Change
+### :boom: Breaking Changes
 
-### :rocket: (Enhancement)
+### :rocket: Features
 
-### :bug: (Bug Fix)
+### :bug: Bug Fixes
 
-### :books: (Refine Doc)
+### :books: Documentation
 
-### :house: (Internal)
+### :house: Internal
 
 `
 


### PR DESCRIPTION
This removes some vestigial lerna-changelog config.

It also tweaks the header names for our changelogs. Happy to discuss or revert these names. Mostly the parentheses seemed odd to me.  The wording changes (different words, pluralize) matches more closely the names being used for the changelogs in contrib repo (using release-please's default section names).