### PR TITLE
refactor(instrumentation-grpc): use relative path for semconv

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -45,6 +45,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 * refactor(otlp-exporter-base): use getStringFromEnv instead of process.env [#5594](https://github.com/open-telemetry/opentelemetry-js/pull/5594) @weyert
 * chore(sdk-logs): refactored imports [#5801](https://github.com/open-telemetry/opentelemetry-js/pull/5801) @svetlanabrennan
+* refactor(instrumentation-grpc): updated path to semconv [#5884](https://github.com/open-telemetry/opentelemetry-js/pull/5884) @overbalance
 
 ## 0.203.0
 

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/clientUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/clientUtils.ts
@@ -30,7 +30,7 @@ import { AttributeNames } from './enums/AttributeNames';
 import {
   ATTR_RPC_GRPC_STATUS_CODE,
   RPC_GRPC_STATUS_CODE_VALUE_OK,
-} from '../src/semconv';
+} from './semconv';
 import {
   _grpcStatusCodeToSpanStatus,
   _grpcStatusCodeToOpenTelemetryStatusCode,

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/instrumentation.ts
@@ -69,7 +69,7 @@ import {
   ATTR_RPC_METHOD,
   ATTR_RPC_SERVICE,
   ATTR_RPC_SYSTEM,
-} from '../src/semconv';
+} from './semconv';
 
 import {
   shouldNotTraceServerCall,

--- a/experimental/packages/opentelemetry-instrumentation-grpc/src/serverUtils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/src/serverUtils.ts
@@ -49,7 +49,7 @@ import { AttributeNames } from './enums/AttributeNames';
 import {
   ATTR_RPC_GRPC_STATUS_CODE,
   RPC_GRPC_STATUS_CODE_VALUE_OK,
-} from '../src/semconv';
+} from './semconv';
 
 export const CALL_SPAN_ENDED = Symbol('opentelemetry call span ended');
 


### PR DESCRIPTION
## Which problem is this PR solving?

Fix the path to semconv.js in `@opentelemetry/instrumentation-grpc`

## Short description of the changes

Update the path from `../src/semconv` -> `./semconv`

## Type of change

- [ ] Refactor

## How Has This Been Tested?

Compile the package and observe the correct path in the build folder: `../src/semconv` -> `./semconv`

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
