### PR TITLE
refactor(resources): replace deprecated semconv consts

### DIFF
--- a/packages/opentelemetry-resources/src/detectors/platform/node/HostDetector.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/HostDetector.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  SEMRESATTRS_HOST_ARCH,
-  SEMRESATTRS_HOST_ID,
-  SEMRESATTRS_HOST_NAME,
-} from '@opentelemetry/semantic-conventions';
+import { ATTR_HOST_ARCH, ATTR_HOST_ID, ATTR_HOST_NAME } from '../../../semconv';
 import { arch, hostname } from 'os';
 import { ResourceDetectionConfig } from '../../../config';
 import {
@@ -36,9 +32,9 @@ import { normalizeArch } from './utils';
 class HostDetector implements ResourceDetector {
   detect(_config?: ResourceDetectionConfig): DetectedResource {
     const attributes: DetectedResourceAttributes = {
-      [SEMRESATTRS_HOST_NAME]: hostname(),
-      [SEMRESATTRS_HOST_ARCH]: normalizeArch(arch()),
-      [SEMRESATTRS_HOST_ID]: getMachineId(),
+      [ATTR_HOST_NAME]: hostname(),
+      [ATTR_HOST_ARCH]: normalizeArch(arch()),
+      [ATTR_HOST_ID]: getMachineId(),
     };
 
     return { attributes };

--- a/packages/opentelemetry-resources/src/detectors/platform/node/OSDetector.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/OSDetector.ts
@@ -15,10 +15,7 @@
  */
 
 import { Attributes } from '@opentelemetry/api';
-import {
-  SEMRESATTRS_OS_TYPE,
-  SEMRESATTRS_OS_VERSION,
-} from '@opentelemetry/semantic-conventions';
+import { ATTR_OS_TYPE, ATTR_OS_VERSION } from '../../../semconv';
 import { platform, release } from 'os';
 import { ResourceDetectionConfig } from '../../../config';
 import { DetectedResource, ResourceDetector } from '../../../types';
@@ -31,8 +28,8 @@ import { normalizeType } from './utils';
 class OSDetector implements ResourceDetector {
   detect(_config?: ResourceDetectionConfig): DetectedResource {
     const attributes: Attributes = {
-      [SEMRESATTRS_OS_TYPE]: normalizeType(platform()),
-      [SEMRESATTRS_OS_VERSION]: release(),
+      [ATTR_OS_TYPE]: normalizeType(platform()),
+      [ATTR_OS_VERSION]: release(),
     };
     return { attributes };
   }

--- a/packages/opentelemetry-resources/src/detectors/platform/node/ProcessDetector.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/ProcessDetector.ts
@@ -16,16 +16,16 @@
 
 import { Attributes, diag } from '@opentelemetry/api';
 import {
-  SEMRESATTRS_PROCESS_COMMAND,
-  SEMRESATTRS_PROCESS_COMMAND_ARGS,
-  SEMRESATTRS_PROCESS_EXECUTABLE_NAME,
-  SEMRESATTRS_PROCESS_EXECUTABLE_PATH,
-  SEMRESATTRS_PROCESS_OWNER,
-  SEMRESATTRS_PROCESS_PID,
-  SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION,
-  SEMRESATTRS_PROCESS_RUNTIME_NAME,
-  SEMRESATTRS_PROCESS_RUNTIME_VERSION,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_PROCESS_COMMAND,
+  ATTR_PROCESS_COMMAND_ARGS,
+  ATTR_PROCESS_EXECUTABLE_NAME,
+  ATTR_PROCESS_EXECUTABLE_PATH,
+  ATTR_PROCESS_OWNER,
+  ATTR_PROCESS_PID,
+  ATTR_PROCESS_RUNTIME_DESCRIPTION,
+  ATTR_PROCESS_RUNTIME_NAME,
+  ATTR_PROCESS_RUNTIME_VERSION,
+} from '../../../semconv';
 import * as os from 'os';
 import { ResourceDetectionConfig } from '../../../config';
 import { DetectedResource, ResourceDetector } from '../../../types';
@@ -37,26 +37,26 @@ import { DetectedResource, ResourceDetector } from '../../../types';
 class ProcessDetector implements ResourceDetector {
   detect(_config?: ResourceDetectionConfig): DetectedResource {
     const attributes: Attributes = {
-      [SEMRESATTRS_PROCESS_PID]: process.pid,
-      [SEMRESATTRS_PROCESS_EXECUTABLE_NAME]: process.title,
-      [SEMRESATTRS_PROCESS_EXECUTABLE_PATH]: process.execPath,
-      [SEMRESATTRS_PROCESS_COMMAND_ARGS]: [
+      [ATTR_PROCESS_PID]: process.pid,
+      [ATTR_PROCESS_EXECUTABLE_NAME]: process.title,
+      [ATTR_PROCESS_EXECUTABLE_PATH]: process.execPath,
+      [ATTR_PROCESS_COMMAND_ARGS]: [
         process.argv[0],
         ...process.execArgv,
         ...process.argv.slice(1),
       ],
-      [SEMRESATTRS_PROCESS_RUNTIME_VERSION]: process.versions.node,
-      [SEMRESATTRS_PROCESS_RUNTIME_NAME]: 'nodejs',
-      [SEMRESATTRS_PROCESS_RUNTIME_DESCRIPTION]: 'Node.js',
+      [ATTR_PROCESS_RUNTIME_VERSION]: process.versions.node,
+      [ATTR_PROCESS_RUNTIME_NAME]: 'nodejs',
+      [ATTR_PROCESS_RUNTIME_DESCRIPTION]: 'Node.js',
     };
 
     if (process.argv.length > 1) {
-      attributes[SEMRESATTRS_PROCESS_COMMAND] = process.argv[1];
+      attributes[ATTR_PROCESS_COMMAND] = process.argv[1];
     }
 
     try {
       const userInfo = os.userInfo();
-      attributes[SEMRESATTRS_PROCESS_OWNER] = userInfo.username;
+      attributes[ATTR_PROCESS_OWNER] = userInfo.username;
     } catch (e) {
       diag.debug(`error obtaining process owner: ${e}`);
     }

--- a/packages/opentelemetry-resources/src/detectors/platform/node/ServiceInstanceIdDetector.ts
+++ b/packages/opentelemetry-resources/src/detectors/platform/node/ServiceInstanceIdDetector.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { SEMRESATTRS_SERVICE_INSTANCE_ID } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_INSTANCE_ID } from '../../../semconv';
 import { randomUUID } from 'crypto';
 import { ResourceDetectionConfig } from '../../../config';
 import { DetectedResource, ResourceDetector } from '../../../types';
@@ -26,7 +26,7 @@ class ServiceInstanceIdDetector implements ResourceDetector {
   detect(_config?: ResourceDetectionConfig): DetectedResource {
     return {
       attributes: {
-        [SEMRESATTRS_SERVICE_INSTANCE_ID]: randomUUID(),
+        [ATTR_SERVICE_INSTANCE_ID]: randomUUID(),
       },
     };
   }

--- a/packages/opentelemetry-resources/src/semconv.ts
+++ b/packages/opentelemetry-resources/src/semconv.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The CPU architecture the host system is running on.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HOST_ARCH = 'host.arch' as const;
+/**
+ * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system.
+ *
+ * @example fdbf79e8af94cb7f9e8df36789187052
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HOST_ID = 'host.id' as const;
+/**
+ * Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user.
+ *
+ * @example opentelemetry-test
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HOST_NAME = 'host.name' as const;
+/**
+ * The operating system type.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_OS_TYPE = 'os.type' as const;
+/**
+ * The version string of the operating system as defined in [Version Attributes](/docs/resource/README.md#version-attributes).
+ *
+ * @example 14.2.1
+ * @example 18.04.1
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_OS_VERSION = 'os.version' as const;
+/**
+ * The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`.
+ *
+ * @example cmd/otelcol
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_PROCESS_COMMAND = 'process.command' as const;
+/**
+ * All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`.
+ *
+ * @example ["cmd/otecol", "--config=config.yaml"]
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_PROCESS_COMMAND_ARGS = 'process.command_args' as const;
+/**
+ * The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`.
+ *
+ * @example otelcol
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_PROCESS_EXECUTABLE_NAME = 'process.executable.name' as const;
+/**
+ * The full path to the process executable. On Linux based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`.
+ *
+ * @example /usr/bin/cmd/otelcol
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_PROCESS_EXECUTABLE_PATH = 'process.executable.path' as const;
+/**
+ * The username of the user that owns the process.
+ *
+ * @example root
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_PROCESS_OWNER = 'process.owner' as const;
+/**
+ * Process identifier (PID).
+ *
+ * @example 1234
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_PROCESS_PID = 'process.pid' as const;
+/**
+ * An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment.
+ *
+ * @example "Eclipse OpenJ9 Eclipse OpenJ9 VM openj9-0.21.0"
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_PROCESS_RUNTIME_DESCRIPTION =
+  'process.runtime.description' as const;
+/**
+ * The name of the runtime of this process.
+ *
+ * @example OpenJDK Runtime Environment
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_PROCESS_RUNTIME_NAME = 'process.runtime.name' as const;
+/**
+ * The version of the runtime of this process, as returned by the runtime without modification.
+ *
+ * @example "14.0.2"
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_PROCESS_RUNTIME_VERSION = 'process.runtime.version' as const;
+/**
+ * The string ID of the service instance.
+ *
+ * @example 627cc493-f310-47de-96bd-71410b7dec09
+ *
+ * @note **MUST** be unique for each instance of the same `service.namespace,service.name` pair (in other words
+ * `service.namespace,service.name,service.instance.id` triplet **MUST** be globally unique). The ID helps to
+ * distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled
+ * service).
+ *
+ * Implementations, such as SDKs, are recommended to generate a random Version 1 or Version 4 [RFC
+ * 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID, but are free to use an inherent unique ID as the source of
+ * this value if stability is desirable. In that case, the ID **SHOULD** be used as source of a UUID Version 5 and
+ * **SHOULD** use the following UUID as the namespace: `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
+ *
+ * UUIDs are typically recommended, as only an opaque value for the purposes of identifying a service instance is
+ * needed. Similar to what can be seen in the man page for the
+ * [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/latest/machine-id.html) file, the underlying
+ * data, such as pod name and namespace should be treated as confidential, being the user's choice to expose it
+ * or not via another resource attribute.
+ *
+ * For applications running behind an application server (like unicorn), we do not recommend using one identifier
+ * for all processes participating in the application. Instead, it's recommended each division (e.g. a worker
+ * thread in unicorn) to have its own instance.id.
+ *
+ * It's not recommended for a Collector to set `service.instance.id` if it can't unambiguously determine the
+ * service instance that is generating that telemetry. For instance, creating an UUID based on `pod.name` will
+ * likely be wrong, as the Collector might not know from which container within that pod the telemetry originated.
+ * However, Collectors can set the `service.instance.id` if they can unambiguously determine the service instance
+ * for that telemetry. This is typically the case for scraping receivers, as they know the target address and
+ * port.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_SERVICE_INSTANCE_ID = 'service.instance.id' as const;


### PR DESCRIPTION
Moved from deprecated to constants that are in incubation.

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This PR is part of the Kubecon 2025 Contribfest. I is a simple migration of deprecated constants from ‘@opentelemetry/semantic-conventions‘.

Fixes #5576

## Short description of the changes

I moved deprecated constants in ‘@opentelemetry/semantic-conventions‘ that were moved into ‘@opentelemetry/semantic-conventions/incubating‘ by following the TSdoc of the module.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] ‘npm test‘ on module ‘@opentelemetry/resources‘
- [x]  ‘npm lint‘ on module ‘@opentelemetry/resources‘

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated
