### PR TITLE
docs: update from deprecated SEMRESATTRS_SERVICE_NAME to ATTR_SERVICE_NAME

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -68,14 +68,14 @@ body:
         const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
         const { ConsoleSpanExporter } = require('@opentelemetry/sdk-trace-base');
         const { resourceFromAttributes } = require('@opentelemetry/resources');
-        const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+        const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
         // configure the SDK to export telemetry data to the console
         // enable all auto-instrumentations from the meta package
         const traceExporter = new ConsoleSpanExporter();
         const sdk = new opentelemetry.NodeSDK({
           resource: resourceFromAttributes({
-            [SEMRESATTRS_SERVICE_NAME]: 'my-service',
+            [ATTR_SERVICE_NAME]: 'my-service',
           }),
           traceExporter,
           instrumentations: [getNodeAutoInstrumentations()]

--- a/examples/basic-tracer-node/index.js
+++ b/examples/basic-tracer-node/index.js
@@ -2,7 +2,7 @@
 
 const opentelemetry = require('@opentelemetry/api');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 const { BasicTracerProvider, ConsoleSpanExporter, SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { AsyncLocalStorageContextManager } = require("@opentelemetry/context-async-hooks");
@@ -24,7 +24,7 @@ const exporter = new JaegerExporter({
  */
 opentelemetry.trace.setGlobalTracerProvider(new BasicTracerProvider({
   resource: resourceFromAttributes({
-    [SEMRESATTRS_SERVICE_NAME]: 'basic-service',
+    [ATTR_SERVICE_NAME]: 'basic-service',
   }),
   spanProcessors: [
     new SimpleSpanProcessor(exporter),

--- a/examples/esm-http-ts/index.ts
+++ b/examples/esm-http-ts/index.ts
@@ -7,7 +7,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { resourceFromAttributes } from '@opentelemetry/resources';
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import http from 'http';
 
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
@@ -16,7 +16,7 @@ const processor = new SimpleSpanProcessor(exporter);
 
 const tracerProvider = new NodeTracerProvider({
   resource: resourceFromAttributes({
-    [SEMRESATTRS_SERVICE_NAME]: 'esm-http-ts-example',
+    [ATTR_SERVICE_NAME]: 'esm-http-ts-example',
   }),
   spanProcessors: [processor],
 });

--- a/examples/grpc-js/tracer.js
+++ b/examples/grpc-js/tracer.js
@@ -4,7 +4,7 @@ const opentelemetry = require('@opentelemetry/api');
 const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 const { SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
@@ -17,7 +17,7 @@ module.exports = (serviceName) => {
   const exporter = useZipkin ? new ZipkinExporter() : new JaegerExporter();
   const provider = new NodeTracerProvider({
     resource: resourceFromAttributes({
-      [SEMRESATTRS_SERVICE_NAME]: serviceName,
+      [ATTR_SERVICE_NAME]: serviceName,
     }),
     spanProcessors: [new SimpleSpanProcessor(exporter)]
   });

--- a/examples/http/tracer.js
+++ b/examples/http/tracer.js
@@ -4,7 +4,7 @@ const opentelemetry = require('@opentelemetry/api');
 const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 const { SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
@@ -17,7 +17,7 @@ module.exports = (serviceName) => {
   const exporter = useZipkin ? new ZipkinExporter() : new JaegerExporter();
   const provider = new NodeTracerProvider({
     resource: resourceFromAttributes({
-      [SEMRESATTRS_SERVICE_NAME]: serviceName,
+      [ATTR_SERVICE_NAME]: serviceName,
     }),
     spanProcessors: [new SimpleSpanProcessor(exporter)]
   });

--- a/examples/https/tracer.js
+++ b/examples/https/tracer.js
@@ -4,7 +4,7 @@ const opentelemetry = require('@opentelemetry/api');
 const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 const { SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
@@ -18,7 +18,7 @@ module.exports = (serviceName) => {
   const exporter = useZipkin ? new ZipkinExporter() : new JaegerExporter();
   const provider = new NodeTracerProvider({
     resource: resourceFromAttributes({
-      [SEMRESATTRS_SERVICE_NAME]: serviceName,
+      [ATTR_SERVICE_NAME]: serviceName,
     }),
     spanProcessors: [new SimpleSpanProcessor(exporter)]
   });

--- a/examples/opentelemetry-web/examples/fetch-proto/index.js
+++ b/examples/opentelemetry-web/examples/fetch-proto/index.js
@@ -7,11 +7,11 @@ const { B3Propagator } = require("@opentelemetry/propagator-b3");
 const { registerInstrumentations } = require("@opentelemetry/instrumentation");
 const { OTLPTraceExporter: OTLPTraceExporterProto } = require("@opentelemetry/exporter-trace-otlp-proto");
 const { resourceFromAttributes } = require("@opentelemetry/resources");
-const { SEMRESATTRS_SERVICE_NAME } = require("@opentelemetry/semantic-conventions");
+const { ATTR_SERVICE_NAME } = require("@opentelemetry/semantic-conventions");
 
 const provider = new WebTracerProvider({
   resource: resourceFromAttributes({
-    [SEMRESATTRS_SERVICE_NAME]: 'fetch-proto-web-service'
+    [ATTR_SERVICE_NAME]: 'fetch-proto-web-service'
   }),
   // Note: For production consider using the "BatchSpanProcessor" to reduce the number of requests
   // to your exporter. Using the SimpleSpanProcessor here as it sends the spans immediately to the

--- a/examples/opentelemetry-web/examples/fetch/index.js
+++ b/examples/opentelemetry-web/examples/fetch/index.js
@@ -7,11 +7,11 @@ const { ZoneContextManager } = require( '@opentelemetry/context-zone');
 const { B3Propagator } = require( '@opentelemetry/propagator-b3');
 const { registerInstrumentations } = require( '@opentelemetry/instrumentation');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
 const provider = new WebTracerProvider({
   resource: resourceFromAttributes({
-    [SEMRESATTRS_SERVICE_NAME]: 'fetch-web-service'
+    [ATTR_SERVICE_NAME]: 'fetch-web-service'
   }),
   // Note: For production consider using the "BatchSpanProcessor" to reduce the number of requests
   // to your exporter. Using the SimpleSpanProcessor here as it sends the spans immediately to the

--- a/examples/opentelemetry-web/examples/fetchXhr/index.js
+++ b/examples/opentelemetry-web/examples/fetchXhr/index.js
@@ -7,11 +7,11 @@ const { XMLHttpRequestInstrumentation } = require('@opentelemetry/instrumentatio
 const { ZoneContextManager } = require('@opentelemetry/context-zone');
 const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
 const provider = new WebTracerProvider({
   resource: resourceFromAttributes({
-    [SEMRESATTRS_SERVICE_NAME]: 'fetch-xhr-web-service'
+    [ATTR_SERVICE_NAME]: 'fetch-xhr-web-service'
   }),
   // Note: For production consider using the "BatchSpanProcessor" to reduce the number of requests
   // to your exporter. Using the SimpleSpanProcessor here as it sends the spans immediately to the

--- a/examples/opentelemetry-web/examples/fetchXhrB3/index.js
+++ b/examples/opentelemetry-web/examples/fetchXhrB3/index.js
@@ -8,11 +8,11 @@ const { ZoneContextManager } = require( '@opentelemetry/context-zone');
 const { B3Propagator } = require( '@opentelemetry/propagator-b3');
 const { registerInstrumentations } = require( '@opentelemetry/instrumentation');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
 const provider = new WebTracerProvider({
   resource: resourceFromAttributes({
-    [SEMRESATTRS_SERVICE_NAME]: 'fetch-xhr-b3-web-service'
+    [ATTR_SERVICE_NAME]: 'fetch-xhr-b3-web-service'
   }),
   // Note: For production consider using the "BatchSpanProcessor" to reduce the number of requests
   // to your exporter. Using the SimpleSpanProcessor here as it sends the spans immediately to the

--- a/examples/opentelemetry-web/examples/xml-http-request/index.js
+++ b/examples/opentelemetry-web/examples/xml-http-request/index.js
@@ -7,11 +7,11 @@ const { OTLPTraceExporter } = require( '@opentelemetry/exporter-trace-otlp-http'
 const { B3Propagator } = require( '@opentelemetry/propagator-b3');
 const { registerInstrumentations } = require( '@opentelemetry/instrumentation');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
 const providerWithZone = new WebTracerProvider({
   resource: resourceFromAttributes({
-    [SEMRESATTRS_SERVICE_NAME]: 'xml-http-web-service'
+    [ATTR_SERVICE_NAME]: 'xml-http-web-service'
   }),
   // Note: For production consider using the "BatchSpanProcessor" to reduce the number of requests
   // to your exporter. Using the SimpleSpanProcessor here as it sends the spans immediately to the

--- a/examples/opentelemetry-web/examples/zipkin/index.js
+++ b/examples/opentelemetry-web/examples/zipkin/index.js
@@ -2,11 +2,11 @@ const { ConsoleSpanExporter, SimpleSpanProcessor } = require('@opentelemetry/sdk
 const { WebTracerProvider } = require('@opentelemetry/sdk-trace-web');
 const { ZipkinExporter } = require('@opentelemetry/exporter-zipkin');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
 const provider = new WebTracerProvider({
   resource: resourceFromAttributes({
-    [SEMRESATTRS_SERVICE_NAME]: 'zipkin-web-service'
+    [ATTR_SERVICE_NAME]: 'zipkin-web-service'
   }),
   // Note: For production consider using the "BatchSpanProcessor" to reduce the number of requests
   // to your exporter. Using the SimpleSpanProcessor here as it sends the spans immediately to the

--- a/examples/opentracing-shim/shim.js
+++ b/examples/opentracing-shim/shim.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
@@ -10,7 +10,7 @@ const { TracerShim } = require('@opentelemetry/shim-opentracing');
 
 function shim(serviceName) {
   const provider = new NodeTracerProvider({
-    resource: resourceFromAttributes({ [SEMRESATTRS_SERVICE_NAME]: serviceName }),
+    resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: serviceName }),
     spanProcessors: [new SimpleSpanProcessor(getExporter(serviceName))],
   });
 

--- a/examples/otlp-exporter-node/metrics.js
+++ b/examples/otlp-exporter-node/metrics.js
@@ -12,9 +12,7 @@ const {
   AggregationType,
 } = require('@opentelemetry/sdk-metrics');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
-const {
-  SEMRESATTRS_SERVICE_NAME,
-} = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
 // Optional and only needed to see the internal diagnostic logging (during development)
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
@@ -28,7 +26,7 @@ const metricExporter = new OTLPMetricExporter({
 // Create an instance of the metric provider
 const meterProvider = new MeterProvider({
   resource: resourceFromAttributes({
-    [SEMRESATTRS_SERVICE_NAME]: 'basic-metric-service',
+    [ATTR_SERVICE_NAME]: 'basic-metric-service',
   }),
   // Define view for the exponential histogram metric
   views: [{

--- a/examples/otlp-exporter-node/tracing.js
+++ b/examples/otlp-exporter-node/tracing.js
@@ -3,7 +3,7 @@
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node')
 const { ConsoleSpanExporter, SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 const {
   diag,
   trace,
@@ -25,7 +25,7 @@ const exporter = new OTLPTraceExporter({
 
 const provider = new NodeTracerProvider({
   resource: resourceFromAttributes({
-    [SEMRESATTRS_SERVICE_NAME]: 'basic-service',
+    [ATTR_SERVICE_NAME]: 'basic-service',
   }),
   spanProcessors: [
     new SimpleSpanProcessor(exporter),

--- a/experimental/examples/opencensus-shim/setup.js
+++ b/experimental/examples/opencensus-shim/setup.js
@@ -26,9 +26,7 @@ const {
 } = require('@opentelemetry/exporter-trace-otlp-grpc');
 const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
 const { resourceFromAttributes } = require('@opentelemetry/resources');
-const {
-  SEMRESATTRS_SERVICE_NAME,
-} = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 const { OpenCensusMetricProducer } = require('@opentelemetry/shim-opencensus');
 const instrumentationHttp = require('@opencensus/instrumentation-http');
 const { TracingBase } = require('@opencensus/nodejs-base');
@@ -46,7 +44,7 @@ module.exports = function setup(serviceName) {
   tracing.tracer = new oc.CoreTracer();
 
   const resource = resourceFromAttributes({
-    [SEMRESATTRS_SERVICE_NAME]: serviceName,
+    [ATTR_SERVICE_NAME]: serviceName,
   });
   const tracerProvider = new NodeTracerProvider({
     resource,

--- a/experimental/packages/opentelemetry-browser-detector/README.md
+++ b/experimental/packages/opentelemetry-browser-detector/README.md
@@ -14,12 +14,12 @@ npm install --save @opentelemetry/opentelemetry-browser-detector
 
 ```js
 import { resourceFromAttributes, detectResources } from '@opentelemetry/resources';
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { browserDetector } from '@opentelemetry/opentelemetry-browser-detector';
 
 async function start(){
   let resource = resourceFromAttributes({
-    [SEMRESATTRS_SERVICE_NAME]: 'Test App Name',
+    [ATTR_SERVICE_NAME]: 'Test App Name',
   });
   let detectedResources= await detectResources({detectors:[browserDetector]});
   resource=resource.merge(detectedResources);

--- a/packages/opentelemetry-resources/README.md
+++ b/packages/opentelemetry-resources/README.md
@@ -16,11 +16,11 @@ npm install --save @opentelemetry/resources
 ## Usage
 
 ```typescript
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 
 const resource = resourceFromAttributes({
-    [SEMRESATTRS_SERVICE_NAME]: 'api-service',
+    [ATTR_SERVICE_NAME]: 'api-service',
 });
 
 const anotherResource = resourceFromAttributes({


### PR DESCRIPTION
This will be one of many PRs updating the semconv pkg exports used for
the 'JS package deprecations'. See
https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions/#deprecations

This PR is limited to READMEs and examples/ so does no impact any
published code.
