### PR TITLE
docs: update otlp exporter example to use recommended patterns

### DIFF
--- a/examples/otlp-exporter-node/docker/collector-config.yaml
+++ b/examples/otlp-exporter-node/docker/collector-config.yaml
@@ -2,17 +2,20 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: "0.0.0.0:4317"
       http:
+        endpoint: "0.0.0.0:4318"
         cors:
           allowed_origins:
             - http://*
             - https://*
-
 exporters:
   zipkin:
     endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
   prometheus:
     endpoint: "0.0.0.0:9464"
+  debug:
+    verbosity: detailed
 
 processors:
   batch:
@@ -24,9 +27,9 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [zipkin]
+      exporters: [zipkin, debug]
       processors: [batch]
     metrics:
       receivers: [otlp]
-      exporters: [prometheus]
+      exporters: [prometheus, debug]
       processors: [batch]

--- a/examples/otlp-exporter-node/docker/docker-compose.yaml
+++ b/examples/otlp-exporter-node/docker/docker-compose.yaml
@@ -1,9 +1,7 @@
-version: "3"
 services:
   # Collector
   collector:
-    image: otel/opentelemetry-collector-contrib:0.53.0
-#    image: otel/opentelemetry-collector-contrib:latest
+    image: otel/opentelemetry-collector-contrib:0.123.0
     command: ["--config=/conf/collector-config.yaml"]
     volumes:
       - ./collector-config.yaml:/conf/collector-config.yaml

--- a/examples/otlp-exporter-node/opentelemetry-metrics.js
+++ b/examples/otlp-exporter-node/opentelemetry-metrics.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { DiagConsoleLogger, DiagLogLevel, diag, metrics } = require('@opentelemetry/api');
+const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-http');
+// const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-grpc');
+// const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-proto');
+// const { ConsoleMetricExporter } = require('@opentelemetry/sdk-metrics');
+const {
+  MeterProvider,
+  PeriodicExportingMetricReader,
+  AggregationType,
+} = require('@opentelemetry/sdk-metrics');
+const { resourceFromAttributes } = require('@opentelemetry/resources');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+
+// Optional: set up diagnostics logging, this can help in troubleshooting during development.
+// - It is recommended to turn this off in production as the DiagConsoleLogger writes to stdout.
+// - If writing to stdout is acceptable to you, it is recommended to change the log level to WARNING or ERROR.
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+
+// Create an OTLP exporter. Not specifying a `url` in the constructor options will have it export to `localhost`
+// and the OTLP port (4318 for HTTP, 4317 for gRPC). You can set additional headers via the constructor options.
+const metricExporter = new OTLPMetricExporter();
+
+// Create an instance of the SDK MeterProvider - this is only directly used during SDK setup, it will be registered with
+// the API at the end.
+const meterProvider = new MeterProvider({
+  resource: resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: 'basic-metric-service',
+  }),
+  // With views, you can change the telemetry exported by your app. In this example, you can re-aggregate a Histogram
+  // named `test_exponential_histogram` as an Exponential Histogram. You can also drop metrics based on their Meter name,
+  // re-name specific metrics, and allow-list or block-list certain attributes.
+  //
+  // Please see the documentation of the `ViewOptions` type for details on how to change metrics streams.
+  views: [{
+    aggregation: { type: AggregationType.EXPONENTIAL_HISTOGRAM },
+    // Note, the instrumentName is the same as the name that has been passed for
+    // the Meter#createHistogram function for exponentialHistogram.
+    instrumentName: 'test_exponential_histogram',
+  }],
+  readers: [
+    new PeriodicExportingMetricReader({
+      exporter: metricExporter,
+      // exporter: new ConsoleMetricExporter(),
+      exportIntervalMillis: 1000,
+    }),
+  ],
+});
+
+// Set up shutdown behavior as OTel JS does NOT automatically shut down and flush data.
+// By setting this up, you can ensure that previously written data is flushed before the process exits.
+// By not setting this up, you risk data-loss on shutdown - especially on short-lived processes.
+
+// Gracefully shutdown Trace SDK if a SIGTERM is received
+process.on('SIGTERM', () => meterProvider.shutdown());
+// Gracefully shutdown Trace SDK if Node.js is exiting normally
+process.once('beforeExit', () => meterProvider.shutdown());
+
+// Register the MeterProvider as the global MeterProvider - this is what makes the MeterProvider available via
+// `metrics.getMeterProvider()` or `metrics.getMeter()`
+// From here on out, you should never have to refer to the SDK MeterProvider again.
+metrics.setGlobalMeterProvider(meterProvider);
+

