### PR TITLE
Do not log detected resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(resource): do not trigger `Accessing resource attributes before async attributes settled` warning when detecting resources [#5546](https://github.com/open-telemetry/opentelemetry-js/pull/5546) @dyladan
+  * verbose logging of detected resource removed
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -638,40 +638,6 @@ describe('Node SDK', () => {
         });
       };
 
-      it('prints detected resources and debug messages to the logger', async () => {
-        const sdk = new NodeSDK({
-          autoDetectResources: true,
-        });
-
-        // This test depends on the env detector to be functioning as intended
-        const mockedLoggerMethod = Sinon.fake();
-        const mockedVerboseLoggerMethod = Sinon.fake();
-
-        diag.setLogger(
-          {
-            debug: mockedLoggerMethod,
-            verbose: mockedVerboseLoggerMethod,
-          } as any,
-          DiagLogLevel.VERBOSE
-        );
-
-        sdk.start();
-        await sdk['_resource'].waitForAsyncAttributes?.();
-
-        // Test that the Env Detector successfully found its resource and populated it with the right values.
-        assert.ok(
-          callArgsContains(mockedLoggerMethod, 'EnvDetector found resource.')
-        );
-        // Regex formatting accounts for whitespace variations in util.inspect output over different node versions
-        assert.ok(
-          callArgsMatches(
-            mockedVerboseLoggerMethod,
-            /{\s+"service\.instance\.id":\s+"627cc493",\s+"service\.name":\s+"my-service",\s+"service\.namespace":\s+"default",\s+"service\.version":\s+"0.0.1"\s+}\s*/gm
-          )
-        );
-        await sdk.shutdown();
-      });
-
       describe('with unknown OTEL_NODE_RESOURCE_DETECTORS value', () => {
         before(() => {
           process.env.OTEL_NODE_RESOURCE_DETECTORS = 'env,os,no-such-detector';

--- a/packages/opentelemetry-resources/src/detect-resources.ts
+++ b/packages/opentelemetry-resources/src/detect-resources.ts
@@ -38,26 +38,8 @@ export const detectResources = (
     }
   });
 
-  // Future check if verbose logging is enabled issue #1903
-  logResources(resources);
-
   return resources.reduce(
     (acc, resource) => acc.merge(resource),
     emptyResource()
   );
-};
-
-/**
- * Writes debug information about the detected resources to the logger defined in the resource detection config, if one is provided.
- *
- * @param resources The array of {@link Resource} that should be logged. Empty entries will be ignored.
- */
-const logResources = (resources: Array<Resource>) => {
-  resources.forEach(resource => {
-    // Print only populated resources
-    if (Object.keys(resource.attributes).length > 0) {
-      const resourceDebugString = JSON.stringify(resource.attributes, null, 4);
-      diag.verbose(resourceDebugString);
-    }
-  });
 };


### PR DESCRIPTION
This removes the logResources call which was triggering a warning that asynchronous resources were accessed before being resolved. Alternative to #5545 

---

> From offline discussion, I'd vote for just dropping the `logResources` call.
> 
> - I cannot imagine there is a spec requirement or breaking concern over `diag.verbose()` output.
> - Side note: You commented on the `logResources()` (for a different reason) in the PR where this was added: https://github.com/open-telemetry/opentelemetry-js/pull/3460#discussion_r1040096977
> - There is already a `diag.debug` that dumps the raw Resource:
> 
> ```
> % cd metapackages/auto-instrumentation-node
> % OTEL_LOG_LEVEL=debug node -r ./build/src/register.js test/test-app/app.js
> ...
> ContainerDetector found resource. ResourceImpl {
>   _rawAttributes: [ [ 'container.id', [Promise] ] ],
>   _asyncAttributesPending: true,
>   _memoizedAttributes: undefined
> }
> EnvDetector found resource. ResourceImpl {
>   _rawAttributes: [],
>   _asyncAttributesPending: false,
>   _memoizedAttributes: undefined
> }
> HostDetector found resource. ResourceImpl {
>   _rawAttributes: [
>     [ 'host.name', 'peach.local' ],
>     [ 'host.arch', 'arm64' ],
>     [ 'host.id', [Promise] ]
>   ],
>   _asyncAttributesPending: true,
>   _memoizedAttributes: undefined
> }
> ...
> ```
> 
> Setting to `OTEL_LOG_LEVEL=verbose` then adds a *second* diag output for the detectors:
> 
> ```
> Trace: {
>     "os.type": "darwin",
>     "os.version": "24.3.0"
> }
>     at DiagConsoleLogger.verbose (/Users/trentm/src/opentelemetry-js-contrib/node_modules/@opentelemetry/api/build/src/diag/consoleLogger.js:46:40)
>     at DiagAPI.verbose (/Users/trentm/src/opentelemetry-js-contrib/node_modules/@opentelemetry/api/build/src/api/diag.js:40:40)
>     at /Users/trentm/src/opentelemetry-js-contrib/node_modules/@opentelemetry/resources/build/src/detect-resources.js:53:24
>     at Array.forEach (<anonymous>)
>     at logResources (/Users/trentm/src/opentelemetry-js-contrib/node_modules/@opentelemetry/resources/build/src/detect-resources.js:49:15)
>     at detectResources (/Users/trentm/src/opentelemetry-js-contrib/node_modules/@opentelemetry/resources/build/src/detect-resources.js:39:5)
>     at NodeSDK.start (/Users/trentm/src/opentelemetry-js-contrib/node_modules/@opentelemetry/sdk-node/build/src/sdk.js:225:83)
>     at Object.<anonymous> (/Users/trentm/src/opentelemetry-js-contrib/metapackages/auto-instrumentations-node/build/src/register.js:27:9)
>     at Module._compile (node:internal/modules/cjs/loader:1364:14)
>     at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
> ```

_Originally posted by @trentm in https://github.com/open-telemetry/opentelemetry-js/pull/5545#discussion_r2002105593_
       