### PR TITLE
chore(otl-exporter-base): make `_delegate` protected

### DIFF
--- a/experimental/packages/otlp-exporter-base/src/OTLPExporterBase.ts
+++ b/experimental/packages/otlp-exporter-base/src/OTLPExporterBase.ts
@@ -18,7 +18,7 @@ import { ExportResult } from '@opentelemetry/core';
 import { IOtlpExportDelegate } from './otlp-export-delegate';
 
 export class OTLPExporterBase<Internal> {
-  constructor(private _delegate: IOtlpExportDelegate<Internal>) {}
+  constructor(protected _delegate: IOtlpExportDelegate<Internal>) {}
 
   /**
    * Export items.


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

We are extending the OTLExporter functionality and need to access the delegate property. However, this property is currently private and not exposed to the derived class, which prevents us from using it.

## Type of change

Please delete options that are not relevant.


## How Has This Been Tested?
N/A



## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
