### PR TITLE
docs(semantic-conventions): correct placement of semconv 1.36.0 changes in changelog

### DIFF
--- a/semantic-conventions/CHANGELOG.md
+++ b/semantic-conventions/CHANGELOG.md
@@ -164,7 +164,6 @@ ATTR_ZOS_SYSPLEX_NAME                                           // zos.sysplex.n
 
 </details>
 
-
 ### :bug: Bug Fixes
 
 ### :books: Documentation


### PR DESCRIPTION
This is preparing for a version **1.36.0** release of the semantic-conventions package. The changes for the upstream semantic-conventions v1.36.0 changes (https://github.com/open-telemetry/opentelemetry-js/pull/5779) were accidentally published as version **1.35.0** (https://github.com/open-telemetry/opentelemetry-js/pull/5793/files#diff-e04894393ed485dee6ef24c193c578001fc6abe86be8eede46e3df699d239724R3).