### PR TITLE
feat(sdk-trace-base)!: remove BasicTracerProvider#register() to improve tree-shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,10 @@ For semantic convention package changes, see the [semconv CHANGELOG](packages/se
   * (user-facing): `ENVIRONMENT` has been removed without replacement
   * (user-facing): `RAW_ENVIRONMENT` has been removed without replacement
   * (user-facing): `parseEnvironment` has been removed without replacement
+* feat(sdk-trace-base): remove `BasicTracerProvider#register()` to improve tree-shaking [#????](https://github.com/open-telemetry/opentelemetry-js/pull/????) @pichlermarc
+  * (user-facing): `BasicTracerProvider#register()` has been removed
+    * to register a global propagator, please use `propagation.setGlobalPropagator()` from `@opentelemetry/api`
+    * to register a global context manager, please use `context.setGlobalContextManager()` from `@opentelemetry/api`
 
 ### :rocket: (Enhancement)
 

--- a/packages/opentelemetry-sdk-trace-base/README.md
+++ b/packages/opentelemetry-sdk-trace-base/README.md
@@ -7,10 +7,13 @@ The `tracing` module contains the foundation for all tracing SDKs of [openteleme
 
 Used standalone, this module provides methods for manual instrumentation of code, offering full control over span creation for client-side JavaScript (browser) and Node.js.
 
-It does **not** provide automated instrumentation of known libraries, context propagation for asynchronous invocations or distributed-context out-of-the-box.
+It does **not** provide automated instrumentation of known libraries, context propagation or distributed-context out-of-the-box.
 
-For automated instrumentation for Node.js, please see
+For a `TracerProvider` that includes default context management and propagation for Node.js, please see
 [@opentelemetry/sdk-trace-node](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node).
+
+For a `TracerProvider` that includes default context management and propagation for Browser, please see
+[@opentelemetry/sdk-trace-web](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web).
 
 ## Installation
 
@@ -22,16 +25,20 @@ npm install --save @opentelemetry/sdk-trace-base
 ## Usage
 
 ```js
-const opentelemetry = require('@opentelemetry/api');
+const { trace } = require('@opentelemetry/api');
 const { BasicTracerProvider } = require('@opentelemetry/sdk-trace-base');
 
 // To start a trace, you first need to initialize the Tracer provider.
 // NOTE: The default OpenTelemetry tracer provider does not record any tracing information.
 //       Registering a working tracer provider allows the API methods to record traces.
-new BasicTracerProvider().register();
+trace.setGlobalTracerProvider(new BasicTracerProvider());
+
+// Important: requires a context manager and propagator to be registered manually.
+// propagation.setGlobalPropagator(propagator);     // replace `propagator` with your `TextMapPropagator`, for example: `W3CTraceContextPropagator` from `@openetelemetry/core`
+// context.setGlobalContextManager(contextManager); // replace `contextManager` with your `ContextManager`: `AsyncLocalStorageContextManager` from `@openetelemetry/async-hooks`
 
 // To create a span in a trace, we used the global singleton tracer to start a new span.
-const span = opentelemetry.trace.getTracer('default').startSpan('foo');
+const span = trace.getTracer('default').startSpan('foo');
 
 // Set a span attribute
 span.setAttribute('key', 'value');

--- a/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/BasicTracerProvider.ts
@@ -14,26 +14,14 @@
  * limitations under the License.
  */
 
-import {
-  context,
-  propagation,
-  TextMapPropagator,
-  trace,
-  TracerProvider,
-  Tracer as ApiTracer,
-} from '@opentelemetry/api';
-import {
-  CompositePropagator,
-  W3CBaggagePropagator,
-  W3CTraceContextPropagator,
-  merge,
-} from '@opentelemetry/core';
+import { TracerProvider, Tracer as ApiTracer } from '@opentelemetry/api';
+import { merge } from '@opentelemetry/core';
 import { defaultResource, Resource } from '@opentelemetry/resources';
 import { SpanProcessor } from './SpanProcessor';
 import { Tracer } from './Tracer';
 import { loadDefaultConfig } from './config';
 import { MultiSpanProcessor } from './MultiSpanProcessor';
-import { SDKRegistrationConfig, TracerConfig } from './types';
+import { TracerConfig } from './types';
 import { reconfigureLimits } from './utility';
 
 export enum ForceFlushState {
@@ -41,10 +29,6 @@ export enum ForceFlushState {
   'timeout',
   'error',
   'unresolved',
-}
-
-function getDefaultPropagators(): TextMapPropagator[] {
-  return [new W3CTraceContextPropagator(), new W3CBaggagePropagator()];
 }
 
 /**
@@ -97,31 +81,6 @@ export class BasicTracerProvider implements TracerProvider {
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return this._tracers.get(key)!;
-  }
-
-  /**
-   * Register this TracerProvider for use with the OpenTelemetry API.
-   * Undefined values may be replaced with defaults, and
-   * null values will be skipped.
-   *
-   * @param config Configuration object for SDK registration
-   */
-  register(config: SDKRegistrationConfig = {}): void {
-    trace.setGlobalTracerProvider(this);
-
-    if (config.contextManager) {
-      context.setGlobalContextManager(config.contextManager);
-    }
-
-    // undefined means "unset", null means don't register propagator
-    if (config.propagator !== null) {
-      propagation.setGlobalPropagator(
-        config.propagator ??
-          new CompositePropagator({
-            propagators: getDefaultPropagators(),
-          })
-      );
-    }
   }
 
   forceFlush(): Promise<void> {

--- a/packages/opentelemetry-sdk-trace-node/src/NodeTracerProvider.ts
+++ b/packages/opentelemetry-sdk-trace-node/src/NodeTracerProvider.ts
@@ -19,6 +19,60 @@ import {
   SDKRegistrationConfig,
 } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerConfig } from './config';
+import {
+  context,
+  ContextManager,
+  propagation,
+  TextMapPropagator,
+  trace,
+} from '@opentelemetry/api';
+import {
+  CompositePropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
+} from '@opentelemetry/core';
+
+function setupContextManager(
+  contextManager: ContextManager | null | undefined
+) {
+  // null means 'do not register'
+  if (contextManager === null) {
+    return;
+  }
+
+  // undefined means 'register default'
+  if (contextManager === undefined) {
+    const defaultContextManager = new AsyncLocalStorageContextManager();
+    defaultContextManager.enable();
+    context.setGlobalContextManager(defaultContextManager);
+    return;
+  }
+
+  contextManager.enable();
+  context.setGlobalContextManager(contextManager);
+}
+
+function setupPropagator(propagator: TextMapPropagator | null | undefined) {
+  // null means 'do not register'
+  if (propagator === null) {
+    return;
+  }
+
+  // undefined means 'register default'
+  if (propagator === undefined) {
+    propagation.setGlobalPropagator(
+      new CompositePropagator({
+        propagators: [
+          new W3CTraceContextPropagator(),
+          new W3CBaggagePropagator(),
+        ],
+      })
+    );
+    return;
+  }
+
+  propagation.setGlobalPropagator(propagator);
+}
 
 /**
  * Register this TracerProvider for use with the OpenTelemetry API.
@@ -32,12 +86,16 @@ export class NodeTracerProvider extends BasicTracerProvider {
     super(config);
   }
 
-  override register(config: SDKRegistrationConfig = {}): void {
-    if (config.contextManager === undefined) {
-      config.contextManager = new AsyncLocalStorageContextManager();
-      config.contextManager.enable();
-    }
-
-    super.register(config);
+  /**
+   * Register this TracerProvider for use with the OpenTelemetry API.
+   * Undefined values may be replaced with defaults, and
+   * null values will be skipped.
+   *
+   * @param config Configuration object for SDK registration
+   */
+  register(config: SDKRegistrationConfig = {}): void {
+    trace.setGlobalTracerProvider(this);
+    setupContextManager(config.contextManager);
+    setupPropagator(config.propagator);
   }
 }

--- a/packages/opentelemetry-sdk-trace-node/test/registration.test.ts
+++ b/packages/opentelemetry-sdk-trace-node/test/registration.test.ts
@@ -64,7 +64,10 @@ describe('API registration', () => {
   it('should register configured implementations', () => {
     const tracerProvider = new NodeTracerProvider();
 
-    const mockContextManager = { disable() {} } as any;
+    const mockContextManager = {
+      enable() {},
+      disable() {},
+    } as any;
     const mockPropagator = {} as any;
 
     tracerProvider.register({

--- a/packages/opentelemetry-sdk-trace-web/src/WebTracerProvider.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/WebTracerProvider.ts
@@ -20,6 +20,60 @@ import {
   TracerConfig,
 } from '@opentelemetry/sdk-trace-base';
 import { StackContextManager } from './StackContextManager';
+import {
+  trace,
+  context,
+  ContextManager,
+  propagation,
+  TextMapPropagator,
+} from '@opentelemetry/api';
+import {
+  CompositePropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
+} from '@opentelemetry/core';
+
+function setupContextManager(
+  contextManager: ContextManager | null | undefined
+) {
+  // null means 'do not register'
+  if (contextManager === null) {
+    return;
+  }
+
+  // undefined means 'register default'
+  if (contextManager === undefined) {
+    const defaultContextManager = new StackContextManager();
+    defaultContextManager.enable();
+    context.setGlobalContextManager(defaultContextManager);
+    return;
+  }
+
+  contextManager.enable();
+  context.setGlobalContextManager(contextManager);
+}
+
+function setupPropagator(propagator: TextMapPropagator | null | undefined) {
+  // null means 'do not register'
+  if (propagator === null) {
+    return;
+  }
+
+  // undefined means 'register default'
+  if (propagator === undefined) {
+    propagation.setGlobalPropagator(
+      new CompositePropagator({
+        propagators: [
+          new W3CTraceContextPropagator(),
+          new W3CBaggagePropagator(),
+        ],
+      })
+    );
+    return;
+  }
+
+  propagation.setGlobalPropagator(propagator);
+}
 
 /**
  * WebTracerConfig provides an interface for configuring a Web Tracer.
@@ -45,14 +99,9 @@ export class WebTracerProvider extends BasicTracerProvider {
    *
    * @param config Configuration object for SDK registration
    */
-  override register(config: SDKRegistrationConfig = {}): void {
-    if (config.contextManager === undefined) {
-      config.contextManager = new StackContextManager();
-    }
-    if (config.contextManager) {
-      config.contextManager.enable();
-    }
-
-    super.register(config);
+  register(config: SDKRegistrationConfig = {}): void {
+    trace.setGlobalTracerProvider(this);
+    setupPropagator(config.propagator);
+    setupContextManager(config.contextManager);
   }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Removes `BasicTracerProvider#register()`, which in the past has auto-registered a `W3CTraceContextPropagator` and `W3CBaggagePropagator`, requiring it being included in bundles even when unused.

`NodeTracerProvider#register()` and `WebTraceProvider#register()` still share the same behavior so impact to end-users should be minimal. Everyone that does not want to use the defaults can now use `BasicTracerProvider` with `trace.setGlobalTracerProvider()`, `propagation.setGlobalPropagator()` and `context.setGlobalContextManager()` to register, while not including the unused context managers/propagators in their bundle.

Refs #5290

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] Unit tests
