### PR TITLE
chore: add constraint for renovate to use npm@>10.8.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,6 +31,9 @@
     "@opentelemetry/resources_1.9.0",
     "@types/node"
   ],
+  "constraints": {
+    "npm": ">10.8.0"
+  },
   "assignees": ["@blumamir", "@dyladan", "@legendecas", "@pichlermarc"],
   "labels": ["dependencies"]
 }


### PR DESCRIPTION
## Which problem is this PR solving?

This PR is using [renovate constraints](https://docs.renovatebot.com/configuration-options/#constraints) to tell renovate to use `npm@>10.8.0` which I'm hoping will eliminate the license-field churn in `package-lock.json` during renovate updates.

See also: https://github.com/npm/cli/issues/7384