### PR TITLE
refactor: use get*FromEnv() for logging setup

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,6 +16,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
+Refactored using get*FromEnv utility function instead of `process.env` for NodeSDK's logging setup.
+
 ## 0.200.0
 
 ### Summary

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -73,6 +73,7 @@ import {
   getBooleanFromEnv,
   getStringFromEnv,
   diagLogLevelFromString,
+  getStringListFromEnv,
 } from '@opentelemetry/core';
 import {
   getResourceDetectorsFromEnv,
@@ -446,8 +447,7 @@ export class NodeSDK {
   }
 
   private configureLoggerProviderFromEnv(): void {
-    const logExportersList = getStringFromEnv('OTEL_LOGS_EXPORTER') ?? '';
-    const enabledExporters = filterBlanksAndNulls(logExportersList.split(','));
+    const enabledExporters = getStringListFromEnv('OTEL_LOGS_EXPORTER') ?? [];
 
     if (enabledExporters.length === 0) {
       diag.debug('OTEL_LOGS_EXPORTER is empty. Using default otlp exporter.');

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -446,7 +446,7 @@ export class NodeSDK {
   }
 
   private configureLoggerProviderFromEnv(): void {
-    const logExportersList = process.env.OTEL_LOGS_EXPORTER ?? '';
+    const logExportersList = getStringFromEnv('OTEL_LOGS_EXPORTER') ?? '';
     const enabledExporters = filterBlanksAndNulls(logExportersList.split(','));
 
     if (enabledExporters.length === 0) {
@@ -466,8 +466,8 @@ export class NodeSDK {
     enabledExporters.forEach(exporter => {
       if (exporter === 'otlp') {
         const protocol = (
-          process.env.OTEL_EXPORTER_OTLP_LOGS_PROTOCOL ??
-          process.env.OTEL_EXPORTER_OTLP_PROTOCOL
+          getStringFromEnv('OTEL_EXPORTER_OTLP_LOGS_PROTOCOL') ??
+          getStringFromEnv('OTEL_EXPORTER_OTLP_PROTOCOL')
         )?.trim();
 
         switch (protocol) {


### PR DESCRIPTION
## Which problem is this PR solving?

Migrated away from using `process.env` to use the `getStringFromEnv`-function

Fixes #5563

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X]  Manually ran the unit tests

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been added
- [ ] Documentation has been updated
