### PR TITLE
[draft] feat: add event name to event API and SDK

### DIFF
--- a/experimental/packages/api-logs/src/types/LogRecord.ts
+++ b/experimental/packages/api-logs/src/types/LogRecord.ts
@@ -50,6 +50,11 @@ export enum SeverityNumber {
 
 export interface LogRecord {
   /**
+   * The unique identifier for the log record.
+   */
+  eventName?: string;
+
+  /**
    * The time when the log record occurred as UNIX Epoch time in nanoseconds.
    */
   timestamp?: TimeInput;

--- a/experimental/packages/otlp-transformer/src/logs/internal-types.ts
+++ b/experimental/packages/otlp-transformer/src/logs/internal-types.ts
@@ -83,6 +83,9 @@ export interface ILogRecord {
 
   /** LogRecord spanId */
   spanId?: string | Uint8Array;
+
+  /** LogRecord eventName */
+  eventName?: string;
 }
 
 /**

--- a/experimental/packages/otlp-transformer/src/logs/internal.ts
+++ b/experimental/packages/otlp-transformer/src/logs/internal.ts
@@ -99,6 +99,7 @@ function toLogRecord(log: ReadableLogRecord, encoder: Encoder): ILogRecord {
     severityNumber: toSeverityNumber(log.severityNumber),
     severityText: log.severityText,
     body: toAnyValue(log.body),
+    eventName: log.eventName,
     attributes: toLogAttributes(log.attributes),
     droppedAttributesCount: log.droppedAttributesCount,
     flags: log.spanContext?.traceFlags,

--- a/experimental/packages/otlp-transformer/test/logs.test.ts
+++ b/experimental/packages/otlp-transformer/test/logs.test.ts
@@ -75,6 +75,7 @@ function createExpectedLogJson(
                 severityNumber: ESeverityNumber.SEVERITY_NUMBER_ERROR,
                 severityText: 'error',
                 body: { stringValue: 'some_log_body' },
+                eventName: "some.event.name",
 
                 attributes: [
                   {
@@ -190,6 +191,7 @@ describe('Logs', () => {
       severityNumber: SeverityNumber.ERROR,
       severityText: 'error',
       body: 'some_log_body',
+      eventName: 'some.event.name',
       spanContext: {
         spanId: '0000000000000002',
         traceFlags: TraceFlags.SAMPLED,

--- a/experimental/packages/sdk-logs/src/LogRecord.ts
+++ b/experimental/packages/sdk-logs/src/LogRecord.ts
@@ -39,6 +39,7 @@ export class LogRecord implements ReadableLogRecord {
   private _severityText?: string;
   private _severityNumber?: logsAPI.SeverityNumber;
   private _body?: LogBody;
+  private _eventName?: string;
   private totalAttributesCount: number = 0;
 
   private _isReadonly: boolean = false;
@@ -74,6 +75,16 @@ export class LogRecord implements ReadableLogRecord {
     return this._body;
   }
 
+  get eventName(): string | undefined {
+    return this._eventName;
+  }
+  set eventName(eventName: string | undefined) {
+    if (this._isLogRecordReadonly()) {
+      return;
+    }
+    this._eventName = eventName;
+  }
+
   get droppedAttributesCount(): number {
     return this.totalAttributesCount - Object.keys(this.attributes).length;
   }
@@ -86,6 +97,7 @@ export class LogRecord implements ReadableLogRecord {
     const {
       timestamp,
       observedTimestamp,
+      eventName,
       severityNumber,
       severityText,
       body,
@@ -109,6 +121,7 @@ export class LogRecord implements ReadableLogRecord {
     this.resource = _sharedState.resource;
     this.instrumentationScope = instrumentationScope;
     this._logRecordLimits = _sharedState.logRecordLimits;
+    this._eventName = eventName;
     this.setAttributes(attributes);
   }
 

--- a/experimental/packages/sdk-logs/src/export/ReadableLogRecord.ts
+++ b/experimental/packages/sdk-logs/src/export/ReadableLogRecord.ts
@@ -30,6 +30,7 @@ export interface ReadableLogRecord {
   readonly severityText?: string;
   readonly severityNumber?: SeverityNumber;
   readonly body?: LogBody;
+  readonly eventName?: string;
   readonly resource: Resource;
   readonly instrumentationScope: InstrumentationScope;
   readonly attributes: LogAttributes;


### PR DESCRIPTION
Leaving as a draft because when I went to test it I found the proto still needs to be updated. This is what I get for saying this would be "simple" yesterday.

Adds event name to the logger emit event API as required by spec.