### PR TITLE
Use JS-specific otelbot with content write permission

### DIFF
--- a/.github/workflows/create-or-update-release-pr.yml
+++ b/.github/workflows/create-or-update-release-pr.yml
@@ -40,8 +40,8 @@ jobs:
       - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: otelbot-token
         with:
-          app-id: ${{ vars.OTELBOT_APP_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          app-id: ${{ vars.OTELBOT_JS_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_JS_PRIVATE_KEY }}
 
       - name: Create/Update Release PR
         run: |


### PR DESCRIPTION
Should fix https://github.com/open-telemetry/opentelemetry-js/actions/runs/17737810798/job/50403997575

Reported by @pichlermarc in https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3040#issuecomment-3292750027