### PR TITLE
ci(move-to-emeritus): use correct branch names for pushing

### DIFF
--- a/.github/workflows/move-to-emeritus.yml
+++ b/.github/workflows/move-to-emeritus.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           git config user.name otelbot
           git config user.email 197425009+otelbot@users.noreply.github.com
-          git checkout -b chore/move-inactive-to-emeritus
+          git checkout -b move-inactive-to-emeritus
           git add README.md
           git commit -m "chore: move inactive members to emeritus"
           git push --set-upstream origin otelbot/move-inactive-to-emeritus --force

--- a/scripts/move-to-emeritus.js
+++ b/scripts/move-to-emeritus.js
@@ -1,4 +1,4 @@
-const { readFile, writeFile } = require('fs/promises');
+const { readFile, writeFile, mkdir } = require('fs/promises');
 
 const repoOwner = 'open-telemetry';
 const token = process.env.GITHUB_TOKEN;
@@ -168,6 +168,7 @@ async function moveMembersToEmeritus(inactiveUsers, sectionRegex, role) {
 }
 
 async function writePrSummary(inactiveUsers, cutoffDate) {
+  await mkdir('.tmp');
   await writeFile('.tmp/emeritus-pr-body.md', `Moving the following members to Emeritus as no reviews were posted since ${cutoffDate.toString()}:\n - ${inactiveUsers.map(user => '@' + user).join('\n - ')}`, 'utf-8');
 }
 


### PR DESCRIPTION
After one of the recent change in the workflow (#5931), the branch names do not match up anymore.