### PR TITLE
refactor(sdk-trace-web): update semconv usage to ATTR_ exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
+* refactor(sdk-trace-web): update semconv usage to ATTR_ exports [#5672](https://github.com/open-telemetry/opentelemetry-js/pull/5672) @trentm
 * refactor(resources): update semconv usage to ATTR_ exports [#5666](https://github.com/open-telemetry/opentelemetry-js/pull/5666) @trentm
 * test(sdk-metrics): fix multiple problematic assertRejects() calls [#5611](https://github.com/open-telemetry/opentelemetry-js/pull/5611) @cjihrig
 * refactor: replace assertRejects() with assert.rejects() [#5614](https://github.com/open-telemetry/opentelemetry-js/pull/5614) @cjihrig

--- a/package-lock.json
+++ b/package-lock.json
@@ -32246,8 +32246,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.0.0",
-        "@opentelemetry/sdk-trace-base": "2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.29.0"
+        "@opentelemetry/sdk-trace-base": "2.0.0"
       },
       "devDependencies": {
         "@babel/core": "7.26.10",
@@ -32255,6 +32254,7 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
         "@opentelemetry/context-zone": "2.0.0",
         "@opentelemetry/resources": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
         "@types/jquery": "3.5.32",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -59,6 +59,7 @@
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@opentelemetry/context-zone": "2.0.0",
     "@opentelemetry/resources": "2.0.0",
+    "@opentelemetry/semantic-conventions": "^1.29.0",
     "@types/jquery": "3.5.32",
     "@types/mocha": "10.0.10",
     "@types/node": "18.6.5",
@@ -89,8 +90,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "2.0.0",
-    "@opentelemetry/sdk-trace-base": "2.0.0",
-    "@opentelemetry/semantic-conventions": "^1.29.0"
+    "@opentelemetry/sdk-trace-base": "2.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-web",
   "sideEffects": false

--- a/packages/opentelemetry-sdk-trace-web/src/semconv.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/semconv.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file contains a copy of unstable semantic convention definitions
+ * used by this package.
+ * @see https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions#unstable-semconv
+ */
+
+/**
+ * Deprecated, use `http.response.header.<key>` instead.
+ *
+ * @example 3495
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replaced by `http.response.header.<key>`.
+ */
+export const ATTR_HTTP_RESPONSE_CONTENT_LENGTH =
+  'http.response_content_length' as const;
+
+/**
+ * Deprecated, use `http.response.body.size` instead.
+ *
+ * @example 5493
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ *
+ * @deprecated Replace by `http.response.body.size`.
+ */
+export const ATTR_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED =
+  'http.response_content_length_uncompressed' as const;

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -27,9 +27,9 @@ import {
   urlMatches,
 } from '@opentelemetry/core';
 import {
-  SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH,
-  SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_HTTP_RESPONSE_CONTENT_LENGTH,
+  ATTR_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
+} from './semconv';
 
 // Used to normalize relative URLs
 let urlNormalizingAnchor: HTMLAnchorElement | undefined;
@@ -113,14 +113,14 @@ export function addSpanNetworkEvents(
     // *old* HTTP semconv (v1.7.0).
     const encodedLength = resource[PTN.ENCODED_BODY_SIZE];
     if (encodedLength !== undefined) {
-      span.setAttribute(SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH, encodedLength);
+      span.setAttribute(ATTR_HTTP_RESPONSE_CONTENT_LENGTH, encodedLength);
     }
 
     const decodedLength = resource[PTN.DECODED_BODY_SIZE];
     // Spec: Not set if transport encoding not used (in which case encoded and decoded sizes match)
     if (decodedLength !== undefined && encodedLength !== decodedLength) {
       span.setAttribute(
-        SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
+        ATTR_HTTP_RESPONSE_CONTENT_LENGTH_UNCOMPRESSED,
         decodedLength
       );
     }

--- a/packages/opentelemetry-sdk-trace-web/test/WebTracerProvider.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/WebTracerProvider.test.ts
@@ -16,7 +16,7 @@
 
 import { context, ContextManager, trace } from '@opentelemetry/api';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
-import { SEMRESATTRS_TELEMETRY_SDK_LANGUAGE } from '@opentelemetry/semantic-conventions';
+import { ATTR_TELEMETRY_SDK_LANGUAGE } from '@opentelemetry/semantic-conventions';
 import { Span } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
 import { WebTracerConfig } from '../src';
@@ -96,7 +96,7 @@ describe('WebTracerProvider', function () {
         assert.ok(span);
         assert.ok(span.resource);
         assert.equal(
-          span.resource.attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
+          span.resource.attributes[ATTR_TELEMETRY_SDK_LANGUAGE],
           'webjs'
         );
       });


### PR DESCRIPTION
This also moves the semantic-conventions dep to a devDep, because
it is no longer used in the runtime code.

Refs: #4896
