### PR TITLE
test: test Node.js 24 in CI

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -18,6 +18,7 @@ jobs:
           - "20"
           - "22"
           - "23"
+          - "24"
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_UNSAFE_PERM: true
@@ -45,7 +46,8 @@ jobs:
         if: ${{
           matrix.node_version == '20' ||
           matrix.node_version == '22' ||
-          matrix.node_version == '23'
+          matrix.node_version == '23' ||
+          matrix.node_version == '24'
           }}
 
       - name: Bootstrap
@@ -55,13 +57,13 @@ jobs:
         run: npm run compile
 
       - run: npm test
-        if: ${{ matrix.node_version != '23' }}
-      # Node.js 23 type stripping conflicts with mocha usage of ts-node.
+        if: ${{ matrix.node_version != '23' && matrix.node_version != '24' }}
+      # Node.js >= 23 type stripping conflicts with mocha usage of ts-node.
       # See https://github.com/open-telemetry/opentelemetry-js/issues/5415
       - run: npm test
         env:
           NODE_OPTIONS: '--no-experimental-strip-types'
-        if: ${{ matrix.node_version == '23' }}
+        if: ${{ matrix.node_version == '23' || matrix.node_version == '24' }}
 
       - name: Report Coverage
         uses: codecov/codecov-action@v5

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -31,6 +31,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 * chore(sdk-node): Refactored using `get*FromEnv` utility function instead of `process.env` for NodeSDK's resource detector setup. [#5582](https://github.com/open-telemetry/opentelemetry-js/pull/5582) @beeme1mr
 * chore(sdk-node): Refactored using `get*FromEnv` utility function instead of `process.env` for NodeSDK's logging setup. [#5563](https://github.com/open-telemetry/opentelemetry-js/issues/5563) @weyert
+* test: test Node.js 24 in CI [#5661](https://github.com/open-telemetry/opentelemetry-js/pull/5661) @cjihrig
 
 ## 0.200.0
 

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-package.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-package.test.ts
@@ -109,10 +109,10 @@ describe('Packages', () => {
         switch (name) {
           case 'axios':
             assert.ok(
-              result.request._headers[DummyPropagation.TRACE_CONTEXT_KEY]
+              result.request.getHeader(DummyPropagation.TRACE_CONTEXT_KEY)
             );
             assert.ok(
-              result.request._headers[DummyPropagation.SPAN_CONTEXT_KEY]
+              result.request.getHeader(DummyPropagation.SPAN_CONTEXT_KEY)
             );
             break;
           case 'superagent':

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-package.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-package.test.ts
@@ -109,10 +109,10 @@ describe('Packages', () => {
         switch (name) {
           case 'axios':
             assert.ok(
-              result.request._headers[DummyPropagation.TRACE_CONTEXT_KEY]
+              result.request.getHeader(DummyPropagation.TRACE_CONTEXT_KEY)
             );
             assert.ok(
-              result.request._headers[DummyPropagation.SPAN_CONTEXT_KEY]
+              result.request.getHeader(DummyPropagation.SPAN_CONTEXT_KEY)
             );
             break;
           case 'superagent':


### PR DESCRIPTION
## Which problem is this PR solving?

Testing on the latest version of Node.js

Fixes # N/A

## Short description of the changes

Node.js v24 was recently released. This change adds it to the CI. (Adapted from https://github.com/open-telemetry/opentelemetry-js/commit/34a2dd574c521fa970e2c0cd60c852110823c962)

## Type of change

- [x] Bug fix?

## How Has This Been Tested?

- [x] Let's see what GitHub Actions says. The full test suite does not run locally for Node 23 or 24.

## Checklist:

- [x] Followed the style guidelines of this project
