### PR TITLE
fix(instrumentation-http): stable client metrics response code

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -14,7 +14,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
-fix(otlp-transformer): do not throw when deserializing empty JSON response [#5551](https://github.com/open-telemetry/opentelemetry-js/pull/5551) @pichlermarc
+* fix(otlp-transformer): do not throw when deserializing empty JSON response [#5551](https://github.com/open-telemetry/opentelemetry-js/pull/5551) @pichlermarc
+* fix(instrumentation-http): report stable client metrics response code [#9586](https://github.com/open-telemetry/opentelemetry-js/pull/9586) @jtescher
 
 ### :books: Documentation
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -68,6 +68,7 @@ import {
   getIncomingStableRequestMetricAttributesOnResponse,
   getOutgoingRequestAttributes,
   getOutgoingRequestAttributesOnResponse,
+  getOutgoingRequestMetricAttributesOnResponse,
   getRequestInfo,
   headerCapture,
   isValidOptionsType,
@@ -386,6 +387,10 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
         const responseAttributes =
           getOutgoingRequestAttributesOnResponse(response);
         span.setAttributes(responseAttributes);
+        stableMetricAttributes = Object.assign(
+          stableMetricAttributes,
+          getOutgoingRequestMetricAttributesOnResponse(responseAttributes)
+        );
 
         if (this.getConfig().responseHook) {
           this._callResponseHook(span, response);

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -409,10 +409,19 @@ export const getOutgoingRequestAttributesOnResponse = (
 export const getOutgoingRequestMetricAttributesOnResponse = (
   spanAttributes: Attributes
 ): Attributes => {
-  return {
-    [ATTR_HTTP_RESPONSE_STATUS_CODE]:
-      spanAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE],
-  };
+  const stableAttributes: Attributes = {};
+
+  if (spanAttributes[ATTR_NETWORK_PROTOCOL_VERSION]) {
+    stableAttributes[ATTR_NETWORK_PROTOCOL_VERSION] =
+      spanAttributes[ATTR_NETWORK_PROTOCOL_VERSION];
+  }
+
+  if (spanAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE]) {
+    stableAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE] =
+      spanAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE];
+  }
+
+  return stableAttributes;
 };
 
 function parseHostHeader(

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -402,6 +402,19 @@ export const getOutgoingRequestAttributesOnResponse = (
   return stableAttributes;
 };
 
+/**
+ * Returns outgoing request Metric attributes scoped to the response data
+ * @param {Attributes} spanAttributes the span attributes
+ */
+export const getOutgoingRequestMetricAttributesOnResponse = (
+  spanAttributes: Attributes
+): Attributes => {
+  return {
+    [ATTR_HTTP_RESPONSE_STATUS_CODE]:
+      spanAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE],
+  };
+};
+
 function parseHostHeader(
   hostHeader: string,
   proto?: string

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
@@ -144,6 +144,7 @@ describe('metrics', () => {
         [ATTR_HTTP_REQUEST_METHOD]: 'GET',
         [ATTR_SERVER_ADDRESS]: 'localhost',
         [ATTR_SERVER_PORT]: 22346,
+        [ATTR_HTTP_RESPONSE_STATUS_CODE]: 200,
       });
     });
   });

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
@@ -144,6 +144,7 @@ describe('metrics', () => {
         [ATTR_HTTP_REQUEST_METHOD]: 'GET',
         [ATTR_SERVER_ADDRESS]: 'localhost',
         [ATTR_SERVER_PORT]: 22346,
+        [ATTR_NETWORK_PROTOCOL_VERSION]: '1.1',
         [ATTR_HTTP_RESPONSE_STATUS_CODE]: 200,
       });
     });


### PR DESCRIPTION
## Which problem is this PR solving?

This adds [http.response.status_code](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/http.md) attributes to client requests when opting in to stable semantic conventions.

Fixes #5624

## Short description of the changes

This records the status code that was received in the response when available when requests end.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tests updated

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
