### PR TITLE
refactor(semantic-conventions): weaver 0.13.0 supports a 'stable_only' arg to semconv_attributes

### DIFF
--- a/scripts/semconv/templates/registry/stable/weaver.yaml
+++ b/scripts/semconv/templates/registry/stable/weaver.yaml
@@ -16,15 +16,16 @@ comment_formats:
     escape_backslashes: true
 default_comment_format: jsdoc
 
-# `exclude_stability` includes `"", null` to skip attributes that
-# accidentally do not have a stability set (e.g. https://github.com/open-telemetry/semantic-conventions/issues/1777).
+# Notes:
+# - Use `""` and `null` with `exclude_stability` to skip attributes/metrics that
+#   accidentally do not have a stability set
+#   (e.g. https://github.com/open-telemetry/semantic-conventions/issues/1777).
 templates:
   - pattern: attributes.ts.j2
     # Remove file name prefix when per-pattern params are available https://github.com/open-telemetry/weaver/issues/288
-    # Switch from 'exclude_stability:["experimental",...]' to 'include_stability:["stable":...]' when available: https://github.com/open-telemetry/weaver/issues/569
     filter: >
       semconv_attributes({
-        "exclude_stability": ["experimental", "", null]
+        "stable_only": true
       }) | {
         stability: "stable",
         attributes: .
@@ -42,7 +43,7 @@ templates:
   - pattern: metrics.ts.j2
     filter: >
       semconv_metrics({
-        "exclude_stability": ["experimental", "", null]
+        "stable_only": true
       }) | {
         stability: "stable",
         metrics: .


### PR DESCRIPTION
This is preferred to exclude_stability, b/c it is expected to be more
resilient with other stability names used for unstable, e.g. 'development',
'rc', 'beta', etc.

This results in the exact same generated files.
