### PR TITLE
ci: harden npm publish workflow by switching to OIDC

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # to generate npm provenance statements
+      id-token: write # to generate npm OIDC and provenance statements
     environment: npm-publish-environment
     steps:
       - name: Setup Node

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -7,33 +7,50 @@ permissions:
   contents: read
 
 jobs:
-  release-to-npm:
+  setup-and-compile:
     runs-on: ubuntu-latest
-    permissions:
-      # needed for NPM provenance
-      id-token: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
-
       - run: npm ci
-
       # NOTE: in the past, we've had situations where the compiled files were missing as the `prepublishOnly` script was
       # missing in some packages. `npx lerna publish` *should* also run compile, but this is intended as a safeguard
       # when that does not happen for whatever reason.
       - run: npm run compile
-
+      - name: Upload contents for publish
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-cache-${{ github.run_number }}
+          path: .
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 10
+  npm-publish:
+    needs: setup-and-compile
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # to generate npm provenance statements
+    environment: npm-publish-environment
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+      - name: Download contents for publish
+        uses: actions/download-artifact@v4
+        with:
+          name: publish-cache-${{ github.run_number }}
       - name: Publish to npm
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
         # NOTE: using --concurrency 1 to reduce the likelihood of a race when publishing,
         # which happens when the npm registry is not fully consistent yet. This can cause the publishing of a package to be


### PR DESCRIPTION
## Which problem is this PR solving?

Nothing has happened to us, but with everything that's been happening recently, this PR does a few things to harden our publishing process:
- switches publishing from token-based to OIDC
  - I have already updated all packages to disallow token publish, and set up OIDC for all of the packages published from this repo
- makes use of a new `npm-publish-environment` environment, to lock down who can actually publish to npm
  - until recently access was more broad, but additonal maintainer approval will now be required for publishing here and in contrib
  - requiring the environment and OIDC will also limit a potential blast radius to one repo, we can set up to require more than one maintainer approval before publishing.
- I have moved `npm ci` to run outside of the deploy environment to further increase complexity of smuggling things in that don't belong here.

Any tokens that we previously used for publishing are already revoked. ✅ 