### PR TITLE
docs: fix api doc links

### DIFF
--- a/doc/context.md
+++ b/doc/context.md
@@ -7,7 +7,7 @@ This document describes the OpenTelemetry context API for JavaScript and how it 
 
 _Context Specification: <https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.0/specification/context/context.md>_
 
-_Context API Reference: <https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api.ContextAPI.html>_
+_Context API Reference: <https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.ContextAPI.html>_
 
 - [Context Manager](#context-manager)
 - [Root Context](#root-context)
@@ -138,7 +138,7 @@ import * as api from "@opentelemetry/api";
 
 // Returns the active context
 // If no context is active, the ROOT_CONTEXT is returned
-const ctx =  api.context.active(); 
+const ctx =  api.context.active();
 ```
 
 ### Set Active Context

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -6,7 +6,7 @@ For a high-level overview of OpenTelemetry metrics in general and definitions of
 
 _Metrics API Specification: <https://github.com/open-telemetry/opentelemetry-specification/blob/v1.14.0/specification/metrics/api.md>_
 
-_Metrics API Reference: <https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api.MetricsAPI.html>_
+_Metrics API Reference: <https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.MetricsAPI.html>_
 
 - [Getting Started](#getting-started)
 - [Acquiring a Meter](#acquiring-a-meter)
@@ -233,7 +233,7 @@ example you see that we accessed our `/` endpoint six times.
 
 ## Acquiring a Meter
 
-In OpenTelemetry, Instruments that allow for measurement operations are acquired through a _meter_. You can get a meter by calling [`getMeter`](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api.MeterProvider.html#getMeter) on the global meter provider. `getMeter` takes the name and version of the application or library acquiring the meter, and provides a meter which can be used to create instruments.
+In OpenTelemetry, Instruments that allow for measurement operations are acquired through a _meter_. You can get a meter by calling [`getMeter`](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.MeterProvider.html#getmeter) on the global meter provider. `getMeter` takes the name and version of the application or library acquiring the meter, and provides a meter which can be used to create instruments.
 
 ```typescript
 import { metrics } from '@opentelemetry/api';
@@ -243,7 +243,7 @@ const meter = metrics.getMeter("my-application", "0.1.0");
 
 ## Create a metric instrument
 
-In OpenTelemetry, all _metrics_ are composed of [`Instruments`](https://open-telemetry.github.io/opentelemetry-js/enums/_opentelemetry_sdk_metrics.InstrumentType.html). An instrument is responsible for reporting measurements,
+In OpenTelemetry, all _metrics_ are composed of [`Instruments`](https://open-telemetry.github.io/opentelemetry-js/enums/_opentelemetry_sdk-metrics.InstrumentType.html). An instrument is responsible for reporting measurements,
 there are four types of instruments that can be created:
 
 - Counter, a synchronous instrument which supports non-negative increments
@@ -253,7 +253,7 @@ there are four types of instruments that can be created:
 - UpDownCounter, a synchronous instrument which supports increments and decrements, such as number of active requests
 - Asynchronous UpDownCounter, an asynchronous instrument which supports increments and decrements
 
-You can create a Counter instrument by calling [`Meter#createCounter`](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api.Meter.html#createCounter). The only required argument to `createCounter` is the _instrument name_, which should describe the item that is being measurement.
+You can create a Counter instrument by calling [`Meter#createCounter`](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.Meter.html#createcounter). The only required argument to `createCounter` is the _instrument name_, which should describe the item that is being measurement.
 
 ```typescript
 const counter = meter.createCounter("events.counter");

--- a/doc/sdk-registration.md
+++ b/doc/sdk-registration.md
@@ -24,6 +24,6 @@ api.context.setGlobalContextManager(asyncHooksContextManager);
 ```
 
 [opentelemetry-js]: https://github.com/open-telemetry/opentelemetry-js
-[trace-api-docs]: https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api.TraceAPI.html
-[propagation-api-docs]: https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api.PropagationAPI.html
-[context-api-docs]: https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api.ContextAPI.html
+[trace-api-docs]: https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.TraceAPI.html
+[propagation-api-docs]: https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.PropagationAPI.html
+[context-api-docs]: https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.ContextAPI.html

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -6,7 +6,7 @@ For a high-level overview of OpenTelemetry tracing in general and definitions of
 
 _Trace API Specification: <https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.0/specification/trace/api.md>_
 
-_Trace API Reference: <https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api.TraceAPI.html>_
+_Trace API Reference: <https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.TraceAPI.html>_
 
 - [Acquiring a Tracer](#acquiring-a-tracer)
 - [Starting and Ending a Span](#starting-and-ending-a-span)
@@ -23,7 +23,7 @@ _Trace API Reference: <https://open-telemetry.github.io/opentelemetry-js/classes
 
 ## Acquiring a Tracer
 
-In OpenTelemetry, tracing operations are performed using methods on a _tracer_. You can get a tracer by calling [`getTracer`](https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api.TraceAPI.html#getTracer) on the global tracer provider. `getTracer` takes the name and version of the application or library acquiring the tracer, and provides a tracer which can be used to trace operations.
+In OpenTelemetry, tracing operations are performed using methods on a _tracer_. You can get a tracer by calling [`getTracer`](https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.TraceAPI.html#getTracer) on the global tracer provider. `getTracer` takes the name and version of the application or library acquiring the tracer, and provides a tracer which can be used to trace operations.
 
 ```typescript
 import { trace } from '@opentelemetry/api';
@@ -33,9 +33,9 @@ const tracer = trace.getTracer("my-application", "0.1.0");
 
 ## Starting and Ending a Span
 
-In OpenTelemetry, all _traces_ are composed of [`Spans`](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api.Span.html). A span describes a single operation with a start time and and end time like a database request, outgoing remote request, or a function invocation. These spans are linked together by parent-child relationships to form a tree. The resultant tree is your trace, and the root of the tree is commonly called the _root span_.
+In OpenTelemetry, all _traces_ are composed of [`Spans`](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.Span.html). A span describes a single operation with a start time and and end time like a database request, outgoing remote request, or a function invocation. These spans are linked together by parent-child relationships to form a tree. The resultant tree is your trace, and the root of the tree is commonly called the _root span_.
 
-You can create a span by calling [`Tracer#startSpan`](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api.Tracer.html#startSpan). The only required argument to `startSpan` is the _span name_, which should describe the operation being performed with low cardinality.
+You can create a span by calling [`Tracer#startSpan`](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.Tracer.html#startSpan). The only required argument to `startSpan` is the _span name_, which should describe the operation being performed with low cardinality.
 
 ```typescript
 const span = tracer.startSpan("my-span-name");


### PR DESCRIPTION
## Which problem is this PR solving?

The new typedoc version generates the docs a bit differently - so the links have changed. This PR fixes the links.