### PR TITLE
ci(move-to-emeritus): create .tmp directory if it does not exist

### DIFF
--- a/scripts/move-to-emeritus.js
+++ b/scripts/move-to-emeritus.js
@@ -1,4 +1,4 @@
-const { readFile, writeFile } = require('fs/promises');
+const { readFile, writeFile, mkdir } = require('fs/promises');
 
 const repoOwner = 'open-telemetry';
 const token = process.env.GITHUB_TOKEN;
@@ -168,6 +168,7 @@ async function moveMembersToEmeritus(inactiveUsers, sectionRegex, role) {
 }
 
 async function writePrSummary(inactiveUsers, cutoffDate) {
+  await mkdir('.tmp');
   await writeFile('.tmp/emeritus-pr-body.md', `Moving the following members to Emeritus as no reviews were posted since ${cutoffDate.toString()}:\n - ${inactiveUsers.map(user => '@' + user).join('\n - ')}`, 'utf-8');
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

Currently the workflow is failing as the `.tmp` directory does not exist, see https://github.com/open-telemetry/opentelemetry-js/actions/runs/17737958454/job/50404477717.