### PR TITLE
Revert "fix(sdk-metrics): improve PeriodicExportingMetricReader() constructor input validation (#5621)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * fix(resource): do not trigger `Accessing resource attributes before async attributes settled` warning when detecting resources [#5546](https://github.com/open-telemetry/opentelemetry-js/pull/5546) @dyladan
   * verbose logging of detected resource removed
 * fix(resource): use dynamic import over require to improve ESM compliance [#5298](https://github.com/open-telemetry/opentelemetry-js/pull/5298) @xiaoxiangmoe
-* fix(sdk-metrics): improve PeriodicExportingMetricReader() constructor input validation [#5621](https://github.com/open-telemetry/opentelemetry-js/pull/5621) @cjihrig
 
 ### :books: Documentation
 

--- a/packages/sdk-metrics/src/export/PeriodicExportingMetricReader.ts
+++ b/packages/sdk-metrics/src/export/PeriodicExportingMetricReader.ts
@@ -60,37 +60,42 @@ export class PeriodicExportingMetricReader extends MetricReader {
   private readonly _exportTimeout: number;
 
   constructor(options: PeriodicExportingMetricReaderOptions) {
-    const {
-      exporter,
-      exportIntervalMillis = 60000,
-      exportTimeoutMillis = 30000,
-      metricProducers,
-    } = options;
-
     super({
-      aggregationSelector: exporter.selectAggregation?.bind(exporter),
+      aggregationSelector: options.exporter.selectAggregation?.bind(
+        options.exporter
+      ),
       aggregationTemporalitySelector:
-        exporter.selectAggregationTemporality?.bind(exporter),
-      metricProducers,
+        options.exporter.selectAggregationTemporality?.bind(options.exporter),
+      metricProducers: options.metricProducers,
     });
 
-    if (exportIntervalMillis <= 0) {
+    if (
+      options.exportIntervalMillis !== undefined &&
+      options.exportIntervalMillis <= 0
+    ) {
       throw Error('exportIntervalMillis must be greater than 0');
     }
 
-    if (exportTimeoutMillis <= 0) {
+    if (
+      options.exportTimeoutMillis !== undefined &&
+      options.exportTimeoutMillis <= 0
+    ) {
       throw Error('exportTimeoutMillis must be greater than 0');
     }
 
-    if (exportIntervalMillis < exportTimeoutMillis) {
+    if (
+      options.exportTimeoutMillis !== undefined &&
+      options.exportIntervalMillis !== undefined &&
+      options.exportIntervalMillis < options.exportTimeoutMillis
+    ) {
       throw Error(
         'exportIntervalMillis must be greater than or equal to exportTimeoutMillis'
       );
     }
 
-    this._exportInterval = exportIntervalMillis;
-    this._exportTimeout = exportTimeoutMillis;
-    this._exporter = exporter;
+    this._exportInterval = options.exportIntervalMillis ?? 60000;
+    this._exportTimeout = options.exportTimeoutMillis ?? 30000;
+    this._exporter = options.exporter;
   }
 
   private async _runOnce(): Promise<void> {

--- a/packages/sdk-metrics/test/export/PeriodicExportingMetricReader.test.ts
+++ b/packages/sdk-metrics/test/export/PeriodicExportingMetricReader.test.ts
@@ -226,26 +226,6 @@ describe('PeriodicExportingMetricReader', () => {
           }),
         /exportIntervalMillis must be greater than or equal to exportTimeoutMillis/
       );
-      assert.throws(
-        () =>
-          new PeriodicExportingMetricReader({
-            exporter: exporter,
-            exportIntervalMillis: 100,
-            // exportTimeoutMillis defaults to 30 seconds, which is greater than exportIntervalMillis.
-            exportTimeoutMillis: undefined,
-          }),
-        /exportIntervalMillis must be greater than or equal to exportTimeoutMillis/
-      );
-      assert.throws(
-        () =>
-          new PeriodicExportingMetricReader({
-            exporter: exporter,
-            // exportIntervalMillis defaults to 60 seconds, which is less than exportTimeoutMillis.
-            exportIntervalMillis: undefined,
-            exportTimeoutMillis: 90_000,
-          }),
-        /exportIntervalMillis must be greater than or equal to exportTimeoutMillis/
-      );
     });
 
     it('should not start exporting', async () => {


### PR DESCRIPTION
## Which problem is this PR solving?

See https://github.com/open-telemetry/opentelemetry-js/pull/5621#issuecomment-2867470770

On a quick initial pass after seeing an approval on the PR I thought this was okay, but I think this has the potential to break a lot of users as it's common to specify just the export interval but not the timeout - which would throw with what's on `main` now if the interval is lower than the timeout. I re-checked the spec and it does not give any guidance on this. Quite a few other implementations seem to skip this check entirely too.

Reopens #5550