### PR TITLE
fix(core): avoid using util in configuration.ts for browser compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,6 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
   * (user-facing): `DEFAULT_ATTRIBUTE_VALUE_COUNT_LIMIT` has been removed, please use `128` instead
   * (user-facing): `DEFAULT_SPAN_ATTRIBUTE_PER_EVENT_COUNT_LIMIT` has been removed, please use `128` instead
   * (user-facing): `DEFAULT_SPAN_ATTRIBUTE_PER_LINK_COUNT_LIMIT` has been removed, please use `128` instead
-* fix(core): avoid using util in configuration.ts for browser compatibility
 
 ### :rocket: (Enhancement)
 
@@ -152,6 +151,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * fix(exporter-zipkin): remove usages of deprecated `url.parse` from `node:url` [#5390](https://github.com/open-telemetry/opentelemetry-js/pull/5390) @chancancode
 * fix(sdk-metrics): do not export from `PeriodicExportingMetricReader` when there are no metrics to export. [#5288](https://github.com/open-telemetry/opentelemetry-js/pull/5288) @jacksonweber
 * fix(sdk-trace-base): always wait on pending export in SimpleSpanProcessor. [#5303](https://github.com/open-telemetry/opentelemetry-js/pull/5303) @anuraaga
+* fix(core): avoid using util in configuration.ts for browser compatibility [#5524](https://github.com/open-telemetry/opentelemetry-js/pull/5524) @sriraamas
 
 ### :books: (Refine Doc)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
   * (user-facing): `DEFAULT_ATTRIBUTE_VALUE_COUNT_LIMIT` has been removed, please use `128` instead
   * (user-facing): `DEFAULT_SPAN_ATTRIBUTE_PER_EVENT_COUNT_LIMIT` has been removed, please use `128` instead
   * (user-facing): `DEFAULT_SPAN_ATTRIBUTE_PER_LINK_COUNT_LIMIT` has been removed, please use `128` instead
+* fix(core): avoid using util in configuration.ts for browser compatibility
 
 ### :rocket: (Enhancement)
 

--- a/packages/opentelemetry-core/src/utils/configuration.ts
+++ b/packages/opentelemetry-core/src/utils/configuration.ts
@@ -41,7 +41,7 @@ export function diagLogLevelFromString(
 
   if (resolvedLogLevel == null) {
     diag.warn(
-      `Unknown log level ${value}, expected one of ${Object.keys(logLevelMap)}, using default`
+      `Unknown log level "${value}", expected one of ${Object.keys(logLevelMap)}, using default`
     );
     return DiagLogLevel.INFO;
   }

--- a/packages/opentelemetry-core/src/utils/configuration.ts
+++ b/packages/opentelemetry-core/src/utils/configuration.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { diag, DiagLogLevel } from '@opentelemetry/api';
-import { inspect } from 'util';
 
 const logLevelMap: { [key: string]: DiagLogLevel } = {
   ALL: DiagLogLevel.ALL,
@@ -42,7 +41,7 @@ export function diagLogLevelFromString(
 
   if (resolvedLogLevel == null) {
     diag.warn(
-      `Unknown log level ${inspect(value)}, expected one of ${inspect(Object.keys(logLevelMap))}, using default`
+      `Unknown log level ${value}, expected one of ${Object.keys(logLevelMap)}, using default`
     );
     return DiagLogLevel.INFO;
   }


### PR DESCRIPTION
Using the `util` module in configuration.ts in opentelemetry-core prevents using sdk-trace-base and other packages in the browser. Removing it and relying on string interpolation, allows using the packages again in the browser.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Followed the style guidelines of this project
