### PR TITLE
fix(otlp-transformer): trunc hrTime to int for nanos converting

### DIFF
--- a/experimental/packages/otlp-transformer/src/common/utils.ts
+++ b/experimental/packages/otlp-transformer/src/common/utils.ts
@@ -21,7 +21,7 @@ import { hexToBinary } from './hex-to-binary';
 
 export function hrTimeToNanos(hrTime: HrTime): bigint {
   const NANOSECONDS = BigInt(1_000_000_000);
-  return BigInt(hrTime[0]) * NANOSECONDS + BigInt(hrTime[1]);
+  return BigInt(Math.trunc(hrTime[0])) * NANOSECONDS + BigInt(Math.trunc(hrTime[1]));
 }
 
 export function toLongBits(value: bigint): LongBits {

--- a/experimental/packages/otlp-transformer/test/trace.test.ts
+++ b/experimental/packages/otlp-transformer/test/trace.test.ts
@@ -544,6 +544,12 @@ describe('Trace', () => {
       assert.deepStrictEqual(JSON.parse(decoder.decode(serialized)), expected);
     });
 
+    it('hrtime contains float value', () => {
+      const span = createSpanWithResource(resource);
+      (span as any).startTime = [1640715557.5, 342725388.5];
+      JsonTraceSerializer.serializeRequest([span]);
+    });
+
     it('deserializes a response', () => {
       const expectedResponse = {
         partialSuccess: {


### PR DESCRIPTION

## Which problem is this PR solving?

This one is for a case I'vs seen in one of our users environments.

In `otlpTransformer` package, `hrTimeToNanos` function, we feed the components of `hrTime` into `BigInt` which will throw if the argument is not an integer:

```
node
Welcome to Node.js v20.19.2.
Type ".help" for more information.
> BigInt(0.5)
Uncaught:
RangeError: The number 0.5 cannot be converted to a BigInt because it is not an integer
    at BigInt (<anonymous>)
```

Followed all the places where we populate the `hrTime` and honestly I am not sure where this non-integer value is coming from, but it doesn't hurt to verify. If a non-int value is somehow find it's way into a span, then the exception will kill the node process which is a big problem and should be avoided. 

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added a unit test. Also there is an app which used to crash in one of odigos users environments and after the fix the crashes went away.

