### PR TITLE
feat(exporter-metrics-otlp-proto): Support to protobuf in browser metrics

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :rocket: Features
 
+* feat(exporter-metrics-otlp-proto): Support to protobuf in browser metrics. [#5710](https://github.com/open-telemetry/opentelemetry-js/pull/5710) @YangJonghun
+
 ### :bug: Bug Fixes
 
 ### :books: Documentation

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/.eslintrc.js
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
         "mocha": true,
         "commonjs": true,
         "node": true,
+        "browser": true
     },
     ...require('../../../eslint.base.js')
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/karma.conf.js
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/karma.conf.js
@@ -14,4 +14,15 @@
  * limitations under the License.
  */
 
-export { OTLPMetricExporter } from './platform';
+const karmaWebpackConfig = require('../../../karma.webpack');
+const karmaBaseConfig = require('../../../karma.base');
+
+module.exports = config => {
+  config.set(
+    Object.assign({}, karmaBaseConfig, {
+      webpack: karmaWebpackConfig,
+      files: ['test/browser/index-webpack.ts'],
+      preprocessors: { 'test/browser/index-webpack.ts': ['webpack'] },
+    })
+  );
+};

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -7,6 +7,12 @@
   "esnext": "build/esnext/index.js",
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js",
+  "browser": {
+    "./src/platform/index.ts": "./src/platform/browser/index.ts",
+    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
+    "./build/esnext/platform/index.js": "./build/esnext/platform/browser/index.js",
+    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
+  },
   "scripts": {
     "prepublishOnly": "npm run compile",
     "compile": "tsc --build tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
@@ -15,6 +21,7 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc mocha 'test/**/*.test.ts' --exclude 'test/browser/**/*.ts'",
+    "test:browser": "karma start --single-run",
     "version": "node ../../../scripts/version-update.js",
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
     "precompile": "cross-var lerna run version --scope $npm_package_name --include-dependencies",
@@ -55,17 +62,30 @@
     "access": "public"
   },
   "devDependencies": {
+    "@babel/core": "7.27.1",
+    "@babel/preset-env": "7.27.2",
     "@opentelemetry/api": "1.9.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.4",
+    "@types/webpack-env": "1.16.3",
+    "babel-loader": "10.0.0",
+    "babel-plugin-istanbul": "7.0.0",
     "cross-var": "1.1.0",
+    "karma": "6.4.4",
+    "karma-chrome-launcher": "3.1.0",
+    "karma-coverage": "2.2.1",
+    "karma-mocha": "2.0.1",
+    "karma-spec-reporter": "0.0.36",
+    "karma-webpack": "5.0.1",
     "lerna": "6.6.2",
     "mocha": "11.1.0",
     "nyc": "17.1.0",
     "sinon": "15.1.2",
     "ts-loader": "9.5.2",
-    "typescript": "5.0.4"
+    "typescript": "5.0.4",
+    "webpack": "5.99.9",
+    "webpack-cli": "6.0.1"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/browser/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/browser/OTLPMetricExporter.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OTLPMetricExporterOptions } from '@opentelemetry/exporter-metrics-otlp-http';
+import { OTLPMetricExporterBase } from '@opentelemetry/exporter-metrics-otlp-http';
+import { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
+import { ProtobufMetricsSerializer } from '@opentelemetry/otlp-transformer';
+import { createLegacyOtlpBrowserExportDelegate } from '@opentelemetry/otlp-exporter-base/browser-http';
+
+export class OTLPMetricExporter extends OTLPMetricExporterBase {
+  constructor(
+    config: OTLPExporterNodeConfigBase & OTLPMetricExporterOptions = {}
+  ) {
+    super(
+      createLegacyOtlpBrowserExportDelegate(
+        config,
+        ProtobufMetricsSerializer,
+        'v1/metrics',
+        { 'Content-Type': 'application/x-protobuf' }
+      ),
+      config
+    );
+  }
+}

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/browser/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/browser/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { OTLPMetricExporter } from './platform';
+export { OTLPMetricExporter } from './OTLPMetricExporter';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { OTLPMetricExporter } from './platform';
+export { OTLPMetricExporter } from './node';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/node/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/node/OTLPMetricExporter.ts
@@ -18,7 +18,7 @@ import { OTLPMetricExporterOptions } from '@opentelemetry/exporter-metrics-otlp-
 import { OTLPMetricExporterBase } from '@opentelemetry/exporter-metrics-otlp-http';
 import { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
 import { ProtobufMetricsSerializer } from '@opentelemetry/otlp-transformer';
-import { VERSION } from './version';
+import { VERSION } from '../../version';
 import {
   convertLegacyHttpOptions,
   createOtlpHttpExportDelegate,

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/node/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/node/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { OTLPMetricExporter } from './platform';
+export { OTLPMetricExporter } from './OTLPMetricExporter';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/browser/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/browser/OTLPMetricExporter.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { OTLPMetricExporter } from '../../src/platform/browser';
+
+/*
+ * NOTE: Tests here are not intended to test the underlying components directly. They are intended as a quick
+ * check if the correct components are used. Use the following packages to test details:
+ * - `@opentelemetry/oltp-exporter-base`: OTLP common exporter logic (handling of concurrent exports, ...)
+ * - `@opentelemetry/otlp-transformer`: Everything regarding serialization and transforming internal representations to OTLP
+ * - `@opentelemetry/otlp-grpc-exporter-base`: gRPC transport
+ */
+
+describe('OTLPTraceExporter', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('export', function () {
+    describe('when sendBeacon is available', function () {
+      it('should successfully send data using sendBeacon', async function () {
+        // arrange
+        const stubBeacon = sinon.stub(navigator, 'sendBeacon');
+        const meterProvider = new MeterProvider({
+          readers: [
+            new PeriodicExportingMetricReader({
+              exporter: new OTLPMetricExporter(),
+            }),
+          ],
+        });
+
+        // act
+        meterProvider
+          .getMeter('test-meter')
+          .createCounter('test-counter')
+          .add(1);
+        await meterProvider.shutdown();
+
+        // assert
+        const args = stubBeacon.args[0];
+        const blob: Blob = args[1] as unknown as Blob;
+        const body = await blob.text();
+        assert.throws(
+          () => JSON.parse(body),
+          'expected requestBody to be in protobuf format, but parsing as JSON succeeded'
+        );
+      });
+    });
+
+    describe('when sendBeacon is not available', function () {
+      beforeEach(function () {
+        // fake sendBeacon not being available
+        (window.navigator as any).sendBeacon = false;
+      });
+
+      it('should successfully send data using XMLHttpRequest', async function () {
+        // arrange
+        const server = sinon.fakeServer.create();
+        server.respondWith('OK');
+        server.respondImmediately = true;
+        server.autoRespond = true;
+        const meterProvider = new MeterProvider({
+          readers: [
+            new PeriodicExportingMetricReader({
+              exporter: new OTLPMetricExporter(),
+            }),
+          ],
+        });
+
+        // act
+        meterProvider
+          .getMeter('test-meter')
+          .createCounter('test-counter')
+          .add(1);
+
+        await meterProvider.shutdown();
+
+        // assert
+        const request = server.requests[0];
+        const body = request.requestBody as unknown as Uint8Array;
+        assert.throws(
+          () => JSON.parse(new TextDecoder().decode(body)),
+          'expected requestBody to be in protobuf format, but parsing as JSON succeeded'
+        );
+      });
+    });
+  });
+});

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/browser/index-webpack.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/browser/index-webpack.ts
@@ -13,5 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const testsContext = require.context('../browser', true, /test$/);
+testsContext.keys().forEach(testsContext);
 
-export { OTLPMetricExporter } from './platform';
+const srcContext = require.context('.', true, /src$/);
+srcContext.keys().forEach(srcContext);

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/node/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/node/OTLPMetricExporter.test.ts
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 import * as http from 'http';
 import * as sinon from 'sinon';
 
-import { OTLPMetricExporter } from '../src/';
+import { OTLPMetricExporter } from '../../src/platform/node';
 import {
   MeterProvider,
   PeriodicExportingMetricReader,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1528,17 +1528,30 @@
         "@opentelemetry/sdk-metrics": "2.0.1"
       },
       "devDependencies": {
+        "@babel/core": "7.27.1",
+        "@babel/preset-env": "7.27.2",
         "@opentelemetry/api": "1.9.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.4",
+        "@types/webpack-env": "1.16.3",
+        "babel-loader": "10.0.0",
+        "babel-plugin-istanbul": "7.0.0",
         "cross-var": "1.1.0",
+        "karma": "6.4.4",
+        "karma-chrome-launcher": "3.1.0",
+        "karma-coverage": "2.2.1",
+        "karma-mocha": "2.0.1",
+        "karma-spec-reporter": "0.0.36",
+        "karma-webpack": "5.0.1",
         "lerna": "6.6.2",
         "mocha": "11.1.0",
         "nyc": "17.1.0",
         "sinon": "15.1.2",
         "ts-loader": "9.5.2",
-        "typescript": "5.0.4"
+        "typescript": "5.0.4",
+        "webpack": "5.99.9",
+        "webpack-cli": "6.0.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1553,6 +1566,128 @@
       "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-proto/node_modules/@webpack-cli/configtest": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
+      "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-proto/node_modules/@webpack-cli/info": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
+      "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-proto/node_modules/@webpack-cli/serve": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
+      "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-proto/node_modules/babel-loader": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.0.0.tgz",
+      "integrity": "sha512-z8jt+EdS61AMw22nSfoNJAZ0vrtmhPRVi6ghL3rCeRZI8cdNYFiV5xeV3HbE7rlZZNmGH8BVccwWt8/ED0QOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.20.0 || ^20.10.0 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0",
+        "webpack": ">=5.61.0"
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-proto/node_modules/webpack-cli": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
+      "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.6.1",
+        "@webpack-cli/configtest": "^3.0.1",
+        "@webpack-cli/info": "^3.0.1",
+        "@webpack-cli/serve": "^3.0.1",
+        "colorette": "^2.0.14",
+        "commander": "^12.1.0",
+        "cross-spawn": "^7.0.3",
+        "envinfo": "^7.14.0",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^3.1.1",
+        "rechoir": "^0.8.0",
+        "webpack-merge": "^6.0.1"
+      },
+      "bin": {
+        "webpack-cli": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack-bundle-analyzer": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "experimental/packages/opentelemetry-exporter-metrics-otlp-proto/node_modules/webpack-merge": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "experimental/packages/opentelemetry-exporter-prometheus": {
       "name": "@opentelemetry/exporter-prometheus",
@@ -35051,6 +35186,8 @@
     "@opentelemetry/exporter-metrics-otlp-proto": {
       "version": "file:experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
       "requires": {
+        "@babel/core": "7.27.1",
+        "@babel/preset-env": "7.27.2",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/core": "2.0.1",
         "@opentelemetry/exporter-metrics-otlp-http": "0.201.1",
@@ -35061,13 +35198,24 @@
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.4",
+        "@types/webpack-env": "1.16.3",
+        "babel-loader": "10.0.0",
+        "babel-plugin-istanbul": "7.0.0",
         "cross-var": "1.1.0",
+        "karma": "6.4.4",
+        "karma-chrome-launcher": "3.1.0",
+        "karma-coverage": "2.2.1",
+        "karma-mocha": "2.0.1",
+        "karma-spec-reporter": "0.0.36",
+        "karma-webpack": "5.0.1",
         "lerna": "6.6.2",
         "mocha": "11.1.0",
         "nyc": "17.1.0",
         "sinon": "15.1.2",
         "ts-loader": "9.5.2",
-        "typescript": "5.0.4"
+        "typescript": "5.0.4",
+        "webpack": "5.99.9",
+        "webpack-cli": "6.0.1"
       },
       "dependencies": {
         "@types/node": {
@@ -35075,6 +35223,68 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
           "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
           "dev": true
+        },
+        "@webpack-cli/configtest": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
+          "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
+          "dev": true,
+          "requires": {}
+        },
+        "@webpack-cli/info": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
+          "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "@webpack-cli/serve": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
+          "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
+          "dev": true,
+          "requires": {}
+        },
+        "babel-loader": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.0.0.tgz",
+          "integrity": "sha512-z8jt+EdS61AMw22nSfoNJAZ0vrtmhPRVi6ghL3rCeRZI8cdNYFiV5xeV3HbE7rlZZNmGH8BVccwWt8/ED0QOHA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^5.0.0"
+          }
+        },
+        "webpack-cli": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
+          "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+          "dev": true,
+          "requires": {
+            "@discoveryjs/json-ext": "^0.6.1",
+            "@webpack-cli/configtest": "^3.0.1",
+            "@webpack-cli/info": "^3.0.1",
+            "@webpack-cli/serve": "^3.0.1",
+            "colorette": "^2.0.14",
+            "commander": "^12.1.0",
+            "cross-spawn": "^7.0.3",
+            "envinfo": "^7.14.0",
+            "fastest-levenshtein": "^1.0.12",
+            "import-local": "^3.0.2",
+            "interpret": "^3.1.1",
+            "rechoir": "^0.8.0",
+            "webpack-merge": "^6.0.1"
+          }
+        },
+        "webpack-merge": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+          "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
+          "dev": true,
+          "requires": {
+            "clone-deep": "^4.0.1",
+            "flat": "^5.0.2",
+            "wildcard": "^2.0.1"
+          }
         }
       }
     },


### PR DESCRIPTION
## Which problem is this PR solving?
Log, Trace support protobuf properly in browser, but Metric crashes because it references `@opentelemetry/otlp-exporter-base/node-http`.

## Short description of the changes
- Meter Exporter supports protobuf in browser

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

## Checklist:
- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
