### PR TITLE
test(sdk-metrics): fix multiple problematic assertRejects() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
+* test(sdk-metrics): fix multiple problematic assertRejects() calls [#5611](https://github.com/open-telemetry/opentelemetry-js/pull/5611) @cjihrig
+
 ## 2.0.0
 
 ### Summary

--- a/packages/sdk-metrics/test/export/MetricReader.test.ts
+++ b/packages/sdk-metrics/test/export/MetricReader.test.ts
@@ -119,7 +119,7 @@ describe('MetricReader', () => {
       reader.setMetricProducer(new TestMetricProducer());
 
       await reader.shutdown();
-      assertRejects(reader.collect(), /MetricReader is shutdown/);
+      await assertRejects(reader.collect(), /MetricReader is shutdown/);
     });
 
     it('should call MetricProducer.collect with timeout', async () => {

--- a/packages/sdk-metrics/test/utils.test.ts
+++ b/packages/sdk-metrics/test/utils.test.ts
@@ -32,11 +32,16 @@ describe('utils', () => {
 
   describe('callWithTimeout', () => {
     it('should reject if given promise not settled before timeout', async () => {
-      sinon.useFakeTimers();
+      const clock = sinon.useFakeTimers();
       const promise = new Promise(() => {
         /** promise never settles */
       });
-      assertRejects(callWithTimeout(promise, 100), TimeoutError);
+      const assertion = assertRejects(
+        callWithTimeout(promise, 100),
+        TimeoutError
+      );
+      clock.tick(101);
+      await assertion;
     });
   });
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Multiple tests were calling `assertRejects()` without awaiting the result. When/if these assertions fail, mocha does not fail the tests due to unhandled rejections.

It's also worth noting that `assertRejects()` might not be needed anymore. There are multiple copies of this function across the codebase, but `assert.rejects()` is in all supported versions of Node. I would like to open a follow up change to migrate to `assert.rejects()` if it's OK with the maintainers.

Fixes N/A

## Short description of the changes

This commit fixes two tests that were not await'ing `assertRejects()` calls.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ran the test suite while intentionally breaking the assertions.

## Checklist:

- [x] Followed the style guidelines of this project
