### PR TITLE
refactor: use  `getStringFromEnv` instead of  `process.env`

### DIFF
--- a/experimental/packages/otlp-grpc-exporter-base/src/configuration/otlp-grpc-env-configuration.ts
+++ b/experimental/packages/otlp-grpc-exporter-base/src/configuration/otlp-grpc-env-configuration.ts
@@ -15,7 +15,7 @@
  */
 import { UnresolvedOtlpGrpcConfiguration } from './otlp-grpc-configuration';
 import type { ChannelCredentials, Metadata } from '@grpc/grpc-js';
-import { parseKeyPairsIntoRecord } from '@opentelemetry/core';
+import { getStringFromEnv, parseKeyPairsIntoRecord } from '@opentelemetry/core';
 import {
   createEmptyMetadata,
   createInsecureCredentials,
@@ -43,9 +43,9 @@ function fallbackIfNullishOrBlank(
 
 function getMetadataFromEnv(signalIdentifier: string): Metadata | undefined {
   const signalSpecificRawHeaders =
-    process.env[`OTEL_EXPORTER_OTLP_${signalIdentifier}_HEADERS`]?.trim();
+    getStringFromEnv(`OTEL_EXPORTER_OTLP_${signalIdentifier}_HEADERS`);
   const nonSignalSpecificRawHeaders =
-    process.env['OTEL_EXPORTER_OTLP_HEADERS']?.trim();
+    getStringFromEnv('OTEL_EXPORTER_OTLP_HEADERS');
 
   const signalSpecificHeaders = parseKeyPairsIntoRecord(
     signalSpecificRawHeaders
@@ -100,9 +100,9 @@ function getUrlFromEnv(signalIdentifier: string) {
   // - https://example.test:4317 -> use secure credentials from environment (or provided via code)
 
   const specificEndpoint =
-    process.env[`OTEL_EXPORTER_OTLP_${signalIdentifier}_ENDPOINT`]?.trim();
+    getStringFromEnv(`OTEL_EXPORTER_OTLP_${signalIdentifier}_ENDPOINT`);
   const nonSpecificEndpoint =
-    process.env[`OTEL_EXPORTER_OTLP_ENDPOINT`]?.trim();
+    getStringFromEnv(`OTEL_EXPORTER_OTLP_ENDPOINT`);
 
   return fallbackIfNullishOrBlank(specificEndpoint, nonSpecificEndpoint);
 }
@@ -128,16 +128,12 @@ function getUrlFromEnv(signalIdentifier: string) {
  * @param signalIdentifier
  */
 function getInsecureSettingFromEnv(signalIdentifier: string): boolean {
-  const signalSpecificInsecureValue = process.env[
-    `OTEL_EXPORTER_OTLP_${signalIdentifier}_INSECURE`
-  ]
-    ?.toLowerCase()
-    .trim();
-  const nonSignalSpecificInsecureValue = process.env[
+  const signalSpecificInsecureValue = getStringFromEnv(
+    `OTEL_EXPORTER_OTLP_${signalIdentifier}_INSECURE`)?.toLowerCase();
+  const nonSignalSpecificInsecureValue = getStringFromEnv(
     `OTEL_EXPORTER_OTLP_INSECURE`
-  ]
-    ?.toLowerCase()
-    .trim();
+  )
+    ?.toLowerCase();
 
   return (
     fallbackIfNullishOrBlank(
@@ -152,8 +148,8 @@ function readFileFromEnv(
   nonSignalSpecificEnvVar: string,
   warningMessage: string
 ): Buffer | undefined {
-  const signalSpecificPath = process.env[signalSpecificEnvVar]?.trim();
-  const nonSignalSpecificPath = process.env[nonSignalSpecificEnvVar]?.trim();
+  const signalSpecificPath = getStringFromEnv(signalSpecificEnvVar);
+  const nonSignalSpecificPath = getStringFromEnv(nonSignalSpecificEnvVar);
 
   const filePath = fallbackIfNullishOrBlank(
     signalSpecificPath,


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the code to user the helper utilities to retrieve environment variable values

Fixes #5560

## Short description of the changes

Switched from using `process.env` to using the helper utility `getStringFromEnv `

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have manually run the `test` script command in the package directory

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been added
- [ ] Documentation has been updated
