### PR TITLE
Add parentSpanContext and remove parentSpanId.

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -400,7 +400,7 @@ describe('fetch', () => {
           const span: tracing.ReadableSpan = exportedSpans[0];
 
           assert.strictEqual(
-            span.parentSpanId,
+            span.parentSpanContext?.spanId,
             rootSpan!.spanContext().spanId,
             'parent span is not root span'
           );
@@ -775,7 +775,7 @@ describe('fetch', () => {
           const span: tracing.ReadableSpan = exportedSpans[0];
 
           assert.strictEqual(
-            span.parentSpanId,
+            span.parentSpanContext?.spanId,
             rootSpan!.spanContext().spanId,
             'parent span is not root span'
           );
@@ -1492,7 +1492,7 @@ describe('fetch', () => {
           const span: tracing.ReadableSpan = exportedSpans[0];
 
           assert.strictEqual(
-            span.parentSpanId,
+            span.parentSpanContext?.spanId,
             rootSpan!.spanContext().spanId,
             'parent span is not root span'
           );
@@ -1542,7 +1542,7 @@ describe('fetch', () => {
           const span: tracing.ReadableSpan = exportedSpans[0];
 
           assert.strictEqual(
-            span.parentSpanId,
+            span.parentSpanContext?.spanId,
             rootSpan!.spanContext().spanId,
             'parent span is not root span'
           );
@@ -1624,7 +1624,7 @@ describe('fetch', () => {
           const span: tracing.ReadableSpan = exportedSpans[0];
 
           assert.strictEqual(
-            span.parentSpanId,
+            span.parentSpanContext?.spanId,
             rootSpan!.spanContext().spanId,
             'parent span is not root span'
           );
@@ -1723,7 +1723,7 @@ describe('fetch', () => {
             const span: tracing.ReadableSpan = exportedSpans[0];
 
             assert.strictEqual(
-              span.parentSpanId,
+              span.parentSpanContext?.spanId,
               rootSpan!.spanContext().spanId,
               'parent span is not root span'
             );
@@ -1781,7 +1781,7 @@ describe('fetch', () => {
             const span: tracing.ReadableSpan = exportedSpans[0];
 
             assert.strictEqual(
-              span.parentSpanId,
+              span.parentSpanContext?.spanId,
               rootSpan!.spanContext().spanId,
               'parent span is not root span'
             );

--- a/experimental/packages/opentelemetry-instrumentation-grpc/test/helper.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/test/helper.ts
@@ -622,7 +622,7 @@ export const runTests = (
                 );
                 assert.strictEqual(
                   rootSpan.spanContext().spanId,
-                  clientSpan.parentSpanId
+                  clientSpan.parentSpanContext?.spanId
                 );
               }
             })
@@ -740,7 +740,7 @@ export const runTests = (
               );
               assert.strictEqual(
                 rootSpan.spanContext().spanId,
-                clientSpan.parentSpanId
+                clientSpan.parentSpanContext?.spanId
               );
             });
         });

--- a/experimental/packages/opentelemetry-instrumentation-grpc/test/protobuf-ts-utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/test/protobuf-ts-utils.ts
@@ -103,6 +103,6 @@ export function assertExportedSpans(
       rootSpan?.spanContext().traceId,
       serverSpan.spanContext().traceId
     );
-    assert.strictEqual(rootSpan?.spanContext().spanId, clientSpan.parentSpanId);
+    assert.strictEqual(rootSpan?.spanContext().spanId, clientSpan.parentSpanContext?.spanId);
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-grpc/test/utils/assertionUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/test/utils/assertionUtils.ts
@@ -99,7 +99,7 @@ export const assertPropagation = (
   const targetSpanContext = incomingSpan.spanContext();
   const sourceSpanContext = outgoingSpan.spanContext();
   assert.strictEqual(targetSpanContext.traceId, sourceSpanContext.traceId);
-  assert.strictEqual(incomingSpan.parentSpanId, sourceSpanContext.spanId);
+  assert.strictEqual(incomingSpan.parentSpanContext?.spanId, sourceSpanContext.spanId);
   assert.strictEqual(
     targetSpanContext.traceFlags,
     sourceSpanContext.traceFlags

--- a/experimental/packages/opentelemetry-instrumentation-http/test/utils/assertSpan.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/utils/assertSpan.ts
@@ -185,8 +185,8 @@ export const assertSpan = (
       validations.component,
       ' must have http.scheme attribute'
     );
-    assert.ok(typeof span.parentSpanId === 'string');
-    assert.ok(isValidSpanId(span.parentSpanId));
+    assert.ok(typeof span.parentSpanContext?.spanId === 'string');
+    assert.ok(isValidSpanId(span.parentSpanContext.spanId));
   } else if (validations.reqHeaders) {
     assert.ok(validations.reqHeaders[DummyPropagation.TRACE_CONTEXT_KEY]);
     assert.ok(validations.reqHeaders[DummyPropagation.SPAN_CONTEXT_KEY]);

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -385,7 +385,7 @@ describe('xhr', () => {
         it('should create a span with correct root span', () => {
           const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
           assert.strictEqual(
-            span.parentSpanId,
+            span.parentSpanContext?.spanId,
             rootSpan.spanContext().spanId,
             'parent span is not root span'
           );
@@ -489,7 +489,7 @@ describe('xhr', () => {
           const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
           const parentSpan: tracing.ReadableSpan = exportSpy.args[1][0][0];
           assert.strictEqual(
-            span.parentSpanId,
+            span.parentSpanContext?.spanId,
             parentSpan.spanContext().spanId,
             'parent span is not root span'
           );
@@ -1583,7 +1583,7 @@ describe('xhr', () => {
         it('should create a span with correct root span', () => {
           const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
           assert.strictEqual(
-            span.parentSpanId,
+            span.parentSpanContext?.spanId,
             rootSpan.spanContext().spanId,
             'parent span is not root span'
           );
@@ -1687,7 +1687,7 @@ describe('xhr', () => {
           const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
           const parentSpan: tracing.ReadableSpan = exportSpy.args[1][0][0];
           assert.strictEqual(
-            span.parentSpanId,
+            span.parentSpanContext?.spanId,
             parentSpan.spanContext().spanId,
             'parent span is not root span'
           );

--- a/experimental/packages/otlp-transformer/src/trace/internal-types.ts
+++ b/experimental/packages/otlp-transformer/src/trace/internal-types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { SpanContext } from '@opentelemetry/api';
 import {
   Fixed64,
   IInstrumentationScope,
@@ -62,8 +63,8 @@ export interface ISpan {
   /** Span traceState */
   traceState?: string | null;
 
-  /** Span parentSpanId */
-  parentSpanId?: string | Uint8Array;
+  /** Span parentSpanContext */
+  parentSpanContext?: SpanContext;
 
   /** Span name */
   name: string;

--- a/experimental/packages/otlp-transformer/src/trace/internal.ts
+++ b/experimental/packages/otlp-transformer/src/trace/internal.ts
@@ -40,7 +40,7 @@ export function sdkSpanToOtlpSpan(span: ReadableSpan, encoder: Encoder): ISpan {
   return {
     traceId: encoder.encodeSpanContext(ctx.traceId),
     spanId: encoder.encodeSpanContext(ctx.spanId),
-    parentSpanId: encoder.encodeOptionalSpanContext(span.parentSpanId),
+    parentSpanContext: span.parentSpanContext,
     traceState: ctx.traceState?.serialize(),
     name: span.name,
     // Span kind is offset by 1 because the API does not define a value for unset

--- a/experimental/packages/otlp-transformer/test/trace.test.ts
+++ b/experimental/packages/otlp-transformer/test/trace.test.ts
@@ -77,7 +77,11 @@ function createExpectedSpanJson(options: OtlpEncodingOptions) {
               {
                 traceId: traceId,
                 spanId: spanId,
-                parentSpanId: parentSpanId,
+                parentSpanContext: {
+                  spanId: parentSpanId,
+                  traceId: traceId,
+                  traceFlags: '01',
+                },
                 traceState: 'span=bar',
                 name: 'span-name',
                 kind: ESpanKind.SPAN_KIND_CLIENT,
@@ -168,7 +172,11 @@ function createExpectedSpanProtobuf() {
                 traceId: traceId,
                 spanId: spanId,
                 traceState: 'span=bar',
-                parentSpanId: parentSpanId,
+                parentSpanContext: {
+                  spanId: parentSpanId,
+                  traceId: traceId,
+                  traceFlags: '01',
+                },
                 name: 'span-name',
                 kind: ESpanKind.SPAN_KIND_CLIENT,
                 links: [
@@ -244,7 +252,11 @@ describe('Trace', () => {
         isRemote: false,
         traceState: new TraceState('span=bar'),
       }),
-      parentSpanId: '0000000000000001',
+      parentSpanContext: {
+        spanId: '0000000000000001',
+        traceId: '',
+        traceFlags: TraceFlags.SAMPLED,
+      },
       attributes: { 'string-attribute': 'some attribute value' },
       duration: [1, 300000000],
       endTime: [1640715558, 642725388],
@@ -330,25 +342,25 @@ describe('Trace', () => {
     });
 
     it('serializes a span without a parent with useHex = true', () => {
-      (span as any).parentSpanId = undefined;
+      (span as any).parentSpanContext = undefined;
       const exportRequest = createExportTraceServiceRequest([span], {
         useHex: true,
       });
       assert.ok(exportRequest);
       assert.strictEqual(
-        exportRequest.resourceSpans?.[0].scopeSpans[0].spans?.[0].parentSpanId,
+        exportRequest.resourceSpans?.[0].scopeSpans[0].spans?.[0].parentSpanContext?.spanId,
         undefined
       );
     });
 
     it('serializes a span without a parent with useHex = false', () => {
-      (span as any).parentSpanId = undefined;
+      (span as any).parentSpanContext = undefined;
       const exportRequest = createExportTraceServiceRequest([span], {
         useHex: false,
       });
       assert.ok(exportRequest);
       assert.strictEqual(
-        exportRequest.resourceSpans?.[0].scopeSpans[0].spans?.[0].parentSpanId,
+        exportRequest.resourceSpans?.[0].scopeSpans[0].spans?.[0].parentSpanContext?.spanId,
         undefined
       );
     });

--- a/experimental/packages/shim-opencensus/test/ShimSpan.test.ts
+++ b/experimental/packages/shim-opencensus/test/ShimSpan.test.ts
@@ -107,7 +107,7 @@ describe('ShimSpan', () => {
 
       assert.strictEqual(childSpan.name, 'span');
       assert.deepStrictEqual(
-        childSpan.parentSpanId,
+        childSpan.parentSpanContext?.spanId,
         parentSpan.spanContext().spanId
       );
     });
@@ -120,7 +120,7 @@ describe('ShimSpan', () => {
 
       assert.strictEqual(childSpan.name, 'child');
       assert.deepStrictEqual(
-        childSpan.parentSpanId,
+        childSpan.parentSpanContext?.spanId,
         parentSpan.spanContext().spanId
       );
     });

--- a/experimental/packages/shim-opencensus/test/ShimTracer.test.ts
+++ b/experimental/packages/shim-opencensus/test/ShimTracer.test.ts
@@ -92,7 +92,7 @@ describe('ShimTracer', () => {
         otelSpans[0].spanContext().traceId,
         '9e7ecdc193765065fee1efe757fdd874'
       );
-      assert.strictEqual(otelSpans[0].parentSpanId, '4bf6239d37d8b0f0');
+      assert.strictEqual(otelSpans[0].parentSpanContext?.spanId, '4bf6239d37d8b0f0');
     });
 
     it('should set the span as root span in context', async () => {
@@ -154,7 +154,7 @@ describe('ShimTracer', () => {
         parent.end();
       });
       assert.strictEqual(
-        childSpan.parentSpanId,
+        childSpan.parentSpanContext?.spanId,
         parentSpan.spanContext().spanId
       );
     });
@@ -171,7 +171,7 @@ describe('ShimTracer', () => {
           }
         );
       });
-      assert.strictEqual(childSpan.parentSpanId, rootSpan.spanContext().spanId);
+      assert.strictEqual(childSpan.parentSpanContext?.spanId, rootSpan.spanContext().spanId);
     });
   });
 

--- a/experimental/packages/shim-opencensus/test/otel-sandwich.test.ts
+++ b/experimental/packages/shim-opencensus/test/otel-sandwich.test.ts
@@ -38,7 +38,7 @@ describe('OpenTelemetry sandwich', () => {
       childSpan.spanContext().traceId,
       parentSpan.spanContext().traceId
     );
-    assert.strictEqual(childSpan.parentSpanId, parentSpan.spanContext().spanId);
+    assert.strictEqual(childSpan.parentSpanContext?.spanId, parentSpan.spanContext().spanId);
   });
 
   it('should maintain parent-child relationship for OC -> OTel', async () => {
@@ -55,7 +55,7 @@ describe('OpenTelemetry sandwich', () => {
       childSpan.spanContext().traceId,
       parentSpan.spanContext().traceId
     );
-    assert.strictEqual(childSpan.parentSpanId, parentSpan.spanContext().spanId);
+    assert.strictEqual(childSpan.parentSpanContext?.spanId, parentSpan.spanContext().spanId);
   });
 
   it('should maintain structure for OTel -> OC -> OTel', async () => {
@@ -80,9 +80,9 @@ describe('OpenTelemetry sandwich', () => {
       parentSpan.spanContext().traceId
     );
     assert.strictEqual(
-      middleSpan.parentSpanId,
+      middleSpan.parentSpanContext?.spanId,
       parentSpan.spanContext().spanId
     );
-    assert.strictEqual(childSpan.parentSpanId, middleSpan.spanContext().spanId);
+    assert.strictEqual(childSpan.parentSpanContext?.spanId, middleSpan.spanContext().spanId);
   });
 });

--- a/packages/opentelemetry-exporter-jaeger/src/transform.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/transform.ts
@@ -43,8 +43,8 @@ export function spanToThrift(span: ReadableSpan): ThriftSpan {
   const traceId = span.spanContext().traceId.padStart(32, '0');
   const traceIdHigh = traceId.slice(0, 16);
   const traceIdLow = traceId.slice(16);
-  const parentSpan = span.parentSpanId
-    ? Utils.encodeInt64(span.parentSpanId)
+  const parentSpan = span.parentSpanContext?.spanId
+    ? Utils.encodeInt64(span.parentSpanContext.spanId)
     : ThriftUtils.emptyBuffer;
 
   const tags = Object.keys(span.attributes).map(

--- a/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
@@ -237,7 +237,11 @@ describe('transform', () => {
           code: api.SpanStatusCode.OK,
         },
         attributes: {},
-        parentSpanId: '3e0c63257de34c92',
+        parentSpanContext: {
+          traceId: 'a4cda95b652f4a1592b449d5929fda1b',
+          spanId: '3e0c63257de34c92',
+          traceFlags: TraceFlags.SAMPLED,
+        },
         links: [
           {
             context: {

--- a/packages/opentelemetry-exporter-zipkin/src/transform.ts
+++ b/packages/opentelemetry-exporter-zipkin/src/transform.ts
@@ -43,7 +43,7 @@ export function toZipkinSpan(
 ): zipkinTypes.Span {
   const zipkinSpan: zipkinTypes.Span = {
     traceId: span.spanContext().traceId,
-    parentId: span.parentSpanId,
+    parentId: span.parentSpanContext?.spanId,
     name: span.name,
     id: span.spanContext().spanId,
     kind: ZIPKIN_SPAN_KIND_MAPPING[span.kind],

--- a/packages/opentelemetry-exporter-zipkin/test/helper.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/helper.ts
@@ -30,7 +30,11 @@ export const mockedReadableSpan: ReadableSpan = {
       traceFlags: TraceFlags.SAMPLED,
     };
   },
-  parentSpanId: '78a8915098864388',
+  parentSpanContext: {
+    spanId: '78a8915098864388',
+    traceId: '1f1008dc8e270e85c40a0d7c3939b278',
+    traceFlags: TraceFlags.SAMPLED,
+  },
   startTime: [1574120165, 429803070],
   endTime: [1574120165, 438688070],
   ended: true,

--- a/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
@@ -138,7 +138,11 @@ describe('Zipkin Exporter - node', () => {
       const span1: ReadableSpan = {
         name: 'my-span',
         kind: api.SpanKind.INTERNAL,
-        parentSpanId,
+        parentSpanContext: {
+          spanId: parentSpanId,
+          traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+          traceFlags: TraceFlags.NONE,
+        },
         spanContext: () => {
           return {
             traceId: 'd4cda95b652f4a1592b449d5929fda1b',
@@ -359,7 +363,11 @@ describe('Zipkin Exporter - node', () => {
     const span1: ReadableSpan = {
       name: 'my-span',
       kind: api.SpanKind.INTERNAL,
-      parentSpanId,
+      parentSpanContext: {
+        spanId: parentSpanId,
+        traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+        traceFlags: TraceFlags.NONE,
+      },
       spanContext: () => ({
         traceId: 'd4cda95b652f4a1592b449d5929fda1b',
         spanId: '6e0c63257de34c92',
@@ -454,7 +462,11 @@ describe('Zipkin Exporter - node', () => {
     const span1: ReadableSpan = {
       name: 'my-span',
       kind: api.SpanKind.INTERNAL,
-      parentSpanId,
+      parentSpanContext: {
+        spanId: parentSpanId,
+        traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+        traceFlags: TraceFlags.NONE,
+      },
       spanContext: () => ({
         traceId: 'd4cda95b652f4a1592b449d5929fda1b',
         spanId: '6e0c63257de34c92',

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -67,7 +67,7 @@ interface SpanOptions {
   spanContext: SpanContext;
   name: string;
   kind: SpanKind;
-  parentSpanId?: string;
+  parentSpanContext?: SpanContext;
   links?: Link[];
   startTime?: TimeInput;
   attributes?: Attributes;
@@ -83,7 +83,7 @@ export class SpanImpl implements Span {
   // purposes but are not intended to be written-to directly.
   private readonly _spanContext: SpanContext;
   readonly kind: SpanKind;
-  readonly parentSpanId?: string;
+  readonly parentSpanContext?: SpanContext;
   readonly attributes: Attributes = {};
   readonly links: Link[] = [];
   readonly events: TimedEvent[] = [];
@@ -127,7 +127,7 @@ export class SpanImpl implements Span {
     this._spanProcessor = opts.spanProcessor;
 
     this.name = opts.name;
-    this.parentSpanId = opts.parentSpanId;
+    this.parentSpanContext = opts.parentSpanContext;
     this.kind = opts.kind;
     this.links = opts.links || [];
     this.startTime = this._getTime(opts.startTime ?? now);

--- a/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
@@ -88,7 +88,6 @@ export class Tracer implements api.Tracer {
     const spanId = this._idGenerator.generateSpanId();
     let traceId;
     let traceState;
-    let parentSpanId;
     if (
       !parentSpanContext ||
       !api.trace.isSpanContextValid(parentSpanContext)
@@ -99,7 +98,6 @@ export class Tracer implements api.Tracer {
       // New child span.
       traceId = parentSpanContext.traceId;
       traceState = parentSpanContext.traceState;
-      parentSpanId = parentSpanContext.spanId;
     }
 
     const spanKind = options.kind ?? api.SpanKind.INTERNAL;
@@ -149,7 +147,7 @@ export class Tracer implements api.Tracer {
       name,
       kind: spanKind,
       links,
-      parentSpanId,
+      parentSpanContext: parentSpanContext,
       attributes: initAttributes,
       startTime: options.startTime,
       spanProcessor: this._spanProcessor,

--- a/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
@@ -69,7 +69,7 @@ export class ConsoleSpanExporter implements SpanExporter {
       },
       instrumentationScope: span.instrumentationScope,
       traceId: span.spanContext().traceId,
-      parentId: span.parentSpanId,
+      parentSpanContext: span.parentSpanContext,
       traceState: span.spanContext().traceState?.serialize(),
       name: span.name,
       id: span.spanContext().spanId,

--- a/packages/opentelemetry-sdk-trace-base/src/export/ReadableSpan.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/ReadableSpan.ts
@@ -30,7 +30,7 @@ export interface ReadableSpan {
   readonly name: string;
   readonly kind: SpanKind;
   readonly spanContext: () => SpanContext;
-  readonly parentSpanId?: string;
+  readonly parentSpanContext?: SpanContext;
   readonly startTime: HrTime;
   readonly endTime: HrTime;
   readonly status: SpanStatus;

--- a/packages/opentelemetry-sdk-trace-base/test/common/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/BasicTracerProvider.test.ts
@@ -588,7 +588,7 @@ describe('BasicTracerProvider', () => {
         )
       );
       assert.ok(span instanceof SpanImpl);
-      assert.deepStrictEqual((span as Span).parentSpanId, undefined);
+      assert.deepStrictEqual((span as Span).parentSpanContext?.spanId, undefined);
     });
 
     it('should start a span with name and with invalid spancontext', () => {

--- a/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
@@ -1005,14 +1005,18 @@ describe('Span', () => {
       spanContext,
       name: 'my-span',
       kind: SpanKind.INTERNAL,
-      parentSpanId: parentId,
+      parentSpanContext: {
+        spanId: parentId,
+        traceId: "",
+        traceFlags: TraceFlags.SAMPLED,
+      },
       spanLimits: tracer.getSpanLimits(),
       spanProcessor: tracer['_spanProcessor'],
     });
 
     assert.strictEqual(span.name, 'my-span');
     assert.strictEqual(span.kind, SpanKind.INTERNAL);
-    assert.strictEqual(span.parentSpanId, parentId);
+    assert.strictEqual(span.parentSpanContext?.spanId, parentId);
     assert.strictEqual(span.spanContext().traceId, spanContext.traceId);
     assert.deepStrictEqual(span.status, {
       code: SpanStatusCode.UNSET,

--- a/packages/opentelemetry-sdk-trace-base/test/common/Tracer.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Tracer.test.ts
@@ -234,7 +234,7 @@ describe('Tracer', () => {
       undefined,
       trace.setSpanContext(ROOT_CONTEXT, parent)
     );
-    assert.strictEqual((span as Span).parentSpanId, parent.spanId);
+    assert.strictEqual((span as Span).parentSpanContext?.spanId, parent.spanId);
     assert.strictEqual(span.spanContext().traceId, parent.traceId);
     assert.strictEqual(span.spanContext().traceState, traceState);
   });
@@ -256,7 +256,7 @@ describe('Tracer', () => {
       undefined,
       trace.setSpanContext(ROOT_CONTEXT, parent)
     );
-    assert.strictEqual((span as Span).parentSpanId, undefined);
+    assert.strictEqual((span as Span).parentSpanContext?.spanId, undefined);
   });
 
   it('should pass the same context to sampler and spanprocessor', () => {
@@ -282,7 +282,7 @@ describe('Tracer', () => {
       tp['_activeSpanProcessor']
     );
     const span = tracer.startSpan('a', {}, context) as Span;
-    assert.strictEqual(span.parentSpanId, parent.spanId);
+    assert.strictEqual(span.parentSpanContext?.spanId, parent.spanId);
     sinon.assert.calledOnceWithExactly(
       shouldSampleSpy,
       context,
@@ -318,7 +318,7 @@ describe('Tracer', () => {
       tp['_activeSpanProcessor']
     );
     const span = tracer.startSpan('a', { root: true }, context) as Span;
-    assert.strictEqual(span.parentSpanId, undefined);
+    assert.strictEqual(span.parentSpanContext?.spanId, undefined);
     sinon.assert.calledOnce(shouldSampleSpy);
     sinon.assert.calledOnce(onStartSpy);
     const samplerContext = shouldSampleSpy.firstCall.args[0];

--- a/packages/opentelemetry-sdk-trace-base/test/common/export/InMemorySpanExporter.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/export/InMemorySpanExporter.test.ts
@@ -63,8 +63,8 @@ describe('InMemorySpanExporter', () => {
       span2.spanContext().traceId,
       span3.spanContext().traceId
     );
-    assert.strictEqual(span1.parentSpanId, span2.spanContext().spanId);
-    assert.strictEqual(span2.parentSpanId, span3.spanContext().spanId);
+    assert.strictEqual(span1.parentSpanContext?.spanId, span2.spanContext().spanId);
+    assert.strictEqual(span2.parentSpanContext?.spanId, span3.spanContext().spanId);
   });
 
   it('should shutdown the exporter', () => {

--- a/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
+++ b/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
@@ -226,7 +226,7 @@ describe('OpenTracing Shim', () => {
           childOf: span,
         }) as SpanShim;
         assert.strictEqual(
-          (childSpan.getSpan() as Span).parentSpanId,
+          (childSpan.getSpan() as Span).parentSpanContext?.spanId,
           context.toSpanId()
         );
         assert.strictEqual(
@@ -240,7 +240,7 @@ describe('OpenTracing Shim', () => {
           childOf: context,
         }) as SpanShim;
         assert.strictEqual(
-          (childSpan.getSpan() as Span).parentSpanId,
+          (childSpan.getSpan() as Span).parentSpanContext?.spanId,
           context.toSpanId()
         );
         assert.strictEqual(


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This PR adds the parentSpanContext to the Span and ReadableSpan in order to adhere to the OTel spec. And removes the `parentSpanId` as it is now redundant.

Targets main OTel branch and will be accompanies another PR against the 1.x branch: #5422.

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/5345

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Existing tests have been updated to include checks for the new `parentSpanContext` values and remove those checks for the former `parentSpanId` value.

- [ ] Test A

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
