### PR TITLE
fix(sdk-node): instantiate baggage processor when env var is set

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -15,6 +15,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :bug: Bug Fixes
 
 fix(otlp-transformer): do not throw when deserializing empty JSON response [#5551](https://github.com/open-telemetry/opentelemetry-js/pull/5551) @pichlermarc
+fix(sdk-node): instantiate baggage processor when env var is set [#5634](https://github.com/open-telemetry/opentelemetry-js/pull/5634) @pichlermarc
 
 ### :books: Documentation
 

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -19,6 +19,7 @@ import {
   CompositePropagator,
   getStringFromEnv,
   getStringListFromEnv,
+  W3CBaggagePropagator,
   W3CTraceContextPropagator,
 } from '@opentelemetry/core';
 import { OTLPTraceExporter as OTLPProtoTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
@@ -201,7 +202,7 @@ export function getPropagatorFromEnv(): TextMapPropagator | null | undefined {
   // Any other propagators (like aws, aws-lambda, should go into `@opentelemetry/auto-configuration-propagators` instead).
   const propagatorsFactory = new Map<string, () => TextMapPropagator>([
     ['tracecontext', () => new W3CTraceContextPropagator()],
-    ['baggage', () => new W3CTraceContextPropagator()],
+    ['baggage', () => new W3CBaggagePropagator()],
     ['b3', () => new B3Propagator()],
     [
       'b3multi',

--- a/experimental/packages/opentelemetry-sdk-node/test/utils.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/utils.test.ts
@@ -64,6 +64,7 @@ describe('getPropagatorFromEnv', function () {
     assert.deepStrictEqual(getPropagatorFromEnv()?.fields(), [
       'traceparent',
       'tracestate',
+      'baggage',
       'b3',
       'x-b3-traceid',
       'x-b3-spanid',


### PR DESCRIPTION
## Which problem is this PR solving?

The baggage propagator is not instantiated when the env var is set.

Fixes #5633