### PR TITLE
docs(exporter-logs-otlp-proto): Fixup markdown table

### DIFF
--- a/experimental/packages/exporter-logs-otlp-proto/README.md
+++ b/experimental/packages/exporter-logs-otlp-proto/README.md
@@ -51,7 +51,7 @@ To override the default timeout duration, use the following options:
 - Set with environment variables:
 
   | Environment variable              | Description |
-  ------------------------------------|-------------|
+  |-----------------------------------|-------------|
   | `OTEL_EXPORTER_OTLP_LOGS_TIMEOUT` | The maximum waiting time, in milliseconds, allowed to send each OTLP trace batch. Default is 10000. |
   | `OTEL_EXPORTER_OTLP_TIMEOUT`      | The maximum waiting time, in milliseconds, allowed to send each OTLP trace and metric batch. Default is 10000. |
 

--- a/experimental/packages/exporter-logs-otlp-proto/README.md
+++ b/experimental/packages/exporter-logs-otlp-proto/README.md
@@ -50,10 +50,10 @@ To override the default timeout duration, use the following options:
 
 - Set with environment variables:
 
-  | Environment variable         | Description |
-------------------------------|----------------------|-------------|
-  | OTEL_EXPORTER_OTLP_LOGS_TIMEOUT | The maximum waiting time, in milliseconds, allowed to send each OTLP trace batch. Default is 10000. |
-  | OTEL_EXPORTER_OTLP_TIMEOUT   | The maximum waiting time, in milliseconds, allowed to send each OTLP trace and metric batch. Default is 10000. |
+  | Environment variable              | Description |
+  ------------------------------------|-------------|
+  | `OTEL_EXPORTER_OTLP_LOGS_TIMEOUT` | The maximum waiting time, in milliseconds, allowed to send each OTLP trace batch. Default is 10000. |
+  | `OTEL_EXPORTER_OTLP_TIMEOUT`      | The maximum waiting time, in milliseconds, allowed to send each OTLP trace and metric batch. Default is 10000. |
 
   > `OTEL_EXPORTER_OTLP_LOGS_TIMEOUT` takes precedence and overrides `OTEL_EXPORTER_OTLP_TIMEOUT`.
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The markdown table in the `exporter-logs-otlp-proto` README was slightly unformatted. Example screenshot from [npmjs](http://web.archive.org/web/20250525010947/https://www.npmjs.com/package/@opentelemetry/exporter-logs-otlp-proto):

![Screenshot of npmjs showing a misrendered plaintext table](https://github.com/user-attachments/assets/cc64a3cf-d5df-44d2-af96-dcee37e141ef)


Here's also a before/after of the file:

![Before and after, showing a misrendered plaintext table before, and a newer properly rendered markdown table](https://github.com/user-attachments/assets/ecf9a6e6-e9d7-4cab-8392-9e3949108da1)

## Type of change

- [x] This is a small documentation update
