### PR TITLE
refactor(opentelemetry-core): simplify `parseKeyPairsIntoRecord()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * test(sdk-metrics): fix multiple problematic assertRejects() calls [#5611](https://github.com/open-telemetry/opentelemetry-js/pull/5611) @cjihrig
 * refactor: replace assertRejects() with assert.rejects() [#5614](https://github.com/open-telemetry/opentelemetry-js/pull/5614) @cjihrig
 * refactor(core): migrate from deprecated semconv constants [#5575](https://github.com/open-telemetry/opentelemetry-js/pull/5575) @alumni55748
+* refactor(opentelemetry-core): simplify `parseKeyPairsIntoRecord()` [#5610](https://github.com/open-telemetry/opentelemetry-js/pull/5610) @cjihrig
 
 ## 2.0.0
 

--- a/packages/opentelemetry-core/src/baggage/utils.ts
+++ b/packages/opentelemetry-core/src/baggage/utils.ts
@@ -85,16 +85,17 @@ export function parsePairKeyValue(
 export function parseKeyPairsIntoRecord(
   value?: string
 ): Record<string, string> {
-  if (typeof value !== 'string' || value.length === 0) return {};
-  return value
-    .split(BAGGAGE_ITEMS_SEPARATOR)
-    .map(entry => {
-      return parsePairKeyValue(entry);
-    })
-    .filter(keyPair => keyPair !== undefined && keyPair.value.length > 0)
-    .reduce<Record<string, string>>((headers, keyPair) => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      headers[keyPair!.key] = keyPair!.value;
-      return headers;
-    }, {});
+  const result: Record<string, string> = {};
+
+  if (typeof value === 'string' && value.length > 0) {
+    value.split(BAGGAGE_ITEMS_SEPARATOR).forEach(entry => {
+      const keyPair = parsePairKeyValue(entry);
+
+      if (keyPair !== undefined && keyPair.value.length > 0) {
+        result[keyPair.key] = keyPair.value;
+      }
+    });
+  }
+
+  return result;
 }

--- a/packages/opentelemetry-core/test/common/baggage/utils.test.ts
+++ b/packages/opentelemetry-core/test/common/baggage/utils.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { parseKeyPairsIntoRecord } from '../../../src/baggage/utils';
+
+describe('parseKeyPairsIntoRecord()', () => {
+  it('returns an empty object when value is not a string', () => {
+    assert.deepStrictEqual(parseKeyPairsIntoRecord(), {});
+  });
+
+  it('returns an empty object when value is the empty string', () => {
+    assert.deepStrictEqual(parseKeyPairsIntoRecord(''), {});
+  });
+
+  it('parses a single key-value pair', () => {
+    const value = 'key1=value1';
+    const result = parseKeyPairsIntoRecord(value);
+    assert.deepStrictEqual(result, { key1: 'value1' });
+  });
+
+  it('parses multiple key-value pairs', () => {
+    const value = 'key1=value1,key2=value2,key3=value3';
+    const result = parseKeyPairsIntoRecord(value);
+    assert.deepStrictEqual(result, {
+      key1: 'value1',
+      key2: 'value2',
+      key3: 'value3',
+    });
+  });
+
+  it('ignores leading and trailing whitespace', () => {
+    const value = '  key1=value1, key2=value2  ';
+    const result = parseKeyPairsIntoRecord(value);
+    assert.deepStrictEqual(result, { key1: 'value1', key2: 'value2' });
+  });
+
+  it('filters out invalid pairs', () => {
+    assert.deepStrictEqual(parseKeyPairsIntoRecord('key1,key2=value2'), {
+      key2: 'value2',
+    });
+  });
+
+  it('filters out empty values', () => {
+    assert.deepStrictEqual(parseKeyPairsIntoRecord('key1=,key2=value2'), {
+      key2: 'value2',
+    });
+  });
+});


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Not a problem, but the `parseKeyPairsIntoRecord()` function can be simplified a bit.

Fixes N/A

## Short description of the changes

This commit refactors `parseKeyPairsIntoRecord()` to use a single `forEach()` loop instead of a series of loops using `map()`, `filter()`, and `reduce()`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran the test suite.

## Checklist:

- [x] Followed the style guidelines of this project
