### PR TITLE
feat(opentelemetry-configuration): creation of basic FileConfigProvider 

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -13,6 +13,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :rocket: Features
 
 *feat(opentelemetry-configuration): creation of basic ConfigProvider [#5809](https://github.com/open-telemetry/opentelemetry-js/pull/5809) @maryliag
+*feat(opentelemetry-configuration): creation of basic FileConfigProvider [#5863](https://github.com/open-telemetry/opentelemetry-js/pull/5863) @maryliag
 
 ### :bug: Bug Fixes
 

--- a/experimental/packages/opentelemetry-configuration/src/ConfigProvider.ts
+++ b/experimental/packages/opentelemetry-configuration/src/ConfigProvider.ts
@@ -16,7 +16,11 @@
 
 import { ConfigProvider } from './IConfigProvider';
 import { EnvironmentConfigProvider } from './EnvironmentConfigProvider';
+import { FileConfigProvider, hasValidConfigFile } from './FileConfigProvider';
 
 export function createConfigProvider(): ConfigProvider {
+  if (hasValidConfigFile()) {
+    return new FileConfigProvider();
+  }
   return new EnvironmentConfigProvider();
 }

--- a/experimental/packages/opentelemetry-configuration/src/FileConfigProvider.ts
+++ b/experimental/packages/opentelemetry-configuration/src/FileConfigProvider.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { getStringFromEnv } from '@opentelemetry/core';
+import {
+  ConfigurationModel,
+  initializeDefaultConfiguration,
+} from './configModel';
+import { ConfigProvider } from './IConfigProvider';
+import * as fs from 'fs';
+
+export class FileConfigProvider implements ConfigProvider {
+  private _config: ConfigurationModel;
+
+  constructor() {
+    this._config = initializeDefaultConfiguration();
+  }
+
+  getInstrumentationConfig(): ConfigurationModel {
+    return this._config;
+  }
+}
+
+export function hasValidConfigFile(): boolean {
+  const configFile = getStringFromEnv('OTEL_EXPERIMENTAL_CONFIG_FILE');
+  if (configFile) {
+    if (!configFile.endsWith('.yaml') || !fs.existsSync(configFile)) {
+      throw new Error(
+        `Config file ${configFile} set on OTEL_EXPERIMENTAL_CONFIG_FILE is not valid`
+      );
+    }
+    return true;
+  }
+  return false;
+}

--- a/experimental/packages/opentelemetry-configuration/test/ConfigProvider.test.ts
+++ b/experimental/packages/opentelemetry-configuration/test/ConfigProvider.test.ts
@@ -121,5 +121,23 @@ describe('ConfigProvider', function () {
         createConfigProvider();
       });
     });
+
+    it('should initialize config with default values with empty string for config file', function () {
+      process.env.OTEL_EXPERIMENTAL_CONFIG_FILE = '';
+      const configProvider = createConfigProvider();
+      assert.deepStrictEqual(
+        configProvider.getInstrumentationConfig(),
+        defaultConfig
+      );
+    });
+
+    it('should initialize config with default values with all whitespace for config file', function () {
+      process.env.OTEL_EXPERIMENTAL_CONFIG_FILE = '  ';
+      const configProvider = createConfigProvider();
+      assert.deepStrictEqual(
+        configProvider.getInstrumentationConfig(),
+        defaultConfig
+      );
+    });
   });
 });

--- a/experimental/packages/opentelemetry-configuration/test/ConfigProvider.test.ts
+++ b/experimental/packages/opentelemetry-configuration/test/ConfigProvider.test.ts
@@ -99,4 +99,27 @@ describe('ConfigProvider', function () {
       );
     });
   });
+
+  describe('get values from config file', function () {
+    afterEach(function () {
+      delete process.env.OTEL_EXPERIMENTAL_CONFIG_FILE;
+    });
+
+    it('should initialize config with default values from valid config file', function () {
+      process.env.OTEL_EXPERIMENTAL_CONFIG_FILE =
+        'test/fixtures/kitchen-sink.yaml';
+      const configProvider = createConfigProvider();
+      assert.deepStrictEqual(
+        configProvider.getInstrumentationConfig(),
+        defaultConfig
+      );
+    });
+
+    it('should return error from invalid config file', function () {
+      process.env.OTEL_EXPERIMENTAL_CONFIG_FILE = './fixtures/kitchen-sink.txt';
+      assert.throws(() => {
+        createConfigProvider();
+      });
+    });
+  });
 });

