### PR TITLE
feat(semantic-conventions): update semantic conventions to v1.31.0

### DIFF
--- a/scripts/semconv/generate.sh
+++ b/scripts/semconv/generate.sh
@@ -7,9 +7,9 @@ ROOT_DIR="${SCRIPT_DIR}/../../"
 
 # Get latest version by running `git tag -l --sort=version:refname | tail -1`
 # ... in git@github.com:open-telemetry/semantic-conventions.git
-SPEC_VERSION=v1.30.0
+SPEC_VERSION=v1.31.0
 # ... in git@github.com:open-telemetry/weaver.git
-GENERATOR_VERSION=v0.12.0
+GENERATOR_VERSION=v0.13.2
 
 # When running on windows and you are getting references to ";C" (like Telemetry;C)
 # then this is an issue with the bash shell, so first run the following in your shell:

--- a/scripts/semconv/templates/registry/stable/docstring.ts.j2
+++ b/scripts/semconv/templates/registry/stable/docstring.ts.j2
@@ -20,7 +20,7 @@
 {% endif -%}
 
 {%- if obj is deprecated %}
-  {%- set deprecated_jsdoc = "\n@deprecated " ~ strong_rfc2119(obj.deprecated) -%}
+  {%- set deprecated_jsdoc = "\n@deprecated " ~ strong_rfc2119(obj.deprecated.note) -%}
 {%- endif -%}
 
 {{ [

--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -9,6 +9,121 @@ All notable changes to the semantic-conventions package will be documented in th
 
 ### :rocket: Features
 
+* feat: update semantic conventions to v1.31.0
+  * Semantic Conventions v1.31.0: [changelog](https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md#v1310) | [latest docs](https://opentelemetry.io/docs/specs/semconv/)
+  * `@opentelemetry/semantic-conventions` (stable) changes: *none*
+  * `@opentelemetry/semantic-conventions/incubating` (unstable) changes: *8 newly deprecated exports, 1 newly undeprecated export, 63 added exports*
+
+#### Unstable changes in v1.31.0
+
+<details>
+<summary>8 newly deprecated exports</summary>
+
+```js
+METRIC_K8S_REPLICATION_CONTROLLER_AVAILABLE_PODS // k8s.replication_controller.available_pods: Replaced by `k8s.replicationcontroller.available_pods`.
+METRIC_K8S_REPLICATION_CONTROLLER_DESIRED_PODS   // k8s.replication_controller.desired_pods: Replaced by `k8s.replicationcontroller.desired_pods`.
+METRIC_SYSTEM_CPU_FREQUENCY                      // system.cpu.frequency: Replaced by `cpu.frequency`.
+METRIC_SYSTEM_CPU_TIME                           // system.cpu.time: Replaced by `cpu.time`.
+METRIC_SYSTEM_CPU_UTILIZATION                    // system.cpu.utilization: Replaced by `cpu.utilization`.
+ATTR_CODE_FILEPATH                               // code.filepath: Replaced by `code.file.path`
+ATTR_CODE_NAMESPACE                              // code.namespace: Value should be included in `code.function.name` which is expected to be a fully-qualified name.
+ATTR_GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT       // gen_ai.openai.request.response_format: Replaced by `gen_ai.output.type`.
+```
+
+</details>
+
+<details>
+<summary>1 newly undeprecated export</summary>
+
+```js
+ATTR_ENDUSER_ID // enduser.id
+```
+
+</details>
+
+<details>
+<summary>63 added exports</summary>
+
+```js
+METRIC_CPU_FREQUENCY                                   // cpu.frequency
+METRIC_CPU_TIME                                        // cpu.time
+METRIC_CPU_UTILIZATION                                 // cpu.utilization
+
+METRIC_HW_HOST_AMBIENT_TEMPERATURE                     // hw.host.ambient_temperature
+METRIC_HW_HOST_ENERGY                                  // hw.host.energy
+METRIC_HW_HOST_HEATING_MARGIN                          // hw.host.heating_margin
+METRIC_HW_HOST_POWER                                   // hw.host.power
+
+METRIC_K8S_REPLICATIONCONTROLLER_AVAILABLE_PODS        // k8s.replicationcontroller.available_pods
+METRIC_K8S_REPLICATIONCONTROLLER_DESIRED_PODS          // k8s.replicationcontroller.desired_pods
+
+METRIC_OTEL_SDK_EXPORTER_SPAN_EXPORTED_COUNT           // otel.sdk.exporter.span.exported.count
+METRIC_OTEL_SDK_EXPORTER_SPAN_INFLIGHT_COUNT           // otel.sdk.exporter.span.inflight.count
+METRIC_OTEL_SDK_PROCESSOR_SPAN_PROCESSED_COUNT         // otel.sdk.processor.span.processed.count
+METRIC_OTEL_SDK_PROCESSOR_SPAN_QUEUE_CAPACITY          // otel.sdk.processor.span.queue.capacity
+METRIC_OTEL_SDK_PROCESSOR_SPAN_QUEUE_SIZE              // otel.sdk.processor.span.queue.size
+METRIC_OTEL_SDK_SPAN_ENDED_COUNT                       // otel.sdk.span.ended.count
+METRIC_OTEL_SDK_SPAN_LIVE_COUNT                        // otel.sdk.span.live.count
+
+ATTR_ANDROID_APP_STATE                                 // android.app.state
+  ANDROID_APP_STATE_VALUE_BACKGROUND                     // "background"
+  ANDROID_APP_STATE_VALUE_CREATED                        // "created"
+  ANDROID_APP_STATE_VALUE_FOREGROUND                     // "foreground"
+
+ATTR_CICD_PIPELINE_RUN_URL_FULL                        // cicd.pipeline.run.url.full
+
+ATTR_CPU_LOGICAL_NUMBER                                // cpu.logical_number
+
+ATTR_ENDUSER_PSEUDO_ID                                 // enduser.pseudo.id
+
+ATTR_GEN_AI_AGENT_DESCRIPTION                          // gen_ai.agent.description
+ATTR_GEN_AI_AGENT_ID                                   // gen_ai.agent.id
+ATTR_GEN_AI_AGENT_NAME                                 // gen_ai.agent.name
+GEN_AI_OPERATION_NAME_VALUE_CREATE_AGENT               // "create_agent"
+GEN_AI_OPERATION_NAME_VALUE_EXECUTE_TOOL               // "execute_tool"
+ATTR_GEN_AI_OUTPUT_TYPE                                // gen_ai.output.type
+  GEN_AI_OUTPUT_TYPE_VALUE_IMAGE                         // "image"
+  GEN_AI_OUTPUT_TYPE_VALUE_JSON                          // "json"
+  GEN_AI_OUTPUT_TYPE_VALUE_SPEECH                        // "speech"
+  GEN_AI_OUTPUT_TYPE_VALUE_TEXT                          // "text"
+ATTR_GEN_AI_REQUEST_CHOICE_COUNT                       // gen_ai.request.choice.count
+GEN_AI_TOKEN_TYPE_VALUE_OUTPUT                         // "output"
+ATTR_GEN_AI_TOOL_CALL_ID                               // gen_ai.tool.call.id
+ATTR_GEN_AI_TOOL_NAME                                  // gen_ai.tool.name
+ATTR_GEN_AI_TOOL_TYPE                                  // gen_ai.tool.type
+
+ATTR_IOS_APP_STATE                                     // ios.app.state
+  IOS_APP_STATE_VALUE_ACTIVE                             // "active"
+  IOS_APP_STATE_VALUE_BACKGROUND                         // "background"
+  IOS_APP_STATE_VALUE_FOREGROUND                         // "foreground"
+  IOS_APP_STATE_VALUE_INACTIVE                           // "inactive"
+  IOS_APP_STATE_VALUE_TERMINATE                          // "terminate"
+
+ATTR_K8S_HPA_NAME                                      // k8s.hpa.name
+ATTR_K8S_HPA_UID                                       // k8s.hpa.uid
+ATTR_K8S_REPLICATIONCONTROLLER_NAME                    // k8s.replicationcontroller.name
+ATTR_K8S_REPLICATIONCONTROLLER_UID                     // k8s.replicationcontroller.uid
+ATTR_K8S_RESOURCEQUOTA_NAME                            // k8s.resourcequota.name
+ATTR_K8S_RESOURCEQUOTA_UID                             // k8s.resourcequota.uid
+
+ATTR_OTEL_COMPONENT_NAME                               // otel.component.name
+ATTR_OTEL_COMPONENT_TYPE                               // otel.component.type
+  OTEL_COMPONENT_TYPE_VALUE_BATCHING_SPAN_PROCESSOR      // "batching_span_processor"
+  OTEL_COMPONENT_TYPE_VALUE_OTLP_GRPC_SPAN_EXPORTER      // "otlp_grpc_span_exporter"
+  OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_JSON_SPAN_EXPORTER // "otlp_http_json_span_exporter"
+  OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_SPAN_EXPORTER      // "otlp_http_span_exporter"
+  OTEL_COMPONENT_TYPE_VALUE_SIMPLE_SPAN_PROCESSOR        // "simple_span_processor"
+ATTR_OTEL_SPAN_SAMPLING_RESULT                         // otel.span.sampling_result
+  OTEL_SPAN_SAMPLING_RESULT_VALUE_DROP                   // "DROP"
+  OTEL_SPAN_SAMPLING_RESULT_VALUE_RECORD_AND_SAMPLE      // "RECORD_AND_SAMPLE"
+  OTEL_SPAN_SAMPLING_RESULT_VALUE_RECORD_ONLY            // "RECORD_ONLY"
+
+ATTR_USER_AGENT_OS_NAME                                // user_agent.os.name
+ATTR_USER_AGENT_OS_VERSION                             // user_agent.os.version
+```
+
+</details>
+
 ### :bug: Bug Fixes
 
 ### :books: Documentation

--- a/semantic-conventions/src/experimental_attributes.ts
+++ b/semantic-conventions/src/experimental_attributes.ts
@@ -19,6 +19,32 @@
 //----------------------------------------------------------------------------------------------------------
 
 /**
+ * This attribute represents the state of the application.
+ *
+ * @example created
+ *
+ * @note The Android lifecycle states are defined in [Activity lifecycle callbacks](https://developer.android.com/guide/components/activities/activity-lifecycle#lc), and from which the `OS identifiers` are derived.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_ANDROID_APP_STATE = 'android.app.state' as const;
+
+/**
+  * Enum value "background" for attribute {@link ATTR_ANDROID_APP_STATE}.
+  */
+export const ANDROID_APP_STATE_VALUE_BACKGROUND = "background" as const;
+
+/**
+  * Enum value "created" for attribute {@link ATTR_ANDROID_APP_STATE}.
+  */
+export const ANDROID_APP_STATE_VALUE_CREATED = "created" as const;
+
+/**
+  * Enum value "foreground" for attribute {@link ATTR_ANDROID_APP_STATE}.
+  */
+export const ANDROID_APP_STATE_VALUE_FOREGROUND = "foreground" as const;
+
+/**
  * Uniquely identifies the framework API revision offered by a version (`os.version`) of the android operating system. More information can be found [here](https://developer.android.com/guide/topics/manifest/uses-sdk-element#ApiLevels).
  *
  * @example 33
@@ -29,13 +55,13 @@
 export const ATTR_ANDROID_OS_API_LEVEL = 'android.os.api_level' as const;
 
 /**
- * Deprecated use the `device.app.lifecycle` event definition including `android.state` as a payload field instead.
+ * Deprecated. Use `android.app.state` instead.
  *
  * @note The Android lifecycle states are defined in [Activity lifecycle callbacks](https://developer.android.com/guide/components/activities/activity-lifecycle#lc), and from which the `OS identifiers` are derived.
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  *
- * @deprecated Replaced by `device.app.lifecycle`.
+ * @deprecated Renamed to `android.app.state`
  */
 export const ATTR_ANDROID_STATE = 'android.state' as const;
 
@@ -961,6 +987,15 @@ export const CICD_PIPELINE_RUN_STATE_VALUE_FINALIZING = "finalizing" as const;
 export const CICD_PIPELINE_RUN_STATE_VALUE_PENDING = "pending" as const;
 
 /**
+ * The [URL](https://wikipedia.org/wiki/URL) of the pipeline run, providing the complete address in order to locate and identify the pipeline run.
+ *
+ * @example https://github.com/open-telemetry/semantic-conventions/actions/runs/9753949763?pr=1075
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_CICD_PIPELINE_RUN_URL_FULL = 'cicd.pipeline.run.url.full' as const;
+
+/**
  * The human readable name of a task within a pipeline. Task here most closely aligns with a [computing process](https://wikipedia.org/wiki/Pipeline_(computing)) in a pipeline. Other terms for tasks include commands, steps, and procedures.
  *
  * @example Run GoLang Linter
@@ -982,7 +1017,7 @@ export const ATTR_CICD_PIPELINE_TASK_NAME = 'cicd.pipeline.task.name' as const;
 export const ATTR_CICD_PIPELINE_TASK_RUN_ID = 'cicd.pipeline.task.run.id' as const;
 
 /**
- * The [URL](https://wikipedia.org/wiki/URL) of the pipeline run providing the complete address in order to locate and identify the pipeline run.
+ * The [URL](https://wikipedia.org/wiki/URL) of the pipeline task run, providing the complete address in order to locate and identify the pipeline task run.
  *
  * @example https://github.com/open-telemetry/semantic-conventions/actions/runs/9753949763/job/26920038674?pr=1075
  *
@@ -1293,7 +1328,7 @@ export const CLOUD_PROVIDER_VALUE_TENCENT_CLOUD = "tencent_cloud" as const;
 export const ATTR_CLOUD_REGION = 'cloud.region' as const;
 
 /**
- * Cloud provider-specific native identifier of the monitored cloud resource (e.g. an [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) on AWS, a [fully qualified resource ID](https://learn.microsoft.com/rest/api/resources/resources/get-by-id) on Azure, a [full resource name](https://cloud.google.com/apis/design/resource_names#full_resource_name) on GCP)
+ * Cloud provider-specific native identifier of the monitored cloud resource (e.g. an [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) on AWS, a [fully qualified resource ID](https://learn.microsoft.com/rest/api/resources/resources/get-by-id) on Azure, a [full resource name](https://google.aip.dev/122#full-resource-names) on GCP)
  *
  * @example arn:aws:lambda:REGION:ACCOUNT_ID:function:my-function
  * @example //run.googleapis.com/projects/PROJECT_ID/locations/LOCATION_ID/services/SERVICE_ID
@@ -1564,6 +1599,8 @@ export const ATTR_CODE_FILE_PATH = 'code.file.path' as const;
  * @example "/usr/local/MyApplication/content_root/app/index.php"
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `code.file.path`
  */
 export const ATTR_CODE_FILEPATH = 'code.filepath' as const;
 
@@ -1579,9 +1616,27 @@ export const ATTR_CODE_FILEPATH = 'code.filepath' as const;
 export const ATTR_CODE_FUNCTION = 'code.function' as const;
 
 /**
- * The method or function name, or equivalent (usually rightmost part of the code unit's name).
+ * The method or function fully-qualified name without arguments. The value should fit the natural representation of the language runtime, which is also likely the same used within `code.stacktrace` attribute value.
  *
- * @example "serveRequest"
+ * @example com.example.MyHttpService.serveRequest
+ * @example GuzzleHttp\\Client::transfer
+ * @example fopen
+ *
+ * @note Values and format depends on each language runtime, thus it is impossible to provide an exhaustive list of examples.
+ * The values are usually the same (or prefixes of) the ones found in native stack trace representation stored in
+ * `code.stacktrace` without information on arguments.
+ *
+ * Examples:
+ *
+ *   - Java method: `com.example.MyHttpService.serveRequest`
+ *   - Java anonymous class method: `com.mycompany.Main$1.myMethod`
+ *   - Java lambda method: `com.mycompany.Main$$Lambda/0x0000748ae4149c00.myMethod`
+ *   - PHP function: `GuzzleHttp\\Client::transfer
+ *   - Go function: `github.com/my/repo/pkg.foo.func5`
+ *   - Elixir: `OpenTelemetry.Ctx.new`
+ *   - Erlang: `opentelemetry_ctx:new`
+ *   - Rust: `playground::my_module::my_cool_func`
+ *   - C function: `fopen`
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -1608,16 +1663,18 @@ export const ATTR_CODE_LINE_NUMBER = 'code.line.number' as const;
 export const ATTR_CODE_LINENO = 'code.lineno' as const;
 
 /**
- * The "namespace" within which `code.function.name` is defined. Usually the qualified class or module name, such that `code.namespace` + some separator + `code.function.name` form a unique identifier for the code unit.
+ * Deprecated, namespace is now included into `code.function.name`
  *
  * @example "com.example.MyHttpService"
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Value should be included in `code.function.name` which is expected to be a fully-qualified name.
  */
 export const ATTR_CODE_NAMESPACE = 'code.namespace' as const;
 
 /**
- * A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.
+ * A stacktrace as a string in the natural representation for the language runtime. The representation is identical to [`exception.stacktrace`](/docs/exceptions/exceptions-spans.md#stacktrace-representation).
  *
  * @example "at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\\n at com.example.GenerateTrace.main(GenerateTrace.java:5)\\n"
  *
@@ -1793,6 +1850,15 @@ export const ATTR_CONTAINER_NAME = 'container.name' as const;
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_CONTAINER_RUNTIME = 'container.runtime' as const;
+
+/**
+ * The logical CPU number [0..n-1]
+ *
+ * @example 1
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_CPU_LOGICAL_NUMBER = 'cpu.logical_number' as const;
 
 /**
  * The mode of the CPU
@@ -2039,13 +2105,14 @@ export const DB_CLIENT_CONNECTIONS_STATE_VALUE_USED = "used" as const;
  * @example public.users
  * @example customers
  *
- * @note It is **RECOMMENDED** to capture the value as provided by the application without attempting to do any case normalization.
+ * @note It is **RECOMMENDED** to capture the value as provided by the application
+ * without attempting to do any case normalization.
  *
  * The collection name **SHOULD NOT** be extracted from `db.query.text`,
- * unless the query format is known to only ever have a single collection name present.
+ * when the database system supports cross-table queries in non-batch operations.
  *
- * For batch operations, if the individual operations are known to have the same collection name
- * then that collection name **SHOULD** be used.
+ * For batch operations, if the individual operations are known to have the same
+ * collection name then that collection name **SHOULD** be used.
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -2425,7 +2492,7 @@ export const ATTR_DB_OPERATION_BATCH_SIZE = 'db.operation.batch.size' as const;
  * without attempting to do any case normalization.
  *
  * The operation name **SHOULD NOT** be extracted from `db.query.text`,
- * unless the query format is known to only ever have a single operation name present.
+ * when the database system supports cross-table queries in non-batch operations.
  *
  * For batch operations, if the individual operations are known to have the same operation name
  * then that operation name **SHOULD** be used prepended by `BATCH `,
@@ -2469,7 +2536,7 @@ export const ATTR_DB_QUERY_PARAMETER = (key: string) => `db.query.parameter.${ke
  * @example get user by id
  *
  * @note `db.query.summary` provides static summary of the query text. It describes a class of database queries and is useful as a grouping key, especially when analyzing telemetry for database calls involving complex queries.
- * Summary may be available to the instrumentation through instrumentation hooks or other means. If it is not available, instrumentations that support query parsing **SHOULD** generate a summary following [Generating query summary](../../docs/database/database-spans.md#generating-a-summary-of-the-query-text) section.
+ * Summary may be available to the instrumentation through instrumentation hooks or other means. If it is not available, instrumentations that support query parsing **SHOULD** generate a summary following [Generating query summary](../database/database-spans.md#generating-a-summary-of-the-query-text) section.
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -2481,7 +2548,7 @@ export const ATTR_DB_QUERY_SUMMARY = 'db.query.summary' as const;
  * @example SELECT * FROM wuser_table where username = ?
  * @example SET mykey ?
  *
- * @note For sanitization see [Sanitization of `db.query.text`](../../docs/database/database-spans.md#sanitization-of-dbquerytext).
+ * @note For sanitization see [Sanitization of `db.query.text`](../database/database-spans.md#sanitization-of-dbquerytext).
  * For batch operations, if the individual operations are known to have the same query text then that query text **SHOULD** be used, otherwise all of the individual query texts **SHOULD** be concatenated with separator `; ` or some other database system specific separator if more applicable.
  * Even though parameterized query text can potentially have sensitive data, by using a parameterized query the user is giving a strong signal that any sensitive data will be passed as parameter values, and the benefit to observability of capturing the static part of the query text by default outweighs the risk.
  *
@@ -3233,15 +3300,32 @@ export const ATTR_DNS_QUESTION_NAME = 'dns.question.name' as const;
 export const ATTR_ELASTICSEARCH_NODE_NAME = 'elasticsearch.node.name' as const;
 
 /**
- * Deprecated, use `user.id` instead.
+ * Unique identifier of an end user in the system. It maybe a username, email address, or other identifier.
  *
- * @example "username"
+ * @example username
+ *
+ * @note Unique identifier of an end user in the system.
+ *
+ * > [!Warning]
+ * > This field contains sensitive (PII) information.
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- *
- * @deprecated Replaced by `user.id` attribute.
  */
 export const ATTR_ENDUSER_ID = 'enduser.id' as const;
+
+/**
+ * Pseudonymous identifier of an end user. This identifier should be a random value that is not directly linked or associated with the end user's actual identity.
+ *
+ * @example QdH5CAWJgqVT4rOr0qtumf
+ *
+ * @note Pseudonymous identifier of an end user.
+ *
+ * > [!Warning]
+ * > This field contains sensitive (linkable PII) information.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_ENDUSER_PSEUDO_ID = 'enduser.pseudo.id' as const;
 
 /**
  * Deprecated, use `user.roles` instead.
@@ -3882,6 +3966,35 @@ export const ATTR_GCP_GCE_INSTANCE_HOSTNAME = 'gcp.gce.instance.hostname' as con
 export const ATTR_GCP_GCE_INSTANCE_NAME = 'gcp.gce.instance.name' as const;
 
 /**
+ * Free-form description of the GenAI agent provided by the application.
+ *
+ * @example Helps with math problems
+ * @example Generates fiction stories
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_GEN_AI_AGENT_DESCRIPTION = 'gen_ai.agent.description' as const;
+
+/**
+ * The unique identifier of the GenAI agent.
+ *
+ * @example asst_5j66UpCpwteGg4YSxUnt7lPY
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_GEN_AI_AGENT_ID = 'gen_ai.agent.id' as const;
+
+/**
+ * Human-readable name of the GenAI agent provided by the application.
+ *
+ * @example Math Tutor
+ * @example Fiction Writer
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_GEN_AI_AGENT_NAME = 'gen_ai.agent.name' as const;
+
+/**
  * Deprecated, use Event API to report completions contents.
  *
  * @example [{'role': 'assistant', 'content': 'The capital of France is Paris.'}]
@@ -3893,11 +4006,11 @@ export const ATTR_GCP_GCE_INSTANCE_NAME = 'gcp.gce.instance.name' as const;
 export const ATTR_GEN_AI_COMPLETION = 'gen_ai.completion' as const;
 
 /**
- * The response format that is requested.
- *
- * @example json
+ * Deprecated, use `gen_ai.output.type`.
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `gen_ai.output.type`.
  */
 export const ATTR_GEN_AI_OPENAI_REQUEST_RESPONSE_FORMAT = 'gen_ai.openai.request.response_format' as const;
 
@@ -3981,14 +4094,55 @@ export const ATTR_GEN_AI_OPERATION_NAME = 'gen_ai.operation.name' as const;
 export const GEN_AI_OPERATION_NAME_VALUE_CHAT = "chat" as const;
 
 /**
+  * Enum value "create_agent" for attribute {@link ATTR_GEN_AI_OPERATION_NAME}.
+  */
+export const GEN_AI_OPERATION_NAME_VALUE_CREATE_AGENT = "create_agent" as const;
+
+/**
   * Enum value "embeddings" for attribute {@link ATTR_GEN_AI_OPERATION_NAME}.
   */
 export const GEN_AI_OPERATION_NAME_VALUE_EMBEDDINGS = "embeddings" as const;
 
 /**
+  * Enum value "execute_tool" for attribute {@link ATTR_GEN_AI_OPERATION_NAME}.
+  */
+export const GEN_AI_OPERATION_NAME_VALUE_EXECUTE_TOOL = "execute_tool" as const;
+
+/**
   * Enum value "text_completion" for attribute {@link ATTR_GEN_AI_OPERATION_NAME}.
   */
 export const GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION = "text_completion" as const;
+
+/**
+ * Represents the content type requested by the client.
+ *
+ * @note This attribute **SHOULD** be used when the client requests output of a specific type. The model may return zero or more outputs of this type.
+ * This attribute specifies the output modality and not the actual output format. For example, if an image is requested, the actual output could be a URL pointing to an image file.
+ * Additional output format details may be recorded in the future in the `gen_ai.output.{type}.*` attributes.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_GEN_AI_OUTPUT_TYPE = 'gen_ai.output.type' as const;
+
+/**
+  * Enum value "image" for attribute {@link ATTR_GEN_AI_OUTPUT_TYPE}.
+  */
+export const GEN_AI_OUTPUT_TYPE_VALUE_IMAGE = "image" as const;
+
+/**
+  * Enum value "json" for attribute {@link ATTR_GEN_AI_OUTPUT_TYPE}.
+  */
+export const GEN_AI_OUTPUT_TYPE_VALUE_JSON = "json" as const;
+
+/**
+  * Enum value "speech" for attribute {@link ATTR_GEN_AI_OUTPUT_TYPE}.
+  */
+export const GEN_AI_OUTPUT_TYPE_VALUE_SPEECH = "speech" as const;
+
+/**
+  * Enum value "text" for attribute {@link ATTR_GEN_AI_OUTPUT_TYPE}.
+  */
+export const GEN_AI_OUTPUT_TYPE_VALUE_TEXT = "text" as const;
 
 /**
  * Deprecated, use Event API to report prompt contents.
@@ -4000,6 +4154,15 @@ export const GEN_AI_OPERATION_NAME_VALUE_TEXT_COMPLETION = "text_completion" as 
  * @deprecated Removed, no replacement at this time.
  */
 export const ATTR_GEN_AI_PROMPT = 'gen_ai.prompt' as const;
+
+/**
+ * The target number of candidate completions to return.
+ *
+ * @example 3
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_GEN_AI_REQUEST_CHOICE_COUNT = 'gen_ai.request.choice.count' as const;
 
 /**
  * The encoding formats requested in an embeddings operation, if specified.
@@ -4232,6 +4395,46 @@ export const GEN_AI_TOKEN_TYPE_VALUE_INPUT = "input" as const;
   * Enum value "output" for attribute {@link ATTR_GEN_AI_TOKEN_TYPE}.
   */
 export const GEN_AI_TOKEN_TYPE_VALUE_COMPLETION = "output" as const;
+
+/**
+  * Enum value "output" for attribute {@link ATTR_GEN_AI_TOKEN_TYPE}.
+  */
+export const GEN_AI_TOKEN_TYPE_VALUE_OUTPUT = "output" as const;
+
+/**
+ * The tool call identifier.
+ *
+ * @example call_mszuSIzqtI65i1wAUOE8w5H4
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_GEN_AI_TOOL_CALL_ID = 'gen_ai.tool.call.id' as const;
+
+/**
+ * Name of the tool utilized by the agent.
+ *
+ * @example Flights
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_GEN_AI_TOOL_NAME = 'gen_ai.tool.name' as const;
+
+/**
+ * Type of the tool utilized by the agent
+ *
+ * @example function
+ * @example extension
+ * @example datastore
+ *
+ * @note Extension: A tool executed on the agent-side to directly call external APIs, bridging the gap between the agent and real-world systems.
+ * Agent-side operations involve actions that are performed by the agent on the server or within the agent's controlled environment.
+ * Function: A tool executed on the client-side, where the agent generates parameters for a predefined function, and the client executes the logic.
+ * Client-side operations are actions taken on the user's end or within the client application.
+ * Datastore: A tool used by the agent to access and query structured or unstructured external data for retrieval-augmented tasks or knowledge updates.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_GEN_AI_TOOL_TYPE = 'gen_ai.tool.type' as const;
 
 /**
  * Deprecated, use `gen_ai.usage.output_tokens` instead.
@@ -5016,13 +5219,47 @@ export const HW_TYPE_VALUE_TEMPERATURE = "temperature" as const;
 export const HW_TYPE_VALUE_VOLTAGE = "voltage" as const;
 
 /**
- * Deprecated use the `device.app.lifecycle` event definition including `ios.state` as a payload field instead.
+ * This attribute represents the state of the application.
  *
- * @note The iOS lifecycle states are defined in the [UIApplicationDelegate documentation](https://developer.apple.com/documentation/uikit/uiapplicationdelegate#1656902), and from which the `OS terminology` column values are derived.
+ * @note The iOS lifecycle states are defined in the [UIApplicationDelegate documentation](https://developer.apple.com/documentation/uikit/uiapplicationdelegate), and from which the `OS terminology` column values are derived.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_IOS_APP_STATE = 'ios.app.state' as const;
+
+/**
+  * Enum value "active" for attribute {@link ATTR_IOS_APP_STATE}.
+  */
+export const IOS_APP_STATE_VALUE_ACTIVE = "active" as const;
+
+/**
+  * Enum value "background" for attribute {@link ATTR_IOS_APP_STATE}.
+  */
+export const IOS_APP_STATE_VALUE_BACKGROUND = "background" as const;
+
+/**
+  * Enum value "foreground" for attribute {@link ATTR_IOS_APP_STATE}.
+  */
+export const IOS_APP_STATE_VALUE_FOREGROUND = "foreground" as const;
+
+/**
+  * Enum value "inactive" for attribute {@link ATTR_IOS_APP_STATE}.
+  */
+export const IOS_APP_STATE_VALUE_INACTIVE = "inactive" as const;
+
+/**
+  * Enum value "terminate" for attribute {@link ATTR_IOS_APP_STATE}.
+  */
+export const IOS_APP_STATE_VALUE_TERMINATE = "terminate" as const;
+
+/**
+ * Deprecated. use the `ios.app.state` instead.
+ *
+ * @note The iOS lifecycle states are defined in the [UIApplicationDelegate documentation](https://developer.apple.com/documentation/uikit/uiapplicationdelegate), and from which the `OS terminology` column values are derived.
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  *
- * @deprecated Moved to a payload field of `device.app.lifecycle`.
+ * @deprecated Renamed to `ios.app.state`
  */
 export const ATTR_IOS_STATE = 'ios.state' as const;
 
@@ -5185,6 +5422,24 @@ export const ATTR_K8S_DEPLOYMENT_NAME = 'k8s.deployment.name' as const;
 export const ATTR_K8S_DEPLOYMENT_UID = 'k8s.deployment.uid' as const;
 
 /**
+ * The name of the horizontal pod autoscaler.
+ *
+ * @example opentelemetry
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_K8S_HPA_NAME = 'k8s.hpa.name' as const;
+
+/**
+ * The UID of the horizontal pod autoscaler.
+ *
+ * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_K8S_HPA_UID = 'k8s.hpa.uid' as const;
+
+/**
  * The name of the Job.
  *
  * @example opentelemetry
@@ -5320,6 +5575,42 @@ export const ATTR_K8S_REPLICASET_NAME = 'k8s.replicaset.name' as const;
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_K8S_REPLICASET_UID = 'k8s.replicaset.uid' as const;
+
+/**
+ * The name of the replication controller.
+ *
+ * @example opentelemetry
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_K8S_REPLICATIONCONTROLLER_NAME = 'k8s.replicationcontroller.name' as const;
+
+/**
+ * The UID of the replication controller.
+ *
+ * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_K8S_REPLICATIONCONTROLLER_UID = 'k8s.replicationcontroller.uid' as const;
+
+/**
+ * The name of the resource quota.
+ *
+ * @example opentelemetry
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_K8S_RESOURCEQUOTA_NAME = 'k8s.resourcequota.name' as const;
+
+/**
+ * The UID of the resource quota.
+ *
+ * @example 275ecb36-5aa8-4c2a-9c47-d8bb681b9aff
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_K8S_RESOURCEQUOTA_UID = 'k8s.resourcequota.uid' as const;
 
 /**
  * The name of the StatefulSet.
@@ -6621,7 +6912,7 @@ export const NODEJS_EVENTLOOP_STATE_VALUE_IDLE = "idle" as const;
  * @example sha256:e4ca62c0d62f3e886e684806dfe9d4e0cda60d54986898173c1083856cfda0f4
  *
  * @note Follows [OCI Image Manifest Specification](https://github.com/opencontainers/image-spec/blob/main/manifest.md), and specifically the [Digest property](https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests).
- * An example can be found in [Example Image Manifest](https://docs.docker.com/registry/spec/manifest-v2-2/#example-image-manifest).
+ * An example can be found in [Example Image Manifest](https://github.com/opencontainers/image-spec/blob/main/manifest.md#example-image-manifest).
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -6751,6 +7042,68 @@ export const OS_TYPE_VALUE_Z_OS = "z_os" as const;
 export const ATTR_OS_VERSION = 'os.version' as const;
 
 /**
+ * A name uniquely identifying the instance of the OpenTelemetry component within its containing SDK instance.
+ *
+ * @example otlp_grpc_span_exporter/0
+ * @example custom-name
+ *
+ * @note Implementations **SHOULD** ensure a low cardinality for this attribute, even across application or SDK restarts.
+ * E.g. implementations **MUST NOT** use UUIDs as values for this attribute.
+ *
+ * Implementations **MAY** achieve these goals by following a `<otel.component.type>/<instance-counter>` pattern, e.g. `batching_span_processor/0`.
+ * Hereby `otel.component.type` refers to the corresponding attribute value of the component.
+ *
+ * The value of `instance-counter` **MAY** be automatically assigned by the component and uniqueness within the enclosing SDK instance **MUST** be guaranteed.
+ * For example, `<instance-counter>` **MAY** be implemented by using a monotonically increasing counter (starting with `0`), which is incremented every time an
+ * instance of the given component type is started.
+ *
+ * With this implementation, for example the first Batching Span Processor would have `batching_span_processor/0`
+ * as `otel.component.name`, the second one `batching_span_processor/1` and so on.
+ * These values will therefore be reused in the case of an application restart.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_OTEL_COMPONENT_NAME = 'otel.component.name' as const;
+
+/**
+ * A name identifying the type of the OpenTelemetry component.
+ *
+ * @example batching_span_processor
+ * @example com.example.MySpanExporter
+ *
+ * @note If none of the standardized values apply, implementations **SHOULD** use the language-defined name of the type.
+ * E.g. for Java the fully qualified classname **SHOULD** be used in this case.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_OTEL_COMPONENT_TYPE = 'otel.component.type' as const;
+
+/**
+  * Enum value "batching_span_processor" for attribute {@link ATTR_OTEL_COMPONENT_TYPE}.
+  */
+export const OTEL_COMPONENT_TYPE_VALUE_BATCHING_SPAN_PROCESSOR = "batching_span_processor" as const;
+
+/**
+  * Enum value "otlp_grpc_span_exporter" for attribute {@link ATTR_OTEL_COMPONENT_TYPE}.
+  */
+export const OTEL_COMPONENT_TYPE_VALUE_OTLP_GRPC_SPAN_EXPORTER = "otlp_grpc_span_exporter" as const;
+
+/**
+  * Enum value "otlp_http_json_span_exporter" for attribute {@link ATTR_OTEL_COMPONENT_TYPE}.
+  */
+export const OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_JSON_SPAN_EXPORTER = "otlp_http_json_span_exporter" as const;
+
+/**
+  * Enum value "otlp_http_span_exporter" for attribute {@link ATTR_OTEL_COMPONENT_TYPE}.
+  */
+export const OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_SPAN_EXPORTER = "otlp_http_span_exporter" as const;
+
+/**
+  * Enum value "simple_span_processor" for attribute {@link ATTR_OTEL_COMPONENT_TYPE}.
+  */
+export const OTEL_COMPONENT_TYPE_VALUE_SIMPLE_SPAN_PROCESSOR = "simple_span_processor" as const;
+
+/**
  * Deprecated. Use the `otel.scope.name` attribute
  *
  * @example io.opentelemetry.contrib.mongodb
@@ -6771,6 +7124,28 @@ export const ATTR_OTEL_LIBRARY_NAME = 'otel.library.name' as const;
  * @deprecated Use the `otel.scope.version` attribute.
  */
 export const ATTR_OTEL_LIBRARY_VERSION = 'otel.library.version' as const;
+
+/**
+ * The result value of the sampler for this span
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_OTEL_SPAN_SAMPLING_RESULT = 'otel.span.sampling_result' as const;
+
+/**
+  * Enum value "DROP" for attribute {@link ATTR_OTEL_SPAN_SAMPLING_RESULT}.
+  */
+export const OTEL_SPAN_SAMPLING_RESULT_VALUE_DROP = "DROP" as const;
+
+/**
+  * Enum value "RECORD_AND_SAMPLE" for attribute {@link ATTR_OTEL_SPAN_SAMPLING_RESULT}.
+  */
+export const OTEL_SPAN_SAMPLING_RESULT_VALUE_RECORD_AND_SAMPLE = "RECORD_AND_SAMPLE" as const;
+
+/**
+  * Enum value "RECORD_ONLY" for attribute {@link ATTR_OTEL_SPAN_SAMPLING_RESULT}.
+  */
+export const OTEL_SPAN_SAMPLING_RESULT_VALUE_RECORD_ONLY = "RECORD_ONLY" as const;
 
 /**
  * The [`service.name`](/docs/resource/README.md#service) of the remote service. **SHOULD** be equal to the actual `service.name` resource attribute of the remote service if any.
@@ -6919,7 +7294,7 @@ export const ATTR_PROCESS_EXECUTABLE_BUILD_ID_HTLHASH = 'process.executable.buil
 export const ATTR_PROCESS_EXECUTABLE_BUILD_ID_PROFILING = 'process.executable.build_id.profiling' as const;
 
 /**
- * The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`.
+ * The name of the process executable. On Linux based systems, this **SHOULD** be set to the base name of the target of `/proc/[pid]/exe`. On Windows, this **SHOULD** be set to the base name of `GetProcessImageFileNameW`.
  *
  * @example otelcol
  *
@@ -7209,7 +7584,7 @@ export const PROFILE_FRAME_TYPE_VALUE_RUBY = "ruby" as const;
 export const PROFILE_FRAME_TYPE_VALUE_V8JS = "v8js" as const;
 
 /**
- * The [error codes](https://connect.build/docs/protocol/#error-codes) of the Connect request. Error codes are always string values.
+ * The [error codes](https://connectrpc.com//docs/protocol/#error-codes) of the Connect request. Error codes are always string values.
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -7750,7 +8125,7 @@ export const STATE_VALUE_IDLE = "idle" as const;
 export const STATE_VALUE_USED = "used" as const;
 
 /**
- * The logical CPU number [0..n-1]
+ * Deprecated, use `cpu.logical_number` instead.
  *
  * @example 1
  *
@@ -8391,7 +8766,7 @@ export const ATTR_TLS_ESTABLISHED = 'tls.established' as const;
 export const ATTR_TLS_NEXT_PROTOCOL = 'tls.next_protocol' as const;
 
 /**
- * Normalized lowercase protocol name parsed from original string of the negotiated [SSL/TLS protocol version](https://www.openssl.org/docs/man1.1.1/man3/SSL_get_version.html#RETURN-VALUES)
+ * Normalized lowercase protocol name parsed from original string of the negotiated [SSL/TLS protocol version](https://docs.openssl.org/1.1.1/man3/SSL_get_version/#return-values)
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -8408,7 +8783,7 @@ export const TLS_PROTOCOL_NAME_VALUE_SSL = "ssl" as const;
 export const TLS_PROTOCOL_NAME_VALUE_TLS = "tls" as const;
 
 /**
- * Numeric part of the version parsed from the original string of the negotiated [SSL/TLS protocol version](https://www.openssl.org/docs/man1.1.1/man3/SSL_get_version.html#RETURN-VALUES)
+ * Numeric part of the version parsed from the original string of the negotiated [SSL/TLS protocol version](https://docs.openssl.org/1.1.1/man3/SSL_get_version/#return-values)
  *
  * @example 1.2
  * @example 3
@@ -8570,7 +8945,7 @@ export const ATTR_URL_PORT = 'url.port' as const;
  * @example example.com
  * @example foo.co.uk
  *
- * @note This value can be determined precisely with the [public suffix list](http://publicsuffix.org). For example, the registered domain for `foo.example.com` is `example.com`. Trying to approximate this by simply taking the last two labels will not work well for TLDs such as `co.uk`.
+ * @note This value can be determined precisely with the [public suffix list](https://publicsuffix.org/). For example, the registered domain for `foo.example.com` is `example.com`. Trying to approximate this by simply taking the last two labels will not work well for TLDs such as `co.uk`.
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -8605,7 +8980,7 @@ export const ATTR_URL_TEMPLATE = 'url.template' as const;
  * @example com
  * @example co.uk
  *
- * @note This value can be determined precisely with the [public suffix list](http://publicsuffix.org).
+ * @note This value can be determined precisely with the [public suffix list](https://publicsuffix.org/).
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -8678,6 +9053,31 @@ export const ATTR_USER_ROLES = 'user.roles' as const;
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_USER_AGENT_NAME = 'user_agent.name' as const;
+
+/**
+ * Human readable operating system name.
+ *
+ * @example iOS
+ * @example Android
+ * @example Ubuntu
+ *
+ * @note For mapping user agent strings to OS names, libraries such as [ua-parser](https://github.com/ua-parser) can be utilized.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_USER_AGENT_OS_NAME = 'user_agent.os.name' as const;
+
+/**
+ * The version string of the operating system as defined in [Version Attributes](/docs/resource/README.md#version-attributes).
+ *
+ * @example 14.2.1
+ * @example 18.04.1
+ *
+ * @note For mapping user agent strings to OS versions, libraries such as [ua-parser](https://github.com/ua-parser) can be utilized.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_USER_AGENT_OS_VERSION = 'user_agent.os.version' as const;
 
 /**
  * Specifies the category of synthetic traffic, such as tests or bots.

--- a/semantic-conventions/src/experimental_metrics.ts
+++ b/semantic-conventions/src/experimental_metrics.ts
@@ -127,6 +127,27 @@ export const METRIC_CONTAINER_NETWORK_IO = 'container.network.io' as const;
 export const METRIC_CONTAINER_UPTIME = 'container.uptime' as const;
 
 /**
+ * Operating frequency of the logical CPU in Hertz.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_CPU_FREQUENCY = 'cpu.frequency' as const;
+
+/**
+ * Seconds each logical CPU spent on each mode
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_CPU_TIME = 'cpu.time' as const;
+
+/**
+ * For each logical CPU, the utilization is calculated as the change in cumulative CPU time (cpu.time) over a measurement interval, divided by the elapsed time.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_CPU_UTILIZATION = 'cpu.utilization' as const;
+
+/**
  * The number of connections that are currently in state described by the `state` attribute
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
@@ -569,6 +590,38 @@ export const METRIC_HW_ENERGY = 'hw.energy' as const;
 export const METRIC_HW_ERRORS = 'hw.errors' as const;
 
 /**
+ * Ambient (external) temperature of the physical host
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_HW_HOST_AMBIENT_TEMPERATURE = 'hw.host.ambient_temperature' as const;
+
+/**
+ * Total energy consumed by the entire physical host, in joules
+ *
+ * @note The overall energy usage of a host **MUST** be reported using the specific `hw.host.energy` and `hw.host.power` metrics **only**, instead of the generic `hw.energy` and `hw.power` described in the previous section, to prevent summing up overlapping values.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_HW_HOST_ENERGY = 'hw.host.energy' as const;
+
+/**
+ * By how many degrees Celsius the temperature of the physical host can be increased, before reaching a warning threshold on one of the internal sensors
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_HW_HOST_HEATING_MARGIN = 'hw.host.heating_margin' as const;
+
+/**
+ * Instantaneous power consumed by the entire physical host in Watts (`hw.host.energy` is preferred)
+ *
+ * @note The overall energy usage of a host **MUST** be reported using the specific `hw.host.energy` and `hw.host.power` metrics **only**, instead of the generic `hw.energy` and `hw.power` described in the previous section, to prevent summing up overlapping values.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_HW_HOST_POWER = 'hw.host.power' as const;
+
+/**
  * Instantaneous power consumed by the component
  *
  * @note It is recommended to report `hw.energy` instead of `hw.power` when possible.
@@ -738,6 +791,9 @@ export const METRIC_K8S_DEPLOYMENT_DESIRED_PODS = 'k8s.deployment.desired_pods' 
  * @note This metric aligns with the `currentReplicas` field of the
  * [K8s HorizontalPodAutoscalerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerstatus-v2-autoscaling)
  *
+ * This metric **SHOULD**, at a minimum, be reported against a
+ * [`k8s.hpa`](../resource/k8s.md#horizontalpodautoscaler) resource.
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_HPA_CURRENT_PODS = 'k8s.hpa.current_pods' as const;
@@ -747,6 +803,9 @@ export const METRIC_K8S_HPA_CURRENT_PODS = 'k8s.hpa.current_pods' as const;
  *
  * @note This metric aligns with the `desiredReplicas` field of the
  * [K8s HorizontalPodAutoscalerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerstatus-v2-autoscaling)
+ *
+ * This metric **SHOULD**, at a minimum, be reported against a
+ * [`k8s.hpa`](../resource/k8s.md#horizontalpodautoscaler) resource.
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -758,6 +817,9 @@ export const METRIC_K8S_HPA_DESIRED_PODS = 'k8s.hpa.desired_pods' as const;
  * @note This metric aligns with the `maxReplicas` field of the
  * [K8s HorizontalPodAutoscalerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerspec-v2-autoscaling)
  *
+ * This metric **SHOULD**, at a minimum, be reported against a
+ * [`k8s.hpa`](../resource/k8s.md#horizontalpodautoscaler) resource.
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_K8S_HPA_MAX_PODS = 'k8s.hpa.max_pods' as const;
@@ -767,6 +829,9 @@ export const METRIC_K8S_HPA_MAX_PODS = 'k8s.hpa.max_pods' as const;
  *
  * @note This metric aligns with the `minReplicas` field of the
  * [K8s HorizontalPodAutoscalerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#horizontalpodautoscalerspec-v2-autoscaling)
+ *
+ * This metric **SHOULD**, at a minimum, be reported against a
+ * [`k8s.hpa`](../resource/k8s.md#horizontalpodautoscaler) resource.
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
@@ -815,7 +880,7 @@ export const METRIC_K8S_JOB_FAILED_PODS = 'k8s.job.failed_pods' as const;
  * The max desired number of pods the job should run at any given time
  *
  * @note This metric aligns with the `parallelism` field of the
- * [K8s JobSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobspec-v1-batch.
+ * [K8s JobSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#jobspec-v1-batch).
  *
  * This metric **SHOULD**, at a minimum, be reported against a
  * [`k8s.job`](../resource/k8s.md#job) resource.
@@ -976,14 +1041,47 @@ export const METRIC_K8S_REPLICASET_AVAILABLE_PODS = 'k8s.replicaset.available_po
 export const METRIC_K8S_REPLICASET_DESIRED_PODS = 'k8s.replicaset.desired_pods' as const;
 
 /**
+ * Deprecated, use `k8s.replicationcontroller.available_pods` instead.
+ *
+ * @note This metric aligns with the `availableReplicas` field of the
+ * [K8s ReplicationControllerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicationcontrollerstatus-v1-core)
+ *
+ * This metric **SHOULD**, at a minimum, be reported against a
+ * [`k8s.replicationcontroller`](../resource/k8s.md#replicationcontroller) resource.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `k8s.replicationcontroller.available_pods`.
+ */
+export const METRIC_K8S_REPLICATION_CONTROLLER_AVAILABLE_PODS = 'k8s.replication_controller.available_pods' as const;
+
+/**
+ * Deprecated, use `k8s.replicationcontroller.desired_pods` instead.
+ *
+ * @note This metric aligns with the `replicas` field of the
+ * [K8s ReplicationControllerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicationcontrollerspec-v1-core)
+ *
+ * This metric **SHOULD**, at a minimum, be reported against a
+ * [`k8s.replicationcontroller`](../resource/k8s.md#replicationcontroller) resource.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `k8s.replicationcontroller.desired_pods`.
+ */
+export const METRIC_K8S_REPLICATION_CONTROLLER_DESIRED_PODS = 'k8s.replication_controller.desired_pods' as const;
+
+/**
  * Total number of available replica pods (ready for at least minReadySeconds) targeted by this replication controller
  *
  * @note This metric aligns with the `availableReplicas` field of the
  * [K8s ReplicationControllerStatus](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicationcontrollerstatus-v1-core)
  *
+ * This metric **SHOULD**, at a minimum, be reported against a
+ * [`k8s.replicationcontroller`](../resource/k8s.md#replicationcontroller) resource.
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const METRIC_K8S_REPLICATION_CONTROLLER_AVAILABLE_PODS = 'k8s.replication_controller.available_pods' as const;
+export const METRIC_K8S_REPLICATIONCONTROLLER_AVAILABLE_PODS = 'k8s.replicationcontroller.available_pods' as const;
 
 /**
  * Number of desired replica pods in this replication controller
@@ -991,9 +1089,12 @@ export const METRIC_K8S_REPLICATION_CONTROLLER_AVAILABLE_PODS = 'k8s.replication
  * @note This metric aligns with the `replicas` field of the
  * [K8s ReplicationControllerSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#replicationcontrollerspec-v1-core)
  *
+ * This metric **SHOULD**, at a minimum, be reported against a
+ * [`k8s.replicationcontroller`](../resource/k8s.md#replicationcontroller) resource.
+ *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const METRIC_K8S_REPLICATION_CONTROLLER_DESIRED_PODS = 'k8s.replication_controller.desired_pods' as const;
+export const METRIC_K8S_REPLICATIONCONTROLLER_DESIRED_PODS = 'k8s.replicationcontroller.desired_pods' as const;
 
 /**
  * The number of replica pods created by the statefulset controller from the statefulset version indicated by currentRevision
@@ -1220,6 +1321,74 @@ export const METRIC_NODEJS_EVENTLOOP_TIME = 'nodejs.eventloop.time' as const;
 export const METRIC_NODEJS_EVENTLOOP_UTILIZATION = 'nodejs.eventloop.utilization' as const;
 
 /**
+ * The number of spans for which the export has finished, either successful or failed
+ *
+ * @note For successful exports, `error.type` **MUST NOT** be set. For failed exports, `error.type` must contain the failure cause.
+ * For exporters with partial success semantics (e.g. OTLP with `rejected_spans`), rejected spans must count as failed and only non-rejected spans count as success.
+ * If no rejection reason is available, `rejected` **SHOULD** be used as value for `error.type`.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_OTEL_SDK_EXPORTER_SPAN_EXPORTED_COUNT = 'otel.sdk.exporter.span.exported.count' as const;
+
+/**
+ * The number of spans which were passed to the exporter, but that have not been exported yet (neither successful, nor failed)
+ *
+ * @note For successful exports, `error.type` **MUST NOT** be set. For failed exports, `error.type` must contain the failure cause.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_OTEL_SDK_EXPORTER_SPAN_INFLIGHT_COUNT = 'otel.sdk.exporter.span.inflight.count' as const;
+
+/**
+ * The number of spans for which the processing has finished, either successful or failed
+ *
+ * @note For successful processing, `error.type` **MUST NOT** be set. For failed processing, `error.type` must contain the failure cause.
+ * For the SDK Simple and Batching Span Processor a span is considered to be processed already when it has been submitted to the exporter, not when the corresponding export call has finished.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_OTEL_SDK_PROCESSOR_SPAN_PROCESSED_COUNT = 'otel.sdk.processor.span.processed.count' as const;
+
+/**
+ * The maximum number of spans the queue of a given instance of an SDK span processor can hold
+ *
+ * @note Only applies to span processors which use a queue, e.g. the SDK Batching Span Processor.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_OTEL_SDK_PROCESSOR_SPAN_QUEUE_CAPACITY = 'otel.sdk.processor.span.queue.capacity' as const;
+
+/**
+ * The number of spans in the queue of a given instance of an SDK span processor
+ *
+ * @note Only applies to span processors which use a queue, e.g. the SDK Batching Span Processor.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_OTEL_SDK_PROCESSOR_SPAN_QUEUE_SIZE = 'otel.sdk.processor.span.queue.size' as const;
+
+/**
+ * The number of created spans for which the end operation was called
+ *
+ * @note For spans with `recording=true`: Implementations **MUST** record both `otel.sdk.span.live.count` and `otel.sdk.span.ended.count`.
+ * For spans with `recording=false`: If implementations decide to record this metric, they **MUST** also record `otel.sdk.span.live.count`.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_OTEL_SDK_SPAN_ENDED_COUNT = 'otel.sdk.span.ended.count' as const;
+
+/**
+ * The number of created spans for which the end operation has not been called yet
+ *
+ * @note For spans with `recording=true`: Implementations **MUST** record both `otel.sdk.span.live.count` and `otel.sdk.span.ended.count`.
+ * For spans with `recording=false`: If implementations decide to record this metric, they **MUST** also record `otel.sdk.span.ended.count`.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_OTEL_SDK_SPAN_LIVE_COUNT = 'otel.sdk.span.live.count' as const;
+
+/**
  * Number of times the process has been context switched.
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
@@ -1404,9 +1573,11 @@ export const METRIC_RPC_SERVER_RESPONSE_SIZE = 'rpc.server.response.size' as con
 export const METRIC_RPC_SERVER_RESPONSES_PER_RPC = 'rpc.server.responses_per_rpc' as const;
 
 /**
- * Reports the current frequency of the CPU in Hz
+ * Deprecated. Use `cpu.frequency` instead.
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `cpu.frequency`.
  */
 export const METRIC_SYSTEM_CPU_FREQUENCY = 'system.cpu.frequency' as const;
 
@@ -1427,16 +1598,20 @@ export const METRIC_SYSTEM_CPU_LOGICAL_COUNT = 'system.cpu.logical.count' as con
 export const METRIC_SYSTEM_CPU_PHYSICAL_COUNT = 'system.cpu.physical.count' as const;
 
 /**
- * Seconds each logical CPU spent on each mode
+ * Deprecated. Use `cpu.time` instead.
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `cpu.time`.
  */
 export const METRIC_SYSTEM_CPU_TIME = 'system.cpu.time' as const;
 
 /**
- * Difference in system.cpu.time since the last measurement, divided by the elapsed time and number of logical CPUs
+ * Deprecated. Use `cpu.utilization` instead.
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `cpu.utilization`.
  */
 export const METRIC_SYSTEM_CPU_UTILIZATION = 'system.cpu.utilization' as const;
 


### PR DESCRIPTION
- Also update "scripts/semconv/changelog-gen.js" to support
  *undeprecated* exports. This version includes one such case.
