### PR TITLE
fix(api-logs,sdk-logs): allow AnyValue attributes for logs and handle circular references

### DIFF
--- a/experimental/packages/api-logs/src/index.ts
+++ b/experimental/packages/api-logs/src/index.ts
@@ -20,6 +20,7 @@ export { SeverityNumber } from './types/LogRecord';
 export type { LogAttributes, LogBody, LogRecord } from './types/LogRecord';
 export type { LoggerOptions } from './types/LoggerOptions';
 export type { AnyValue, AnyValueMap } from './types/AnyValue';
+export { isLogAttributeValue } from './utils/validation';
 export { NOOP_LOGGER, NoopLogger } from './NoopLogger';
 export { NOOP_LOGGER_PROVIDER, NoopLoggerProvider } from './NoopLoggerProvider';
 export { ProxyLogger } from './ProxyLogger';

--- a/experimental/packages/api-logs/src/utils/validation.ts
+++ b/experimental/packages/api-logs/src/utils/validation.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AnyValue } from '../types/AnyValue';
+
+/**
+ * Validates if a value is a valid AnyValue for Log Attributes according to OpenTelemetry spec.
+ * Log Attributes support a superset of standard Attributes and must support:
+ * - Scalar values: string, boolean, signed 64 bit integer, or double precision floating point
+ * - Byte arrays (Uint8Array)
+ * - Arrays of any values (heterogeneous arrays allowed)
+ * - Maps from string to any value (nested objects)
+ * - Empty values (null/undefined)
+ * 
+ * @param val - The value to validate
+ * @returns true if the value is a valid AnyValue, false otherwise
+ */
+export function isLogAttributeValue(val: unknown): val is AnyValue {
+  return isLogAttributeValueInternal(val, new WeakSet());
+}
+
+function isLogAttributeValueInternal(val: unknown, visited: WeakSet<object>): val is AnyValue {
+  // null and undefined are explicitly allowed
+  if (val == null) {
+    return true;
+  }
+
+  // Scalar values
+  if (typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean') {
+    return true;
+  }
+
+  // Byte arrays
+  if (val instanceof Uint8Array) {
+    return true;
+  }
+
+  // For objects and arrays, check for circular references
+  if (typeof val === 'object') {
+    if (visited.has(val as object)) {
+      // Circular reference detected - reject it
+      return false;
+    }
+    visited.add(val as object);
+
+    // Arrays (can contain any AnyValue, including heterogeneous)
+    if (Array.isArray(val)) {
+      return val.every(item => isLogAttributeValueInternal(item, visited));
+    }
+
+    // Only accept plain objects (not built-in objects like Date, RegExp, Error, etc.)
+    // Check if it's a plain object by verifying its constructor is Object or it has no constructor
+    const obj = val as Record<string, unknown>;
+    if (obj.constructor !== Object && obj.constructor !== undefined) {
+      return false;
+    }
+
+    // Objects/Maps (including empty objects)
+    // All object properties must be valid AnyValues
+    return Object.values(obj).every(item => isLogAttributeValueInternal(item, visited));
+  }
+
+  return false;
+} 

