### PR TITLE
ci: disable --experimental-strip-types on Node.js 22 (for windows tests too)

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -101,6 +101,8 @@ jobs:
 
       - name: Unit tests
         run: npm run test
+        env:
+          NODE_OPTIONS: '--no-experimental-strip-types'
   browser-tests:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Refs: https://github.com/open-telemetry/opentelemetry-js/pull/5851

