### PR TITLE
fix(exporter-logs/trace-otlp-grpc): fix error for missing dependency otlp-exporter-base (backport)

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -11,10 +11,7 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
-* fix(instrumentation-grpc): monitor error events with events.errorMonitor [#5369](https://github.com/open-telemetry/opentelemetry-js/pull/5369) @cjihrig
-* fix(exporter-metrics-otlp-http): browser OTLPMetricExporter was not passing config to OTLPMetricExporterBase super class [#5331](https://github.com/open-telemetry/opentelemetry-js/pull/5331) @trentm
-* fix(instrumentation-fetch, instrumentation-xhr): Ignore network events with zero-timings [#5332](https://github.com/open-telemetry/opentelemetry-js/pull/5332) @chancancode
-* fix(exporter-logs/trace-otlp-grpc): fix error for missing dependency otlp-exporter-base [#5412](https://github.com/open-telemetry/opentelemetry-js/pull/5412) @JamieDanielson
+* fix(exporter-logs/trace-otlp-grpc): fix error for missing dependency otlp-exporter-base [#](https://github.com/open-telemetry/opentelemetry-js/pull/) @JamieDanielson
 
 ### :books: (Refine Doc)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes to experimental packages in this project will be documented 
 
 ### :bug: (Bug Fix)
 
+* fix(instrumentation-grpc): monitor error events with events.errorMonitor [#5369](https://github.com/open-telemetry/opentelemetry-js/pull/5369) @cjihrig
+* fix(exporter-metrics-otlp-http): browser OTLPMetricExporter was not passing config to OTLPMetricExporterBase super class [#5331](https://github.com/open-telemetry/opentelemetry-js/pull/5331) @trentm
+* fix(instrumentation-fetch, instrumentation-xhr): Ignore network events with zero-timings [#5332](https://github.com/open-telemetry/opentelemetry-js/pull/5332) @chancancode
+* fix(exporter-logs/trace-otlp-grpc): fix error for missing dependency otlp-exporter-base [#5412](https://github.com/open-telemetry/opentelemetry-js/pull/5412) @JamieDanielson
+
 ### :books: (Refine Doc)
 
 ### :house: (Internal)

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
     "@opentelemetry/core": "1.30.1",
+    "@opentelemetry/otlp-exporter-base": "0.57.1",
     "@opentelemetry/otlp-grpc-exporter-base": "0.57.1",
     "@opentelemetry/otlp-transformer": "0.57.1",
     "@opentelemetry/sdk-logs": "0.57.1"

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.7.1",
     "@opentelemetry/core": "1.30.1",
+    "@opentelemetry/otlp-exporter-base": "0.57.1",
     "@opentelemetry/otlp-grpc-exporter-base": "0.57.1",
     "@opentelemetry/otlp-transformer": "0.57.1",
     "@opentelemetry/resources": "1.30.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -393,6 +393,7 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/otlp-exporter-base": "0.57.1",
         "@opentelemetry/otlp-grpc-exporter-base": "0.57.1",
         "@opentelemetry/otlp-transformer": "0.57.1",
         "@opentelemetry/sdk-logs": "0.57.1"


### PR DESCRIPTION
## Which problem is this PR solving?

Backport #5412 to v1.x branch

#5031 was a large refactor for OTLP exporters, and a dependency that was previously listed as a dev dependency is now required as a production dependency. Upgrading to [experimental/v0.56.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental/v0.56.0) caused an error in Yarn PnP:

```
2025-01-09T01:35:53.432Z   220 U Error: @opentelemetry/exporter-logs-otlp-grpc tried to access @opentelemetry/otlp-exporter-base, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```

## Short description of the changes

- move `@opentelemetry/otlp-exporter-base` to be production dependency

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