--- a/experimental/packages/api-logs/test/common/utils/validation.test.ts
+++ b/experimental/packages/api-logs/test/common/utils/validation.test.ts
@@ -1,0 +1,255 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import { isLogAttributeValue } from '../../../src/utils/validation';
+
+describe('isLogAttributeValue', () => {
+  describe('should accept scalar values', () => {
+    it('should accept strings', () => {
+      assert.strictEqual(isLogAttributeValue('test'), true);
+      assert.strictEqual(isLogAttributeValue(''), true);
+      assert.strictEqual(isLogAttributeValue('multi\nline'), true);
+      assert.strictEqual(isLogAttributeValue('unicode: 🎉'), true);
+    });
+
+    it('should accept numbers', () => {
+      assert.strictEqual(isLogAttributeValue(42), true);
+      assert.strictEqual(isLogAttributeValue(0), true);
+      assert.strictEqual(isLogAttributeValue(-123), true);
+      assert.strictEqual(isLogAttributeValue(3.14159), true);
+      assert.strictEqual(isLogAttributeValue(Number.MAX_SAFE_INTEGER), true);
+      assert.strictEqual(isLogAttributeValue(Number.MIN_SAFE_INTEGER), true);
+      assert.strictEqual(isLogAttributeValue(Infinity), true);
+      assert.strictEqual(isLogAttributeValue(-Infinity), true);
+      assert.strictEqual(isLogAttributeValue(NaN), true);
+    });
+
+    it('should accept booleans', () => {
+      assert.strictEqual(isLogAttributeValue(true), true);
+      assert.strictEqual(isLogAttributeValue(false), true);
+    });
+  });
+
+  describe('should accept null and undefined values', () => {
+    it('should accept null', () => {
+      assert.strictEqual(isLogAttributeValue(null), true);
+    });
+
+    it('should accept undefined', () => {
+      assert.strictEqual(isLogAttributeValue(undefined), true);
+    });
+  });
+
+  describe('should accept byte arrays', () => {
+    it('should accept Uint8Array', () => {
+      assert.strictEqual(isLogAttributeValue(new Uint8Array([1, 2, 3])), true);
+      assert.strictEqual(isLogAttributeValue(new Uint8Array(0)), true);
+      assert.strictEqual(isLogAttributeValue(new Uint8Array([255, 0, 128])), true);
+    });
+  });
+
+  describe('should accept arrays', () => {
+    it('should accept homogeneous arrays', () => {
+      assert.strictEqual(isLogAttributeValue(['a', 'b', 'c']), true);
+      assert.strictEqual(isLogAttributeValue([1, 2, 3]), true);
+      assert.strictEqual(isLogAttributeValue([true, false]), true);
+    });
+
+    it('should accept heterogeneous arrays', () => {
+      assert.strictEqual(isLogAttributeValue(['string', 42, true]), true);
+      assert.strictEqual(isLogAttributeValue([null, undefined, 'test']), true);
+      assert.strictEqual(isLogAttributeValue(['test', new Uint8Array([1, 2])]), true);
+    });
+
+    it('should accept nested arrays', () => {
+      assert.strictEqual(isLogAttributeValue([['a', 'b'], [1, 2]]), true);
+      assert.strictEqual(isLogAttributeValue([[1, 2, 3], ['nested', 'array']]), true);
+    });
+
+    it('should accept arrays with null/undefined', () => {
+      assert.strictEqual(isLogAttributeValue([null, 'test', undefined]), true);
+      assert.strictEqual(isLogAttributeValue([]), true);
+    });
+
+    it('should accept arrays with objects', () => {
+      assert.strictEqual(isLogAttributeValue([{ key: 'value' }, 'string']), true);
+    });
+  });
+
+  describe('should accept objects/maps', () => {
+    it('should accept simple objects', () => {
+      assert.strictEqual(isLogAttributeValue({ key: 'value' }), true);
+      assert.strictEqual(isLogAttributeValue({ num: 42, bool: true }), true);
+    });
+
+    it('should accept empty objects', () => {
+      assert.strictEqual(isLogAttributeValue({}), true);
+    });
+
+    it('should accept nested objects', () => {
+      const nested = {
+        level1: {
+          level2: {
+            deep: 'value',
+            number: 123
+          }
+        }
+      };
+      assert.strictEqual(isLogAttributeValue(nested), true);
+    });
+
+    it('should accept objects with arrays', () => {
+      const obj = {
+        strings: ['a', 'b'],
+        numbers: [1, 2, 3],
+        mixed: ['str', 42, true]
+      };
+      assert.strictEqual(isLogAttributeValue(obj), true);
+    });
+
+    it('should accept objects with null/undefined values', () => {
+      assert.strictEqual(isLogAttributeValue({ nullVal: null, undefVal: undefined }), true);
+    });
+
+    it('should accept objects with byte arrays', () => {
+      assert.strictEqual(isLogAttributeValue({ bytes: new Uint8Array([1, 2, 3]) }), true);
+    });
+  });
+
+  describe('should accept complex combinations', () => {
+    it('should accept deeply nested structures', () => {
+      const complex = {
+        scalars: {
+          str: 'test',
+          num: 42,
+          bool: true
+        },
+        arrays: {
+          homogeneous: ['a', 'b', 'c'],
+          heterogeneous: [1, 'two', true, null],
+          nested: [[1, 2], ['a', 'b']]
+        },
+        bytes: new Uint8Array([255, 254, 253]),
+        nullish: {
+          nullValue: null,
+          undefinedValue: undefined
+        },
+        empty: {}
+      };
+      assert.strictEqual(isLogAttributeValue(complex), true);
+    });
+
+    it('should accept arrays of complex objects', () => {
+      const arrayOfObjects = [
+        { name: 'obj1', value: 123 },
+        { name: 'obj2', nested: { deep: 'value' } },
+        { bytes: new Uint8Array([1, 2, 3]) }
+      ];
+      assert.strictEqual(isLogAttributeValue(arrayOfObjects), true);
+    });
+  });
+
+  describe('should reject invalid values', () => {
+    it('should reject functions', () => {
+      assert.strictEqual(isLogAttributeValue(() => {}), false);
+      assert.strictEqual(isLogAttributeValue(function() {}), false);
+    });
+
+    it('should reject symbols', () => {
+      assert.strictEqual(isLogAttributeValue(Symbol('test')), false);
+      assert.strictEqual(isLogAttributeValue(Symbol.for('test')), false);
+    });
+
+    it('should reject Date objects', () => {
+      assert.strictEqual(isLogAttributeValue(new Date()), false);
+    });
+
+    it('should reject RegExp objects', () => {
+      assert.strictEqual(isLogAttributeValue(/test/), false);
+    });
+
+    it('should reject Error objects', () => {
+      assert.strictEqual(isLogAttributeValue(new Error('test')), false);
+    });
+
+    it('should reject class instances', () => {
+      class TestClass {
+        value = 'test';
+      }
+      assert.strictEqual(isLogAttributeValue(new TestClass()), false);
+    });
+
+    it('should reject arrays containing invalid values', () => {
+      assert.strictEqual(isLogAttributeValue(['valid', () => {}]), false);
+      assert.strictEqual(isLogAttributeValue([Symbol('test'), 'valid']), false);
+      assert.strictEqual(isLogAttributeValue([new Date()]), false);
+    });
+
+    it('should reject objects containing invalid values', () => {
+      assert.strictEqual(isLogAttributeValue({ valid: 'test', invalid: () => {} }), false);
+      assert.strictEqual(isLogAttributeValue({ symbol: Symbol('test') }), false);
+      assert.strictEqual(isLogAttributeValue({ date: new Date() }), false);
+    });
+
+    it('should reject deeply nested invalid values', () => {
+      const nested = {
+        level1: {
+          level2: {
+            valid: 'value',
+            invalid: Symbol('test')
+          }
+        }
+      };
+      assert.strictEqual(isLogAttributeValue(nested), false);
+    });
+
+    it('should reject arrays with nested invalid values', () => {
+      const nestedArray = [
+        ['valid', 'array'],
+        ['has', Symbol('invalid')]
+      ];
+      assert.strictEqual(isLogAttributeValue(nestedArray), false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle circular references gracefully', () => {
+      const circular: any = { a: 'test' };
+      circular.self = circular;
+      
+      // This should not throw an error, though it might return false
+      // The exact behavior isn't specified in the OpenTelemetry spec
+      const result = isLogAttributeValue(circular);
+      assert.strictEqual(typeof result, 'boolean');
+    });
+
+    it('should handle very deep nesting', () => {
+      let deep: any = 'bottom';
+      for (let i = 0; i < 100; i++) {
+        deep = { level: i, nested: deep };
+      }
+      
+      const result = isLogAttributeValue(deep);
+      assert.strictEqual(typeof result, 'boolean');
+    });
+
+    it('should handle large arrays', () => {
+      const largeArray = new Array(1000).fill('test');
+      assert.strictEqual(isLogAttributeValue(largeArray), true);
+    });
+  });
+}); 

--- a/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
@@ -25,6 +25,7 @@ import {
   TraceFlags,
 } from '@opentelemetry/api';
 import * as logsAPI from '@opentelemetry/api-logs';
+import { AnyValue } from '@opentelemetry/api-logs';
 import type { HrTime } from '@opentelemetry/api';
 import { hrTimeToMilliseconds, timeInputToHrTime } from '@opentelemetry/core';
 import { defaultResource } from '@opentelemetry/resources';
@@ -424,6 +425,195 @@ describe('LogRecord', () => {
         'Can not execute the operation on emitted log record'
       );
       warnStub.restore();
+    });
+  });
+
+  describe('OpenTelemetry Log Attributes spec compliance', () => {
+    describe('should support all AnyValue types per OpenTelemetry spec', () => {
+      it('should support scalar values (string, number, boolean)', () => {
+        const { logRecord } = setup();
+        logRecord.setAttribute('string', 'test');
+        logRecord.setAttribute('number', 42);
+        logRecord.setAttribute('boolean', true);
+        logRecord.setAttribute('negativeNumber', -123.45);
+        
+        assert.strictEqual(logRecord.attributes.string, 'test');
+        assert.strictEqual(logRecord.attributes.number, 42);
+        assert.strictEqual(logRecord.attributes.boolean, true);
+        assert.strictEqual(logRecord.attributes.negativeNumber, -123.45);
+      });
+
+      it('should support byte arrays (Uint8Array)', () => {
+        const { logRecord } = setup();
+        const byteArray = new Uint8Array([1, 2, 3, 4, 5]);
+        logRecord.setAttribute('bytes', byteArray);
+        
+        assert.deepStrictEqual(logRecord.attributes.bytes, byteArray);
+        assert.ok(logRecord.attributes.bytes instanceof Uint8Array);
+      });
+
+      it('should support heterogeneous arrays (arrays with mixed types)', () => {
+        const { logRecord } = setup();
+        const mixedArray = ['string', 42, true, null, new Uint8Array([1, 2])];
+        logRecord.setAttribute('mixedArray', mixedArray);
+        
+        assert.deepStrictEqual(logRecord.attributes.mixedArray, mixedArray);
+      });
+
+      it('should support nested arrays', () => {
+        const { logRecord } = setup();
+        const nestedArray = [['a', 'b'], [1, 2], [true, false]];
+        logRecord.setAttribute('nestedArray', nestedArray);
+        
+        assert.deepStrictEqual(logRecord.attributes.nestedArray, nestedArray);
+      });
+
+      it('should support nested objects/maps', () => {
+        const { logRecord } = setup();
+        const nestedObject = {
+          level1: {
+            level2: {
+              string: 'deep value',
+              number: 123,
+              array: ['nested', 'array']
+            }
+          },
+          topLevel: 'value'
+        };
+        logRecord.setAttribute('nested', nestedObject);
+        
+        assert.deepStrictEqual(logRecord.attributes.nested, nestedObject);
+      });
+
+      it('should support empty objects', () => {
+        const { logRecord } = setup();
+        const emptyObj = {};
+        logRecord.setAttribute('empty', emptyObj);
+        
+        assert.deepStrictEqual(logRecord.attributes.empty, emptyObj);
+      });
+
+      it('should support null and undefined values', () => {
+        const { logRecord } = setup();
+        logRecord.setAttribute('nullValue', null);
+        logRecord.setAttribute('undefinedValue', undefined);
+        
+        assert.strictEqual(logRecord.attributes.nullValue, null);
+        assert.strictEqual(logRecord.attributes.undefinedValue, undefined);
+      });
+
+      it('should support complex combinations of AnyValue types', () => {
+        const { logRecord } = setup();
+        const complexValue = {
+          scalars: {
+            str: 'test',
+            num: 42,
+            bool: true
+          },
+          arrays: {
+            homogeneous: ['a', 'b', 'c'],
+            heterogeneous: [1, 'two', true, null],
+            nested: [[1, 2], ['a', 'b']]
+          },
+          bytes: new Uint8Array([255, 254, 253]),
+          nullish: {
+            nullValue: null,
+            undefinedValue: undefined
+          },
+          empty: {}
+        };
+        logRecord.setAttribute('complex', complexValue);
+        
+        assert.deepStrictEqual(logRecord.attributes.complex, complexValue);
+      });
+    });
+
+    describe('should properly truncate string values in complex structures', () => {
+      it('should truncate strings in nested objects', () => {
+        const { logRecord } = setup({ attributeValueLengthLimit: 5 });
+        const nestedObject = {
+          level1: {
+            shortString: 'ok',
+            longString: 'this is too long'
+          },
+          topLevelLong: 'also too long'
+        };
+        logRecord.setAttribute('nested', nestedObject);
+        
+        const expected = {
+          level1: {
+            shortString: 'ok',
+            longString: 'this '
+          },
+          topLevelLong: 'also '
+        };
+        assert.deepStrictEqual(logRecord.attributes.nested, expected);
+      });
+
+      it('should truncate strings in heterogeneous arrays', () => {
+        const { logRecord } = setup({ attributeValueLengthLimit: 5 });
+        const mixedArray = ['short', 'this is too long', 42, true, 'another long string'];
+        logRecord.setAttribute('mixed', mixedArray);
+        
+        const expected = ['short', 'this ', 42, true, 'anoth'];
+        assert.deepStrictEqual(logRecord.attributes.mixed, expected);
+      });
+
+      it('should not truncate non-string values', () => {
+        const { logRecord } = setup({ attributeValueLengthLimit: 5 });
+        const byteArray = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+        logRecord.setAttribute('bytes', byteArray);
+        
+        // Byte arrays should not be truncated
+        assert.deepStrictEqual(logRecord.attributes.bytes, byteArray);
+      });
+    });
+
+    describe('should reject invalid values', () => {
+      it('should reject functions', () => {
+        const warnStub = sinon.spy(diag, 'warn');
+        const { logRecord } = setup();
+        logRecord.setAttribute('func', (() => 'test') as unknown as AnyValue);
+        
+        assert.strictEqual(logRecord.attributes.func, undefined);
+        sinon.assert.calledWith(warnStub, 'Invalid attribute value set for key: func');
+        warnStub.restore();
+      });
+
+      it('should reject symbols', () => {
+        const warnStub = sinon.spy(diag, 'warn');
+        const { logRecord } = setup();
+        logRecord.setAttribute('symbol', Symbol('test') as any);
+        
+        assert.strictEqual(logRecord.attributes.symbol, undefined);
+        sinon.assert.calledWith(warnStub, 'Invalid attribute value set for key: symbol');
+        warnStub.restore();
+      });
+
+      it('should reject objects with invalid nested values', () => {
+        const warnStub = sinon.spy(diag, 'warn');
+        const { logRecord } = setup();
+        const invalidNested = {
+          valid: 'string',
+          invalid: Symbol('test')
+        };
+        logRecord.setAttribute('nested', invalidNested as any);
+        
+        assert.strictEqual(logRecord.attributes.nested, undefined);
+        sinon.assert.calledWith(warnStub, 'Invalid attribute value set for key: nested');
+        warnStub.restore();
+      });
+
+      it('should reject arrays with invalid nested values', () => {
+        const warnStub = sinon.spy(diag, 'warn');
+        const { logRecord } = setup();
+        const invalidArray = ['valid', Symbol('invalid')];
+        logRecord.setAttribute('array', invalidArray as any);
+        
+        assert.strictEqual(logRecord.attributes.array, undefined);
+        sinon.assert.calledWith(warnStub, 'Invalid attribute value set for key: array');
+        warnStub.restore();
+      });
     });
   });
 

