### PR TITLE
Chore(opentelemetry-instrumentation): Add override keyword and access…

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -124,7 +124,7 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
     );
   }
 
-  init(): void {}
+  protected override init(): void {}
 
   /**
    * Add cors pre flight child span

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
@@ -109,7 +109,7 @@ export class GrpcInstrumentation extends InstrumentationBase<GrpcInstrumentation
     );
   }
 
-  init() {
+  protected override init() {
     return [
       new InstrumentationNodeModuleDefinition(
         '@grpc/grpc-js',

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -197,7 +197,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
     this._headerCapture = this._createHeaderCapture();
   }
 
-  init(): [
+  protected override init(): [
     InstrumentationNodeModuleDefinition,
     InstrumentationNodeModuleDefinition,
   ] {

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -128,7 +128,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
     );
   }
 
-  init() {}
+  protected override init() {}
 
   /**
    * Adds custom headers to XMLHttpRequest


### PR DESCRIPTION
… modifier to init()

The init() function is a template method that all classes derived from InstrumentationAbstract must override. Adding an access modifier aligns it with the parent class. Explicitly adding the override keyword improves code readability.

Tests:
npm run compile
npm run lint
npm run test


