### PR TITLE
fix(sdk-node): do not return early if OTEL_METRICS_EXPORTER is empty

### DIFF
--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -109,10 +109,7 @@ function getValueInMillis(envName: string, defaultValue: number): number {
  */
 function configureMetricProviderFromEnv(): IMetricReader[] {
   const metricReaders: IMetricReader[] = [];
-  const metricsExporterList = process.env.OTEL_METRICS_EXPORTER?.trim();
-  if (!metricsExporterList) {
-    return metricReaders;
-  }
+  const metricsExporterList = process.env.OTEL_METRICS_EXPORTER?.trim() ?? ''; 
   const enabledExporters = filterBlanksAndNulls(metricsExporterList.split(','));
 
   if (enabledExporters.length === 0) {
@@ -447,7 +444,7 @@ export class NodeSDK {
   }
 
   private configureLoggerProviderFromEnv(): void {
-    const logExportersList = process.env.OTEL_LOGS_EXPORTER ?? '';
+    const logExportersList = process.env.OTEL_LOGS_EXPORTER?.trim() ?? '';
     const enabledExporters = filterBlanksAndNulls(logExportersList.split(','));
 
     if (enabledExporters.length === 0) {


### PR DESCRIPTION
Return default metrics exporter config correctly if OTEL_METRICS_EXPORTER is not defined / empty.

## Which problem is this PR solving?

Empty OTEL_METRICS_EXPORTER doesn't auto initialize metrics exporter.

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/5447

## Short description of the changes

Removes an early return in `configureMetricProviderFromEnv` when `OTEL_METRICS_EXPORTER` is empty, returning the default metrics export config instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Tested in a live node app

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
