### PR TITLE
fix(instrumentation): change `SemconvStability` export from `const enum` to `enum`

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(instrumentation): Change `SemconvStability` export from `const enum` to `enum` to allow single-file transpilation tooling to work with code that uses `SemconvStability`. [#5691](https://github.com/open-telemetry/opentelemetry-js/issues/5691) @trentm
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/experimental/packages/opentelemetry-instrumentation/src/semconvStability.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/semconvStability.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export const enum SemconvStability {
+export enum SemconvStability {
   /** Emit only stable semantic conventions. */
   STABLE = 0x1,
   /** Emit only old semantic conventions. */


### PR DESCRIPTION
Change `SemconvStability` export from `const enum` to `enum` to allow single-file transpilation tooling to work with code that uses `SemconvStability`

Refs: #5691
Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2671#issuecomment-2886789314
