### PR TITLE
chore: enable tsconfig isolatedModules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
+* chore: enable tsconfig isolatedModules [#5697](https://github.com/open-telemetry/opentelemetry-js/pull/5697) @legendecas
+
 ## 2.0.1
 
 ### :bug: Bug Fixes

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### :house: (Internal)
 
 * refactor(api): remove "export *" in favor of explicit named exports [#4880](https://github.com/open-telemetry/opentelemetry-js/pull/4880) @robbkidd
+* chore: enable tsconfig isolatedModules [#5697](https://github.com/open-telemetry/opentelemetry-js/pull/5697) @legendecas
 
 ## 1.9.0
 

--- a/api/src/experimental/index.ts
+++ b/api/src/experimental/index.ts
@@ -20,4 +20,4 @@
  */
 
 export { wrapTracer, SugaredTracer } from './trace/SugaredTracer';
-export { SugaredSpanOptions } from './trace/SugaredOptions';
+export type { SugaredSpanOptions } from './trace/SugaredOptions';

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -18,23 +18,27 @@
  * @module @opentelemetry/api
  */
 
-export { BaggageEntry, BaggageEntryMetadata, Baggage } from './baggage/types';
+export type {
+  BaggageEntry,
+  BaggageEntryMetadata,
+  Baggage,
+} from './baggage/types';
 export { baggageEntryMetadataFromString } from './baggage/utils';
-export { Exception } from './common/Exception';
-export { HrTime, TimeInput } from './common/Time';
-export { Attributes, AttributeValue } from './common/Attributes';
+export type { Exception } from './common/Exception';
+export type { HrTime, TimeInput } from './common/Time';
+export type { Attributes, AttributeValue } from './common/Attributes';
 
 // Context APIs
 export { createContextKey, ROOT_CONTEXT } from './context/context';
-export { Context, ContextManager } from './context/types';
+export type { Context, ContextManager } from './context/types';
 export type { ContextAPI } from './api/context';
 
 // Diag APIs
 export { DiagConsoleLogger } from './diag/consoleLogger';
-export {
+export { DiagLogLevel } from './diag/types';
+export type {
   DiagLogFunction,
   DiagLogger,
-  DiagLogLevel,
   ComponentLoggerOptions,
   DiagLoggerOptions,
 } from './diag/types';
@@ -42,10 +46,10 @@ export type { DiagAPI } from './api/diag';
 
 // Metrics APIs
 export { createNoopMeter } from './metrics/NoopMeter';
-export { MeterOptions, Meter } from './metrics/Meter';
-export { MeterProvider } from './metrics/MeterProvider';
-export {
-  ValueType,
+export type { MeterOptions, Meter } from './metrics/Meter';
+export type { MeterProvider } from './metrics/MeterProvider';
+export { ValueType } from './metrics/Metric';
+export type {
   Counter,
   Gauge,
   Histogram,
@@ -61,7 +65,7 @@ export {
   MetricAttributeValue,
   ObservableCallback,
 } from './metrics/Metric';
-export {
+export type {
   BatchObservableResult,
   ObservableResult,
 } from './metrics/ObservableResult';
@@ -69,32 +73,34 @@ export type { MetricsAPI } from './api/metrics';
 
 // Propagation APIs
 export {
+  defaultTextMapGetter,
+  defaultTextMapSetter,
+} from './propagation/TextMapPropagator';
+export type {
   TextMapPropagator,
   TextMapSetter,
   TextMapGetter,
-  defaultTextMapGetter,
-  defaultTextMapSetter,
 } from './propagation/TextMapPropagator';
 export type { PropagationAPI } from './api/propagation';
 
 // Trace APIs
-export { SpanAttributes, SpanAttributeValue } from './trace/attributes';
-export { Link } from './trace/link';
-export { ProxyTracer, TracerDelegator } from './trace/ProxyTracer';
+export type { SpanAttributes, SpanAttributeValue } from './trace/attributes';
+export type { Link } from './trace/link';
+export { ProxyTracer, type TracerDelegator } from './trace/ProxyTracer';
 export { ProxyTracerProvider } from './trace/ProxyTracerProvider';
-export { Sampler } from './trace/Sampler';
-export { SamplingDecision, SamplingResult } from './trace/SamplingResult';
-export { SpanContext } from './trace/span_context';
+export type { Sampler } from './trace/Sampler';
+export { SamplingDecision, type SamplingResult } from './trace/SamplingResult';
+export type { SpanContext } from './trace/span_context';
 export { SpanKind } from './trace/span_kind';
-export { Span } from './trace/span';
-export { SpanOptions } from './trace/SpanOptions';
-export { SpanStatus, SpanStatusCode } from './trace/status';
+export type { Span } from './trace/span';
+export type { SpanOptions } from './trace/SpanOptions';
+export { type SpanStatus, SpanStatusCode } from './trace/status';
 export { TraceFlags } from './trace/trace_flags';
-export { TraceState } from './trace/trace_state';
+export type { TraceState } from './trace/trace_state';
 export { createTraceState } from './trace/internal/utils';
-export { TracerProvider } from './trace/tracer_provider';
-export { Tracer } from './trace/tracer';
-export { TracerOptions } from './trace/tracer_options';
+export type { TracerProvider } from './trace/tracer_provider';
+export type { Tracer } from './trace/tracer';
+export type { TracerOptions } from './trace/tracer_options';
 export {
   isSpanContextValid,
   isValidTraceId,

--- a/experimental/packages/api-events/src/index.ts
+++ b/experimental/packages/api-events/src/index.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-export { EventLogger } from './types/EventLogger';
-export { EventLoggerProvider } from './types/EventLoggerProvider';
-export { Event } from './types/Event';
-export { EventLoggerOptions } from './types/EventLoggerOptions';
+export type { EventLogger } from './types/EventLogger';
+export type { EventLoggerProvider } from './types/EventLoggerProvider';
+export type { Event } from './types/Event';
+export type { EventLoggerOptions } from './types/EventLoggerOptions';
 
 import { EventsAPI } from './api/events';
 export const events = EventsAPI.getInstance();

--- a/experimental/packages/api-logs/src/index.ts
+++ b/experimental/packages/api-logs/src/index.ts
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-export { Logger } from './types/Logger';
-export { LoggerProvider } from './types/LoggerProvider';
-export {
-  LogAttributes,
-  LogBody,
-  LogRecord,
-  SeverityNumber,
-} from './types/LogRecord';
-export { LoggerOptions } from './types/LoggerOptions';
-export { AnyValue, AnyValueMap } from './types/AnyValue';
+export type { Logger } from './types/Logger';
+export type { LoggerProvider } from './types/LoggerProvider';
+export { SeverityNumber } from './types/LogRecord';
+export type { LogAttributes, LogBody, LogRecord } from './types/LogRecord';
+export type { LoggerOptions } from './types/LoggerOptions';
+export type { AnyValue, AnyValueMap } from './types/AnyValue';
 export { NOOP_LOGGER, NoopLogger } from './NoopLogger';
 export { NOOP_LOGGER_PROVIDER, NoopLoggerProvider } from './NoopLoggerProvider';
 export { ProxyLogger } from './ProxyLogger';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/index.ts
@@ -15,10 +15,8 @@
  */
 
 export { OTLPMetricExporter } from './platform';
-export {
-  OTLPMetricExporterOptions,
-  AggregationTemporalityPreference,
-} from './OTLPMetricExporterOptions';
+export { AggregationTemporalityPreference } from './OTLPMetricExporterOptions';
+export type { OTLPMetricExporterOptions } from './OTLPMetricExporterOptions';
 export {
   CumulativeTemporalitySelector,
   DeltaTemporalitySelector,

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/index.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/index.ts
@@ -16,4 +16,4 @@
 
 export { PrometheusExporter } from './PrometheusExporter';
 export { PrometheusSerializer } from './PrometheusSerializer';
-export { ExporterConfig } from './export/types';
+export type { ExporterConfig } from './export/types';

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/index.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export {
+export { FetchInstrumentation } from './fetch';
+export type {
   FetchCustomAttributeFunction,
   FetchRequestHookFunction,
-  FetchInstrumentation,
   FetchInstrumentationConfig,
 } from './fetch';

--- a/experimental/packages/opentelemetry-instrumentation-http/src/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 export { HttpInstrumentation } from './http';
-export {
+export type {
   HttpCustomAttributeFunction,
   HttpInstrumentationConfig,
   HttpRequestCustomAttributeFunction,

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/index.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-export {
+export { XMLHttpRequestInstrumentation } from './xhr';
+export type {
   XHRCustomAttributeFunction,
-  XMLHttpRequestInstrumentation,
   XMLHttpRequestInstrumentationConfig,
 } from './xhr';

--- a/experimental/packages/opentelemetry-instrumentation/src/index.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/index.ts
@@ -18,7 +18,7 @@ export { registerInstrumentations } from './autoLoader';
 export { InstrumentationBase } from './platform/index';
 export { InstrumentationNodeModuleDefinition } from './instrumentationNodeModuleDefinition';
 export { InstrumentationNodeModuleFile } from './instrumentationNodeModuleFile';
-export {
+export type {
   Instrumentation,
   InstrumentationConfig,
   InstrumentationModuleDefinition,
@@ -26,7 +26,7 @@ export {
   ShimWrapped,
   SpanCustomizationHook,
 } from './types';
-export { AutoLoaderOptions, AutoLoaderResult } from './types_internal';
+export type { AutoLoaderOptions, AutoLoaderResult } from './types_internal';
 export {
   isWrapped,
   safeExecuteInTheMiddle,

--- a/experimental/packages/opentelemetry-sdk-node/src/index.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/index.ts
@@ -25,5 +25,6 @@ export * as metrics from '@opentelemetry/sdk-metrics';
 export * as node from '@opentelemetry/sdk-trace-node';
 export * as resources from '@opentelemetry/resources';
 export * as tracing from '@opentelemetry/sdk-trace-base';
-export { LoggerProviderConfig, MeterProviderConfig, NodeSDK } from './sdk';
-export { NodeSDKConfiguration } from './types';
+export { NodeSDK } from './sdk';
+export type { LoggerProviderConfig, MeterProviderConfig } from './sdk';
+export type { NodeSDKConfiguration } from './types';

--- a/experimental/packages/otlp-exporter-base/src/index.ts
+++ b/experimental/packages/otlp-exporter-base/src/index.ts
@@ -17,25 +17,23 @@
 export { OTLPExporterBase } from './OTLPExporterBase';
 export { OTLPExporterError } from './types';
 
-export {
+export type {
   ExportResponse,
   ExportResponseFailure,
   ExportResponseSuccess,
   ExportResponseRetryable,
 } from './export-response';
 
-export { IExporterTransport } from './exporter-transport';
+export type { IExporterTransport } from './exporter-transport';
 
 export {
-  OtlpSharedConfiguration,
   mergeOtlpSharedConfigurationWithDefaults,
   getSharedConfigurationDefaults,
 } from './configuration/shared-configuration';
+export type { OtlpSharedConfiguration } from './configuration/shared-configuration';
 
-export {
-  OTLPExporterNodeConfigBase,
-  CompressionAlgorithm,
-} from './configuration/legacy-node-configuration';
-export { OTLPExporterConfigBase } from './configuration/legacy-base-configuration';
-export { IOtlpExportDelegate } from './otlp-export-delegate';
+export { CompressionAlgorithm } from './configuration/legacy-node-configuration';
+export type { OTLPExporterNodeConfigBase } from './configuration/legacy-node-configuration';
+export type { OTLPExporterConfigBase } from './configuration/legacy-base-configuration';
+export type { IOtlpExportDelegate } from './otlp-export-delegate';
 export { createOtlpNetworkExportDelegate } from './otlp-network-export-delegate';

--- a/experimental/packages/otlp-grpc-exporter-base/src/index.ts
+++ b/experimental/packages/otlp-grpc-exporter-base/src/index.ts
@@ -16,4 +16,4 @@
 
 export { convertLegacyOtlpGrpcOptions } from './configuration/convert-legacy-otlp-grpc-options';
 export { createOtlpGrpcExportDelegate } from './otlp-grpc-export-delegate';
-export { OTLPGRPCExporterConfigNode } from './types';
+export type { OTLPGRPCExporterConfigNode } from './types';

--- a/experimental/packages/otlp-transformer/src/index.ts
+++ b/experimental/packages/otlp-transformer/src/index.ts
@@ -14,15 +14,18 @@
  * limitations under the License.
  */
 
-export {
+export type {
   IExportMetricsPartialSuccess,
   IExportMetricsServiceResponse,
 } from './metrics';
-export {
+export type {
   IExportTracePartialSuccess,
   IExportTraceServiceResponse,
 } from './trace';
-export { IExportLogsServiceResponse, IExportLogsPartialSuccess } from './logs';
+export type {
+  IExportLogsServiceResponse,
+  IExportLogsPartialSuccess,
+} from './logs';
 
 export { ProtobufLogsSerializer } from './logs/protobuf';
 export { ProtobufMetricsSerializer } from './metrics/protobuf';
@@ -32,4 +35,4 @@ export { JsonLogsSerializer } from './logs/json';
 export { JsonMetricsSerializer } from './metrics/json';
 export { JsonTraceSerializer } from './trace/json';
 
-export { ISerializer } from './i-serializer';
+export type { ISerializer } from './i-serializer';

--- a/experimental/packages/otlp-transformer/src/logs/index.ts
+++ b/experimental/packages/otlp-transformer/src/logs/index.ts
@@ -15,7 +15,7 @@
  */
 
 // IMPORTANT: exports added here are public
-export {
+export type {
   IExportLogsServiceResponse,
   IExportLogsPartialSuccess,
 } from './export-response';

--- a/experimental/packages/otlp-transformer/src/metrics/index.ts
+++ b/experimental/packages/otlp-transformer/src/metrics/index.ts
@@ -15,7 +15,7 @@
  */
 
 // IMPORTANT: exports added here are public
-export {
+export type {
   IExportMetricsPartialSuccess,
   IExportMetricsServiceResponse,
 } from './export-response';

--- a/experimental/packages/otlp-transformer/src/trace/index.ts
+++ b/experimental/packages/otlp-transformer/src/trace/index.ts
@@ -15,7 +15,7 @@
  */
 
 // IMPORTANT: exports added here are public
-export {
+export type {
   IExportTracePartialSuccess,
   IExportTraceServiceResponse,
 } from './export-response';

--- a/experimental/packages/sampler-jaeger-remote/src/index.ts
+++ b/experimental/packages/sampler-jaeger-remote/src/index.ts
@@ -15,4 +15,5 @@
  */
 
 export { JaegerRemoteSampler } from './JaegerRemoteSampler';
-export { StrategyType, ProbabilisticSamplingOptions } from './types';
+export { StrategyType } from './types';
+export type { ProbabilisticSamplingOptions } from './types';

--- a/experimental/packages/sdk-logs/src/index.ts
+++ b/experimental/packages/sdk-logs/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export {
+export type {
   LoggerProviderConfig,
   LogRecordLimits,
   BufferConfig,
@@ -22,11 +22,11 @@ export {
 } from './types';
 export { LoggerProvider } from './LoggerProvider';
 export { LogRecord } from './LogRecord';
-export { LogRecordProcessor } from './LogRecordProcessor';
-export { ReadableLogRecord } from './export/ReadableLogRecord';
+export type { LogRecordProcessor } from './LogRecordProcessor';
+export type { ReadableLogRecord } from './export/ReadableLogRecord';
 export { NoopLogRecordProcessor } from './export/NoopLogRecordProcessor';
 export { ConsoleLogRecordExporter } from './export/ConsoleLogRecordExporter';
-export { LogRecordExporter } from './export/LogRecordExporter';
+export type { LogRecordExporter } from './export/LogRecordExporter';
 export { SimpleLogRecordProcessor } from './export/SimpleLogRecordProcessor';
 export { InMemoryLogRecordExporter } from './export/InMemoryLogRecordExporter';
 export { BatchLogRecordProcessor } from './platform';

--- a/experimental/packages/web-common/src/index.ts
+++ b/experimental/packages/web-common/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export { SessionProvider } from './types/SessionProvider';
+export type { SessionProvider } from './types/SessionProvider';
 export {
   createSessionSpanProcessor,
   createSessionLogRecordProcessor,

--- a/packages/opentelemetry-context-zone-peer-dep/src/index.ts
+++ b/packages/opentelemetry-context-zone-peer-dep/src/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { ZoneContextManager } from './ZoneContextManager';
-export { Func, TargetWithEvents } from './types';
+export type { Func, TargetWithEvents } from './types';

--- a/packages/opentelemetry-context-zone/src/index.ts
+++ b/packages/opentelemetry-context-zone/src/index.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-export {
+export { ZoneContextManager } from '@opentelemetry/context-zone-peer-dep';
+export type {
   Func,
   TargetWithEvents,
-  ZoneContextManager,
 } from '@opentelemetry/context-zone-peer-dep';
 import 'zone.js';

--- a/packages/opentelemetry-core/src/index.ts
+++ b/packages/opentelemetry-core/src/index.ts
@@ -15,7 +15,8 @@
  */
 
 export { W3CBaggagePropagator } from './baggage/propagation/W3CBaggagePropagator';
-export { AnchoredClock, Clock } from './common/anchored-clock';
+export { AnchoredClock } from './common/anchored-clock';
+export type { Clock } from './common/anchored-clock';
 export { isAttributeValue, sanitizeAttributes } from './common/attributes';
 export {
   globalErrorHandler,
@@ -36,8 +37,9 @@ export {
   millisToHrTime,
   timeInputToHrTime,
 } from './common/time';
-export { ErrorHandler, InstrumentationScope } from './common/types';
-export { ExportResult, ExportResultCode } from './ExportResult';
+export type { ErrorHandler, InstrumentationScope } from './common/types';
+export { ExportResultCode } from './ExportResult';
+export type { ExportResult } from './ExportResult';
 export { parseKeyPairsIntoRecord } from './baggage/utils';
 export {
   SDK_INFO,
@@ -49,10 +51,8 @@ export {
   otperformance,
   unrefTimer,
 } from './platform';
-export {
-  CompositePropagator,
-  CompositePropagatorConfig,
-} from './propagation/composite';
+export { CompositePropagator } from './propagation/composite';
+export type { CompositePropagatorConfig } from './propagation/composite';
 export {
   TRACE_PARENT_HEADER,
   TRACE_STATE_HEADER,
@@ -60,12 +60,12 @@ export {
   parseTraceParent,
 } from './trace/W3CTraceContextPropagator';
 export {
-  RPCMetadata,
   RPCType,
   deleteRPCMetadata,
   getRPCMetadata,
   setRPCMetadata,
 } from './trace/rpc-metadata';
+export type { RPCMetadata } from './trace/rpc-metadata';
 export {
   isTracingSuppressed,
   suppressTracing,

--- a/packages/opentelemetry-exporter-jaeger/src/index.ts
+++ b/packages/opentelemetry-exporter-jaeger/src/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { JaegerExporter } from './jaeger';
-export { ExporterConfig } from './types';
+export type { ExporterConfig } from './types';

--- a/packages/opentelemetry-exporter-zipkin/src/index.ts
+++ b/packages/opentelemetry-exporter-zipkin/src/index.ts
@@ -15,5 +15,5 @@
  */
 
 export { prepareSend } from './platform';
-export { ExporterConfig } from './types';
+export type { ExporterConfig } from './types';
 export { ZipkinExporter } from './zipkin';

--- a/packages/opentelemetry-propagator-b3/src/index.ts
+++ b/packages/opentelemetry-propagator-b3/src/index.ts
@@ -23,4 +23,5 @@ export {
   X_B3_SPAN_ID,
   X_B3_TRACE_ID,
 } from './constants';
-export { B3InjectEncoding, B3PropagatorConfig } from './types';
+export { B3InjectEncoding } from './types';
+export type { B3PropagatorConfig } from './types';

--- a/packages/opentelemetry-resources/src/index.ts
+++ b/packages/opentelemetry-resources/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export { ResourceDetectionConfig } from './config';
+export type { ResourceDetectionConfig } from './config';
 export { detectResources } from './detect-resources';
 export {
   envDetector,
@@ -23,14 +23,14 @@ export {
   processDetector,
   serviceInstanceIdDetector,
 } from './detectors';
-export { Resource } from './Resource';
+export type { Resource } from './Resource';
 export {
   resourceFromAttributes,
   defaultResource,
   emptyResource,
 } from './ResourceImpl';
 export { defaultServiceName } from './platform';
-export {
+export type {
   ResourceDetector,
   DetectedResource,
   DetectedResourceAttributes,

--- a/packages/opentelemetry-sdk-trace-base/src/index.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/index.ts
@@ -18,19 +18,20 @@ export { BasicTracerProvider } from './BasicTracerProvider';
 export { BatchSpanProcessor, RandomIdGenerator } from './platform';
 export { ConsoleSpanExporter } from './export/ConsoleSpanExporter';
 export { InMemorySpanExporter } from './export/InMemorySpanExporter';
-export { ReadableSpan } from './export/ReadableSpan';
+export type { ReadableSpan } from './export/ReadableSpan';
 export { SimpleSpanProcessor } from './export/SimpleSpanProcessor';
-export { SpanExporter } from './export/SpanExporter';
+export type { SpanExporter } from './export/SpanExporter';
 export { NoopSpanProcessor } from './export/NoopSpanProcessor';
 export { AlwaysOffSampler } from './sampler/AlwaysOffSampler';
 export { AlwaysOnSampler } from './sampler/AlwaysOnSampler';
 export { ParentBasedSampler } from './sampler/ParentBasedSampler';
 export { TraceIdRatioBasedSampler } from './sampler/TraceIdRatioBasedSampler';
-export { Sampler, SamplingDecision, SamplingResult } from './Sampler';
-export { Span } from './Span';
-export { SpanProcessor } from './SpanProcessor';
-export { TimedEvent } from './TimedEvent';
-export {
+export { SamplingDecision } from './Sampler';
+export type { Sampler, SamplingResult } from './Sampler';
+export type { Span } from './Span';
+export type { SpanProcessor } from './SpanProcessor';
+export type { TimedEvent } from './TimedEvent';
+export type {
   BatchSpanProcessorBrowserConfig,
   BufferConfig,
   GeneralLimits,
@@ -38,4 +39,4 @@ export {
   SpanLimits,
   TracerConfig,
 } from './types';
-export { IdGenerator } from './IdGenerator';
+export type { IdGenerator } from './IdGenerator';

--- a/packages/opentelemetry-sdk-trace-node/src/index.ts
+++ b/packages/opentelemetry-sdk-trace-node/src/index.ts
@@ -14,33 +14,35 @@
  * limitations under the License.
  */
 
-export { NodeTracerConfig } from './config';
+export type { NodeTracerConfig } from './config';
 export { NodeTracerProvider } from './NodeTracerProvider';
 export {
   AlwaysOffSampler,
   AlwaysOnSampler,
   BasicTracerProvider,
   BatchSpanProcessor,
-  BatchSpanProcessorBrowserConfig,
-  BufferConfig,
   ConsoleSpanExporter,
-  GeneralLimits,
-  IdGenerator,
   InMemorySpanExporter,
   NoopSpanProcessor,
   ParentBasedSampler,
   RandomIdGenerator,
+  SamplingDecision,
+  SimpleSpanProcessor,
+  TraceIdRatioBasedSampler,
+} from '@opentelemetry/sdk-trace-base';
+export type {
+  BatchSpanProcessorBrowserConfig,
+  BufferConfig,
+  GeneralLimits,
+  IdGenerator,
   ReadableSpan,
   Sampler,
-  SamplingDecision,
   SamplingResult,
   SDKRegistrationConfig,
-  SimpleSpanProcessor,
   Span,
   SpanExporter,
   SpanLimits,
   SpanProcessor,
   TimedEvent,
-  TraceIdRatioBasedSampler,
   TracerConfig,
 } from '@opentelemetry/sdk-trace-base';

--- a/packages/opentelemetry-sdk-trace-web/src/index.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/index.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-export { WebTracerConfig, WebTracerProvider } from './WebTracerProvider';
+export { WebTracerProvider } from './WebTracerProvider';
+export type { WebTracerConfig } from './WebTracerProvider';
 export { StackContextManager } from './StackContextManager';
 export { PerformanceTimingNames } from './enums/PerformanceTimingNames';
-export {
+export type {
   PerformanceEntries,
   PerformanceLegacy,
   PerformanceResourceTimingInfo,
   PropagateTraceHeaderCorsUrls,
 } from './types';
 export {
-  URLLike,
   addSpanNetworkEvent,
   addSpanNetworkEvents,
   getElementXPath,
@@ -35,31 +35,34 @@ export {
   shouldPropagateTraceHeaders,
   sortResources,
 } from './utils';
+export type { URLLike } from './utils';
 export {
   AlwaysOffSampler,
   AlwaysOnSampler,
   BasicTracerProvider,
   BatchSpanProcessor,
-  BatchSpanProcessorBrowserConfig,
-  BufferConfig,
   ConsoleSpanExporter,
-  GeneralLimits,
-  IdGenerator,
   InMemorySpanExporter,
   NoopSpanProcessor,
   ParentBasedSampler,
   RandomIdGenerator,
+  SamplingDecision,
+  SimpleSpanProcessor,
+  TraceIdRatioBasedSampler,
+} from '@opentelemetry/sdk-trace-base';
+export type {
+  BatchSpanProcessorBrowserConfig,
+  BufferConfig,
+  GeneralLimits,
+  IdGenerator,
   ReadableSpan,
   Sampler,
-  SamplingDecision,
   SamplingResult,
   SDKRegistrationConfig,
-  SimpleSpanProcessor,
   Span,
   SpanExporter,
   SpanLimits,
   SpanProcessor,
   TimedEvent,
-  TraceIdRatioBasedSampler,
   TracerConfig,
 } from '@opentelemetry/sdk-trace-base';

--- a/packages/sdk-metrics/src/aggregator/index.ts
+++ b/packages/sdk-metrics/src/aggregator/index.ts
@@ -22,4 +22,4 @@ export {
 } from './ExponentialHistogram';
 export { LastValueAccumulation, LastValueAggregator } from './LastValue';
 export { SumAccumulation, SumAggregator } from './Sum';
-export { Aggregator } from './types';
+export type { Aggregator } from './types';

--- a/packages/sdk-metrics/src/exemplar/index.ts
+++ b/packages/sdk-metrics/src/exemplar/index.ts
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-export { Exemplar } from './Exemplar';
-export { ExemplarFilter } from './ExemplarFilter';
+export type { Exemplar } from './Exemplar';
+export type { ExemplarFilter } from './ExemplarFilter';
 export { AlwaysSampleExemplarFilter } from './AlwaysSampleExemplarFilter';
 export { NeverSampleExemplarFilter } from './NeverSampleExemplarFilter';
 export { WithTraceExemplarFilter } from './WithTraceExemplarFilter';
-export {
-  ExemplarReservoir,
-  FixedSizeExemplarReservoirBase,
-} from './ExemplarReservoir';
+export type { ExemplarReservoir } from './ExemplarReservoir';
+export { FixedSizeExemplarReservoirBase } from './ExemplarReservoir';
 export { AlignedHistogramBucketExemplarReservoir } from './AlignedHistogramBucketExemplarReservoir';
 export { SimpleFixedSizeExemplarReservoir } from './SimpleFixedSizeExemplarReservoir';

--- a/packages/sdk-metrics/src/index.ts
+++ b/packages/sdk-metrics/src/index.ts
@@ -14,27 +14,26 @@
  * limitations under the License.
  */
 
-export {
+export type {
   Sum,
   LastValue,
   Histogram,
   ExponentialHistogram,
 } from './aggregator/types';
 
-export {
+export type {
   AggregationSelector,
   AggregationTemporalitySelector,
 } from './export/AggregationSelector';
 
 export { AggregationTemporality } from './export/AggregationTemporality';
 
-export {
+export { DataPointType, InstrumentType } from './export/MetricData';
+export type {
   DataPoint,
-  DataPointType,
   SumMetricData,
   GaugeMetricData,
   HistogramMetricData,
-  InstrumentType,
   ExponentialHistogramMetricData,
   ResourceMetrics,
   ScopeMetrics,
@@ -43,33 +42,33 @@ export {
   CollectionResult,
 } from './export/MetricData';
 
-export { PushMetricExporter } from './export/MetricExporter';
+export type { PushMetricExporter } from './export/MetricExporter';
 
-export {
-  IMetricReader,
-  MetricReader,
-  MetricReaderOptions,
-} from './export/MetricReader';
+export { MetricReader } from './export/MetricReader';
+export type { IMetricReader, MetricReaderOptions } from './export/MetricReader';
 
-export {
-  PeriodicExportingMetricReader,
-  PeriodicExportingMetricReaderOptions,
-} from './export/PeriodicExportingMetricReader';
+export { PeriodicExportingMetricReader } from './export/PeriodicExportingMetricReader';
+export type { PeriodicExportingMetricReaderOptions } from './export/PeriodicExportingMetricReader';
 
 export { InMemoryMetricExporter } from './export/InMemoryMetricExporter';
 
 export { ConsoleMetricExporter } from './export/ConsoleMetricExporter';
 
-export { MetricCollectOptions, MetricProducer } from './export/MetricProducer';
+export type {
+  MetricCollectOptions,
+  MetricProducer,
+} from './export/MetricProducer';
 
-export { MeterProvider, MeterProviderOptions } from './MeterProvider';
+export { MeterProvider } from './MeterProvider';
+export type { MeterProviderOptions } from './MeterProvider';
 
-export { AggregationOption, AggregationType } from './view/AggregationOption';
+export { AggregationType } from './view/AggregationOption';
+export type { AggregationOption } from './view/AggregationOption';
 
-export { ViewOptions } from './view/View';
+export type { ViewOptions } from './view/View';
 
+export type { IAttributesProcessor } from './view/AttributesProcessor';
 export {
-  IAttributesProcessor,
   createAllowListAttributesProcessor,
   createDenyListAttributesProcessor,
 } from './view/AttributesProcessor';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "inlineSources": true,
+    "isolatedModules": true,
     "module": "node16",
     "moduleResolution": "node16",
     "esModuleInterop": false,


### PR DESCRIPTION
## Which problem is this PR solving?

Enables `isolatedModules` in `tsconfig.base.json`

Refs: https://github.com/open-telemetry/opentelemetry-js/issues/5691

## Short description of the changes

No runtime side-effects are expected. This PR marks all type re-exports as `export type`.

## Type of change

Please delete options that are not relevant.

- [x] Internal change.

## How Has This Been Tested?

- [x] `npm run compile` passed

## Checklist:

- [x] Followed the style guidelines of this project

