### PR TITLE
ci: add write permissions for secuity events

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
 
 permissions:
+  security-events: write
   contents: read
 
 jobs:


### PR DESCRIPTION
## Which problem is this PR solving?

In #5771, we reduced the workflows to the minimum token permissions. However, CodeQL has been failing and needs `security-events: write` permissions to work.


