### PR TITLE
chore: skip npmjs.com in linkchecking while it returns 403 to non-browsers

### DIFF
--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -531,7 +531,7 @@ at: <https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/e
 ## Exporting measurements to OpenTelemetry Protocol
 
 OpenTelemetry JavaScript comes with three different kinds of exporters that export
-the OTLP protocol, a) [over HTTP](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http), b) [over GRPC](https://www.npmjs.com/package/@opentelemetry/exporter-metrics-otlp-grpc), c) [over Protobuf](https://www.npmjs.com/package/@opentelemetry/exporter-metrics-otlp-proto). (XXX Trent wuz here.)
+the OTLP protocol, a) [over HTTP](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-http), b) [over GRPC](https://www.npmjs.com/package/@opentelemetry/exporter-metrics-otlp-grpc), c) [over Protobuf](https://www.npmjs.com/package/@opentelemetry/exporter-metrics-otlp-proto).
 
 The example below shows how you can configure OpenTelemetry JavaScript to use
 the OTLP exporter using http/protobuf.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "predocs-test": "npm run docs",
     "docs": "typedoc --readme none && touch docs/.nojekyll",
     "docs-deploy": "gh-pages --dotfiles --dist docs",
-    "docs:test": "linkinator docs --silent --retry && linkinator doc/*.md --skip http://localhost:3000 --skip http://localhost:9464 --skip https://github.com/ --silent --retry --directory-listing",
+    "docs:test": "linkinator docs --silent --retry && linkinator doc/*.md --skip http://localhost:3000 --skip http://localhost:9464 --skip https://github.com/ --skip https://www.npmjs.com/ --silent --retry --directory-listing",
     "lint": "lerna run lint && npm run lint:markdown && npm run lint:semconv-deps",
     "lint:changed": "lerna run --concurrency 1 --stream lint --since HEAD --exclude-dependents",
     "lint:fix": "lerna run lint:fix && npm run lint:markdown:fix",


### PR DESCRIPTION
(https://github.com/open-telemetry/opentelemetry-js/pull/5839#issuecomment-3313271719 for background.)

npmjs.com is returning 403s for link checks. This breaks linting (in the `npm run docs:test` step). For example:

```
% curl -I https://www.npmjs.com/
HTTP/2 403
date: Fri, 19 Sep 2025 18:27:54 GMT
```