### PR TITLE
docs: clarify that Resource is not user-implementable

### DIFF
--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -21,6 +21,11 @@ import { RawResourceAttribute } from './types';
  * An interface that represents a resource. A Resource describes the entity for which signals (metrics or trace) are
  * collected.
  *
+ * This interface is NOT user-implementable. Valid ways to obtain a {@link Resource} are by using either of these functions
+ *  - {@link resourceFromAttributes}
+ *  - {@link emptyResource}
+ *  - {@link defaultResource}
+ *  - {@link detectResources}
  */
 export interface Resource {
   /**


### PR DESCRIPTION
## Which problem is this PR solving?

It's not clear that `Resource` is not intended to be implemented by the end-user. This adds a comment on how to obtain a `Resource`.

refs #5540 

