### PR TITLE
feat(resources): use functions over constants for default and empty resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,8 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
   * Renames `Resource` class to `ResourceImpl` and makes it package-private
   * Renames `IResource` interface to `Resource`
   * Export function `resourceFromAttributes` to create a `Resource` from a `DetectedAttributes` object
+  * Export function `defaultResource` to create a default resource [#5467](https://github.com/open-telemetry/opentelemetry-js/pull/5467) @pichlermarc
+  * Export function `emptyResource` to create an empty resource [#5467](https://github.com/open-telemetry/opentelemetry-js/pull/5467) @pichlermarc
   * Only export types and functions. This aids in cross-version compatibility and makes it more easily extensible in the future.
 
 ### :rocket: (Enhancement)

--- a/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
+++ b/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
@@ -19,7 +19,7 @@ import {
   DetectedResource,
   ResourceDetector,
   ResourceDetectionConfig,
-  EMPTY_RESOURCE,
+  emptyResource,
 } from '@opentelemetry/resources';
 import { BROWSER_ATTRIBUTES, UserAgentData } from './types';
 
@@ -30,7 +30,7 @@ class BrowserDetector implements ResourceDetector {
   detect(config?: ResourceDetectionConfig): DetectedResource {
     const isBrowser = typeof navigator !== 'undefined';
     if (!isBrowser) {
-      return EMPTY_RESOURCE;
+      return emptyResource();
     }
     const browserResource: Attributes = getBrowserAttributes();
     return this._getResourceAttributes(browserResource, config);
@@ -53,7 +53,7 @@ class BrowserDetector implements ResourceDetector {
       diag.debug(
         'BrowserDetector failed: Unable to find required browser resources. '
       );
-      return EMPTY_RESOURCE;
+      return emptyResource();
     } else {
       return { attributes: browserResource };
     }

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/util.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/util.ts
@@ -29,23 +29,19 @@ export function mockHrTime() {
   sinon.useFakeTimers(mockedHrTimeMs);
 }
 
-export const serviceName = defaultResource().attributes[
-  SEMRESATTRS_SERVICE_NAME
-]?.toString()
+export const serviceName = defaultResource()
+  .attributes[SEMRESATTRS_SERVICE_NAME]?.toString()
   .replace(/\\/g, '\\\\')
   .replace(/\n/g, '\\n');
-export const sdkLanguage = defaultResource().attributes[
-  SEMRESATTRS_TELEMETRY_SDK_LANGUAGE
-]?.toString()
+export const sdkLanguage = defaultResource()
+  .attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE]?.toString()
   .replace(/\\/g, '\\\\')
   .replace(/\n/g, '\\n');
-export const sdkName = defaultResource().attributes[
-  SEMRESATTRS_TELEMETRY_SDK_NAME
-]?.toString()
+export const sdkName = defaultResource()
+  .attributes[SEMRESATTRS_TELEMETRY_SDK_NAME]?.toString()
   .replace(/\\/g, '\\\\')
   .replace(/\n/g, '\\n');
-export const sdkVersion = defaultResource().attributes[
-  SEMRESATTRS_TELEMETRY_SDK_VERSION
-]?.toString()
+export const sdkVersion = defaultResource()
+  .attributes[SEMRESATTRS_TELEMETRY_SDK_VERSION]?.toString()
   .replace(/\\/g, '\\\\')
   .replace(/\n/g, '\\n');

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/util.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/util.ts
@@ -15,7 +15,7 @@
  */
 
 import * as sinon from 'sinon';
-import { DEFAULT_RESOURCE } from '@opentelemetry/resources';
+import { defaultResource } from '@opentelemetry/resources';
 import {
   SEMRESATTRS_SERVICE_NAME,
   SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
@@ -29,22 +29,22 @@ export function mockHrTime() {
   sinon.useFakeTimers(mockedHrTimeMs);
 }
 
-export const serviceName = DEFAULT_RESOURCE.attributes[
+export const serviceName = defaultResource().attributes[
   SEMRESATTRS_SERVICE_NAME
 ]?.toString()
   .replace(/\\/g, '\\\\')
   .replace(/\n/g, '\\n');
-export const sdkLanguage = DEFAULT_RESOURCE.attributes[
+export const sdkLanguage = defaultResource().attributes[
   SEMRESATTRS_TELEMETRY_SDK_LANGUAGE
 ]?.toString()
   .replace(/\\/g, '\\\\')
   .replace(/\n/g, '\\n');
-export const sdkName = DEFAULT_RESOURCE.attributes[
+export const sdkName = defaultResource().attributes[
   SEMRESATTRS_TELEMETRY_SDK_NAME
 ]?.toString()
   .replace(/\\/g, '\\\\')
   .replace(/\n/g, '\\n');
-export const sdkVersion = DEFAULT_RESOURCE.attributes[
+export const sdkVersion = defaultResource().attributes[
   SEMRESATTRS_TELEMETRY_SDK_VERSION
 ]?.toString()
   .replace(/\\/g, '\\\\')

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -27,7 +27,7 @@ import {
   registerInstrumentations,
 } from '@opentelemetry/instrumentation';
 import {
-  DEFAULT_RESOURCE,
+  defaultResource,
   detectResources,
   envDetector,
   hostDetector,
@@ -245,7 +245,7 @@ export class NodeSDK {
 
     this._configuration = configuration;
 
-    this._resource = configuration.resource ?? DEFAULT_RESOURCE;
+    this._resource = configuration.resource ?? defaultResource();
     this._autoDetectResources = configuration.autoDetectResources ?? true;
     if (!this._autoDetectResources) {
       this._resourceDetectors = [];

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -66,7 +66,7 @@ import {
   hostDetector,
   serviceInstanceIdDetector,
   DetectedResource,
-  DEFAULT_RESOURCE,
+  defaultResource,
 } from '@opentelemetry/resources';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { logs, ProxyLoggerProvider } from '@opentelemetry/api-logs';
@@ -956,7 +956,7 @@ describe('Node SDK', () => {
         const resource = sdk['_resource'];
         await resource.waitForAsyncAttributes?.();
 
-        assert.deepStrictEqual(resource, DEFAULT_RESOURCE);
+        assert.deepStrictEqual(resource, defaultResource());
         await sdk.shutdown();
       });
     });

--- a/experimental/packages/sampler-jaeger-remote/README.md
+++ b/experimental/packages/sampler-jaeger-remote/README.md
@@ -19,7 +19,7 @@ To integrate the Jaeger Remote Sampler with your application, configure it with 
 
 ```javascript
 const { JaegerRemoteSampler } = require('@opentelemetry/sampler-jaeger-remote');
-const { DEFAULT_RESOURCE, resourceFromAttributes } = require('@opentelemetry/resources');
+const { defaultResource, resourceFromAttributes } = require('@opentelemetry/resources');
 const { NodeTracerProvider } = require('@opentelemetry/node');
 
 // Jaeger agent endpoint
@@ -30,7 +30,7 @@ const sampler = new JaegerRemoteSampler({
   poolingInterval: 60000  // 60 seconds
 });
 const provider = new NodeTracerProvider({
-  resource: DEFAULT_RESOURCE.merge(resourceFromAttributes({
+  resource: defaultResource().merge(resourceFromAttributes({
     'service.name': 'your-service-name'
   })),
   sampler

--- a/experimental/packages/sdk-logs/src/LoggerProvider.ts
+++ b/experimental/packages/sdk-logs/src/LoggerProvider.ts
@@ -16,7 +16,7 @@
 import { diag } from '@opentelemetry/api';
 import type * as logsAPI from '@opentelemetry/api-logs';
 import { NOOP_LOGGER } from '@opentelemetry/api-logs';
-import { DEFAULT_RESOURCE } from '@opentelemetry/resources';
+import { defaultResource } from '@opentelemetry/resources';
 import { BindOnceFuture, merge } from '@opentelemetry/core';
 
 import type { LoggerProviderConfig } from './types';
@@ -34,7 +34,7 @@ export class LoggerProvider implements logsAPI.LoggerProvider {
 
   constructor(config: LoggerProviderConfig = {}) {
     const mergedConfig = merge({}, loadDefaultConfig(), config);
-    const resource = config.resource ?? DEFAULT_RESOURCE;
+    const resource = config.resource ?? defaultResource();
     this._sharedState = new LoggerProviderSharedState(
       resource,
       mergedConfig.forceFlushTimeoutMillis,

--- a/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
@@ -27,7 +27,7 @@ import {
 import * as logsAPI from '@opentelemetry/api-logs';
 import type { HrTime } from '@opentelemetry/api';
 import { hrTimeToMilliseconds, timeInputToHrTime } from '@opentelemetry/core';
-import { DEFAULT_RESOURCE } from '@opentelemetry/resources';
+import { defaultResource } from '@opentelemetry/resources';
 
 import {
   LogRecordLimits,
@@ -47,7 +47,7 @@ const setup = (logRecordLimits?: LogRecordLimits, data?: logsAPI.LogRecord) => {
     version: 'test version',
     schemaUrl: 'test schema url',
   };
-  const resource = DEFAULT_RESOURCE;
+  const resource = defaultResource();
   const sharedState = new LoggerProviderSharedState(
     resource,
     Infinity,

--- a/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
@@ -16,7 +16,7 @@
 import { logs, NoopLogger } from '@opentelemetry/api-logs';
 import { diag } from '@opentelemetry/api';
 import {
-  DEFAULT_RESOURCE,
+  defaultResource,
   resourceFromAttributes,
 } from '@opentelemetry/resources';
 import * as assert from 'assert';
@@ -63,7 +63,7 @@ describe('LoggerProvider', () => {
       it('should have default resource if not pass', () => {
         const provider = new LoggerProvider();
         const { resource } = provider['_sharedState'];
-        assert.deepStrictEqual(resource, DEFAULT_RESOURCE);
+        assert.deepStrictEqual(resource, defaultResource());
       });
 
       it('should not have default resource if passed', function () {

--- a/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
@@ -33,7 +33,7 @@ import { BatchLogRecordProcessorBase } from '../../../src/export/BatchLogRecordP
 import { reconfigureLimits } from '../../../src/config';
 import { LoggerProviderSharedState } from '../../../src/internal/LoggerProviderSharedState';
 import {
-  DEFAULT_RESOURCE,
+  defaultResource,
   Resource,
   resourceFromAttributes,
 } from '@opentelemetry/resources';
@@ -48,7 +48,7 @@ const createLogRecord = (
   resource?: Resource
 ): LogRecord => {
   const sharedState = new LoggerProviderSharedState(
-    resource || DEFAULT_RESOURCE,
+    resource || defaultResource(),
     Infinity,
     reconfigureLimits(limits ?? {})
   );

--- a/experimental/packages/sdk-logs/test/common/export/SimpleLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/SimpleLogRecordProcessor.test.ts
@@ -22,7 +22,7 @@ import {
   setGlobalErrorHandler,
 } from '@opentelemetry/core';
 import {
-  DEFAULT_RESOURCE,
+  defaultResource,
   Resource,
   resourceFromAttributes,
 } from '@opentelemetry/resources';
@@ -39,7 +39,7 @@ import { TestExporterWithDelay } from './TestExporterWithDelay';
 
 const setup = (exporter: LogRecordExporter, resource?: Resource) => {
   const sharedState = new LoggerProviderSharedState(
-    resource || DEFAULT_RESOURCE,
+    resource || defaultResource(),
     Infinity,
     reconfigureLimits({})
   );

--- a/experimental/packages/shim-opencensus/src/OpenCensusMetricProducer.ts
+++ b/experimental/packages/shim-opencensus/src/OpenCensusMetricProducer.ts
@@ -16,7 +16,7 @@
  */
 
 import * as oc from '@opencensus/core';
-import { EMPTY_RESOURCE } from '@opentelemetry/resources';
+import { emptyResource } from '@opentelemetry/resources';
 import {
   CollectionResult,
   MetricData,
@@ -80,7 +80,7 @@ export class OpenCensusMetricProducer implements MetricProducer {
       errors: [],
       resourceMetrics: {
         // Resource is ignored by the SDK, it just uses the SDK's resource
-        resource: EMPTY_RESOURCE,
+        resource: emptyResource(),
         scopeMetrics,
       },
     };

--- a/experimental/packages/shim-opencensus/test/OpenCensusMetricProducer.test.ts
+++ b/experimental/packages/shim-opencensus/test/OpenCensusMetricProducer.test.ts
@@ -16,7 +16,7 @@
 
 import * as oc from '@opencensus/core';
 import { ValueType } from '@opentelemetry/api';
-import { EMPTY_RESOURCE } from '@opentelemetry/resources';
+import { emptyResource } from '@opentelemetry/resources';
 import {
   AggregationTemporality,
   DataPointType,
@@ -43,7 +43,7 @@ describe('OpenCensusMetricProducer', () => {
 
     assert.deepStrictEqual(
       resourceMetrics.resourceMetrics.resource,
-      EMPTY_RESOURCE
+      emptyResource()
     );
   });
 

--- a/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/transform.test.ts
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 import { spanToThrift } from '../src/transform';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import {
-  EMPTY_RESOURCE,
+  emptyResource,
   resourceFromAttributes,
 } from '@opentelemetry/resources';
 import * as api from '@opentelemetry/api';
@@ -180,7 +180,7 @@ describe('transform', () => {
         links: [],
         events: [],
         duration: [32, 800000000],
-        resource: EMPTY_RESOURCE,
+        resource: emptyResource(),
         instrumentationScope: {
           name: 'default',
           version: '0.0.1',
@@ -250,7 +250,7 @@ describe('transform', () => {
         ],
         events: [],
         duration: [32, 800000000],
-        resource: EMPTY_RESOURCE,
+        resource: emptyResource(),
         instrumentationScope: {
           name: 'default',
           version: '0.0.1',
@@ -298,7 +298,7 @@ describe('transform', () => {
         links: [],
         events: [],
         duration: [32, 800000000],
-        resource: EMPTY_RESOURCE,
+        resource: emptyResource(),
         instrumentationScope: {
           name: 'default',
           version: '0.0.1',

--- a/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
+++ b/packages/opentelemetry-exporter-zipkin/test/node/zipkin.test.ts
@@ -24,7 +24,7 @@ import {
 } from '@opentelemetry/core';
 import * as api from '@opentelemetry/api';
 import {
-  EMPTY_RESOURCE,
+  emptyResource,
   resourceFromAttributes,
 } from '@opentelemetry/resources';
 import { ZipkinExporter } from '../../src';
@@ -57,7 +57,7 @@ function getReadableSpan() {
     attributes: {},
     links: [],
     events: [],
-    resource: EMPTY_RESOURCE,
+    resource: emptyResource(),
     instrumentationScope: { name: 'default', version: '0.0.1' },
     droppedAttributesCount: 0,
     droppedEventsCount: 0,
@@ -168,7 +168,7 @@ describe('Zipkin Exporter - node', () => {
             attributes: { key3: 'value3' },
           },
         ],
-        resource: EMPTY_RESOURCE,
+        resource: emptyResource(),
         instrumentationScope: { name: 'default', version: '0.0.1' },
         droppedAttributesCount: 0,
         droppedEventsCount: 0,
@@ -194,7 +194,7 @@ describe('Zipkin Exporter - node', () => {
         attributes: {},
         links: [],
         events: [],
-        resource: EMPTY_RESOURCE,
+        resource: emptyResource(),
         instrumentationScope: { name: 'default', version: '0.0.1' },
         droppedAttributesCount: 0,
         droppedEventsCount: 0,
@@ -483,7 +483,7 @@ describe('Zipkin Exporter - node', () => {
           attributes: { key3: 'value3' },
         },
       ],
-      resource: EMPTY_RESOURCE,
+      resource: emptyResource(),
       instrumentationScope: { name: 'default', version: '0.0.1' },
       droppedAttributesCount: 0,
       droppedEventsCount: 0,
@@ -509,7 +509,7 @@ describe('Zipkin Exporter - node', () => {
       },
       links: [],
       events: [],
-      resource: EMPTY_RESOURCE,
+      resource: emptyResource(),
       instrumentationScope: { name: 'default', version: '0.0.1' },
       droppedAttributesCount: 0,
       droppedEventsCount: 0,

--- a/packages/opentelemetry-resources/src/ResourceImpl.ts
+++ b/packages/opentelemetry-resources/src/ResourceImpl.ts
@@ -147,10 +147,15 @@ export function resourceFromDetectedResource(
   return new ResourceImpl(detectedResource);
 }
 
-export const EMPTY_RESOURCE = resourceFromAttributes({});
-export const DEFAULT_RESOURCE = resourceFromAttributes({
-  [ATTR_SERVICE_NAME]: defaultServiceName(),
-  [ATTR_TELEMETRY_SDK_LANGUAGE]: SDK_INFO[ATTR_TELEMETRY_SDK_LANGUAGE],
-  [ATTR_TELEMETRY_SDK_NAME]: SDK_INFO[ATTR_TELEMETRY_SDK_NAME],
-  [ATTR_TELEMETRY_SDK_VERSION]: SDK_INFO[ATTR_TELEMETRY_SDK_VERSION],
-});
+export function emptyResource(): Resource {
+  return resourceFromAttributes({});
+}
+
+export function defaultResource(): Resource {
+  return resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: defaultServiceName(),
+    [ATTR_TELEMETRY_SDK_LANGUAGE]: SDK_INFO[ATTR_TELEMETRY_SDK_LANGUAGE],
+    [ATTR_TELEMETRY_SDK_NAME]: SDK_INFO[ATTR_TELEMETRY_SDK_NAME],
+    [ATTR_TELEMETRY_SDK_VERSION]: SDK_INFO[ATTR_TELEMETRY_SDK_VERSION],
+  });
+}

--- a/packages/opentelemetry-resources/src/detect-resources.ts
+++ b/packages/opentelemetry-resources/src/detect-resources.ts
@@ -16,7 +16,7 @@
 
 import { diag } from '@opentelemetry/api';
 import { Resource } from './Resource';
-import { EMPTY_RESOURCE, resourceFromDetectedResource } from './ResourceImpl';
+import { emptyResource, resourceFromDetectedResource } from './ResourceImpl';
 import { ResourceDetectionConfig } from './config';
 
 /**
@@ -34,7 +34,7 @@ export const detectResources = (
       return resource;
     } catch (e) {
       diag.debug(`${d.constructor.name} failed: ${e.message}`);
-      return EMPTY_RESOURCE;
+      return emptyResource();
     }
   });
 
@@ -43,7 +43,7 @@ export const detectResources = (
 
   return resources.reduce(
     (acc, resource) => acc.merge(resource),
-    EMPTY_RESOURCE
+    emptyResource()
   );
 };
 

--- a/packages/opentelemetry-resources/src/index.ts
+++ b/packages/opentelemetry-resources/src/index.ts
@@ -26,8 +26,8 @@ export {
 export { Resource } from './Resource';
 export {
   resourceFromAttributes,
-  DEFAULT_RESOURCE,
-  EMPTY_RESOURCE,
+  defaultResource,
+  emptyResource,
 } from './ResourceImpl';
 export { defaultServiceName } from './platform';
 export {

--- a/packages/opentelemetry-resources/test/Resource.test.ts
+++ b/packages/opentelemetry-resources/test/Resource.test.ts
@@ -25,11 +25,7 @@ import {
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { describeBrowser, describeNode } from './util';
-import {
-  DEFAULT_RESOURCE,
-  EMPTY_RESOURCE,
-  resourceFromAttributes,
-} from '../src';
+import { defaultResource, emptyResource, resourceFromAttributes } from '../src';
 
 describe('Resource', () => {
   const resource1 = resourceFromAttributes({
@@ -45,7 +41,6 @@ describe('Resource', () => {
     'k8s.io/container/name': 'c2',
     'k8s.io/location': 'location1',
   });
-  const emptyResource = resourceFromAttributes({});
 
   it('should return merged resource', () => {
     const expectedResource = resourceFromAttributes({
@@ -79,13 +74,13 @@ describe('Resource', () => {
   });
 
   it('should return merged resource when first resource is empty', () => {
-    const actualResource = emptyResource.merge(resource2);
+    const actualResource = emptyResource().merge(resource2);
     assert.strictEqual(Object.keys(actualResource.attributes).length, 2);
     assert.deepStrictEqual(actualResource.attributes, resource2.attributes);
   });
 
   it('should return merged resource when other resource is empty', () => {
-    const actualResource = resource1.merge(emptyResource);
+    const actualResource = resource1.merge(emptyResource());
     assert.strictEqual(Object.keys(actualResource.attributes).length, 3);
     assert.deepStrictEqual(actualResource.attributes, resource1.attributes);
   });
@@ -131,8 +126,8 @@ describe('Resource', () => {
 
     it('should return false for asyncAttributesPending if no promise provided', () => {
       assert.ok(!resourceFromAttributes({ foo: 'bar' }).asyncAttributesPending);
-      assert.ok(!EMPTY_RESOURCE.asyncAttributesPending);
-      assert.ok(!DEFAULT_RESOURCE.asyncAttributesPending);
+      assert.ok(!emptyResource().asyncAttributesPending);
+      assert.ok(!defaultResource().asyncAttributesPending);
     });
 
     it('should return false for asyncAttributesPending once promise settles', async () => {
@@ -267,7 +262,7 @@ describe('Resource', () => {
 
   describeNode('.default()', () => {
     it('should return a default resource', () => {
-      const resource = DEFAULT_RESOURCE;
+      const resource = defaultResource();
       assert.strictEqual(
         resource.attributes[SEMRESATTRS_TELEMETRY_SDK_NAME],
         SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_NAME]
@@ -289,7 +284,7 @@ describe('Resource', () => {
 
   describeBrowser('.default()', () => {
     it('should return a default resource', () => {
-      const resource = DEFAULT_RESOURCE;
+      const resource = defaultResource();
       assert.strictEqual(
         resource.attributes[SEMRESATTRS_TELEMETRY_SDK_NAME],
         SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_NAME]

--- a/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts
@@ -28,7 +28,7 @@ import {
   W3CTraceContextPropagator,
   merge,
 } from '@opentelemetry/core';
-import { DEFAULT_RESOURCE, Resource } from '@opentelemetry/resources';
+import { defaultResource, Resource } from '@opentelemetry/resources';
 import { SpanProcessor } from './SpanProcessor';
 import { Tracer } from './Tracer';
 import { loadDefaultConfig } from './config';
@@ -62,7 +62,7 @@ export class BasicTracerProvider implements TracerProvider {
       loadDefaultConfig(),
       reconfigureLimits(config)
     );
-    this._resource = mergedConfig.resource ?? DEFAULT_RESOURCE;
+    this._resource = mergedConfig.resource ?? defaultResource();
 
     this._config = Object.assign({}, mergedConfig, {
       resource: this._resource,

--- a/packages/opentelemetry-sdk-trace-base/test/common/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/BasicTracerProvider.test.ts
@@ -31,7 +31,7 @@ import {
 import { CompositePropagator } from '@opentelemetry/core';
 import { TraceState } from '@opentelemetry/core';
 import {
-  DEFAULT_RESOURCE,
+  defaultResource,
   resourceFromAttributes,
 } from '@opentelemetry/resources';
 import * as assert from 'assert';
@@ -729,7 +729,7 @@ describe('BasicTracerProvider', () => {
   describe('.resource', () => {
     it('should use the default resource when no resource is provided', function () {
       const tracerProvider = new BasicTracerProvider();
-      assert.deepStrictEqual(tracerProvider['_resource'], DEFAULT_RESOURCE);
+      assert.deepStrictEqual(tracerProvider['_resource'], defaultResource());
     });
 
     it('should use not use the default if resource passed', function () {

--- a/packages/sdk-metrics/src/MeterProvider.ts
+++ b/packages/sdk-metrics/src/MeterProvider.ts
@@ -21,7 +21,7 @@ import {
   MeterOptions,
   createNoopMeter,
 } from '@opentelemetry/api';
-import { DEFAULT_RESOURCE, Resource } from '@opentelemetry/resources';
+import { defaultResource, Resource } from '@opentelemetry/resources';
 import { IMetricReader } from './export/MetricReader';
 import { MeterProviderSharedState } from './state/MeterProviderSharedState';
 import { MetricCollector } from './state/MetricCollector';
@@ -47,7 +47,7 @@ export class MeterProvider implements IMeterProvider {
 
   constructor(options?: MeterProviderOptions) {
     this._sharedState = new MeterProviderSharedState(
-      options?.resource ?? DEFAULT_RESOURCE
+      options?.resource ?? defaultResource()
     );
     if (options?.views != null && options.views.length > 0) {
       for (const viewOption of options.views) {

--- a/packages/sdk-metrics/test/Instruments.test.ts
+++ b/packages/sdk-metrics/test/Instruments.test.ts
@@ -35,7 +35,7 @@ import {
   commonAttributes,
   commonValues,
   defaultInstrumentationScope,
-  defaultResource,
+  testResource,
 } from './util';
 import { ObservableResult, ValueType } from '@opentelemetry/api';
 import { IMetricReader } from '../src/export/MetricReader';
@@ -816,7 +816,7 @@ function setup() {
   const deltaReader = new TestDeltaMetricReader();
   const cumulativeReader = new TestMetricReader();
   const meterProvider = new MeterProvider({
-    resource: defaultResource,
+    resource: testResource,
     readers: [deltaReader, cumulativeReader],
   });
   const meter = meterProvider.getMeter(
@@ -858,7 +858,7 @@ async function validateExport(
   const { scope, metrics } = scopeMetrics[0];
 
   assert.ok(!resource.asyncAttributesPending);
-  assert.deepStrictEqual(resource.attributes, defaultResource.attributes);
+  assert.deepStrictEqual(resource.attributes, testResource.attributes);
   assert.deepStrictEqual(scope, defaultInstrumentationScope);
 
   const metric = metrics[0];

--- a/packages/sdk-metrics/test/Meter.test.ts
+++ b/packages/sdk-metrics/test/Meter.test.ts
@@ -31,7 +31,7 @@ import { MeterProviderSharedState } from '../src/state/MeterProviderSharedState'
 import { MeterSharedState } from '../src/state/MeterSharedState';
 import {
   defaultInstrumentationScope,
-  defaultResource,
+  testResource,
   invalidNames,
   validNames,
 } from './util';
@@ -44,7 +44,7 @@ describe('Meter', () => {
   describe('createCounter', () => {
     testWithNames('counter', name => {
       const meterSharedState = new MeterSharedState(
-        new MeterProviderSharedState(defaultResource),
+        new MeterProviderSharedState(testResource),
         defaultInstrumentationScope
       );
       const meter = new Meter(meterSharedState);
@@ -56,7 +56,7 @@ describe('Meter', () => {
   describe('createUpDownCounter', () => {
     testWithNames('UpDownCounter', name => {
       const meterSharedState = new MeterSharedState(
-        new MeterProviderSharedState(defaultResource),
+        new MeterProviderSharedState(testResource),
         defaultInstrumentationScope
       );
       const meter = new Meter(meterSharedState);
@@ -68,7 +68,7 @@ describe('Meter', () => {
   describe('createHistogram', () => {
     testWithNames('Histogram', name => {
       const meterSharedState = new MeterSharedState(
-        new MeterProviderSharedState(defaultResource),
+        new MeterProviderSharedState(testResource),
         defaultInstrumentationScope
       );
       const meter = new Meter(meterSharedState);
@@ -80,7 +80,7 @@ describe('Meter', () => {
   describe('createObservableGauge', () => {
     testWithNames('ObservableGauge', name => {
       const meterSharedState = new MeterSharedState(
-        new MeterProviderSharedState(defaultResource),
+        new MeterProviderSharedState(testResource),
         defaultInstrumentationScope
       );
       const meter = new Meter(meterSharedState);
@@ -92,7 +92,7 @@ describe('Meter', () => {
   describe('createGauge', () => {
     testWithNames('Gauge', name => {
       const meterSharedState = new MeterSharedState(
-        new MeterProviderSharedState(defaultResource),
+        new MeterProviderSharedState(testResource),
         defaultInstrumentationScope
       );
       const meter = new Meter(meterSharedState);
@@ -104,7 +104,7 @@ describe('Meter', () => {
   describe('createObservableCounter', () => {
     testWithNames('ObservableCounter', name => {
       const meterSharedState = new MeterSharedState(
-        new MeterProviderSharedState(defaultResource),
+        new MeterProviderSharedState(testResource),
         defaultInstrumentationScope
       );
       const meter = new Meter(meterSharedState);
@@ -116,7 +116,7 @@ describe('Meter', () => {
   describe('createObservableUpDownCounter', () => {
     testWithNames('ObservableUpDownCounter', name => {
       const meterSharedState = new MeterSharedState(
-        new MeterProviderSharedState(defaultResource),
+        new MeterProviderSharedState(testResource),
         defaultInstrumentationScope
       );
       const meter = new Meter(meterSharedState);
@@ -130,7 +130,7 @@ describe('Meter', () => {
   describe('addBatchObservableCallback', () => {
     it('should register callback without exception', () => {
       const meterSharedState = new MeterSharedState(
-        new MeterProviderSharedState(defaultResource),
+        new MeterProviderSharedState(testResource),
         defaultInstrumentationScope
       );
       const meter = new Meter(meterSharedState);
@@ -149,7 +149,7 @@ describe('Meter', () => {
 
     it('should be tolerant with unknown observables', () => {
       const meterSharedState = new MeterSharedState(
-        new MeterProviderSharedState(defaultResource),
+        new MeterProviderSharedState(testResource),
         defaultInstrumentationScope
       );
       const meter = new Meter(meterSharedState);
@@ -162,7 +162,7 @@ describe('Meter', () => {
   describe('removeBatchObservableCallback', () => {
     it('should remove callback without exception', () => {
       const meterSharedState = new MeterSharedState(
-        new MeterProviderSharedState(defaultResource),
+        new MeterProviderSharedState(testResource),
         defaultInstrumentationScope
       );
       const meter = new Meter(meterSharedState);

--- a/packages/sdk-metrics/test/MeterProvider.test.ts
+++ b/packages/sdk-metrics/test/MeterProvider.test.ts
@@ -26,7 +26,7 @@ import {
   assertScopeMetrics,
   assertMetricData,
   assertPartialDeepStrictEqual,
-  defaultResource,
+  testResource,
 } from './util';
 import { TestMetricReader } from './export/TestMetricReader';
 import * as sinon from 'sinon';
@@ -34,7 +34,7 @@ import { Meter } from '../src/Meter';
 import { createAllowListAttributesProcessor } from '../src/view/AttributesProcessor';
 import { AggregationType } from '../src/view/AggregationOption';
 import {
-  DEFAULT_RESOURCE,
+  defaultResource,
   resourceFromAttributes,
 } from '@opentelemetry/resources';
 
@@ -50,7 +50,7 @@ describe('MeterProvider', () => {
     });
 
     it('construct with resource', () => {
-      const meterProvider = new MeterProvider({ resource: defaultResource });
+      const meterProvider = new MeterProvider({ resource: testResource });
       assert.ok(meterProvider instanceof MeterProvider);
     });
 
@@ -68,7 +68,7 @@ describe('MeterProvider', () => {
 
       // Perform collection.
       const { resourceMetrics } = await reader.collect();
-      assert.deepStrictEqual(resourceMetrics.resource, DEFAULT_RESOURCE);
+      assert.deepStrictEqual(resourceMetrics.resource, defaultResource());
     });
 
     it('should use the resource passed in constructor', async function () {
@@ -103,7 +103,7 @@ describe('MeterProvider', () => {
 
       // Perform collection.
       const { resourceMetrics } = await reader.collect();
-      assert.deepStrictEqual(resourceMetrics.resource, DEFAULT_RESOURCE);
+      assert.deepStrictEqual(resourceMetrics.resource, defaultResource());
     });
   });
 
@@ -132,7 +132,7 @@ describe('MeterProvider', () => {
     it('get meter with same identity', async () => {
       const reader = new TestMetricReader();
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         readers: [reader],
       });
 
@@ -192,7 +192,7 @@ describe('MeterProvider', () => {
     it('with existing instrument should rename', async () => {
       const reader = new TestMetricReader();
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         // Add view to rename 'non-renamed-instrument' to 'renamed-instrument'
         views: [
           {
@@ -262,7 +262,7 @@ describe('MeterProvider', () => {
 
       // Add view to drop all attributes except 'attrib1'
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         views: [
           {
             attributesProcessors: [
@@ -330,7 +330,7 @@ describe('MeterProvider', () => {
 
       // Add view that renames 'test-counter' to 'renamed-instrument'
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         views: [
           {
             name: 'renamed-instrument',
@@ -401,7 +401,7 @@ describe('MeterProvider', () => {
     it('with meter name should apply view to only the selected meter', async () => {
       const reader = new TestMetricReader();
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         views: [
           // Add view that renames 'test-counter' to 'renamed-instrument' on 'meter1'
           {
@@ -474,7 +474,7 @@ describe('MeterProvider', () => {
     it('with different instrument types does not throw', async () => {
       const reader = new TestMetricReader();
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         // Add Views to rename both instruments (of different types) to the same name.
         views: [
           {
@@ -543,7 +543,7 @@ describe('MeterProvider', () => {
       const reader = new TestMetricReader();
 
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         views: [
           {
             instrumentUnit: 'ms',
@@ -611,7 +611,7 @@ describe('MeterProvider', () => {
     it('should respect the aggregationCardinalityLimit', async () => {
       const reader = new TestMetricReader();
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         readers: [reader],
         views: [
           {
@@ -656,7 +656,7 @@ describe('MeterProvider', () => {
     it('should respect the aggregationCardinalityLimit for observable counter', async () => {
       const reader = new TestMetricReader();
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         readers: [reader],
         views: [
           {
@@ -707,7 +707,7 @@ describe('MeterProvider', () => {
         cardinalitySelector: (instrumentType: InstrumentType) => 2, // Set cardinality limit to 2 via cardinalitySelector
       });
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         readers: [reader],
       });
 
@@ -748,7 +748,7 @@ describe('MeterProvider', () => {
     it('should respect the default aggregationCardinalityLimit', async () => {
       const reader = new TestMetricReader();
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         readers: [reader],
       });
 
@@ -792,7 +792,7 @@ describe('MeterProvider', () => {
       const reader1ShutdownSpy = sinon.spy(reader1, 'shutdown');
       const reader2ShutdownSpy = sinon.spy(reader2, 'shutdown');
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         readers: [reader1, reader2],
       });
 
@@ -818,7 +818,7 @@ describe('MeterProvider', () => {
       const reader1ForceFlushSpy = sinon.spy(reader1, 'forceFlush');
       const reader2ForceFlushSpy = sinon.spy(reader2, 'forceFlush');
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         readers: [reader1, reader2],
       });
 

--- a/packages/sdk-metrics/test/export/ConsoleMetricExporter.test.ts
+++ b/packages/sdk-metrics/test/export/ConsoleMetricExporter.test.ts
@@ -19,7 +19,7 @@ import { ConsoleMetricExporter } from '../../src/export/ConsoleMetricExporter';
 import { PeriodicExportingMetricReader } from '../../src/export/PeriodicExportingMetricReader';
 import { ResourceMetrics } from '../../src/export/MetricData';
 import { MeterProvider } from '../../src/MeterProvider';
-import { defaultResource } from '../util';
+import { testResource } from '../util';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { assertAggregationTemporalitySelector } from './utils';
@@ -64,7 +64,7 @@ describe('ConsoleMetricExporter', () => {
         exportTimeoutMillis: 100,
       });
       meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         readers: [metricReader],
       });
       meter = meterProvider.getMeter('ConsoleMetricExporter', '1.0.0');

--- a/packages/sdk-metrics/test/export/InMemoryMetricExporter.test.ts
+++ b/packages/sdk-metrics/test/export/InMemoryMetricExporter.test.ts
@@ -21,7 +21,7 @@ import { InMemoryMetricExporter } from '../../src/export/InMemoryMetricExporter'
 import { ResourceMetrics } from '../../src/export/MetricData';
 import { PeriodicExportingMetricReader } from '../../src/export/PeriodicExportingMetricReader';
 import { MeterProvider } from '../../src/MeterProvider';
-import { defaultResource } from '../util';
+import { testResource } from '../util';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 
 async function waitForNumberOfExports(
@@ -56,7 +56,7 @@ describe('InMemoryMetricExporter', () => {
       exportTimeoutMillis: 100,
     });
     meterProvider = new MeterProvider({
-      resource: defaultResource,
+      resource: testResource,
       readers: [metricReader],
     });
     meter = meterProvider.getMeter('InMemoryMetricExporter', '1.0.0');

--- a/packages/sdk-metrics/test/export/MetricReader.test.ts
+++ b/packages/sdk-metrics/test/export/MetricReader.test.ts
@@ -34,7 +34,7 @@ import {
   assertAggregationSelector,
   assertAggregationTemporalitySelector,
 } from './utils';
-import { defaultResource } from '../util';
+import { testResource } from '../util';
 import { ValueType } from '@opentelemetry/api';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 
@@ -150,7 +150,7 @@ describe('MetricReader', () => {
         metricProducers: [additionalProducer],
       });
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         readers: [reader],
       });
 
@@ -165,7 +165,7 @@ describe('MetricReader', () => {
       // Should keep the SDK's Resource only
       assert.deepStrictEqual(
         collectionResult.resourceMetrics.resource.attributes,
-        defaultResource.attributes
+        testResource.attributes
       );
       assert.strictEqual(
         collectionResult.resourceMetrics.scopeMetrics.length,

--- a/packages/sdk-metrics/test/export/TestMetricProducer.ts
+++ b/packages/sdk-metrics/test/export/TestMetricProducer.ts
@@ -16,10 +16,10 @@
 
 import { CollectionResult, ResourceMetrics } from '../../src/export/MetricData';
 import { MetricProducer } from '../../src/export/MetricProducer';
-import { defaultResource } from '../util';
+import { testResource } from '../util';
 
 export const emptyResourceMetrics = {
-  resource: defaultResource,
+  resource: testResource,
   scopeMetrics: [],
 };
 

--- a/packages/sdk-metrics/test/state/MeterSharedState.test.ts
+++ b/packages/sdk-metrics/test/state/MeterSharedState.test.ts
@@ -27,7 +27,7 @@ import {
 import {
   assertMetricData,
   defaultInstrumentationScope,
-  defaultResource,
+  testResource,
   sleep,
 } from '../util';
 import {
@@ -46,7 +46,7 @@ describe('MeterSharedState', () => {
   describe('registerMetricStorage', () => {
     function setupMeter(views?: ViewOptions[], readers?: IMetricReader[]) {
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         views,
         readers: readers,
       });
@@ -189,7 +189,7 @@ describe('MeterSharedState', () => {
       const deltaReader = new TestDeltaMetricReader();
 
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         views: views,
         readers: [cumulativeReader, deltaReader],
       });

--- a/packages/sdk-metrics/test/state/MetricCollector.test.ts
+++ b/packages/sdk-metrics/test/state/MetricCollector.test.ts
@@ -23,7 +23,7 @@ import { MeterProviderSharedState } from '../../src/state/MeterProviderSharedSta
 import { MetricCollector } from '../../src/state/MetricCollector';
 import {
   defaultInstrumentationScope,
-  defaultResource,
+  testResource,
   assertMetricData,
   assertDataPoint,
   ObservableCallbackDelegate,
@@ -42,7 +42,7 @@ describe('MetricCollector', () => {
   describe('constructor', () => {
     it('should construct MetricCollector without exceptions', () => {
       const meterProviderSharedState = new MeterProviderSharedState(
-        defaultResource
+        testResource
       );
       const readers = [new TestMetricReader(), new TestDeltaMetricReader()];
       for (const reader of readers) {
@@ -57,7 +57,7 @@ describe('MetricCollector', () => {
     function setupInstruments() {
       const reader = new TestMetricReader();
       const meterProvider = new MeterProvider({
-        resource: defaultResource,
+        resource: testResource,
         readers: [reader],
       });
 

--- a/packages/sdk-metrics/test/util.ts
+++ b/packages/sdk-metrics/test/util.ts
@@ -23,7 +23,7 @@ import {
 } from '@opentelemetry/api';
 import { InstrumentationScope } from '@opentelemetry/core';
 import {
-  DEFAULT_RESOURCE,
+  defaultResource,
   resourceFromAttributes,
 } from '@opentelemetry/resources';
 import * as assert from 'assert';
@@ -46,7 +46,7 @@ export type Measurement = {
   context?: Context;
 };
 
-export const defaultResource = DEFAULT_RESOURCE.merge(
+export const testResource = defaultResource().merge(
   resourceFromAttributes({ resourceKey: 'my-resource' })
 );
 


### PR DESCRIPTION
## Which problem is this PR solving?

My suggestion from https://github.com/open-telemetry/opentelemetry-js/pull/5421#discussion_r1945153102 - using functions over constants to create an empty or default resource, aligning with the other factory function `resourceFromAttributes`

Fixes # (issue)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Unit tests