--- a/experimental/packages/sdk-logs/test/common/utils.ts
+++ b/experimental/packages/sdk-logs/test/common/utils.ts
@@ -22,13 +22,11 @@ export const validAttributes = {
   'array<number>': [1, 2],
   'array<bool>': [true, false],
   object: { bar: 'foo' },
+  'empty-object': {},
+  'non-homogeneous-array': [0, ''],
 };
 
 export const invalidAttributes = {
-  // invalid attribute empty object
-  object: {},
-  // invalid attribute inhomogeneous array
-  'non-homogeneous-array': [0, ''],
   // This empty length attribute should not be set
   '': 'empty-key',
 };


### PR DESCRIPTION

# Make Log Attributes fully spec compliant and handle circular references


## Which problem is this PR solving?

The current Log Attributes implementation is not fully compliant with the [OpenTelemetry specification](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-attributes). The specification states that Log Attributes should support "any type, a superset of standard Attribute" including:

- Byte arrays (`Uint8Array`)
- Heterogeneous arrays (mixed types like `[1, "two", true, null]`)
- Nested objects/maps with recursive `AnyValue` support
- Empty objects (`{}`)
- Null/undefined values

However, the current implementation uses the restrictive `isAttributeValue()` function from `@opentelemetry/core` which only supports homogeneous arrays and primitives. Additionally, there was an early return for `null` values preventing spec-compliant null attributes from being set.

