### PR TITLE
ci: stop testing against Node.js v23, v24 suffices

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
           - "20.6.0"
           - "20"
           - "22"
-          - "23"
+          - "24"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -44,7 +44,7 @@ jobs:
         if: ${{
           matrix.node_version == '20' ||
           matrix.node_version == '22' ||
-          matrix.node_version == '23'
+          matrix.node_version == '24'
           }}
 
       - name: Bootstrap

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,7 +20,6 @@ jobs:
           - "20.6.0"
           - "20"
           - "22"
-          - "23"
           - "24"
     runs-on: ubuntu-latest
     env:
@@ -49,7 +48,6 @@ jobs:
         if: ${{
           matrix.node_version == '20' ||
           matrix.node_version == '22' ||
-          matrix.node_version == '23' ||
           matrix.node_version == '24'
           }}
 
@@ -60,13 +58,13 @@ jobs:
         run: npm run compile
 
       - run: npm test
-        if: ${{ matrix.node_version != '22' && matrix.node_version != '23' && matrix.node_version != '24' }}
-      # Node.js >= 23 type stripping conflicts with mocha usage of ts-node.
+        if: ${{ matrix.node_version != '22' && matrix.node_version != '24' }}
+      # Node.js type stripping conflicts with mocha usage of ts-node.
       # See https://github.com/open-telemetry/opentelemetry-js/issues/5415
       - run: npm test
         env:
           NODE_OPTIONS: '--no-experimental-strip-types'
-        if: ${{ matrix.node_version == '22' || matrix.node_version == '23' || matrix.node_version == '24' }}
+        if: ${{ matrix.node_version == '22' || matrix.node_version == '24' }}
 
       - name: Report Coverage
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
No need to be testing against Node.js v23 when we can test v24.

(FWIW, https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2984 added testing Node.js v24 for the contrib repo.)