### PR TITLE
Improve e2e stability

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -4,11 +4,11 @@
   "description": "End-to-end tests for OpenTelemetry JS",
   "version": "0.0.0",
   "scripts": {
-    "test:e2e": "npm run run-collector && npm run export-telemetry && npm run verify && npm run stop-collector",
+    "test:e2e": "npm run stop-collector; npm run run-collector && npm run export-telemetry && npm run verify || npm run stop-collector",
     "lint": "eslint . --ext .mjs",
     "lint:fix": "eslint . --ext .mjs --fix",
-    "run-collector": "docker run -d --rm --name otelcol-e2e -v $(pwd)/collector-config.yaml:/etc/otelcol/config.yaml -v $(pwd)/collector-output.json:/tmp/collector-output.json -p 4317:4317 -p 4318:4318 -w /tmp otel/opentelemetry-collector-contrib:latest --config /etc/otelcol/config.yaml && sleep 5",
-    "export-telemetry": "node test.mjs",
+    "run-collector": "docker run --pull=always -d --rm --name otelcol-e2e -v $(pwd)/collector-config.yaml:/etc/otelcol/config.yaml -v $(pwd)/collector-output.json:/tmp/collector-output.json -p 4317:4317 -p 4318:4318 -w /tmp otel/opentelemetry-collector-contrib:latest --config /etc/otelcol/config.yaml && sleep 5",
+    "export-telemetry": "node test.mjs; sleep 5",
     "prerun-collector": "node -e \"require('fs').writeFileSync('collector-output.json', '')\"",
     "stop-collector": "docker stop otelcol-e2e",
     "verify": "node verify.mjs"


### PR DESCRIPTION
Fixes the following issues with e2e tests: 

1. collector continues running if tests stop
2. tests fail if collector is already running
3. verification happens before collector finishes writing output to disk
4. local collector container may not actually be latest