### PR TITLE
feat(instrumentation-http): Introduce contextHook

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -661,7 +661,8 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
           spanAttributes[ATTR_NETWORK_PROTOCOL_VERSION];
       }
 
-      const ctx = propagation.extract(ROOT_CONTEXT, headers);
+      let ctx = propagation.extract(ROOT_CONTEXT, headers);
+      ctx = instrumentation.getConfig().contextHook?.(ctx, request) || ctx;
       const span = instrumentation._startHttpSpan(method, spanOptions, ctx);
       const rpcMetadata: RPCMetadata = {
         type: RPCType.HTTP,

--- a/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Span, Attributes } from '@opentelemetry/api';
+import { Span, Attributes, Context } from '@opentelemetry/api';
 import {
   ClientRequest,
   IncomingMessage,
@@ -36,6 +36,10 @@ export interface IgnoreIncomingRequestFunction {
 
 export interface IgnoreOutgoingRequestFunction {
   (request: RequestOptions): boolean;
+}
+
+export interface HttpCustomContextFunction {
+  (context: Context, request: IncomingMessage): Context;
 }
 
 export interface HttpRequestCustomAttributeFunction {
@@ -68,6 +72,8 @@ export interface HttpInstrumentationConfig extends InstrumentationConfig {
   disableOutgoingRequestInstrumentation?: boolean;
   /** Function for adding custom attributes after response is handled */
   applyCustomAttributesOnSpan?: HttpCustomAttributeFunction;
+  /** Functions for adding modifying the context of incoming requests */
+  contextHook?: HttpCustomContextFunction;
   /** Function for adding custom attributes before request is handled */
   requestHook?: HttpRequestCustomAttributeFunction;
   /** Function for adding custom attributes before response is handled */


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Allow for open telemetry Context to be customized with additional values.

Fixes #5537

## Short description of the changes

Introduce a new option for the http instrumentation to allow users to add data to the open telemetry Context at the point it is created, with the information derived from the incoming request.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Introduced a new unit test: `should keep make the context from contextHook available`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
