### PR TITLE
feat(sdk-trace-base): add tracerFactory option to TracerConfig

### DIFF
--- a/experimental/packages/opentelemetry-sdk-node/src/types.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/types.ts
@@ -26,6 +26,7 @@ import {
   SpanLimits,
   SpanProcessor,
   IdGenerator,
+  TracerFactory,
 } from '@opentelemetry/sdk-trace-base';
 
 export interface NodeSDKConfiguration {
@@ -48,4 +49,5 @@ export interface NodeSDKConfiguration {
   traceExporter: SpanExporter;
   spanLimits: SpanLimits;
   idGenerator: IdGenerator;
+  tracerFactory: TracerFactory;
 }

--- a/packages/opentelemetry-sdk-trace-base/src/index.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/index.ts
@@ -38,5 +38,6 @@ export type {
   SDKRegistrationConfig,
   SpanLimits,
   TracerConfig,
+  TracerFactory,
 } from './types';
 export type { IdGenerator } from './IdGenerator';

--- a/packages/opentelemetry-sdk-trace-base/src/types.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/types.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { ContextManager, TextMapPropagator } from '@opentelemetry/api';
+import { ContextManager, TextMapPropagator, Tracer } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
 import { IdGenerator } from './IdGenerator';
 import { Sampler } from './Sampler';
 import { SpanProcessor } from './SpanProcessor';
+import { InstrumentationScope } from '@opentelemetry/core';
 
 /**
  * TracerConfig provides an interface for configuring a Basic Tracer.
@@ -54,7 +55,19 @@ export interface TracerConfig {
    * List of SpanProcessor for the tracer
    */
   spanProcessors?: SpanProcessor[];
+
+  /**
+   * Factory function for creating a tracer instance
+   */
+  tracerFactory?: TracerFactory;
 }
+
+export type TracerFactory = (
+  instrumentationScope: InstrumentationScope,
+  config: TracerConfig,
+  resource: Resource,
+  spanProcessor: SpanProcessor
+) => Tracer;
 
 /**
  * Configuration options for registering the API with the SDK.

--- a/packages/opentelemetry-sdk-trace-base/test/common/BasicTracerProvider.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/BasicTracerProvider.test.ts
@@ -104,6 +104,38 @@ describe('BasicTracerProvider', () => {
       });
     });
 
+    describe('when "tracerFactory" option defined', () => {
+      it('should use custom tracer factory when provided', () => {
+        const customTracerFactory = sinon
+          .stub()
+          .returns(
+            new Tracer(
+              { name: 'test', version: '1.0.0' },
+              {},
+              defaultResource(),
+              new NoopSpanProcessor()
+            )
+          );
+
+        const tracerProvider = new BasicTracerProvider({
+          tracerFactory: customTracerFactory,
+        });
+
+        const tracer = tracerProvider.getTracer('test-tracer');
+
+        sinon.assert.calledOnce(customTracerFactory);
+
+        assert.ok(tracer instanceof Tracer);
+      });
+
+      it('should use default factory when tracerFactory is undefined', () => {
+        const tracerProvider = new BasicTracerProvider({});
+        const tracer = tracerProvider.getTracer('default-tracer');
+
+        assert.ok(tracer instanceof Tracer);
+      });
+    });
+
     describe('generalLimits', () => {
       describe('when not defined default values', () => {
         it('should have tracer with default values', () => {


### PR DESCRIPTION


<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Allows a different Tracer/Span implementation to be used by the TracerProvider and the SDKs in cases where behavior needs to be customized by passing a `tracerFactory` option to `NodeSDK` and `BasicTracerProvider`.  This allows customizing this one component of otel without having to write my own SDK and BasicTracerProvider and support code. 

I observed significant increases in CPU usage from garbage collection/memory pressure in an application when increasing the percentage of traces that were recorded (even if not sampled). Doing some memory benchmarking/profiling, it turns out that creating a single 20 attribute span (200B data) allocates 4.8KiB across 111 objects while a NonRecordingSpan takes 1.4 KiB across 40 objects. With [optimization](https://github.com/schleyfox/otel-js-lightweight-tracer), I was able to reduce this to 650B across 18 objects per Span. Unfortunately, these optimizations are unlikely to be broadly applicable or acceptable to this project as the bulk of the improvement came from removing attribute sanitization (previously identified in https://github.com/open-telemetry/opentelemetry-js/pull/4558), runtime type checking of attributes, and the enforcement of limits on attribute count or size (and the other optimizations are objectively quite ugly). These will have to stay as custom implementations of Tracer/Span.

There was no way for me to inject a custom Tracer implementation without fully reimplementing NodeSDK, so this adds an optional way to pass a tracerFactory through the sdk and the tracer provider like:

```
const sdk = new NodeSDK({
  tracerFactory: lightweightTracerFactory,
  ...
})
```

You can see the intended usage (and full benchmarks/code) in https://github.com/schleyfox/otel-js-lightweight-tracer

## Short description of the changes

Adds an optional `tracerFactory` function to `TracerConfig` that is used by `BasicTracerProvider` to construct a `Tracer`.

### Notes

From a naming perspective, it seems silly to have a tracerFactory that gets passed to a tracerProvider, ideally, you'd just inject a custom `tracerProvider` like you would a `sampler` or `traceExporter`, but that's awkward because constructing the tracerProvider depends on the `resource` and `spanProcessors` that are created when the sdk is started.

<details>
<summary>Code ref</summary>

```ts
  public start(): void {
  ...

    if (this._autoDetectResources) {
      const internalConfig: ResourceDetectionConfig = {
        detectors: this._resourceDetectors,
      };

      this._resource = this._resource.merge(detectResources(internalConfig));
    }

    this._resource =
      this._serviceName === undefined
        ? this._resource
        : this._resource.merge(
            resourceFromAttributes({
              [ATTR_SERVICE_NAME]: this._serviceName,
            })
          );

    const spanProcessors = this._tracerProviderConfig
      ? this._tracerProviderConfig.spanProcessors
      : getSpanProcessorsFromEnv();

    this._tracerProvider = new NodeTracerProvider({
      ...this._configuration,
      resource: this._resource,
      spanProcessors,
    }); 
```

</details>

The TracerProvider also handles not just the creation of Tracers, but also their caching/management. Logic that I had no desire to reimplement (subclassing BasicTracingProvider would work, but also seems misaligned with the direction in https://github.com/open-telemetry/opentelemetry-js/issues/5283)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests
- [x] Locally exercised this under benchmarks in https://github.com/schleyfox/otel-js-lightweight-tracer

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