This PR also addresses the circular reference investigation requested in the logs roadmap by implementing proper circular reference detection and handling.

Fixes #5744

## Short description of the changes

1. **Created `isLogAttributeValue()` validation function** in `@opentelemetry/api-logs` that supports all `AnyValue` types per the OpenTelemetry spec
2. **Added circular reference detection** using `WeakSet` to prevent stack overflow during validation
3. **Updated `LogRecordImpl`** to use the new spec-compliant validation function
4. **Enhanced truncation logic** to handle nested objects and heterogeneous arrays
5. **Removed null value early return** to allow spec-compliant null attributes
6. **Added comprehensive test coverage** with 32+ tests covering all spec requirements and edge cases

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] **Full test suite passes**: All existing tests continue to pass (101 passing, 0 failing)
- [x] **New validation function tests**: 32 comprehensive tests in `validation.test.ts` covering:
  - All scalar values (string, number, boolean)
  - Byte arrays (`Uint8Array`)
  - Heterogeneous arrays with mixed types
  - Nested objects and complex combinations
  - Circular reference detection and graceful handling
  - Invalid value rejection (functions, symbols, built-in objects)
  - Edge cases (deep nesting, large arrays)
- [x] **LogRecord integration tests**: 15 new tests in `LogRecord.test.ts` verifying:
  - All `AnyValue` types work with `setAttribute()`
  - Proper truncation of strings in complex structures
  - Null/undefined value support
  - Complex nested attribute structures


## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated (via comprehensive test documentation and JSDoc comments)

**Files changed**:
- `experimental/packages/api-logs/src/utils/validation.ts` (new)
- `experimental/packages/api-logs/src/index.ts` (export added)
- `experimental/packages/api-logs/test/common/utils/validation.test.ts` (new)
- `experimental/packages/sdk-logs/src/LogRecordImpl.ts` (updated)
- `experimental/packages/sdk-logs/test/common/LogRecord.test.ts` (tests added)
- `experimental/packages/sdk-logs/test/common/utils.ts` (updated for new behavior)