### PR TITLE
ci: drop unsafe-perm in workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,8 +20,6 @@ jobs:
     container:
       image: ubuntu:24.04
     timeout-minutes: 10
-    env:
-      NPM_CONFIG_UNSAFE_PERM: true
     steps:
       # Apt packages:
       # - git: Needed for 'npm run submodule'

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -2,14 +2,12 @@ name: SBOM
 on:
   release:
     types: [published]
-          
+
 permissions: read-all
 
 jobs:
   generate-sboms:
     runs-on: ubuntu-latest
-    env:
-      NPM_CONFIG_UNSAFE_PERM: true
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -32,13 +30,13 @@ jobs:
             echo "Generating SBOM for $dir_name"
             npm sbom --sbom-format=spdx --legacy-peer-deps --workspace ${dir} > "opentelemetry-js_${dir_name}.spdx.json"
           done
-        
+
       - name: Generate SBOM for the API package
         if: startsWith(github.ref, 'refs/tags/api/')
         run: |
           npm sbom --sbom-format=spdx --legacy-peer-deps --workspace api > opentelemetry-js_api.spdx.json
 
-      - name: Generate SBOMs for experimental packages 
+      - name: Generate SBOMs for experimental packages
         if: startsWith(github.ref, 'refs/tags/experimental/')
         run: |
           for dir in $(find experimental/packages -mindepth 1 -maxdepth 1 -type d)

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,8 +22,6 @@ jobs:
           - "22"
           - "24"
     runs-on: ubuntu-latest
-    env:
-      NPM_CONFIG_UNSAFE_PERM: true
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -74,8 +72,6 @@ jobs:
           verbose: true
   node-windows-tests:
     runs-on: windows-latest
-    env:
-      NPM_CONFIG_UNSAFE_PERM: true
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -103,8 +99,6 @@ jobs:
           NODE_OPTIONS: '--no-experimental-strip-types'
   browser-tests:
     runs-on: ubuntu-latest
-    env:
-      NPM_CONFIG_UNSAFE_PERM: true
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -132,8 +126,6 @@ jobs:
           verbose: true
   webworker-tests:
     runs-on: ubuntu-latest
-    env:
-      NPM_CONFIG_UNSAFE_PERM: true
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Which problem is this PR solving?

It will stop working in the next major version of npm - I'm not sure what we were using this for (AFAIK it has been here for a very long time).