### PR TITLE
feat(sdk-logs)!: removed deprecated `LoggerProvider#addLogRecordProcessor()`

### DIFF
--- a/experimental/examples/logs/index.ts
+++ b/experimental/examples/logs/index.ts
@@ -25,10 +25,13 @@ import {
 // Optional and only needed to see the internal diagnostic logging (during development)
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 
-const loggerProvider = new LoggerProvider();
-loggerProvider.addLogRecordProcessor(
-  new SimpleLogRecordProcessor(new ConsoleLogRecordExporter())
-);
+const loggerProvider = new LoggerProvider({
+  processors: [
+    new SimpleLogRecordProcessor(
+      new ConsoleLogRecordExporter()
+    )
+  ],
+});
 
 logs.setGlobalLoggerProvider(loggerProvider);
 

--- a/experimental/packages/exporter-logs-otlp-grpc/README.md
+++ b/experimental/packages/exporter-logs-otlp-grpc/README.md
@@ -39,11 +39,9 @@ const collectorOptions = {
 };
 
 const loggerExporter = new OTLPLogExporter(collectorOptions);
-const loggerProvider = new LoggerProvider();
-
-loggerProvider.addLogRecordProcessor(
-  new BatchLogRecordProcessor(loggerExporter)
-);
+const loggerProvider = new LoggerProvider({
+  processors: [new BatchRecordProcessor(loggerExporter)]
+});
 
 ['SIGINT', 'SIGTERM'].forEach(signal => {
   process.on(signal, () => loggerProvider.shutdown().catch(console.error));

--- a/experimental/packages/exporter-logs-otlp-http/README.md
+++ b/experimental/packages/exporter-logs-otlp-http/README.md
@@ -37,9 +37,9 @@ const collectorOptions = {
   concurrencyLimit: 1, // an optional limit on pending requests
 };
 const logExporter = new OTLPLogExporter(collectorOptions);
-const loggerProvider = new LoggerProvider();
-
-loggerProvider.addLogRecordProcessor(new BatchLogRecordProcessor(logExporter));
+const loggerProvider = new LoggerProvider({
+  processors: [new BatchRecordProcessor(logExporter)]
+});
 
 const logger = loggerProvider.getLogger('default', '1.0.0');
 // Emit a log
@@ -66,9 +66,9 @@ const collectorOptions = {
   concurrencyLimit: 1, // an optional limit on pending requests
 };
 const logExporter = new OTLPLogExporter(collectorOptions);
-const loggerProvider = new LoggerProvider();
-
-loggerProvider.addLogRecordProcessor(new BatchLogRecordProcessor(logExporter));
+const loggerProvider = new LoggerProvider({
+  processors: [new BatchRecordProcessor(logExporter)]
+});
 
 const logger = loggerProvider.getLogger('default', '1.0.0');
 // Emit a log

--- a/experimental/packages/exporter-logs-otlp-proto/README.md
+++ b/experimental/packages/exporter-logs-otlp-proto/README.md
@@ -31,9 +31,11 @@ const collectorOptions = {
   }, //an optional object containing custom headers to be sent with each request will only work with http
 };
 
-const logProvider = new LoggerProvider({resource: resourceFromAttributes({'service.name': 'testApp'})});
 const logExporter = new OTLPLogExporter(collectorOptions);
-logProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(exporter));
+const logProvider = new LoggerProvider({
+  resource: resourceFromAttributes({'service.name': 'testApp'}),
+  processors: [new SimpleLogRecordProcessor(logExporter)]
+  });
 
 const logger = logProvider.getLogger('test_log_instrumentation');
 

--- a/experimental/packages/sdk-logs/README.md
+++ b/experimental/packages/sdk-logs/README.md
@@ -31,11 +31,10 @@ const {
 } = require('@opentelemetry/sdk-logs');
 
 // To start a logger, you first need to initialize the Logger provider.
-const loggerProvider = new LoggerProvider();
-// Add a processor to export log record
-loggerProvider.addLogRecordProcessor(
-  new SimpleLogRecordProcessor(new ConsoleLogRecordExporter())
-);
+// and add a processor to export log record
+const loggerProvider = new LoggerProvider({
+  processors: [new SimpleLogRecordProcessor(new ConsoleLogRecordExporter())]
+});
 
 //  To create a log record, you first need to get a Logger instance
 const logger = loggerProvider.getLogger('default');

--- a/experimental/packages/sdk-logs/src/LoggerProvider.ts
+++ b/experimental/packages/sdk-logs/src/LoggerProvider.ts
@@ -23,8 +23,6 @@ import type { LoggerProviderConfig } from './types';
 import { Logger } from './Logger';
 import { loadDefaultConfig, reconfigureLimits } from './config';
 import { LoggerProviderSharedState } from './internal/LoggerProviderSharedState';
-import { LogRecordProcessor } from './LogRecordProcessor';
-import { MultiLogRecordProcessor } from './MultiLogRecordProcessor';
 
 export const DEFAULT_LOGGER_NAME = 'unknown';
 
@@ -73,32 +71,6 @@ export class LoggerProvider implements logsAPI.LoggerProvider {
     }
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return this._sharedState.loggers.get(key)!;
-  }
-
-  /**
-   * @deprecated add your processors in the constructors instead.
-   *
-   * Adds a new {@link LogRecordProcessor} to this logger.
-   * @param processor the new LogRecordProcessor to be added.
-   */
-  public addLogRecordProcessor(processor: LogRecordProcessor) {
-    if (this._sharedState.registeredLogRecordProcessors.length === 0) {
-      // since we might have enabled by default a batchProcessor, we disable it
-      // before adding the new one
-      this._sharedState.activeProcessor
-        .shutdown()
-        .catch(err =>
-          diag.error(
-            'Error while trying to shutdown current log record processor',
-            err
-          )
-        );
-    }
-    this._sharedState.registeredLogRecordProcessors.push(processor);
-    this._sharedState.activeProcessor = new MultiLogRecordProcessor(
-      this._sharedState.registeredLogRecordProcessors,
-      this._sharedState.forceFlushTimeoutMillis
-    );
   }
 
   /**

--- a/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
@@ -203,15 +203,16 @@ describe('LoggerProvider', () => {
 
   describe('addLogRecordProcessor', () => {
     it('should add logRecord processor', () => {
+      const logRecordProcessor = new NoopLogRecordProcessor();
       const provider = new LoggerProvider({
-        processors: [new NoopLogRecordProcessor()],
+        processors: [logRecordProcessor],
       });
       const sharedState = provider['_sharedState'];
       assert.ok(sharedState.activeProcessor instanceof MultiLogRecordProcessor);
       assert.strictEqual(sharedState.activeProcessor.processors.length, 1);
       assert.strictEqual(
         sharedState.activeProcessor.processors[0],
-        provider['processors'][0]
+        logRecordProcessor
       );
     });
   });

--- a/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
@@ -203,15 +203,15 @@ describe('LoggerProvider', () => {
 
   describe('addLogRecordProcessor', () => {
     it('should add logRecord processor', () => {
-      const provider = new LoggerProvider();
+      const provider = new LoggerProvider({
+        processors: [new NoopLogRecordProcessor()],
+      });
       const sharedState = provider['_sharedState'];
-      const logRecordProcessor = new NoopLogRecordProcessor();
-      provider.addLogRecordProcessor(logRecordProcessor);
       assert.ok(sharedState.activeProcessor instanceof MultiLogRecordProcessor);
       assert.strictEqual(sharedState.activeProcessor.processors.length, 1);
       assert.strictEqual(
         sharedState.activeProcessor.processors[0],
-        logRecordProcessor
+        provider['processors'][0]
       );
     });
   });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Removed deprecated `LoggerProvider#addLogRecordProcessor()` in favor os the constructor option. See linked issue for more details. 

Fixes #5738 

## Short description of the changes
- Removed `LoggerProvider#addLogRecordProcessor()`
- Updated exporters readme mention of adding this logger provider
- Updated test

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Updated test

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
