### PR TITLE
chore: temporarily disable API docs updates while main is frozen for releases

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,8 +1,11 @@
 name: Deploy API Documentation
 
-on:
-  release:
-    types: [published]
+# Disable API doc updates from "main" while "main" is frozen for https://github.com/open-telemetry/opentelemetry-js/milestone/17
+# TODO: renable this once ready for releases from "main" again.
+# on:
+#   release:
+#     types: [published]
+on: []
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Refs: https://github.com/open-telemetry/opentelemetry-js/pull/5435
