### PR TITLE
docs(sdk-metrics): align documentation with current state

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -362,13 +362,15 @@ for the resulting metric. The first step is select to the metrics to whom the Vi
 is relevant, the second step is to configure the customizations for the the selected
 metrics.
 
-A Metric View is a class that can be instantiated via:
+A Metric View can be added to a `MeterProvider` like so
 
 ````typescript
-const view = new View({
-  name: 'metric-view', // optionally, give the view a unique name
-  // select instruments with a specific name
-  instrumentName: 'http.server.duration',
+new MeterProvider({
+  views: [{
+    name: 'metric-view', // optionally, give the view a unique name
+    // select instruments with a specific name
+    instrumentName: 'http.server.duration',
+  }]
 });
 ````
 
@@ -396,20 +398,22 @@ should be used to define the bucket sizes for the Histogram instrument.
 Below an example is given how you can define explicit buckets for a histogram.
 
 ```typescript
-// Define view for the histogram metric
-const histogramView = new View({
-  aggregation: new ExplicitBucketHistogramAggregation([0, 1, 5, 10, 15, 20, 25, 30]),
-  instrumentName: 'http.server.duration',
-  instrumentType: InstrumentType.HISTOGRAM,
-});
-
-// Note, the instrumentName is the same as the name that has been passed for
-// the Meter#createHistogram function
-
 // Create an instance of the metric provider
 const meterProvider = new MeterProvider({
   views: [
-    histogramView
+    // Define view for the histogram metric
+    {
+      aggregation: {
+        type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,
+        options: {
+          boundaries: [0, 1, 5, 10, 15, 20, 25, 30],
+        }
+      },
+      // Note, the instrumentName is the same as the name that has been passed for
+      // the Meter#createHistogram function
+      instrumentName: 'http.server.duration',
+      instrumentType: InstrumentType.HISTOGRAM,
+    }
   ]
 });
 
@@ -441,20 +445,20 @@ instruments with a specific name:
 The following view drops all instruments that are associated with a meter named `pubsub`:
 
 ```typescript
-const dropView = new View({
-  aggregation: new DropAggregation(),
+{
+  aggregation: { type: AggregationType.DROP },
   meterName: 'pubsub',
-});
+}
 ```
 
 Alternatively, you can also drop instruments with a specific instrument name,
 for example, all instruments of which the name starts with `http`:
 
 ```typescript
-const dropView = new View({
-  aggregation: new DropAggregation(),
+{
+  aggregation: { type: AggregationType.DROP },
   instrumentName: 'http*',
-});
+}
 ```
 
 ### Customizing the metric attributes of instrument
@@ -467,12 +471,12 @@ In the example below will drop all attributes except attribute `environment` for
 all instruments.
 
 ```typescript
-new View({
+{
   // only export the attribute 'environment'
   attributeKeys: ['environment'],
   // apply the view to all instruments
   instrumentName: '*',
-})
+}
 ```
 
 ## Exporting measurements

--- a/examples/otlp-exporter-node/metrics.js
+++ b/examples/otlp-exporter-node/metrics.js
@@ -6,10 +6,10 @@ const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-htt
 // const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-proto');
 // const { ConsoleMetricExporter } = require('@opentelemetry/sdk-metrics');
 const {
-  ExponentialHistogramAggregation,
   MeterProvider,
   PeriodicExportingMetricReader,
   View,
+  AggregationType,
 } = require('@opentelemetry/sdk-metrics');
 const { Resource } = require('@opentelemetry/resources');
 const {
@@ -25,20 +25,18 @@ const metricExporter = new OTLPMetricExporter({
   // },
 });
 
-// Define view for the exponential histogram metric
-const expHistogramView = new View({
-  aggregation: new ExponentialHistogramAggregation(),
-  // Note, the instrumentName is the same as the name that has been passed for
-  // the Meter#createHistogram function for exponentialHistogram.
-  instrumentName: 'test_exponential_histogram',
-});
-
 // Create an instance of the metric provider
 const meterProvider = new MeterProvider({
   resource: new Resource({
     [SEMRESATTRS_SERVICE_NAME]: 'basic-metric-service',
   }),
-  views: [expHistogramView],
+  // Define view for the exponential histogram metric
+  views: [{
+      aggregation: { type: AggregationType.EXPONENTIAL_HISTOGRAM },
+      // Note, the instrumentName is the same as the name that has been passed for
+      // the Meter#createHistogram function for exponentialHistogram.
+      instrumentName: 'test_exponential_histogram',
+  }],
   readers: [
     new PeriodicExportingMetricReader({
       exporter: metricExporter,

--- a/packages/sdk-metrics/README.md
+++ b/packages/sdk-metrics/README.md
@@ -64,9 +64,17 @@ Views can be registered when instantiating a `MeterProvider`:
 const meterProvider = new MeterProvider({
   views: [
     // override the bucket boundaries on `my.histogram` to [0, 50, 100]
-    new View({ aggregation: new ExplicitBucketHistogramAggregation([0, 50, 100]), instrumentName: 'my.histogram'}),
+    {
+      aggregation: {
+        type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,
+        options: {
+          boundaries: [0, 50, 100]
+        }
+      },
+      instrumentName: 'my.histogram'
+    },
     // rename 'my.counter' to 'my.renamed.counter'
-    new View({ name: 'my.renamed.counter', instrumentName: 'my.counter'})
+    { name: 'my.renamed.counter', instrumentName: 'my.counter'}
   ]
 })
 ```


### PR DESCRIPTION
## Which problem is this PR solving?

Metrics SDK docs are out of date in a few places, this PR aligns them with the state on `main`.

Follows up on #4931