--- a/examples/otlp-exporter-node/opentelemetry-traces.js
+++ b/examples/otlp-exporter-node/opentelemetry-traces.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node')
+const { ConsoleSpanExporter, SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
+const { resourceFromAttributes } = require('@opentelemetry/resources');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const {
+  diag,
+  DiagConsoleLogger,
+  DiagLogLevel,
+} = require('@opentelemetry/api');
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
+// const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc');
+// const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-proto');
+
+// Optional: set up diagnostics logging, this can help in troubleshooting during development.
+// - It is recommended to turn this off in production as the DiagConsoleLogger writes to stdout.
+// - If writing to stdout is acceptable to you, it is recommended to change the log level to WARNING or ERROR.
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+
+// Create an OTLP exporter. Not specifying a `url` in the constructor options will have it export to `localhost`
+// and the OTLP port (4318 for HTTP, 4317 for gRPC). You can set additional headers via the constructor options.
+const exporter = new OTLPTraceExporter();
+
+const provider = new NodeTracerProvider({
+  resource: resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: 'basic-service',
+  }),
+  spanProcessors: [
+    new SimpleSpanProcessor(exporter),
+    new SimpleSpanProcessor(new ConsoleSpanExporter()),
+  ]
+});
+
+// Set up shutdown behavior as OTel JS does NOT automatically shut down and flush data.
+// By setting this up, you can ensure that previously written data is flushed before the process exits.
+// By not setting this up, you risk data-loss on shutdown - especially on short-lived processes.
+
+// Gracefully shutdown Trace SDK if a SIGTERM is received
+process.on('SIGTERM', () => provider.shutdown());
+// Gracefully shutdown Trace SDK if Node.js is exiting normally
+process.once('beforeExit', () => provider.shutdown());
+
+// Register the NodeTracerProvider as the global TracerProvider - this is what makes the NodeTracerProvider available via
+// `trace.getTracerProvider()` or `trace.getTracer()`.
+// From here on out, you should never have to refer to the SDK NodeTracerProvider again.
+provider.register();

--- a/examples/otlp-exporter-node/package.json
+++ b/examples/otlp-exporter-node/package.json
@@ -5,11 +5,11 @@
   "description": "Example of using @opentelemetry/collector-exporter in Node.js",
   "main": "index.js",
   "scripts": {
-    "start:tracing": "node tracing.js",
-    "start:metrics": "node metrics.js",
-    "docker:start": "cd ./docker && docker-compose down && docker-compose up",
-    "docker:startd": "cd ./docker && docker-compose down && docker-compose up -d",
-    "docker:stop": "cd ./docker && docker-compose down",
+    "start:tracing": "node --require ./opentelemetry-traces.js tracing.js",
+    "start:metrics": "node --require ./opentelemetry-metrics.js metrics.js",
+    "docker:start": "cd ./docker && docker compose down && docker compose up",
+    "docker:startd": "cd ./docker && docker compose down && docker compose up -d",
+    "docker:stop": "cd ./docker && docker compose down",
     "align-api-deps": "node ../../scripts/align-api-deps.js"
   },
   "repository": {


### PR DESCRIPTION
## Which problem is this PR solving?

The example has numerous issues that this PR addresses:

- our collector image and config is outdated
- we're using non-recommended patterns in the example, which people may copy and get confused about
- we're not registering shutdown listeners in the example, which causes problems
- we're not really explaining why we're doing the things we're doing, which often leads to questions

I'll gradually update all other examples to a similar pattern too.

Fixes #5602 

## How Has This Been Tested?

- [x] Manual testing
