### PR TITLE
Log detected resources without triggering unresolved check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(resource): do not trigger `Accessing resource attributes before async attributes settled` warning when detecting resources [#5545](https://github.com/open-telemetry/opentelemetry-js/pull/5545) @dyladan
+
 ### :books: Documentation
 
 ### :house: Internal


### PR DESCRIPTION
Fixes an issue where logging the detected resources triggered a warning that unresolved attributes have been accessed: https://github.com/open-telemetry/opentelemetry-js/blob/7fde94081ed141c7d61db269b77d5765887a9665/packages/opentelemetry-resources/src/detect-resources.ts#L42