### PR TITLE
deps: clean up dependencies

### DIFF
--- a/experimental/packages/sampler-jaeger-remote/package.json
+++ b/experimental/packages/sampler-jaeger-remote/package.json
@@ -48,6 +48,7 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "devDependencies": {
+    "@opentelemetry/api": "1.9.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5312,6 +5312,7 @@
         "@opentelemetry/sdk-trace-base": "1.30.0"
       },
       "devDependencies": {
+        "@opentelemetry/api": "1.9.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -33148,7 +33149,6 @@
       },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.3",
@@ -33185,50 +33185,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "packages/opentelemetry-resources/node_modules/@opentelemetry/resources_1.9.0": {
-      "name": "@opentelemetry/resources",
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.9.0.tgz",
-      "integrity": "sha512-zCyien0p3XWarU6zv72c/JZ6QlG5QW/hc61Nh5TSR1K9ndnljzAGrH55x4nfyQdubfoh9QxLNh9FXH0fWK6vcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.9.0",
-        "@opentelemetry/semantic-conventions": "1.9.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "packages/opentelemetry-resources/node_modules/@opentelemetry/resources_1.9.0/node_modules/@opentelemetry/core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.9.0.tgz",
-      "integrity": "sha512-Koy1ApRUp5DB5KpOqhDk0JjO9x6QeEkmcePl8qQDsXZGF4MuHUBShXibd+J2tRNckTsvgEHi1uEuUckDgN+c/A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.9.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "packages/opentelemetry-resources/node_modules/@opentelemetry/resources_1.9.0/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.0.tgz",
-      "integrity": "sha512-po7penSfQ/Z8352lRVDpaBrd9znwA5mHGqXR7nDEiVnxkDFkBIhVf/tKeAJDIq/erFpcRowKFeCsr5eqqcSyFQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "packages/opentelemetry-resources/node_modules/@types/node": {
@@ -41734,7 +41690,6 @@
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@opentelemetry/core": "1.30.0",
-        "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@opentelemetry/semantic-conventions": "^1.29.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
@@ -41763,33 +41718,6 @@
           "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
           "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
           "dev": true
-        },
-        "@opentelemetry/resources_1.9.0": {
-          "version": "npm:@opentelemetry/resources@1.9.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.9.0.tgz",
-          "integrity": "sha512-zCyien0p3XWarU6zv72c/JZ6QlG5QW/hc61Nh5TSR1K9ndnljzAGrH55x4nfyQdubfoh9QxLNh9FXH0fWK6vcg==",
-          "dev": true,
-          "requires": {
-            "@opentelemetry/core": "1.9.0",
-            "@opentelemetry/semantic-conventions": "1.9.0"
-          },
-          "dependencies": {
-            "@opentelemetry/core": {
-              "version": "1.9.0",
-              "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.9.0.tgz",
-              "integrity": "sha512-Koy1ApRUp5DB5KpOqhDk0JjO9x6QeEkmcePl8qQDsXZGF4MuHUBShXibd+J2tRNckTsvgEHi1uEuUckDgN+c/A==",
-              "dev": true,
-              "requires": {
-                "@opentelemetry/semantic-conventions": "1.9.0"
-              }
-            },
-            "@opentelemetry/semantic-conventions": {
-              "version": "1.9.0",
-              "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.0.tgz",
-              "integrity": "sha512-po7penSfQ/Z8352lRVDpaBrd9znwA5mHGqXR7nDEiVnxkDFkBIhVf/tKeAJDIq/erFpcRowKFeCsr5eqqcSyFQ==",
-              "dev": true
-            }
-          }
         },
         "@types/node": {
           "version": "18.6.5",
@@ -41886,6 +41814,7 @@
     "@opentelemetry/sampler-jaeger-remote": {
       "version": "file:experimental/packages/sampler-jaeger-remote",
       "requires": {
+        "@opentelemetry/api": "1.9.0",
         "@opentelemetry/sdk-trace-base": "1.30.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -64,7 +64,6 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
-    "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.3",


### PR DESCRIPTION
## Which problem is this PR solving?

- a dev dependency for `@opentelemetry/api` was missing in `@opentelemetry/sampler-jaeger-remote`
 - this may cause problems with new API versions
- a dependency to the now unused `@opentelemetry/resources@1.9.0` was still there
 - does not cause any problems, but we can remove it since we don't need it anymore

## Type of change

- [x] dependencies

## How Has This Been Tested?

- [ ] Unit tests
