### PR TITLE
fix(sdk-metrics): improve PeriodicExportingMetricReader() constructor input validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-metrics): improve PeriodicExportingMetricReader() constructor input validation [#xxxx](https://github.com/open-telemetry/opentelemetry-js/pull/xxxx) @cjihrig
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/packages/sdk-metrics/src/export/PeriodicExportingMetricReader.ts
+++ b/packages/sdk-metrics/src/export/PeriodicExportingMetricReader.ts
@@ -60,42 +60,45 @@ export class PeriodicExportingMetricReader extends MetricReader {
   private readonly _exportTimeout: number;
 
   constructor(options: PeriodicExportingMetricReaderOptions) {
+    const { exporter, exportIntervalMillis = 60000, metricProducers } = options;
+    let { exportTimeoutMillis = 30000 } = options;
+
     super({
-      aggregationSelector: options.exporter.selectAggregation?.bind(
-        options.exporter
-      ),
+      aggregationSelector: exporter.selectAggregation?.bind(exporter),
       aggregationTemporalitySelector:
-        options.exporter.selectAggregationTemporality?.bind(options.exporter),
-      metricProducers: options.metricProducers,
+        exporter.selectAggregationTemporality?.bind(exporter),
+      metricProducers,
     });
 
-    if (
-      options.exportIntervalMillis !== undefined &&
-      options.exportIntervalMillis <= 0
-    ) {
+    if (exportIntervalMillis <= 0) {
       throw Error('exportIntervalMillis must be greater than 0');
     }
 
-    if (
-      options.exportTimeoutMillis !== undefined &&
-      options.exportTimeoutMillis <= 0
-    ) {
+    if (exportTimeoutMillis <= 0) {
       throw Error('exportTimeoutMillis must be greater than 0');
     }
 
-    if (
-      options.exportTimeoutMillis !== undefined &&
-      options.exportIntervalMillis !== undefined &&
-      options.exportIntervalMillis < options.exportTimeoutMillis
-    ) {
-      throw Error(
-        'exportIntervalMillis must be greater than or equal to exportTimeoutMillis'
-      );
+    if (exportIntervalMillis < exportTimeoutMillis) {
+      if (
+        'exportIntervalMillis' in options &&
+        'exportTimeoutMillis' in options
+      ) {
+        // An invalid combination of values was explicitly provided.
+        throw Error(
+          'exportIntervalMillis must be greater than or equal to exportTimeoutMillis'
+        );
+      } else {
+        // An invalid combination of value was implicitly provided.
+        api.diag.warn(
+          `Timeout of ${exportTimeoutMillis} exceeds the interval of ${exportIntervalMillis}. Clamping timeout to interval duration.`
+        );
+        exportTimeoutMillis = exportIntervalMillis;
+      }
     }
 
-    this._exportInterval = options.exportIntervalMillis ?? 60000;
-    this._exportTimeout = options.exportTimeoutMillis ?? 30000;
-    this._exporter = options.exporter;
+    this._exportInterval = exportIntervalMillis;
+    this._exportTimeout = exportTimeoutMillis;
+    this._exporter = exporter;
   }
 
   private async _runOnce(): Promise<void> {

--- a/packages/sdk-metrics/test/export/PeriodicExportingMetricReader.test.ts
+++ b/packages/sdk-metrics/test/export/PeriodicExportingMetricReader.test.ts
@@ -228,6 +228,26 @@ describe('PeriodicExportingMetricReader', () => {
       );
     });
 
+    it('should clamp when timeout implicitly exceeds interval', () => {
+      const exporter = new TestDeltaMetricExporter();
+
+      const p1 = new PeriodicExportingMetricReader({
+        exporter,
+        // exportTimeoutMillis defaults to 30 seconds, which is greater than exportIntervalMillis.
+        exportIntervalMillis: 100,
+      }) as any;
+      assert.strictEqual(p1._exportInterval, 100);
+      assert.strictEqual(p1._exportTimeout, 100);
+
+      const p2 = new PeriodicExportingMetricReader({
+        exporter,
+        // exportIntervalMillis defaults to 60 seconds, which is less than exportTimeoutMillis.
+        exportTimeoutMillis: 90_000,
+      }) as any;
+      assert.strictEqual(p2._exportInterval, 60_000);
+      assert.strictEqual(p2._exportTimeout, 60_000);
+    });
+
     it('should not start exporting', async () => {
       const exporter = new TestDeltaMetricExporter();
       const exporterMock = sinon.mock(exporter);


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes #5550

## Short description of the changes

This commit is another take on #5621. That PR needed to be reverted because it could break existing code that implicitly set PeriodicExportingMetricReader timeout and interval values.

This time around, instead of throwing, bad implicit values are clamped as suggested in #5671.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Ran the existing unit tests and added a few more assertions.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