--- a/experimental/packages/opentelemetry-configuration/test/fixtures/kitchen-sink.yaml
+++ b/experimental/packages/opentelemetry-configuration/test/fixtures/kitchen-sink.yaml
@@ -1,0 +1,947 @@
+# kitchen-sink.yaml demonstrates all configurable surface area, including explanatory comments.
+#
+# It DOES NOT represent expected real world configuration, as it makes strange configuration
+# choices in an effort to exercise the full surface area.
+#
+# Configuration values are set to their defaults when default values are defined.
+
+# The file format version.
+# The yaml format is documented at
+# https://github.com/open-telemetry/opentelemetry-configuration/tree/main/schema
+file_format: "1.0-rc.1"
+# Configure if the SDK is disabled or not.
+# If omitted or null, false is used.
+disabled: false
+# Configure the log level of the internal logger used by the SDK.
+# If omitted, info is used.
+log_level: info
+# Configure general attribute limits. See also tracer_provider.limits, logger_provider.limits.
+attribute_limits:
+  # Configure max attribute value size. 
+  # Value must be non-negative.
+  # If omitted or null, there is no limit.
+  attribute_value_length_limit: 4096
+  # Configure max attribute count. 
+  # Value must be non-negative.
+  # If omitted or null, 128 is used.
+  attribute_count_limit: 128
+# Configure logger provider.
+# If omitted, a noop logger provider is used.
+logger_provider:
+  # Configure log record processors.
+  processors:
+    - # Configure a batch log record processor.
+      batch:
+        # Configure delay interval (in milliseconds) between two consecutive exports. 
+        # Value must be non-negative.
+        # If omitted or null, 1000 is used.
+        schedule_delay: 5000
+        # Configure maximum allowed time (in milliseconds) to export data. 
+        # Value must be non-negative. A value of 0 indicates no limit (infinity).
+        # If omitted or null, 30000 is used.
+        export_timeout: 30000
+        # Configure maximum queue size. Value must be positive.
+        # If omitted or null, 2048 is used.
+        max_queue_size: 2048
+        # Configure maximum batch size. Value must be positive.
+        # If omitted or null, 512 is used.
+        max_export_batch_size: 512
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
+            endpoint: http://localhost:4318/v1/logs
+            # Configure certificate used to verify a server's TLS credentials. 
+            # Absolute path to certificate file in PEM format.
+            # If omitted or null, system default certificate verification is used for secure connections.
+            certificate_file: /app/cert.pem
+            # Configure mTLS private client key. 
+            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
+            # If omitted or null, mTLS is not used.
+            client_key_file: /app/cert.pem
+            # Configure mTLS client certificate. 
+            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
+            # If omitted or null, mTLS is not used.
+            client_certificate_file: /app/cert.pem
+            # Configure headers. Entries have higher priority than entries from .headers_list.
+            # If an entry's .value is null, the entry is ignored.
+            headers:
+              - name: api-key
+                value: "1234"
+            # Configure headers. Entries have lower priority than entries from .headers.
+            # The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
+            # If omitted or null, no headers are added.
+            headers_list: "api-key=1234"
+            # Configure compression.
+            # Values include: gzip, none. Implementations may support other compression algorithms.
+            # If omitted or null, none is used.
+            compression: gzip
+            # Configure max time (in milliseconds) to wait for each export. 
+            # Value must be non-negative. A value of 0 indicates no limit (infinity).
+            # If omitted or null, 10000 is used.
+            timeout: 10000
+            # Configure the encoding used for messages. 
+            # Values include: protobuf, json. Implementations may not support json.
+            # If omitted or null, protobuf is used.
+            encoding: protobuf
+    - # Configure a batch log record processor.
+      batch:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with gRPC transport.
+          otlp_grpc:
+            # Configure endpoint.
+            # If omitted or null, http://localhost:4317 is used.
+            endpoint: http://localhost:4317
+            # Configure certificate used to verify a server's TLS credentials. 
+            # Absolute path to certificate file in PEM format.
+            # If omitted or null, system default certificate verification is used for secure connections.
+            certificate_file: /app/cert.pem
+            # Configure mTLS private client key. 
+            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
+            # If omitted or null, mTLS is not used.
+            client_key_file: /app/cert.pem
+            # Configure mTLS client certificate. 
+            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
+            # If omitted or null, mTLS is not used.
+            client_certificate_file: /app/cert.pem
+            # Configure headers. Entries have higher priority than entries from .headers_list.
+            # If an entry's .value is null, the entry is ignored.
+            headers:
+              - name: api-key
+                value: "1234"
+            # Configure headers. Entries have lower priority than entries from .headers.
+            # The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
+            # If omitted or null, no headers are added.
+            headers_list: "api-key=1234"
+            # Configure compression.
+            # Values include: gzip, none. Implementations may support other compression algorithms.
+            # If omitted or null, none is used.
+            compression: gzip
+            # Configure max time (in milliseconds) to wait for each export. 
+            # Value must be non-negative. A value of 0 indicates no limit (infinity).
+            # If omitted or null, 10000 is used.
+            timeout: 10000
+            # Configure client transport security for the exporter's connection. 
+            # Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
+            # If omitted or null, false is used.
+            insecure: false
+    - # Configure a batch log record processor.
+      batch:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with file transport.
+          # This type is in development and subject to breaking changes in minor versions.
+          otlp_file/development:
+            # Configure output stream. 
+            # Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # If omitted or null, stdout is used.
+            output_stream: file:///var/log/logs.jsonl
+    - # Configure a batch log record processor.
+      batch:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with file transport.
+          # This type is in development and subject to breaking changes in minor versions.
+          otlp_file/development:
+            # Configure output stream. 
+            # Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # If omitted or null, stdout is used.
+            output_stream: stdout
+    - # Configure a simple log record processor.
+      simple:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be console.
+          console:
+  # Configure log record limits. See also attribute_limits.
+  limits:
+    # Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit. 
+    # Value must be non-negative.
+    # If omitted or null, there is no limit.
+    attribute_value_length_limit: 4096
+    # Configure max attribute count. Overrides .attribute_limits.attribute_count_limit. 
+    # Value must be non-negative.
+    # If omitted or null, 128 is used.
+    attribute_count_limit: 128
+  # Configure loggers.
+  # This type is in development and subject to breaking changes in minor versions.
+  logger_configurator/development:
+    # Configure the default logger config used there is no matching entry in .logger_configurator/development.loggers.
+    default_config:
+      # Configure if the logger is enabled or not.
+      disabled: true
+    # Configure loggers.
+    loggers:
+      - # Configure logger names to match, evaluated as follows:
+        #
+        #  * If the logger name exactly matches.
+        #  * If the logger name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+        name: io.opentelemetry.contrib.*
+        # The logger config.
+        config:
+          # Configure if the logger is enabled or not.
+          disabled: false
+# Configure meter provider.
+# If omitted, a noop meter provider is used.
+meter_provider:
+  # Configure metric readers.
+  readers:
+    - # Configure a pull based metric reader.
+      pull:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be prometheus.
+          # This type is in development and subject to breaking changes in minor versions.
+          prometheus/development:
+            # Configure host.
+            # If omitted or null, localhost is used.
+            host: localhost
+            # Configure port.
+            # If omitted or null, 9464 is used.
+            port: 9464
+            # Configure Prometheus Exporter to produce metrics without a unit suffix or UNIT metadata.
+            # If omitted or null, false is used.
+            without_units: false
+            # Configure Prometheus Exporter to produce metrics without a type suffix.
+            # If omitted or null, false is used.
+            without_type_suffix: false
+            # Configure Prometheus Exporter to produce metrics without a scope info metric.
+            # If omitted or null, false is used.
+            without_scope_info: false
+            # Configure Prometheus Exporter to add resource attributes as metrics attributes.
+            with_resource_constant_labels:
+              # Configure resource attributes to be included.
+              # Attribute keys from resources are evaluated to match as follows:
+              #  * If the value of the attribute key exactly matches.
+              #  * If the value of the attribute key matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+              # If omitted, no resource attributes are included.
+              included:
+                - "service*"
+              # Configure resource attributes to be excluded. Applies after .with_resource_constant_labels.included (i.e. excluded has higher priority than included).
+              # Attribute keys from resources are evaluated to match as follows:
+              #  * If the value of the attribute key exactly matches.
+              #  * If the value of the attribute key matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+              # If omitted, .included resource attributes are included.
+              excluded:
+                - "service.attr1"
+        # Configure metric producers.
+        producers:
+          - # Configure metric producer to be opencensus.
+            opencensus:
+        # Configure cardinality limits.
+        cardinality_limits:
+          # Configure default cardinality limit for all instrument types.
+          # Instrument-specific cardinality limits take priority. 
+          # If omitted or null, 2000 is used.
+          default: 2000
+          # Configure default cardinality limit for counter instruments.
+          # If omitted or null, the value from .default is used.
+          counter: 2000
+          # Configure default cardinality limit for gauge instruments.
+          # If omitted or null, the value from .default is used.
+          gauge: 2000
+          # Configure default cardinality limit for histogram instruments.
+          # If omitted or null, the value from .default is used.
+          histogram: 2000
+          # Configure default cardinality limit for observable_counter instruments.
+          # If omitted or null, the value from .default is used.
+          observable_counter: 2000
+          # Configure default cardinality limit for observable_gauge instruments.
+          # If omitted or null, the value from .default is used.
+          observable_gauge: 2000
+          # Configure default cardinality limit for observable_up_down_counter instruments.
+          # If omitted or null, the value from .default is used.
+          observable_up_down_counter: 2000
+          # Configure default cardinality limit for up_down_counter instruments.
+          # If omitted or null, the value from .default is used.
+          up_down_counter: 2000
+    - # Configure a periodic metric reader.
+      periodic:
+        # Configure delay interval (in milliseconds) between start of two consecutive exports. 
+        # Value must be non-negative.
+        # If omitted or null, 60000 is used.
+        interval: 60000
+        # Configure maximum allowed time (in milliseconds) to export data. 
+        # Value must be non-negative. A value of 0 indicates no limit (infinity).
+        # If omitted or null, 30000 is used.
+        timeout: 30000
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
+            # Configure endpoint, including the metric specific path.
+            # If omitted or null, http://localhost:4318/v1/metrics is used.
+            endpoint: http://localhost:4318/v1/metrics
+            # Configure certificate used to verify a server's TLS credentials. 
+            # Absolute path to certificate file in PEM format.
+            # If omitted or null, system default certificate verification is used for secure connections.
+            certificate_file: /app/cert.pem
+            # Configure mTLS private client key. 
+            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
+            # If omitted or null, mTLS is not used.
+            client_key_file: /app/cert.pem
+            # Configure mTLS client certificate. 
+            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
+            # If omitted or null, mTLS is not used.
+            client_certificate_file: /app/cert.pem
+            # Configure headers. Entries have higher priority than entries from .headers_list.
+            # If an entry's .value is null, the entry is ignored.
+            headers:
+              - name: api-key
+                value: "1234"
+            # Configure headers. Entries have lower priority than entries from .headers.
+            # The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
+            # If omitted or null, no headers are added.
+            headers_list: "api-key=1234"
+            # Configure compression.
+            # Values include: gzip, none. Implementations may support other compression algorithms.
+            # If omitted or null, none is used.
+            compression: gzip
+            # Configure max time (in milliseconds) to wait for each export. 
+            # Value must be non-negative. A value of 0 indicates no limit (infinity).
+            # If omitted or null, 10000 is used.
+            timeout: 10000
+            # Configure the encoding used for messages. 
+            # Values include: protobuf, json. Implementations may not support json.
+            # If omitted or null, protobuf is used.
+            encoding: protobuf
+            # Configure temporality preference. 
+            # Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, cumulative is used.
+            temporality_preference: delta
+            # Configure default histogram aggregation. 
+            # Values include: explicit_bucket_histogram, base2_exponential_bucket_histogram. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, explicit_bucket_histogram is used.
+            default_histogram_aggregation: base2_exponential_bucket_histogram
+        # Configure metric producers.
+        producers:
+          - # Configure metric producer to be prometheus.
+            prometheus:
+        # Configure cardinality limits.
+        cardinality_limits:
+          # Configure default cardinality limit for all instrument types.
+          # Instrument-specific cardinality limits take priority. 
+          # If omitted or null, 2000 is used.
+          default: 2000
+          # Configure default cardinality limit for counter instruments.
+          # If omitted or null, the value from .default is used.
+          counter: 2000
+          # Configure default cardinality limit for gauge instruments.
+          # If omitted or null, the value from .default is used.
+          gauge: 2000
+          # Configure default cardinality limit for histogram instruments.
+          # If omitted or null, the value from .default is used.
+          histogram: 2000
+          # Configure default cardinality limit for observable_counter instruments.
+          # If omitted or null, the value from .default is used.
+          observable_counter: 2000
+          # Configure default cardinality limit for observable_gauge instruments.
+          # If omitted or null, the value from .default is used.
+          observable_gauge: 2000
+          # Configure default cardinality limit for observable_up_down_counter instruments.
+          # If omitted or null, the value from .default is used.
+          observable_up_down_counter: 2000
+          # Configure default cardinality limit for up_down_counter instruments.
+          # If omitted or null, the value from .default is used.
+          up_down_counter: 2000
+    - # Configure a periodic metric reader.
+      periodic:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with gRPC transport.
+          otlp_grpc:
+            # Configure endpoint.
+            # If omitted or null, http://localhost:4317 is used.
+            endpoint: http://localhost:4317
+            # Configure certificate used to verify a server's TLS credentials. 
+            # Absolute path to certificate file in PEM format.
+            # If omitted or null, system default certificate verification is used for secure connections.
+            certificate_file: /app/cert.pem
+            # Configure mTLS private client key. 
+            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
+            # If omitted or null, mTLS is not used.
+            client_key_file: /app/cert.pem
+            # Configure mTLS client certificate. 
+            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
+            # If omitted or null, mTLS is not used.
+            client_certificate_file: /app/cert.pem
+            # Configure headers. Entries have higher priority than entries from .headers_list.
+            # If an entry's .value is null, the entry is ignored.
+            headers:
+              - name: api-key
+                value: "1234"
+            # Configure headers. Entries have lower priority than entries from .headers.
+            # The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
+            # If omitted or null, no headers are added.
+            headers_list: "api-key=1234"
+            # Configure compression.
+            # Values include: gzip, none. Implementations may support other compression algorithms.
+            # If omitted or null, none is used.
+            compression: gzip
+            # Configure max time (in milliseconds) to wait for each export. 
+            # Value must be non-negative. A value of 0 indicates no limit (infinity).
+            # If omitted or null, 10000 is used.
+            timeout: 10000
+            # Configure client transport security for the exporter's connection. 
+            # Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
+            # If omitted or null, false is used.
+            insecure: false
+            # Configure temporality preference. 
+            # Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, cumulative is used.
+            temporality_preference: delta
+            # Configure default histogram aggregation. 
+            # Values include: explicit_bucket_histogram, base2_exponential_bucket_histogram. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, explicit_bucket_histogram is used.
+            default_histogram_aggregation: base2_exponential_bucket_histogram
+    - # Configure a periodic metric reader.
+      periodic:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with file transport.
+          # This type is in development and subject to breaking changes in minor versions.
+          otlp_file/development:
+            # Configure output stream. 
+            # Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # If omitted or null, stdout is used.
+            output_stream: file:///var/log/metrics.jsonl
+            # Configure temporality preference. Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, cumulative is used.
+            temporality_preference: delta
+            # Configure default histogram aggregation. Values include: explicit_bucket_histogram, base2_exponential_bucket_histogram. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, explicit_bucket_histogram is used.
+            default_histogram_aggregation: base2_exponential_bucket_histogram
+    - # Configure a periodic metric reader.
+      periodic:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with file transport.
+          # This type is in development and subject to breaking changes in minor versions.
+          otlp_file/development:
+            # Configure output stream. 
+            # Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # If omitted or null, stdout is used.
+            output_stream: stdout
+            # Configure temporality preference. Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, cumulative is used.
+            temporality_preference: delta
+            # Configure default histogram aggregation. Values include: explicit_bucket_histogram, base2_exponential_bucket_histogram. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
+            # If omitted or null, explicit_bucket_histogram is used.
+            default_histogram_aggregation: base2_exponential_bucket_histogram
+    - # Configure a periodic metric reader.
+      periodic:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be console.
+          console:
+  # Configure views. 
+  # Each view has a selector which determines the instrument(s) it applies to, and a configuration for the resulting stream(s).
+  views:
+    - # Configure view selector. 
+      # Selection criteria is additive as described in https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-selection-criteria.
+      selector:
+        # Configure instrument name selection criteria.
+        # If omitted or null, all instrument names match.
+        instrument_name: my-instrument
+        # Configure instrument type selection criteria.
+        # Values include: counter, gauge, histogram, observable_counter, observable_gauge, observable_up_down_counter, up_down_counter.
+        # If omitted or null, all instrument types match.
+        instrument_type: histogram
+        # Configure the instrument unit selection criteria.
+        # If omitted or null, all instrument units match.
+        unit: ms
+        # Configure meter name selection criteria.
+        # If omitted or null, all meter names match.
+        meter_name: my-meter
+        # Configure meter version selection criteria.
+        # If omitted or null, all meter versions match.
+        meter_version: 1.0.0
+        # Configure meter schema url selection criteria.
+        # If omitted or null, all meter schema URLs match.
+        meter_schema_url: https://opentelemetry.io/schemas/1.16.0
+      # Configure view stream.
+      stream:
+        # Configure metric name of the resulting stream(s).
+        # If omitted or null, the instrument's original name is used.
+        name: new_instrument_name
+        # Configure metric description of the resulting stream(s).
+        # If omitted or null, the instrument's origin description is used.
+        description: new_description
+        # Configure aggregation of the resulting stream(s). 
+        # Values include: default, drop, explicit_bucket_histogram, base2_exponential_bucket_histogram, last_value, sum. For behavior of values see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#aggregation.
+        # If omitted, default is used.
+        aggregation:
+          # Configure aggregation to be explicit_bucket_histogram.
+          explicit_bucket_histogram:
+            # Configure bucket boundaries.
+            # If omitted, [0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000] is used.
+            boundaries:
+              [
+                0.0,
+                5.0,
+                10.0,
+                25.0,
+                50.0,
+                75.0,
+                100.0,
+                250.0,
+                500.0,
+                750.0,
+                1000.0,
+                2500.0,
+                5000.0,
+                7500.0,
+                10000.0
+              ]
+            # Configure record min and max.
+            # If omitted or null, true is used.
+            record_min_max: true
+        # Configure the aggregation cardinality limit.
+        # If omitted or null, the metric reader's default cardinality limit is used.
+        aggregation_cardinality_limit: 2000
+        # Configure attribute keys retained in the resulting stream(s).
+        attribute_keys:
+          # Configure list of attribute keys to include in the resulting stream(s). All other attributes are dropped. 
+          # If omitted, all attributes are included.
+          included:
+            - key1
+            - key2
+          # Configure list of attribute keys to exclude from the resulting stream(s). Applies after .attribute_keys.included (i.e. excluded has higher priority than included).
+          # If omitted, .attribute_keys.included are included.
+          excluded:
+            - key3
+  # Configure the exemplar filter. 
+  # Values include: trace_based, always_on, always_off. For behavior of values see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#metrics-sdk-configuration.
+  # If omitted or null, trace_based is used.
+  exemplar_filter: trace_based
+  # Configure meters.
+  # This type is in development and subject to breaking changes in minor versions.
+  meter_configurator/development:
+    # Configure the default meter config used there is no matching entry in .meter_configurator/development.meters.
+    default_config:
+      # Configure if the meter is enabled or not.
+      disabled: true
+    # Configure meters.
+    meters:
+      - # Configure meter names to match, evaluated as follows:
+        #
+        #  * If the meter name exactly matches.
+        #  * If the meter name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+        name: io.opentelemetry.contrib.*
+        # The meter config.
+        config:
+          # Configure if the meter is enabled or not.
+          disabled: false
+# Configure text map context propagators.
+# If omitted, a noop propagator is used.
+propagator:
+  # Configure the propagators in the composite text map propagator. Entries from .composite_list are appended to the list here with duplicates filtered out.
+  # Built-in propagator keys include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party keys include: xray. 
+  # If the resolved list of propagators (from .composite and .composite_list) is empty, a noop propagator is used.
+  composite:
+    - # Include the w3c trace context propagator.
+      tracecontext:
+    - # Include the w3c baggage propagator.
+      baggage:
+    - # Include the zipkin b3 propagator.
+      b3:
+    - # Include the zipkin b3 multi propagator.
+      b3multi:
+    - # Include the jaeger propagator.
+      jaeger:
+    - # Include the opentracing propagator.
+      ottrace:
+  # Configure the propagators in the composite text map propagator. Entries are appended to .composite with duplicates filtered out.
+  # The value is a comma separated list of propagator identifiers matching the format of OTEL_PROPAGATORS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details.
+  # Built-in propagator identifiers include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party identifiers include: xray. 
+  # If the resolved list of propagators (from .composite and .composite_list) is empty, a noop propagator is used.
+  composite_list: "tracecontext,baggage,b3,b3multi,jaeger,ottrace,xray"
+# Configure tracer provider.
+# If omitted, a noop tracer provider is used.
+tracer_provider:
+  # Configure span processors.
+  processors:
+    - # Configure a batch span processor.
+      batch:
+        # Configure delay interval (in milliseconds) between two consecutive exports. 
+        # Value must be non-negative.
+        # If omitted or null, 5000 is used.
+        schedule_delay: 5000
+        # Configure maximum allowed time (in milliseconds) to export data. 
+        # Value must be non-negative. A value of 0 indicates no limit (infinity).
+        # If omitted or null, 30000 is used.
+        export_timeout: 30000
+        # Configure maximum queue size. Value must be positive.
+        # If omitted or null, 2048 is used.
+        max_queue_size: 2048
+        # Configure maximum batch size. Value must be positive.
+        # If omitted or null, 512 is used.
+        max_export_batch_size: 512
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with HTTP transport.
+          otlp_http:
+            # Configure endpoint, including the trace specific path.
+            # If omitted or null, http://localhost:4318/v1/traces is used.
+            endpoint: http://localhost:4318/v1/traces
+            # Configure certificate used to verify a server's TLS credentials. 
+            # Absolute path to certificate file in PEM format.
+            # If omitted or null, system default certificate verification is used for secure connections.
+            certificate_file: /app/cert.pem
+            # Configure mTLS private client key. 
+            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
+            # If omitted or null, mTLS is not used.
+            client_key_file: /app/cert.pem
+            # Configure mTLS client certificate. 
+            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
+            # If omitted or null, mTLS is not used.
+            client_certificate_file: /app/cert.pem
+            # Configure headers. Entries have higher priority than entries from .headers_list.
+            # If an entry's .value is null, the entry is ignored.
+            headers:
+              - name: api-key
+                value: "1234"
+            # Configure headers. Entries have lower priority than entries from .headers.
+            # The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
+            # If omitted or null, no headers are added.
+            headers_list: "api-key=1234"
+            # Configure compression.
+            # Values include: gzip, none. Implementations may support other compression algorithms.
+            # If omitted or null, none is used.
+            compression: gzip
+            # Configure max time (in milliseconds) to wait for each export. 
+            # Value must be non-negative. A value of 0 indicates no limit (infinity).
+            # If omitted or null, 10000 is used.
+            timeout: 10000
+            # Configure the encoding used for messages. 
+            # Values include: protobuf, json. Implementations may not support json.
+            # If omitted or null, protobuf is used.
+            encoding: protobuf
+    - # Configure a batch span processor.
+      batch:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with gRPC transport.
+          otlp_grpc:
+            # Configure endpoint.
+            # If omitted or null, http://localhost:4317 is used.
+            endpoint: http://localhost:4317
+            # Configure certificate used to verify a server's TLS credentials. 
+            # Absolute path to certificate file in PEM format.
+            # If omitted or null, system default certificate verification is used for secure connections.
+            certificate_file: /app/cert.pem
+            # Configure mTLS private client key. 
+            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
+            # If omitted or null, mTLS is not used.
+            client_key_file: /app/cert.pem
+            # Configure mTLS client certificate. 
+            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
+            # If omitted or null, mTLS is not used.
+            client_certificate_file: /app/cert.pem
+            # Configure headers. Entries have higher priority than entries from .headers_list.
+            # If an entry's .value is null, the entry is ignored.
+            headers:
+              - name: api-key
+                value: "1234"
+            # Configure headers. Entries have lower priority than entries from .headers.
+            # The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
+            # If omitted or null, no headers are added.
+            headers_list: "api-key=1234"
+            # Configure compression.
+            # Values include: gzip, none. Implementations may support other compression algorithms.
+            # If omitted or null, none is used.
+            compression: gzip
+            # Configure max time (in milliseconds) to wait for each export. 
+            # Value must be non-negative. A value of 0 indicates no limit (infinity).
+            # If omitted or null, 10000 is used.
+            timeout: 10000
+            # Configure client transport security for the exporter's connection. 
+            # Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
+            # If omitted or null, false is used.
+            insecure: false
+    - # Configure a batch span processor.
+      batch:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with file transport.
+          # This type is in development and subject to breaking changes in minor versions.
+          otlp_file/development:
+            # Configure output stream. 
+            # Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # If omitted or null, stdout is used.
+            output_stream: file:///var/log/traces.jsonl
+    - # Configure a batch span processor.
+      batch:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be OTLP with file transport.
+          # This type is in development and subject to breaking changes in minor versions.
+          otlp_file/development:
+            # Configure output stream. 
+            # Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
+            # If omitted or null, stdout is used.
+            output_stream: stdout
+    - # Configure a batch span processor.
+      batch:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be zipkin.
+          zipkin:
+            # Configure endpoint.
+            # If omitted or null, http://localhost:9411/api/v2/spans is used.
+            endpoint: http://localhost:9411/api/v2/spans
+            # Configure max time (in milliseconds) to wait for each export. 
+            # Value must be non-negative. A value of 0 indicates indefinite.
+            # If omitted or null, 10000 is used.
+            timeout: 10000
+    - # Configure a simple span processor.
+      simple:
+        # Configure exporter.
+        exporter:
+          # Configure exporter to be console.
+          console:
+  # Configure span limits. See also attribute_limits.
+  limits:
+    # Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit. 
+    # Value must be non-negative.
+    # If omitted or null, there is no limit.
+    attribute_value_length_limit: 4096
+    # Configure max attribute count. Overrides .attribute_limits.attribute_count_limit. 
+    # Value must be non-negative.
+    # If omitted or null, 128 is used.
+    attribute_count_limit: 128
+    # Configure max span event count. 
+    # Value must be non-negative.
+    # If omitted or null, 128 is used.
+    event_count_limit: 128
+    # Configure max span link count. 
+    # Value must be non-negative.
+    # If omitted or null, 128 is used.
+    link_count_limit: 128
+    # Configure max attributes per span event. 
+    # Value must be non-negative.
+    # If omitted or null, 128 is used.
+    event_attribute_count_limit: 128
+    # Configure max attributes per span link. 
+    # Value must be non-negative.
+    # If omitted or null, 128 is used.
+    link_attribute_count_limit: 128
+  # Configure the sampler.
+  # If omitted, parent based sampler with a root of always_on is used.
+  sampler:
+    # Configure sampler to be parent_based.
+    parent_based:
+      # Configure root sampler.
+      # If omitted or null, always_on is used.
+      root:
+        # Configure sampler to be trace_id_ratio_based.
+        trace_id_ratio_based:
+          # Configure trace_id_ratio.
+          # If omitted or null, 1.0 is used.
+          ratio: 0.0001
+      # Configure remote_parent_sampled sampler.
+      # If omitted or null, always_on is used.
+      remote_parent_sampled:
+        # Configure sampler to be always_on.
+        always_on:
+      # Configure remote_parent_not_sampled sampler.
+      # If omitted or null, always_off is used.
+      remote_parent_not_sampled:
+        # Configure sampler to be always_off.
+        always_off:
+      # Configure local_parent_sampled sampler.
+      # If omitted or null, always_on is used.
+      local_parent_sampled:
+        # Configure sampler to be always_on.
+        always_on:
+      # Configure local_parent_not_sampled sampler.
+      # If omitted or null, always_off is used.
+      local_parent_not_sampled:
+        # Configure sampler to be always_off.
+        always_off:
+  # Configure tracers.
+  # This type is in development and subject to breaking changes in minor versions.
+  tracer_configurator/development:
+    # Configure the default tracer config used there is no matching entry in .tracer_configurator/development.tracers.
+    default_config:
+      # Configure if the tracer is enabled or not.
+      disabled: true
+    # Configure tracers.
+    tracers:
+      - # Configure tracer names to match, evaluated as follows:
+        #
+        #  * If the tracer name exactly matches.
+        #  * If the tracer name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+        name: io.opentelemetry.contrib.*
+        # The tracer config.
+        config:
+          # Configure if the tracer is enabled or not.
+          disabled: false
+# Configure resource for all signals.
+# If omitted, the default resource is used.
+resource:
+  # Configure resource attributes. Entries have higher priority than entries from .resource.attributes_list.
+  # Entries must contain .name and .value, and may optionally include .type. If an entry's .type omitted or null, string is used.
+  # The .value's type must match the .type. Values for .type include: string, bool, int, double, string_array, bool_array, int_array, double_array.
+  attributes:
+    - name: service.name
+      value: unknown_service
+    - name: string_key
+      value: value
+      type: string
+    - name: bool_key
+      value: true
+      type: bool
+    - name: int_key
+      value: 1
+      type: int
+    - name: double_key
+      value: 1.1
+      type: double
+    - name: string_array_key
+      value: [ "value1", "value2" ]
+      type: string_array
+    - name: bool_array_key
+      value: [ true, false ]
+      type: bool_array
+    - name: int_array_key
+      value: [ 1, 2 ]
+      type: int_array
+    - name: double_array_key
+      value: [ 1.1, 2.2 ]
+      type: double_array
+  # Configure resource attributes. Entries have lower priority than entries from .resource.attributes.
+  # The value is a list of comma separated key-value pairs matching the format of OTEL_RESOURCE_ATTRIBUTES. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details.
+  # If omitted or null, no resource attributes are added.
+  attributes_list: "service.namespace=my-namespace,service.version=1.0.0"
+  # Configure resource detection.
+  # This type is in development and subject to breaking changes in minor versions.
+  # If omitted or null, resource detection is disabled.
+  detection/development:
+    # Configure attributes provided by resource detectors.
+    attributes:
+      # Configure list of attribute key patterns to include from resource detectors.
+      # Attribute keys from resource detectors are evaluated to match as follows:
+      #  * If the value of the attribute key exactly matches.
+      #  * If the value of the attribute key matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+      # If omitted, all attributes are included.
+      included:
+        - process.*
+      # Configure list of attribute key patterns to exclude from resource detectors. Applies after .resource.detectors.attributes.included (i.e. excluded has higher priority than included).
+      # Attribute keys from resource detectors are evaluated to match as follows:
+      #  * If the value of the attribute key exactly matches.
+      #  * If the value of the attribute key matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
+      # If omitted, .included attributes are included.
+      excluded:
+        - process.command_args
+    # Configure resource detectors.
+    # Resource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language. 
+    # If omitted or null, no resource detectors are enabled.
+    detectors:
+      - # Enable the container resource detector, which populates container.* attributes.
+        container:
+      - # Enable the host resource detector, which populates host.* and os.* attributes.
+        host:
+      - # Enable the process resource detector, which populates process.* attributes.
+        process:
+      - # Enable the service detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id.
+        service:
+  # Configure resource schema URL.
+  # If omitted or null, no schema URL is used.
+  schema_url: https://opentelemetry.io/schemas/1.16.0
+# Configure instrumentation.
+# This type is in development and subject to breaking changes in minor versions.
+instrumentation/development:
+  # Configure general SemConv options that may apply to multiple languages and instrumentations.
+  # Instrumenation may merge general config options with the language specific configuration at .instrumentation.<language>.
+  general:
+    # Configure instrumentations following the peer semantic conventions.
+    # See peer semantic conventions: https://opentelemetry.io/docs/specs/semconv/attributes-registry/peer/
+    peer:
+      # Configure the service mapping for instrumentations following peer.service semantic conventions.
+      # Each entry is a key value pair where "peer" defines the IP address and "service" defines the corresponding logical name of the service.
+      # See peer.service semantic conventions: https://opentelemetry.io/docs/specs/semconv/general/attributes/#general-remote-service-attributes
+      service_mapping:
+        - peer: 1.2.3.4
+          service: FooService
+        - peer: 2.3.4.5
+          service: BarService
+    # Configure instrumentations following the http semantic conventions.
+    # See http semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/
+    http:
+      # Configure instrumentations following the http client semantic conventions.
+      client:
+        # Configure headers to capture for outbound http requests.
+        request_captured_headers:
+          - Content-Type
+          - Accept
+        # Configure headers to capture for outbound http responses.
+        response_captured_headers:
+          - Content-Type
+          - Content-Encoding
+      # Configure instrumentations following the http server semantic conventions.
+      server:
+        # Configure headers to capture for inbound http requests.
+        request_captured_headers:
+          - Content-Type
+          - Accept
+        # Configure headers to capture for outbound http responses.
+        response_captured_headers:
+          - Content-Type
+          - Content-Encoding
+  # Configure C++ language-specific instrumentation libraries.
+  cpp:
+    # Configure the instrumentation corresponding to key "example".
+    example:
+      property: "value"
+  # Configure .NET language-specific instrumentation libraries.
+  dotnet:
+    # Configure the instrumentation corresponding to key "example".
+    example:
+      property: "value"
+  # Configure Erlang language-specific instrumentation libraries.
+  erlang:
+    # Configure the instrumentation corresponding to key "example".
+    example:
+      property: "value"
+  # Configure Go language-specific instrumentation libraries.
+  go:
+    # Configure the instrumentation corresponding to key "example".
+    example:
+      property: "value"
+  # Configure Java language-specific instrumentation libraries.
+  java:
+    # Configure the instrumentation corresponding to key "example".
+    example:
+      property: "value"
+  # Configure JavaScript language-specific instrumentation libraries.
+  js:
+    # Configure the instrumentation corresponding to key "example".
+    example:
+      property: "value"
+  # Configure PHP language-specific instrumentation libraries.
+  php:
+    # Configure the instrumentation corresponding to key "example".
+    example:
+      property: "value"
+  # Configure Python language-specific instrumentation libraries.
+  python:
+    # Configure the instrumentation corresponding to key "example".
+    example:
+      property: "value"
+  # Configure Ruby language-specific instrumentation libraries.
+  ruby:
+    # Configure the instrumentation corresponding to key "example".
+    example:
+      property: "value"
+  # Configure Rust language-specific instrumentation libraries.
+  rust:
+    # Configure the instrumentation corresponding to key "example".
+    example:
+      property: "value"
+  # Configure Swift language-specific instrumentation libraries.
+  swift:
+    # Configure the instrumentation corresponding to key "example".
+    example:
+      property: "value"


### PR DESCRIPTION
Solves #5814 

This PR creates the structure for a FileConfigProvider. In this PR it only checks if the file exists and is a YAML, returning an error otherwise.
Parse of the file will be done on a following PR