### PR TITLE
feat(@opentelemetry/sdk-logs): align LoggerProvider constructor options with Trace and Metrics SDK

### DIFF
--- a/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
@@ -78,14 +78,15 @@ describe('OTLPLogExporter', function () {
 
   it('successfully exports data', async () => {
     // arrange
-    const loggerProvider = new LoggerProvider();
-    loggerProvider.addLogRecordProcessor(
-      new SimpleLogRecordProcessor(
-        new OTLPLogExporter({
-          url: 'http://localhost:1503',
-        })
-      )
-    );
+    const loggerProvider = new LoggerProvider({
+      processors: [
+        new SimpleLogRecordProcessor(
+          new OTLPLogExporter({
+            url: 'http://localhost:1503',
+          })
+        ),
+      ],
+    });
 
     // act
     loggerProvider.getLogger('test-logger').emit({

--- a/experimental/packages/exporter-logs-otlp-http/test/browser/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-http/test/browser/OTLPLogExporter.test.ts
@@ -39,10 +39,9 @@ describe('OTLPLogExporter', function () {
       it('should successfully send data using sendBeacon', async function () {
         // arrange
         const stubBeacon = sinon.stub(navigator, 'sendBeacon');
-        const loggerProvider = new LoggerProvider();
-        loggerProvider.addLogRecordProcessor(
-          new SimpleLogRecordProcessor(new OTLPLogExporter())
-        );
+        const loggerProvider = new LoggerProvider({
+          processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+        });
 
         // act
         loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
@@ -68,10 +67,9 @@ describe('OTLPLogExporter', function () {
       it('should successfully send data using XMLHttpRequest', async function () {
         // arrange
         const server = sinon.fakeServer.create();
-        const loggerProvider = new LoggerProvider();
-        loggerProvider.addLogRecordProcessor(
-          new SimpleLogRecordProcessor(new OTLPLogExporter())
-        );
+        const loggerProvider = new LoggerProvider({
+          processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+        });
 
         // act
         loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });

--- a/experimental/packages/exporter-logs-otlp-http/test/node/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-http/test/node/OTLPLogExporter.test.ts
@@ -62,10 +62,9 @@ describe('OTLPLogExporter', () => {
         buff = Buffer.concat([buff, chunk]);
       });
 
-      const loggerProvider = new LoggerProvider();
-      loggerProvider.addLogRecordProcessor(
-        new SimpleLogRecordProcessor(new OTLPLogExporter())
-      );
+      const loggerProvider = new LoggerProvider({
+        processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+      });
 
       loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
       loggerProvider.shutdown();

--- a/experimental/packages/exporter-logs-otlp-proto/test/browser/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/test/browser/OTLPLogExporter.test.ts
@@ -39,10 +39,9 @@ describe('OTLPLogExporter', function () {
       it('should successfully send data using sendBeacon', async function () {
         // arrange
         const stubBeacon = sinon.stub(navigator, 'sendBeacon');
-        const loggerProvider = new LoggerProvider();
-        loggerProvider.addLogRecordProcessor(
-          new SimpleLogRecordProcessor(new OTLPLogExporter())
-        );
+        const loggerProvider = new LoggerProvider({
+          processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+        });
 
         // act
         loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
@@ -68,10 +67,9 @@ describe('OTLPLogExporter', function () {
       it('should successfully send data using XMLHttpRequest', async function () {
         // arrange
         const server = sinon.fakeServer.create();
-        const loggerProvider = new LoggerProvider();
-        loggerProvider.addLogRecordProcessor(
-          new SimpleLogRecordProcessor(new OTLPLogExporter())
-        );
+        const loggerProvider = new LoggerProvider({
+          processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+        });
 
         // act
         loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });

--- a/experimental/packages/exporter-logs-otlp-proto/test/node/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/test/node/OTLPLogExporter.test.ts
@@ -62,10 +62,9 @@ describe('OTLPLogExporter', () => {
         buff = Buffer.concat([buff, chunk]);
       });
 
-      const loggerProvider = new LoggerProvider();
-      loggerProvider.addLogRecordProcessor(
-        new SimpleLogRecordProcessor(new OTLPLogExporter())
-      );
+      const loggerProvider = new LoggerProvider({
+        processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+      });
 
       loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
       loggerProvider.shutdown();

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -384,12 +384,8 @@ export class NodeSDK {
     if (this._loggerProviderConfig) {
       const loggerProvider = new LoggerProvider({
         resource: this._resource,
+        processors: this._loggerProviderConfig.logRecordProcessors,
       });
-
-      for (const logRecordProcessor of this._loggerProviderConfig
-        .logRecordProcessors) {
-        loggerProvider.addLogRecordProcessor(logRecordProcessor);
-      }
 
       this._loggerProvider = loggerProvider;
 

--- a/experimental/packages/sdk-logs/src/LoggerProvider.ts
+++ b/experimental/packages/sdk-logs/src/LoggerProvider.ts
@@ -20,11 +20,11 @@ import { defaultResource } from '@opentelemetry/resources';
 import { BindOnceFuture, merge } from '@opentelemetry/core';
 
 import type { LoggerProviderConfig } from './types';
-import type { LogRecordProcessor } from './LogRecordProcessor';
 import { Logger } from './Logger';
 import { loadDefaultConfig, reconfigureLimits } from './config';
-import { MultiLogRecordProcessor } from './MultiLogRecordProcessor';
 import { LoggerProviderSharedState } from './internal/LoggerProviderSharedState';
+import { LogRecordProcessor } from './LogRecordProcessor';
+import { MultiLogRecordProcessor } from './MultiLogRecordProcessor';
 
 export const DEFAULT_LOGGER_NAME = 'unknown';
 
@@ -38,7 +38,8 @@ export class LoggerProvider implements logsAPI.LoggerProvider {
     this._sharedState = new LoggerProviderSharedState(
       resource,
       mergedConfig.forceFlushTimeoutMillis,
-      reconfigureLimits(mergedConfig.logRecordLimits)
+      reconfigureLimits(mergedConfig.logRecordLimits),
+      config?.processors ?? []
     );
     this._shutdownOnce = new BindOnceFuture(this._shutdown, this);
   }

--- a/experimental/packages/sdk-logs/src/LoggerProvider.ts
+++ b/experimental/packages/sdk-logs/src/LoggerProvider.ts
@@ -76,6 +76,8 @@ export class LoggerProvider implements logsAPI.LoggerProvider {
   }
 
   /**
+   * @deprecated add your processors in the constructors instead.
+   * 
    * Adds a new {@link LogRecordProcessor} to this logger.
    * @param processor the new LogRecordProcessor to be added.
    */

--- a/experimental/packages/sdk-logs/src/LoggerProvider.ts
+++ b/experimental/packages/sdk-logs/src/LoggerProvider.ts
@@ -77,7 +77,7 @@ export class LoggerProvider implements logsAPI.LoggerProvider {
 
   /**
    * @deprecated add your processors in the constructors instead.
-   * 
+   *
    * Adds a new {@link LogRecordProcessor} to this logger.
    * @param processor the new LogRecordProcessor to be added.
    */

--- a/experimental/packages/sdk-logs/src/internal/LoggerProviderSharedState.ts
+++ b/experimental/packages/sdk-logs/src/internal/LoggerProviderSharedState.ts
@@ -19,6 +19,7 @@ import { Resource } from '@opentelemetry/resources';
 import { LogRecordProcessor } from '../LogRecordProcessor';
 import { LogRecordLimits } from '../types';
 import { NoopLogRecordProcessor } from '../export/NoopLogRecordProcessor';
+import { MultiLogRecordProcessor } from '../MultiLogRecordProcessor';
 
 export class LoggerProviderSharedState {
   readonly loggers: Map<string, Logger> = new Map();
@@ -28,8 +29,17 @@ export class LoggerProviderSharedState {
   constructor(
     readonly resource: Resource,
     readonly forceFlushTimeoutMillis: number,
-    readonly logRecordLimits: Required<LogRecordLimits>
+    readonly logRecordLimits: Required<LogRecordLimits>,
+    readonly processors: LogRecordProcessor[]
   ) {
-    this.activeProcessor = new NoopLogRecordProcessor();
+    if (processors.length > 0) {
+      this.registeredLogRecordProcessors = processors;
+      this.activeProcessor = new MultiLogRecordProcessor(
+        this.registeredLogRecordProcessors,
+        this.forceFlushTimeoutMillis
+      );
+    } else {
+      this.activeProcessor = new NoopLogRecordProcessor();
+    }
   }
 }

--- a/experimental/packages/sdk-logs/src/types.ts
+++ b/experimental/packages/sdk-logs/src/types.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Resource } from '@opentelemetry/resources';
+import { LogRecordProcessor } from './LogRecordProcessor';
 
 export interface LoggerProviderConfig {
   /** Resource associated with trace telemetry  */
@@ -28,6 +29,9 @@ export interface LoggerProviderConfig {
 
   /** Log Record Limits*/
   logRecordLimits?: LogRecordLimits;
+
+  /** Log Record Processors */
+  processors?: LogRecordProcessor[];
 }
 
 export interface LogRecordLimits {

--- a/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
@@ -51,7 +51,8 @@ const setup = (logRecordLimits?: LogRecordLimits, data?: logsAPI.LogRecord) => {
   const sharedState = new LoggerProviderSharedState(
     resource,
     Infinity,
-    reconfigureLimits(logRecordLimits ?? {})
+    reconfigureLimits(logRecordLimits ?? {}),
+    []
   );
   const logRecord = new LogRecord(
     sharedState,
@@ -424,8 +425,7 @@ describe('LogRecord', () => {
         forceFlush: () => Promise.resolve(),
         shutdown: () => Promise.resolve(),
       };
-      const provider = new LoggerProvider();
-      provider.addLogRecordProcessor(processor);
+      const provider = new LoggerProvider({ processors: [processor] });
       provider.getLogger('default').emit({ body: 'test' });
       assert.ok(emitted);
     });

--- a/experimental/packages/sdk-logs/test/common/Logger.test.ts
+++ b/experimental/packages/sdk-logs/test/common/Logger.test.ts
@@ -23,9 +23,8 @@ import { LogRecord as ApiLogRecord } from '@opentelemetry/api-logs';
 import { Logger } from '../../src/Logger';
 
 const setup = () => {
-  const loggerProvider = new LoggerProvider();
   const logProcessor = new NoopLogRecordProcessor();
-  loggerProvider.addLogRecordProcessor(logProcessor);
+  const loggerProvider = new LoggerProvider({ processors: [logProcessor] });
   const logger = loggerProvider.getLogger('test name', 'test version', {
     schemaUrl: 'test schema url',
   }) as Logger;

--- a/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
@@ -203,10 +203,9 @@ describe('LoggerProvider', () => {
 
   describe('addLogRecordProcessor', () => {
     it('should add logRecord processor', () => {
-      const provider = new LoggerProvider();
-      const sharedState = provider['_sharedState'];
       const logRecordProcessor = new NoopLogRecordProcessor();
-      provider.addLogRecordProcessor(logRecordProcessor);
+      const provider = new LoggerProvider({ processors: [logRecordProcessor] });
+      const sharedState = provider['_sharedState'];
       assert.ok(sharedState.activeProcessor instanceof MultiLogRecordProcessor);
       assert.strictEqual(sharedState.activeProcessor.processors.length, 1);
       assert.strictEqual(
@@ -225,12 +224,11 @@ describe('LoggerProvider', () => {
       );
       forceFlushStub.resolves();
 
-      const provider = new LoggerProvider();
       const logRecordProcessorOne = new NoopLogRecordProcessor();
       const logRecordProcessorTwo = new NoopLogRecordProcessor();
-
-      provider.addLogRecordProcessor(logRecordProcessorOne);
-      provider.addLogRecordProcessor(logRecordProcessorTwo);
+      const provider = new LoggerProvider({
+        processors: [logRecordProcessorOne, logRecordProcessorTwo],
+      });
 
       provider
         .forceFlush()
@@ -254,12 +252,11 @@ describe('LoggerProvider', () => {
       );
       forceFlushStub.returns(Promise.reject('Error'));
 
-      const provider = new LoggerProvider();
       const logRecordProcessorOne = new NoopLogRecordProcessor();
       const logRecordProcessorTwo = new NoopLogRecordProcessor();
-
-      provider.addLogRecordProcessor(logRecordProcessorOne);
-      provider.addLogRecordProcessor(logRecordProcessorTwo);
+      const provider = new LoggerProvider({
+        processors: [logRecordProcessorOne, logRecordProcessorTwo],
+      });
 
       provider
         .forceFlush()
@@ -277,9 +274,8 @@ describe('LoggerProvider', () => {
 
   describe('.shutdown()', () => {
     it('should trigger shutdown when manually invoked', () => {
-      const provider = new LoggerProvider();
       const processor = new NoopLogRecordProcessor();
-      provider.addLogRecordProcessor(processor);
+      const provider = new LoggerProvider({ processors: [processor] });
       const shutdownStub = sinon.stub(processor, 'shutdown');
       provider.shutdown();
       sinon.assert.calledOnce(shutdownStub);
@@ -294,9 +290,10 @@ describe('LoggerProvider', () => {
     });
 
     it('should not force flush on shutdown', () => {
-      const provider = new LoggerProvider();
       const logRecordProcessor = new NoopLogRecordProcessor();
-      provider.addLogRecordProcessor(logRecordProcessor);
+      const provider = new LoggerProvider({
+        processors: [logRecordProcessor],
+      });
       const forceFlushStub = sinon.stub(logRecordProcessor, 'forceFlush');
       const warnStub = sinon.spy(diag, 'warn');
       provider.shutdown();
@@ -306,9 +303,10 @@ describe('LoggerProvider', () => {
     });
 
     it('should not shutdown on shutdown', () => {
-      const provider = new LoggerProvider();
       const logRecordProcessor = new NoopLogRecordProcessor();
-      provider.addLogRecordProcessor(logRecordProcessor);
+      const provider = new LoggerProvider({
+        processors: [logRecordProcessor],
+      });
       const shutdownStub = sinon.stub(logRecordProcessor, 'shutdown');
       const warnStub = sinon.spy(diag, 'warn');
       provider.shutdown();

--- a/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
@@ -203,9 +203,10 @@ describe('LoggerProvider', () => {
 
   describe('addLogRecordProcessor', () => {
     it('should add logRecord processor', () => {
-      const logRecordProcessor = new NoopLogRecordProcessor();
-      const provider = new LoggerProvider({ processors: [logRecordProcessor] });
+      const provider = new LoggerProvider();
       const sharedState = provider['_sharedState'];
+      const logRecordProcessor = new NoopLogRecordProcessor();
+      provider.addLogRecordProcessor(logRecordProcessor);
       assert.ok(sharedState.activeProcessor instanceof MultiLogRecordProcessor);
       assert.strictEqual(sharedState.activeProcessor.processors.length, 1);
       assert.strictEqual(

--- a/experimental/packages/sdk-logs/test/common/MultiLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/MultiLogRecordProcessor.test.ts
@@ -60,8 +60,7 @@ describe('MultiLogRecordProcessor', () => {
   describe('onEmit', () => {
     it('should handle empty log record processor', () => {
       const { multiProcessor } = setup();
-      const provider = new LoggerProvider();
-      provider.addLogRecordProcessor(multiProcessor);
+      const provider = new LoggerProvider({ processors: [multiProcessor] });
       const logger = provider.getLogger('default');
       logger.emit({ body: 'one' });
       multiProcessor.shutdown();
@@ -70,8 +69,7 @@ describe('MultiLogRecordProcessor', () => {
     it('should handle one log record processor', () => {
       const processor1 = new TestProcessor();
       const { multiProcessor } = setup([processor1]);
-      const provider = new LoggerProvider();
-      provider.addLogRecordProcessor(multiProcessor);
+      const provider = new LoggerProvider({ processors: [multiProcessor] });
       const logger = provider.getLogger('default');
       assert.strictEqual(processor1.logRecords.length, 0);
 
@@ -84,8 +82,7 @@ describe('MultiLogRecordProcessor', () => {
       const processor1 = new TestProcessor();
       const processor2 = new TestProcessor();
       const { multiProcessor } = setup([processor1, processor2]);
-      const provider = new LoggerProvider();
-      provider.addLogRecordProcessor(multiProcessor);
+      const provider = new LoggerProvider({ processors: [multiProcessor] });
       const logger = provider.getLogger('default');
 
       assert.strictEqual(processor1.logRecords.length, 0);
@@ -186,8 +183,7 @@ describe('MultiLogRecordProcessor', () => {
       const processor1 = new TestProcessor();
       const processor2 = new TestProcessor();
       const { multiProcessor } = setup([processor1, processor2]);
-      const provider = new LoggerProvider();
-      provider.addLogRecordProcessor(multiProcessor);
+      const provider = new LoggerProvider({ processors: [multiProcessor] });
       const logger = provider.getLogger('default');
 
       assert.strictEqual(processor1.logRecords.length, 0);

--- a/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
@@ -49,7 +49,8 @@ const createLogRecord = (
   const sharedState = new LoggerProviderSharedState(
     resource || defaultResource(),
     Infinity,
-    reconfigureLimits(limits ?? {})
+    reconfigureLimits(limits ?? {}),
+    []
   );
   const logRecord = new LogRecord(
     sharedState,

--- a/experimental/packages/sdk-logs/test/common/export/ConsoleLogRecordExporter.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/ConsoleLogRecordExporter.test.ts
@@ -45,10 +45,9 @@ describe('ConsoleLogRecordExporter', () => {
         const consoleExporter = new ConsoleLogRecordExporter();
         const spyConsole = sinon.spy(console, 'dir');
         const spyExport = sinon.spy(consoleExporter, 'export');
-        const provider = new LoggerProvider();
-        provider.addLogRecordProcessor(
-          new SimpleLogRecordProcessor(consoleExporter)
-        );
+        const provider = new LoggerProvider({
+          processors: [new SimpleLogRecordProcessor(consoleExporter)],
+        });
 
         provider
           .getLogger(instrumentationScopeName, instrumentationScopeVersion)

--- a/experimental/packages/sdk-logs/test/common/export/InMemoryLogRecordExporter.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/InMemoryLogRecordExporter.test.ts
@@ -25,9 +25,10 @@ import {
 } from '../../../src';
 
 const setup = () => {
-  const provider = new LoggerProvider();
   const memoryExporter = new InMemoryLogRecordExporter();
-  provider.addLogRecordProcessor(new SimpleLogRecordProcessor(memoryExporter));
+  const provider = new LoggerProvider({
+    processors: [new SimpleLogRecordProcessor(memoryExporter)],
+  });
   return { provider, memoryExporter };
 };
 

--- a/experimental/packages/sdk-logs/test/common/export/SimpleLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/SimpleLogRecordProcessor.test.ts
@@ -41,7 +41,8 @@ const setup = (exporter: LogRecordExporter, resource?: Resource) => {
   const sharedState = new LoggerProviderSharedState(
     resource || defaultResource(),
     Infinity,
-    reconfigureLimits({})
+    reconfigureLimits({}),
+    []
   );
   const logRecord = new LogRecord(
     sharedState,

--- a/experimental/packages/web-common/test/SessionLogRecordProcessor.test.ts
+++ b/experimental/packages/web-common/test/SessionLogRecordProcessor.test.ts
@@ -36,9 +36,9 @@ describe('SessionLogRecordProcessor', function () {
 
     const exporter = new InMemoryLogRecordExporter();
     const processor = new SessionLogRecordProcessor(sessionProvider);
-    const provider = new LoggerProvider();
-    provider.addLogRecordProcessor(processor);
-    provider.addLogRecordProcessor(new SimpleLogRecordProcessor(exporter));
+    const provider = new LoggerProvider({
+      processors: [processor, new SimpleLogRecordProcessor(exporter)],
+    });
 
     const logger = provider.getLogger('session-testing');
     logger.emit({ body: 'test-body' });
@@ -56,9 +56,9 @@ describe('SessionLogRecordProcessor', function () {
 
     const exporter = new InMemoryLogRecordExporter();
     const processor = new SessionLogRecordProcessor(sessionProvider);
-    const provider = new LoggerProvider();
-    provider.addLogRecordProcessor(processor);
-    provider.addLogRecordProcessor(new SimpleLogRecordProcessor(exporter));
+    const provider = new LoggerProvider({
+      processors: [processor, new SimpleLogRecordProcessor(exporter)],
+    });
 
     const logger = provider.getLogger('session-testing');
     logger.emit({ body: 'test-body' });
@@ -70,9 +70,9 @@ describe('SessionLogRecordProcessor', function () {
   it('does not add session.id attribute when there is no provider', function () {
     const exporter = new InMemoryLogRecordExporter();
     const processor = new SessionLogRecordProcessor(null as any);
-    const provider = new LoggerProvider();
-    provider.addLogRecordProcessor(processor);
-    provider.addLogRecordProcessor(new SimpleLogRecordProcessor(exporter));
+    const provider = new LoggerProvider({
+      processors: [processor, new SimpleLogRecordProcessor(exporter)],
+    });
 
     const logger = provider.getLogger('session-testing');
     logger.emit({ body: 'test-body' });


### PR DESCRIPTION
Fixes #5559

Moved the "logic" from `LoggerProvider#addLogRecordProcessor()` to the `LoggerProviderSharedState`.
