### PR TITLE
fix(sdk-metrics): remove invalid default value for 'startTime' param to ExponentialHistogramAccumulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-metrics): Remove invalid default value for `startTime` param to ExponentialHistogramAccumulation. This only impacted the closurescript compiler. [#5763](https://github.com/open-telemetry/opentelemetry-js/pull/5763) @trentm
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/packages/sdk-metrics/src/aggregator/ExponentialHistogram.ts
+++ b/packages/sdk-metrics/src/aggregator/ExponentialHistogram.ts
@@ -65,7 +65,7 @@ const MIN_MAX_SIZE = 2;
 
 export class ExponentialHistogramAccumulation implements Accumulation {
   constructor(
-    public startTime: HrTime = startTime,
+    public startTime: HrTime,
     private _maxSize = DEFAULT_MAX_SIZE,
     private _recordMinMax = true,
     private _sum = 0,


### PR DESCRIPTION
Fixes: https://github.com/open-telemetry/opentelemetry-js/issues/5755
