### PR TITLE
fix(instrumentation-http): report error.type metrics attribute

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -66,6 +66,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * fix(otlp-transformer): do not throw when deserializing empty JSON response [#5551](https://github.com/open-telemetry/opentelemetry-js/pull/5551) @pichlermarc
 * fix(instrumentation-http): report stable client metrics response code [#9586](https://github.com/open-telemetry/opentelemetry-js/pull/9586) @jtescher
 * fix(sdk-node): instantiate baggage processor when env var is set [#5634](https://github.com/open-telemetry/opentelemetry-js/pull/5634) @pichlermarc
+* fix(instrumentation-http): report `error.type` metrics attribute [#5647](https://github.com/open-telemetry/opentelemetry-js/pull/5647)
 
 ### :house: Internal
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -53,6 +53,7 @@ import {
 } from '@opentelemetry/instrumentation';
 import { errorMonitor } from 'events';
 import {
+  ATTR_ERROR_TYPE,
   ATTR_HTTP_REQUEST_METHOD,
   ATTR_HTTP_RESPONSE_STATUS_CODE,
   ATTR_NETWORK_PROTOCOL_VERSION,
@@ -516,17 +517,12 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
             return;
           }
           responseFinished = true;
-          setSpanWithError(span, error, this._semconvStability);
-          span.setStatus({
-            code: SpanStatusCode.ERROR,
-            message: error.message,
-          });
-          this._closeHttpSpan(
+          this._onIncomingResponseError(
             span,
-            SpanKind.CLIENT,
-            startTime,
             oldMetricAttributes,
-            stableMetricAttributes
+            stableMetricAttributes,
+            startTime,
+            error
           );
         });
       }
@@ -551,14 +547,12 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
         return;
       }
       responseFinished = true;
-      setSpanWithError(span, error, this._semconvStability);
-
-      this._closeHttpSpan(
+      this._onIncomingResponseError(
         span,
-        SpanKind.CLIENT,
-        startTime,
         oldMetricAttributes,
-        stableMetricAttributes
+        stableMetricAttributes,
+        startTime,
+        error
       );
     });
 
@@ -705,17 +699,12 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
             () => original.apply(this, [event, ...args]),
             error => {
               if (error) {
-                setSpanWithError(
+                instrumentation._onServerResponseError(
                   span,
-                  error,
-                  instrumentation._semconvStability
-                );
-                instrumentation._closeHttpSpan(
-                  span,
-                  SpanKind.SERVER,
-                  startTime,
                   oldMetricAttributes,
-                  stableMetricAttributes
+                  stableMetricAttributes,
+                  startTime,
+                  error
                 );
                 throw error;
               }
@@ -851,14 +840,12 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
           },
           error => {
             if (error) {
-              setSpanWithError(span, error, instrumentation._semconvStability);
-
-              instrumentation._closeHttpSpan(
+              instrumentation._onIncomingResponseError(
                 span,
-                SpanKind.CLIENT,
-                startTime,
                 oldMetricAttributes,
-                stableMetricAttributes
+                stableMetricAttributes,
+                startTime,
+                error
               );
               throw error;
             }
@@ -937,6 +924,25 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
     );
   }
 
+  private _onIncomingResponseError(
+    span: Span,
+    oldMetricAttributes: Attributes,
+    stableMetricAttributes: Attributes,
+    startTime: HrTime,
+    error: Err
+  ) {
+    setSpanWithError(span, error, this._semconvStability);
+    stableMetricAttributes[ATTR_ERROR_TYPE] = error.name;
+
+    this._closeHttpSpan(
+      span,
+      SpanKind.CLIENT,
+      startTime,
+      oldMetricAttributes,
+      stableMetricAttributes
+    );
+  }
+
   private _onServerResponseError(
     span: Span,
     oldMetricAttributes: Attributes,
@@ -945,7 +951,8 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
     error: Err
   ) {
     setSpanWithError(span, error, this._semconvStability);
-    // TODO get error attributes for metrics
+    stableMetricAttributes[ATTR_ERROR_TYPE] = error.name;
+
     this._closeHttpSpan(
       span,
       SpanKind.SERVER,

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -517,7 +517,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
             return;
           }
           responseFinished = true;
-          this._onIncomingResponseError(
+          this._onOutgoingRequestError(
             span,
             oldMetricAttributes,
             stableMetricAttributes,
@@ -547,7 +547,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
         return;
       }
       responseFinished = true;
-      this._onIncomingResponseError(
+      this._onOutgoingRequestError(
         span,
         oldMetricAttributes,
         stableMetricAttributes,
@@ -840,7 +840,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
           },
           error => {
             if (error) {
-              instrumentation._onIncomingResponseError(
+              instrumentation._onOutgoingRequestError(
                 span,
                 oldMetricAttributes,
                 stableMetricAttributes,
@@ -924,7 +924,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
     );
   }
 
-  private _onIncomingResponseError(
+  private _onOutgoingRequestError(
     span: Span,
     oldMetricAttributes: Attributes,
     stableMetricAttributes: Attributes,


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This reports the `error.type` attribute on HTTP metrics wherever it is already reported on HTTP spans as [required by the spec](https://github.com/open-telemetry/semantic-conventions/blob/4676c009fa6b8f4ed7d2321c991024373e77428e/docs/http/http-metrics.md?plain=1#L111-L126).

Fixes #5627 

## Short description of the changes

Updates the metrics attributes from the `_on***Error` helpers and uses those wherever appropriate.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I added a test for client metrics but couldn't figure out a way to test server metrics since it involves throwing within the server request handler which is an uncaught exception.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
