### PR TITLE
Fix link to auto-instrumentations-node package

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm install --save @opentelemetry/sdk-node
 npm install --save @opentelemetry/auto-instrumentations-node
 ```
 
-**Note:** `auto-instrumentations-node` is a meta package from [opentelemetry-js-contrib](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/metapackages/auto-instrumentations-node) that provides a simple way to initialize multiple Node.js instrumentations.
+**Note:** `auto-instrumentations-node` is a meta package from [opentelemetry-js-contrib](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/auto-instrumentations-node) that provides a simple way to initialize multiple Node.js instrumentations.
 
 ### Set up Tracing
 


### PR DESCRIPTION
## Which problem is this PR solving?

Updated link in README for auto-instrumentations-node package, since the existing one was returning a 404 after it was moved in https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2928
