### PR TITLE
feat(opentelemetry-resources): add schema url

### DIFF
--- a/experimental/packages/otlp-transformer/src/common/internal-types.ts
+++ b/experimental/packages/otlp-transformer/src/common/internal-types.ts
@@ -21,6 +21,9 @@ export interface Resource {
 
   /** Resource droppedAttributesCount */
   droppedAttributesCount: number;
+
+  /** Resource schemaUrl */
+  schemaUrl?: string;
 }
 
 /** Properties of an InstrumentationScope. */

--- a/experimental/packages/otlp-transformer/src/common/internal.ts
+++ b/experimental/packages/otlp-transformer/src/common/internal.ts
@@ -24,10 +24,15 @@ import { InstrumentationScope } from '@opentelemetry/core';
 import { Resource as ISdkResource } from '@opentelemetry/resources';
 
 export function createResource(resource: ISdkResource): Resource {
-  return {
+  const result: Resource = {
     attributes: toAttributes(resource.attributes),
     droppedAttributesCount: 0,
   };
+
+  const schemaUrl = resource.getSchemaUrl?.();
+  if (schemaUrl && schemaUrl !== '') result.schemaUrl = schemaUrl;
+
+  return result;
 }
 
 export function createInstrumentationScope(

--- a/packages/opentelemetry-resources/src/Resource.ts
+++ b/packages/opentelemetry-resources/src/Resource.ts
@@ -59,4 +59,11 @@ export interface Resource {
   merge(other: Resource | null): Resource;
 
   getRawAttributes(): RawResourceAttribute[];
+
+  /**
+   * Get the schema URL for this resource.
+   *
+   * @returns the schema URL or undefined if not set
+   */
+  getSchemaUrl?(): string | undefined;
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/4182

## Short description of the changes

The JavaScript SDK, unlike most others, currently does not give the ability to provide a Schema URL to a resource. See: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#resource-creation

This PR implements the ability to provide it.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] should create resource with schema URL
- [x] should create resource without schema URL
- [x] should merge resources with schema URL priority given to other resource
- [x] should retain schema URL from base resource when other has no schema URL
- [x] should retain schema URL from the resource that has it when merging
- [x] should have empty schema URL when merging resources with no schema URL
- [x] should handle merging with empty string schema URLs
- [x] should maintain backward compatibility - getSchemaUrl is optional
- [x] should work with async attributes and schema URLs

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
