### PR TITLE
ci: add sdk-v1.x dist-tag when publishing from v1.x 

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -38,4 +38,4 @@ jobs:
         # (packages are in-fact published in the correct order), but the race on the registry still applies.
         # If this happens, run the workflow again - there should be enough time for everything to settle until this workflow
         # attempts to publish again.
-        run: npx lerna publish --concurrency 1 from-package --no-push --no-private --no-git-tag-version --no-verify-access --dist-tag=v1.x --dist-tag=ts4.4 --yes
+        run: npx lerna publish --concurrency 1 from-package --no-push --no-private --no-git-tag-version --no-verify-access --dist-tag=sdk-v1.x --yes

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -38,4 +38,4 @@ jobs:
         # (packages are in-fact published in the correct order), but the race on the registry still applies.
         # If this happens, run the workflow again - there should be enough time for everything to settle until this workflow
         # attempts to publish again.
-        run: npx lerna publish --concurrency 1 from-package --no-push --no-private --no-git-tag-version --no-verify-access --yes
+        run: npx lerna publish --concurrency 1 from-package --no-push --no-private --no-git-tag-version --no-verify-access --dist-tag=v1.x --dist-tag=ts4.4 --yes


### PR DESCRIPTION
## Which problem is this PR solving?

> [!IMPORTANT]
> This PR targets `v1.x` - keeping as draft until we're ready to release 2.x, until then releases from this branch should still target `latest`

To avoid having releases from `v1.x` end up with the `latest` tag automatically, this PR adds specific dist-tag to publishes from the `v1.x` branch.

The dist-tag chosen:
- `sdk-v1.x` to show that the packages are compatible with `v1.x`
- I did not put another `ts4.4` tag as originally planned as lerna errors when using more than one tag.