### PR TITLE
refactor(opentelemetry-sdk-node): use new get*FromEnv() function in NodeSDK's metrics setup

### DIFF
--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -116,7 +116,7 @@ function getValueInMillis(envName: string, defaultValue: number): number {
  */
 function configureMetricProviderFromEnv(): IMetricReader[] {
   const metricReaders: IMetricReader[] = [];
-  const enabledExporters = getStringListFromEnv('OTEL_METRICS_EXPORTER')
+  const enabledExporters = getStringListFromEnv('OTEL_METRICS_EXPORTER');
   if (!enabledExporters) {
     return metricReaders;
   }

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -78,7 +78,6 @@ import {
 import {
   getResourceDetectorsFromEnv,
   getSpanProcessorsFromEnv,
-  filterBlanksAndNulls,
   getPropagatorFromEnv,
 } from './utils';
 

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -72,6 +72,7 @@ import { NodeSDKConfiguration } from './types';
 import {
   getBooleanFromEnv,
   getStringFromEnv,
+  getStringListFromEnv,
   diagLogLevelFromString,
   getStringListFromEnv,
 } from '@opentelemetry/core';
@@ -115,11 +116,10 @@ function getValueInMillis(envName: string, defaultValue: number): number {
  */
 function configureMetricProviderFromEnv(): IMetricReader[] {
   const metricReaders: IMetricReader[] = [];
-  const metricsExporterList = process.env.OTEL_METRICS_EXPORTER?.trim();
-  if (!metricsExporterList) {
+  const enabledExporters = getStringListFromEnv('OTEL_METRICS_EXPORTER')
+  if (!enabledExporters) {
     return metricReaders;
   }
-  const enabledExporters = filterBlanksAndNulls(metricsExporterList.split(','));
 
   if (enabledExporters.length === 0) {
     diag.debug('OTEL_METRICS_EXPORTER is empty. Using default otlp exporter.');

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -74,7 +74,6 @@ import {
   getStringFromEnv,
   getStringListFromEnv,
   diagLogLevelFromString,
-  getStringListFromEnv,
 } from '@opentelemetry/core';
 import {
   getResourceDetectorsFromEnv,


### PR DESCRIPTION
## Which problem is this PR solving?

Migrate from old process.env to use new get*FromEnv() function in NodeSDK's metrics setup
Part of Contribfest at KubeCon 2025

Fixes #5564

## Short description of the changes

use new get*FromEnv()

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
