### PR TITLE
feat(exporter-metrics-otlp-http)!: do not read environment variables from window

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to experimental packages in this project will be documented 
 * chore!: Raise the minimum supported Node.js version to `^18.19.0 || >=20.6.0`. Support for Node.js 14, 16, and early minor versions of 18 and 20 have been dropped. This applies to all packages except the 'api' and 'semantic-conventions' packages. [#5395](https://github.com/open-telemetry/opentelemetry-js/issues/5395) @trentm
 * feat(sdk-node)!: use `IMetricReader` over `MetricReader` [#5311](https://github.com/open-telemetry/opentelemetry-js/pull/5311)
   * (user-facing): `NodeSDKConfiguration` now provides the more general `IMetricReader` type over `MetricReader`
+* feat(exporter-metrics-otlp-http)!: do not read environment variables from window in browsers [#????](https://github.com/open-telemetry/opentelemetry-js/pull/????) @pichlermarc
+  * (user-facing): all configuration previously possible via `window.OTEL_*` is now not supported anymore, please pass configuration options to constructors instead.
+  * Note: Node.js environment variable configuration continues to work as-is.
 
 ### :rocket: (Enhancement)
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to experimental packages in this project will be documented 
 * chore!: Raise the minimum supported Node.js version to `^18.19.0 || >=20.6.0`. Support for Node.js 14, 16, and early minor versions of 18 and 20 have been dropped. This applies to all packages except the 'api' and 'semantic-conventions' packages. [#5395](https://github.com/open-telemetry/opentelemetry-js/issues/5395) @trentm
 * feat(sdk-node)!: use `IMetricReader` over `MetricReader` [#5311](https://github.com/open-telemetry/opentelemetry-js/pull/5311)
   * (user-facing): `NodeSDKConfiguration` now provides the more general `IMetricReader` type over `MetricReader`
-* feat(exporter-metrics-otlp-http)!: do not read environment variables from window in browsers [#????](https://github.com/open-telemetry/opentelemetry-js/pull/????) @pichlermarc
+* feat(exporter-metrics-otlp-http)!: do not read environment variables from window in browsers [#5473](https://github.com/open-telemetry/opentelemetry-js/pull/5473) @pichlermarc
   * (user-facing): all configuration previously possible via `window.OTEL_*` is now not supported anymore, please pass configuration options to constructors instead.
   * Note: Node.js environment variable configuration continues to work as-is.
 

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/OTLPMetricExporterBase.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/OTLPMetricExporterBase.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getEnv } from '@opentelemetry/core';
+import { getStringFromEnv } from '@opentelemetry/core';
 import {
   AggregationTemporality,
   AggregationTemporalitySelector,
@@ -71,9 +71,10 @@ export const LowMemoryTemporalitySelector: AggregationTemporalitySelector = (
 };
 
 function chooseTemporalitySelectorFromEnvironment() {
-  const env = getEnv();
-  const configuredTemporality =
-    env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE.trim().toLowerCase();
+  const configuredTemporality = (
+    getStringFromEnv('OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE') ??
+    'cumulative'
+  ).toLowerCase();
 
   if (configuredTemporality === 'cumulative') {
     return CumulativeTemporalitySelector;
@@ -86,7 +87,7 @@ function chooseTemporalitySelectorFromEnvironment() {
   }
 
   diag.warn(
-    `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE is set to '${env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE}', but only 'cumulative' and 'delta' are allowed. Using default ('cumulative') instead.`
+    `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE is set to '${configuredTemporality}', but only 'cumulative' and 'delta' are allowed. Using default ('cumulative') instead.`
   );
   return CumulativeTemporalitySelector;
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Migrates from `getEnv()` to using the new `get*FromEnv()` methods added in #5443. Also inlines the defaults. This drops
"env var configuration" (via `window.OTEL_*` ) in browser environments.

This breaking change now will enable us to split the env var config code completely in a non-breaking feature release later.

Refs #5217

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Unit tests
