### PR TITLE
docs: update Contributing Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,15 +85,8 @@ for general practices for OpenTelemetry project.
 #### Conventional commit
 
 The Conventional Commits specification is a lightweight convention on top of commit messages. It provides an easy set of rules for creating an explicit commit history; which makes it easier to write automated tools on top of. This convention dovetails with SemVer, by describing the features, fixes, and breaking changes made in commit messages. You can see examples [here](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#examples).
-We use [commitlint](https://github.com/conventional-changelog/commitlint) and [husky](https://github.com/typicode/husky) to prevent bad commit message.
-For example, you want to submit the following commit message `git commit -s -am "my bad commit"`.
-You will receive the following error :
 
-```text
-✖   type must be one of [ci, feat, fix, docs, style, refactor, perf, test, revert, chore] [type-enum]
-```
-
-Here an example that will pass the verification: `git commit -s -am "chore(opentelemetry-core): update deps"`
+It is recommended to have your commit messages follow the Conventional Commits specification, with possible types listed in [.commitlint.rc.yml](.commitlintrc.yml). Here an example that uses the recommended format: `git commit -s -am "chore(opentelemetry-core): update deps"`
 
 ### Changelog
 


### PR DESCRIPTION
## Which problem is this PR solving?

The Contributing Guide refers to enforcement of Conventional Commits via commitlint and husky, which is no logner the case as of #2898.

## Short description of the changes

Updating the Contributing Guide to reflect how Conventional Commits are now a recommendation that is not enforced.

## How Has This Been Tested?

Rendered the Markdown and ensured that it looks correct.