### PR TITLE
[docs] Upgrade note with Jest version requirements and workaround for older versions of Jest

### DIFF
--- a/doc/frequently-asked-questions.md
+++ b/doc/frequently-asked-questions.md
@@ -10,12 +10,13 @@ Test suite failures of the form:
 Cannot find module @opentelemetry/foo/bar from @opentelemetry/...
 ```
 
-but package `@opentelemetry/foo` is installed occur with Jest < v29.4. Upgrade
-to a newer version of Jest to resolve the issue. Earlier versions of
-`jest-resolve` cannot find the nested module imports used by some OpenTelemetry
-packages since version 0.56 and higher. [#5618](https://github.com/open-telemetry/opentelemetry-js/issues/5618)
+but package `@opentelemetry/foo` is installed may occur with Jest < v29.4.
+This is because older versions of `jest-resolve` cannot find the nested module
+imports used by some OpenTelemetry packages since version 0.56 and higher.
+See [#5618](https://github.com/open-telemetry/opentelemetry-js/issues/5618)
 
-Here is a workaround for older versions of Jest using a `moduleNameMapper` rule.
+Either upgrade to a newer version of Jest to resolve the issue, or use this
+workaround for older versions of Jest by adding a `moduleNameMapper` rule.
 Add this line to your `jest.config.js`:
 
 ``` javascript

--- a/doc/frequently-asked-questions.md
+++ b/doc/frequently-asked-questions.md
@@ -5,9 +5,11 @@ This FAQ has bits of advice and workarounds for common problems.
 ## I'm using Jest and get import errors when I run my test suite
 
 Test suite failures of the form:
+
 ``` text
 Cannot find module @opentelemetry/foo/bar from @opentelemetry/...
 ```
+
 but package `@opentelemetry/foo` is installed occur with Jest < v29.4. Upgrade
 to a newer version of Jest to resolve the issue. Earlier versions of
 `jest-resolve` cannot find the nested module imports used by some OpenTelemetry
@@ -15,6 +17,7 @@ packages since version 0.56 and higher. [#5618](https://github.com/open-telemetr
 
 Here is a workaround for older versions of Jest using a `moduleNameMapper` rule.
 Add this line to your `jest.config.js`:
+
 ``` javascript
 module.exports = {
   moduleNameMapper: {
@@ -22,4 +25,3 @@ module.exports = {
   }
 }
 ```
-

--- a/doc/frequently-asked-questions.md
+++ b/doc/frequently-asked-questions.md
@@ -1,0 +1,25 @@
+# Frequently Asked Questions
+
+This FAQ has bits of advice and workarounds for common problems.
+
+## I'm using Jest and get import errors when I run my test suite
+
+Test suite failures of the form:
+``` text
+Cannot find module @opentelemetry/foo/bar from @opentelemetry/...
+```
+but package `@opentelemetry/foo` is installed occur with Jest < v29.4. Upgrade
+to a newer version of Jest to resolve the issue. Earlier versions of
+`jest-resolve` cannot find the nested module imports used by some OpenTelemetry
+packages since version 0.56 and higher. [#5618](https://github.com/open-telemetry/opentelemetry-js/issues/5618)
+
+Here is a workaround for older versions of Jest using a `moduleNameMapper` rule.
+Add this line to your `jest.config.js`:
+``` javascript
+module.exports = {
+  moduleNameMapper: {
+    '^@opentelemetry/([^/]+)/(.+)$': '<rootDir>/node_modules/@opentelemetry/$1/build/src/index-$2',
+  }
+}
+```
+

--- a/doc/upgrade-to-2.x.md
+++ b/doc/upgrade-to-2.x.md
@@ -625,7 +625,7 @@ assert.deepStrictEqual(resource.attributes, { ... });
 
 This section describes the remaining breaking changes, not otherwise mentioned in a section above.
 
-- use the `Attributes` type instead of the deprecated `SpanAttributes` and `MetricAttributes` types from the API package.
+- Usage of the deprecated `SpanAttributes` and `MetricAttributes` types from the API package has been changed to use the `Attributes` type.
 
 - bumped minimum version of `@opentelemetry/api` peer dependency to 1.1.0 for the following packages: `@opentelemetry/core` [#4408](https://github.com/open-telemetry/opentelemetry-js/pull/4408), `@opentelemetry/resources` [#4428](https://github.com/open-telemetry/opentelemetry-js/pull/4428), `@opentelemetry/sdk-trace-base` [#5009](https://github.com/open-telemetry/opentelemetry-js/pull/5009), `@opentelemetry/shim-opentracing` [#4430](https://github.com/open-telemetry/opentelemetry-js/pull/4430)
 

--- a/doc/upgrade-to-2.x.md
+++ b/doc/upgrade-to-2.x.md
@@ -625,7 +625,7 @@ assert.deepStrictEqual(resource.attributes, { ... });
 
 This section describes the remaining breaking changes, not otherwise mentioned in a section above.
 
-- Usage of the deprecated `SpanAttributes` and `MetricAttributes` types from the API package has been changed to use the `Attributes` type.
+Usage of the deprecated `SpanAttributes` and `MetricAttributes` types from the API package has been changed to use the `Attributes` type.
 
 - bumped minimum version of `@opentelemetry/api` peer dependency to 1.1.0 for the following packages: `@opentelemetry/core` [#4408](https://github.com/open-telemetry/opentelemetry-js/pull/4408), `@opentelemetry/resources` [#4428](https://github.com/open-telemetry/opentelemetry-js/pull/4428), `@opentelemetry/sdk-trace-base` [#5009](https://github.com/open-telemetry/opentelemetry-js/pull/5009), `@opentelemetry/shim-opentracing` [#4430](https://github.com/open-telemetry/opentelemetry-js/pull/4430)
 

--- a/doc/upgrade-to-2.x.md
+++ b/doc/upgrade-to-2.x.md
@@ -625,7 +625,7 @@ assert.deepStrictEqual(resource.attributes, { ... });
 
 This section describes the remaining breaking changes, not otherwise mentioned in a section above.
 
-Usage of the deprecated `SpanAttributes` and `MetricAttributes` types from the API package has been changed to use the `Attributes` type.
+- use the `Attributes` type instead of the deprecated `SpanAttributes` and `MetricAttributes` types from the API package.
 
 - bumped minimum version of `@opentelemetry/api` peer dependency to 1.1.0 for the following packages: `@opentelemetry/core` [#4408](https://github.com/open-telemetry/opentelemetry-js/pull/4408), `@opentelemetry/resources` [#4428](https://github.com/open-telemetry/opentelemetry-js/pull/4428), `@opentelemetry/sdk-trace-base` [#5009](https://github.com/open-telemetry/opentelemetry-js/pull/5009), `@opentelemetry/shim-opentracing` [#4430](https://github.com/open-telemetry/opentelemetry-js/pull/4430)
 


### PR DESCRIPTION
## Which problem is this PR solving?

Document that Jest v29.4 or higher is required to support submodule imports as used by several packages.

And I just figured out a workaround! Added that, too.

Resolves #5618 and probably #5557 (pending confirmation from the OP there)
