### PR TITLE
fix: broken links in readme file

### DIFF
--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -109,20 +109,20 @@ The default will change to `false` in a future iteration of this package.
 
 ### metricReader
 
-Add a [MetricReader](../opentelemetry-sdk-metrics/src/export/MetricReader.ts)
+Add a [MetricReader](../../../packages/sdk-metrics/src/export/MetricReader.ts)
 that will be passed to the `MeterProvider`. If `metricReader` is not configured,
 the metrics SDK will not be initialized and registered.
 
 ### views
 
 A list of views to be passed to the `MeterProvider`.
-Accepts an array of [View](../opentelemetry-sdk-metrics/src/view/View.ts)-instances.
+Accepts an array of [View](../../../packages/sdk-metrics/src/view/View.ts)-instances.
 This parameter can be used to configure explicit bucket sizes of histogram metrics.
 
 ### instrumentations
 
 Configure instrumentations. By default none of the instrumentation is enabled,
-if you want to enable them you can use either [metapackage](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node)
+if you want to enable them you can use either [metapackage](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/auto-instrumentations-node)
 or configure each instrumentation individually.
 
 ### resource
@@ -173,7 +173,7 @@ Configure tracing parameters. These are the same trace parameters used to [confi
 
 ### serviceName
 
-Configure the [service name](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service).
+Configure the [service name](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/service.md#service-name).
 
 ## Disable the SDK from the environment
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Invalid links in the README file

Fixes # - N/A

## Short description of the changes

There are several links that take you to 404 pages. I fixed the ones that I could find as I was reading the docs.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

N/A

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated
