### PR TITLE
ci: add workflow to move inactive approvers/maintainers to emeritus

### DIFF
--- a/.github/workflows/move-to-emeritus.yml
+++ b/.github/workflows/move-to-emeritus.yml
@@ -1,0 +1,51 @@
+name: Move inactive members to Emeritus
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  create-or-update-emeritus-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fork
+        run: gh repo fork open-telemetry/opentelemetry-js
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          repository: opentelemetrybot/opentelemetry-js
+          ref: main
+          token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+      - name: Sync with upstream
+        run: |
+          git remote show origin
+          git remote add upstream https://github.com/open-telemetry/opentelemetry-js.git
+          git fetch upstream
+          git reset --hard upstream/main
+          git push origin main --force
+
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+          node-version: 22
+
+      - run: node scripts/move-to-emeritus.js
+
+      - name: Create/Update Move to Emeritus PR
+        run: |
+          git config user.name opentelemetrybot
+          git config user.email 107717825+opentelemetrybot@users.noreply.github.com
+          git checkout -b chore/move-inactive-to-emeritus
+          git add README.md
+          git commit -m "chore: move inactive members to emeritus"
+          git push --set-upstream $PR_REMOTE chore/move-inactive-to-emeritus --force
+          gh pr create --repo open-telemetry/opentelemetry-js --title 'chore: move inactive members to emeritus' --body-file ./.tmp/emeritus-pr-body.md || gh pr edit --repo open-telemetry/opentelemetry-js $PR_OWNER:chore/move-inactive-to-emeritus --body-file ./.tmp/emeritus-pr-body.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          PR_REMOTE: origin
+          PR_OWNER: opentelemetrybot

