### PR TITLE
refactor(otlp-exporter-base): remove pre-Node.js 14 compatibility code

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -9,6 +9,9 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :boom: Breaking Changes
 
 * feat(sdk-logs)!: Removed deprecated LoggerProvider#addLogRecordProcessor() [#5764](https://github.com/open-telemetry/opentelemetry-js/pull/5764) @svetlanabrennan
+* feat(sdk-logs)!: Changed `LogRecord` class to be an interface [#5749](https://github.com/open-telemetry/opentelemetry-js/pull/5749) @svetlanabrennan
+  * user-facing: `LogRecord` class is now not exported anymore. A newly exported interface `SdkLogRecord` is used in its place.
+* feat!: Removed `api-events` and `sdk-events` [#5737](https://github.com/open-telemetry/opentelemetry-js/pull/5737) @svetlanabrennan
 
 ### :rocket: Features
 
@@ -18,10 +21,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
-* feat(sdk-logs)!: Changed `LogRecord` class to be an interface [#5749](https://github.com/open-telemetry/opentelemetry-js/pull/5749) @svetlanabrennan
-  * user-facing: `LogRecord` class is now not exported anymore. A newly exported interface `SdkLogRecord` is used in its place.
-* refactor: Removed `api-events` and `sdk-events` [#5737](https://github.com/open-telemetry/opentelemetry-js/pull/5737) @svetlanabrennan
 * chore: Regenerated certs [#5752](https://github.com/open-telemetry/opentelemetry-js/pull/5752) @svetlanabrennan
+* refactor(otlp-exporter-base): remove compatibility code that was intended for now unsupported runtime Node.js v14 @pichlermarc
 
 ## 0.202.0
 

--- a/experimental/packages/otlp-exporter-base/src/transport/http-transport-utils.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/http-transport-utils.ts
@@ -41,7 +41,6 @@ export function sendWithHttp(
   timeoutMillis: number
 ): void {
   const parsedUrl = new URL(params.url);
-  const nodeVersion = Number(process.versions.node.split('.')[0]);
 
   const options: http.RequestOptions | https.RequestOptions = {
     hostname: parsedUrl.hostname,
@@ -92,18 +91,11 @@ export function sendWithHttp(
       error: new Error('Request Timeout'),
     });
   });
+
   req.on('error', (error: Error) => {
     onDone({
       status: 'failure',
       error,
-    });
-  });
-
-  const reportTimeoutErrorEvent = nodeVersion >= 14 ? 'close' : 'abort';
-  req.on(reportTimeoutErrorEvent, () => {
-    onDone({
-      status: 'failure',
-      error: new Error('Request timed out'),
     });
   });
 


### PR DESCRIPTION
## Which problem is this PR solving?

As far as I can tell, this code is never called unless the `req.setTimeout()` callback is called before it on Node.js >=18, so it is safe to drop.

## How Has This Been Tested?

- [x] Unit tests
