### PR TITLE
refactor(instrumentation-http): migrate away from getEnv()

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to experimental packages in this project will be documented 
 * refactor(exporter-prometheus): remove unnecessary isNaN() check [#5377](https://github.com/open-telemetry/opentelemetry-js/pull/5377) @cjihrig
 * refactor(sdk-node): move code to auto-instantiate propagators into utils [#5355](https://github.com/open-telemetry/opentelemetry-js/pull/5355) @pichlermarc
 * chore: unpin `@opentelemetry/semantic-conventions` dep to allow better de-duplication in installs [#5439](https://github.com/open-telemetry/opentelemetry-js/pull/5439) @trentm
+* refactor(instrumentation-http): migrate away from getEnv() [????](https://github.com/open-telemetry/opentelemetry-js/pull/????) @pichlermarc
 
 ## 0.57.0
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -39,7 +39,7 @@ All notable changes to experimental packages in this project will be documented 
 * refactor(exporter-prometheus): remove unnecessary isNaN() check [#5377](https://github.com/open-telemetry/opentelemetry-js/pull/5377) @cjihrig
 * refactor(sdk-node): move code to auto-instantiate propagators into utils [#5355](https://github.com/open-telemetry/opentelemetry-js/pull/5355) @pichlermarc
 * chore: unpin `@opentelemetry/semantic-conventions` dep to allow better de-duplication in installs [#5439](https://github.com/open-telemetry/opentelemetry-js/pull/5439) @trentm
-* refactor(instrumentation-http): migrate away from getEnv() [????](https://github.com/open-telemetry/opentelemetry-js/pull/????) @pichlermarc
+* refactor(instrumentation-http): migrate away from getEnv() [#5469](https://github.com/open-telemetry/opentelemetry-js/pull/5469) @pichlermarc
 
 ## 0.57.0
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -30,10 +30,14 @@ import {
   ValueType,
 } from '@opentelemetry/api';
 import {
+  getStringListFromEnv,
   hrTime,
   hrTimeDuration,
   hrTimeToMilliseconds,
   suppressTracing,
+  RPCMetadata,
+  RPCType,
+  setRPCMetadata,
 } from '@opentelemetry/core';
 import type * as http from 'http';
 import type * as https from 'https';
@@ -46,12 +50,6 @@ import {
   InstrumentationNodeModuleDefinition,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
-import {
-  RPCMetadata,
-  RPCType,
-  setRPCMetadata,
-  getEnv,
-} from '@opentelemetry/core';
 import { errorMonitor } from 'events';
 import {
   ATTR_HTTP_REQUEST_METHOD,
@@ -108,7 +106,8 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
     super('@opentelemetry/instrumentation-http', VERSION, config);
     this._headerCapture = this._createHeaderCapture();
 
-    for (const entry of getEnv().OTEL_SEMCONV_STABILITY_OPT_IN) {
+    for (const entry of getStringListFromEnv('OTEL_SEMCONV_STABILITY_OPT_IN') ??
+      []) {
       if (entry.toLowerCase() === 'http/dup') {
         // http/dup takes highest precedence. If it is found, there is no need to read the rest of the list
         this._semconvStability = SemconvStability.DUPLICATE;


### PR DESCRIPTION
## Which problem is this PR solving?

Migrates away from `getEnv()` to the new functions and inline-defaults introduced in https://github.com/open-telemetry/opentelemetry-js/pull/5443. Since the HTTP instrumentation can only be used on Node.js, everything stays as-is for the end-user. This is a pure refactor.

Refs https://github.com/open-telemetry/opentelemetry-js/issues/5217

## Type of change

- [x] refactor 

## How Has This Been Tested?

- [x] Existing tests