--- a/scripts/move-to-emeritus.js
+++ b/scripts/move-to-emeritus.js
@@ -1,0 +1,194 @@
+const { readFile, writeFile } = require('fs/promises');
+
+const repoOwner = 'open-telemetry';
+const token = process.env.GITHUB_TOKEN;
+
+async function getMembersFromSection(sectionRegex) {
+  const readme = await readFile('README.md', 'utf8');
+  const roleSection = readme.match(sectionRegex);
+  if (!roleSection) return [];
+
+  const matches = [...roleSection[0].matchAll(/\[.*?\]\(https:\/\/github\.com\/([a-zA-Z0-9-_]+)\)/g)];
+  const handles = matches.map(m => m[1]);
+  return [...new Set(handles)];
+}
+
+async function fetchWithRetry(url, options, retries = 3, delay = 1000) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url, options);
+      if (!res.ok) {
+        throw new Error(`HTTP error! Status: ${res.status}`);
+      }
+      return res;
+    } catch (error) {
+      console.warn(`Attempt ${attempt} failed: ${error.message}`);
+      if (attempt < retries) {
+        await new Promise(resolve => setTimeout(resolve, delay));
+      } else {
+        throw new Error(`All ${retries} attempts failed.`);
+      }
+    }
+  }
+}
+
+async function fetchPaginatedJSON(url, filterData) {
+  let results = [];
+  let nextUrl = url;
+
+  while (nextUrl) {
+    const res = await fetchWithRetry(nextUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'User-Agent': 'review-check-script',
+        Accept: 'application/vnd.github+json'
+      }
+    });
+
+    if (!res.ok) throw new Error(`Fetch failed: ${res.status} ${res.statusText}`);
+
+    const data = filterData(await res.json());
+
+    if (data.length === 0) {
+      // don't continue if everything has been filtered.
+      return results;
+    }
+
+    results = results.concat(data);
+
+    const linkHeader = res.headers.get('link');
+    const nextMatch = linkHeader && linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+    nextUrl = nextMatch ? nextMatch[1] : null;
+  }
+
+  return results;
+}
+
+function getPullRequestsUntilCutoffDate(repoOwner, repoName, cutoffDate) {
+  const pullsUrl = `https://api.github.com/repos/${repoOwner}/${repoName}/pulls?state=all&per_page=100&sort=updated&direction=desc`;
+  return fetchPaginatedJSON(pullsUrl, pulls => {
+    // only allow PRs that have been updated after the cutoff date
+    return pulls.filter(pr => {
+      // PRs may be updated after they merged (branches deleted after merge update the PR), so we use the merge or close date before
+      // using updated_at.
+      if (pr.merged_at) {
+        return new Date(pr.merged_at) > cutoffDate;
+      }
+
+      if (pr.closed_at) {
+        return new Date(pr.closed_at) > cutoffDate;
+      }
+
+      return new Date(pr.updated_at) > cutoffDate;
+    });
+  });
+}
+
+async function getPullRequestReviewersUntilCutoffDate(repoOwner, repoName, pr, cutoffDate) {
+  const reviewsUrl = `https://api.github.com/repos/${repoOwner}/${repoName}/pulls/${pr.number}/reviews?per_page=100`;
+  const reviews = await fetchPaginatedJSON(
+    reviewsUrl,
+    data => data // no-op filter
+  );
+  return reviews
+    .filter(r => new Date(r.submitted_at) > cutoffDate)
+    .map(r => r.user.login);
+}
+
+async function removeActiveMembersFromList(presumedInactiveUsers, repoName, repoOwner, cutoffDate) {
+  const pulls = await getPullRequestsUntilCutoffDate(repoOwner, repoName, cutoffDate);
+
+  for (const pr of pulls) {
+    const activeReviewers = await getPullRequestReviewersUntilCutoffDate(
+      repoOwner,
+      repoName,
+      pr,
+      cutoffDate
+    );
+
+    console.debug(repoName, pr.number, activeReviewers);
+
+    for (const reviewer of activeReviewers) {
+      const index = presumedInactiveUsers.indexOf(reviewer);
+      if (index > -1) {
+        presumedInactiveUsers.splice(index, 1);
+      }
+
+      if (presumedInactiveUsers.length === 0) {
+        return;
+      }
+    }
+  }
+}
+
+async function moveMembersToEmeritus(inactiveUsers, sectionRegex, role) {
+  let readme = await readFile('README.md', 'utf8');
+
+  // Match Member and Emeriti sections
+  const membersSectionMatch = readme.match(sectionRegex);
+  const emeritiSectionMatch = readme.match(/(###\s+Emeriti[\s\S]*?)(?=\nFor more information)/i);
+
+  if (!membersSectionMatch || !emeritiSectionMatch) return;
+
+  let membersSection = membersSectionMatch[0];
+  let emeritiSection = emeritiSectionMatch[0];
+
+  const membersToMove = [];
+
+   // Remove members from their section
+  membersSection = membersSection
+    .split('\n')
+    .filter(line => {
+      const match = line.match(/\[.*?\]\(https:\/\/github\.com\/([a-zA-Z0-9-_]+)\)/);
+      if (match) {
+        const username = match[1];
+        if (inactiveUsers.includes(username)) {
+          // remove affiliation and keep member lines for later
+          const splitLine = line.trim().split(',');
+          membersToMove.push(splitLine.slice(0, splitLine.length - 1).join(',') + ', ' + role);
+          return false; // remove this line
+        }
+      }
+      return true; // keep this line
+    })
+    .join('\n');
+
+  if (membersToMove.length === 0) {
+    return;
+  }
+
+  // Append new Emeriti lines
+  emeritiSection = emeritiSection.trim() + '\n' + membersToMove.join('\n') + '\n';
+
+  // Finally, replace sections in README with the updated section
+  readme = readme.replace(membersSectionMatch[0], membersSection);
+  readme = readme.replace(emeritiSectionMatch[0], emeritiSection);
+
+  await writeFile('README.md', readme, 'utf8');
+}
+
+async function writePrSummary(inactiveUsers, cutoffDate) {
+  await writeFile('.tmp/emeritus-pr-body.md', `Moving the following members to Emeritus as no reviews were posted since ${cutoffDate.toString()}:\n - ${inactiveUsers.map(user => '@' + user).join('\n - ')}`, 'utf-8');
+}
+
+(async () => {
+  const cutoffDate = new Date();
+  cutoffDate.setMonth(cutoffDate.getMonth() - 4);
+
+  const approverSectionRegex = /(###\s+Approvers[\s\S]*?)(?=\n###|\n##|\n#|$)/i;
+  const maintainerSectionRegex = /(###\s+Maintainers[\s\S]*?)(?=\n###|\n##|\n#|$)/i;
+
+  const possiblyInactiveApprovers = await getMembersFromSection(approverSectionRegex);
+  const possiblyInactiveMaintainers = await getMembersFromSection(maintainerSectionRegex);
+
+  const possiblyInactiveMembers = [...possiblyInactiveApprovers, ...possiblyInactiveMaintainers];
+  await removeActiveMembersFromList(possiblyInactiveMembers, 'opentelemetry-js', repoOwner, cutoffDate);
+  await removeActiveMembersFromList(possiblyInactiveMembers, 'opentelemetry-js-contrib', repoOwner, cutoffDate);
+
+  console.info(`Inactive members (no reviews since ${cutoffDate.toISOString()}):`, possiblyInactiveMembers);
+
+  await moveMembersToEmeritus(possiblyInactiveMembers, approverSectionRegex, 'Approver');
+  await moveMembersToEmeritus(possiblyInactiveMembers, maintainerSectionRegex, 'Maintainer');
+
+  await writePrSummary(possiblyInactiveMembers, cutoffDate);
+})();


### PR DESCRIPTION
## Which problem is this PR solving?

This PR introduces partial automation for a task that is necessary but often emotionally taxing: maintaining accurate membership in the @open-telemetry/javascript-approvers and @open-telemetry/javascript-maintainers groups.

While the process of removing inactive members is not personal, it can feel personal. That emotional overhead tends to make this task harder than it should be, and often consumes more mental energy than the actual work involved. Automating parts of it helps reduce that burden and allows us to focus on finding new members to fill that role, rather than stressing over the removal part.

This initial automation focuses on Maintainers and Approvers as we:
- have the highest visibility and impact, requiring backfills when members step away.
- are expected to regularly review PRs, making activity assessment straightforward by checking for recent review activity.

The script uses very long threshold: **4 months of no review activity** triggers a PR to propose moving a member to emeritus status. This PR still has to be manually approved by the remaining maintainers, and after the PR is merged, the group itself has to be manually updated. A single review within that period - regardless of whether it’s on their own PR or someone else's - prevents being auto-moved to emeritus. I chose this time frame to accommodate very-long vacations and other planned absences. For longer periods of inactivity, contributors are encouraged to reach out to the Maintainers.

I plan to further tweak the script in the coming months, including other members like Triagers and Component Owners as well.