### PR TITLE
chore(deps): Update `require-in-the-middle` to v8.0.0

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@opentelemetry/api-logs": "0.205.0",
     "import-in-the-middle": "^1.8.1",
-    "require-in-the-middle": "^7.1.1"
+    "require-in-the-middle": "^8.0.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/shim-opencensus/package.json
+++ b/experimental/packages/shim-opencensus/package.json
@@ -69,7 +69,7 @@
     "@opentelemetry/core": "2.1.0",
     "@opentelemetry/resources": "2.1.0",
     "@opentelemetry/sdk-metrics": "2.1.0",
-    "require-in-the-middle": "^7.1.1"
+    "require-in-the-middle": "^8.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/shim-opencensus",
   "sideEffects": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1036,7 +1036,7 @@
       "dependencies": {
         "@opentelemetry/api-logs": "0.205.0",
         "import-in-the-middle": "^1.8.1",
-        "require-in-the-middle": "^7.1.1"
+        "require-in-the-middle": "^8.0.0"
       },
       "devDependencies": {
         "@babel/core": "7.27.1",
@@ -1845,7 +1845,7 @@
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/resources": "2.1.0",
         "@opentelemetry/sdk-metrics": "2.1.0",
-        "require-in-the-middle": "^7.1.1"
+        "require-in-the-middle": "^8.0.0"
       },
       "devDependencies": {
         "@opencensus/core": "0.1.0",
@@ -22008,17 +22008,16 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.0.tgz",
+      "integrity": "sha512-9s0pnM5tH8G4dSI3pms2GboYOs25LwOGnRMxN/Hx3TYT1K0rh6OjaWf4dI0DAQnMyaEXWoGVnSTPQasqwzTTAA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.8"
+        "module-details-from-path": "^1.0.3"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/require-main-filename": {
@@ -30885,7 +30884,7 @@
         "lerna": "6.6.2",
         "mocha": "11.7.2",
         "nyc": "17.1.0",
-        "require-in-the-middle": "^7.1.1",
+        "require-in-the-middle": "^8.0.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.4",
         "typescript": "5.0.4",
@@ -31788,7 +31787,7 @@
         "lerna": "6.6.2",
         "mocha": "11.7.2",
         "nyc": "17.1.0",
-        "require-in-the-middle": "^7.1.1",
+        "require-in-the-middle": "^8.0.0",
         "sinon": "18.0.1",
         "typescript": "5.0.4"
       },
@@ -42985,13 +42984,12 @@
       "dev": true
     },
     "require-in-the-middle": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.0.tgz",
+      "integrity": "sha512-9s0pnM5tH8G4dSI3pms2GboYOs25LwOGnRMxN/Hx3TYT1K0rh6OjaWf4dI0DAQnMyaEXWoGVnSTPQasqwzTTAA==",
       "requires": {
         "debug": "^4.3.5",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.8"
+        "module-details-from-path": "^1.0.3"
       }
     },
     "require-main-filename": {


### PR DESCRIPTION
A new version of `require-in-the-middle` has been released which bumps the minimum supported Node version to v8.10.0 and allowed us to remove some dependencies. 

Before they looked like this:

<img width="897" height="212" alt="image" src="https://github.com/user-attachments/assets/a2850f95-95fd-4bed-a94a-635ccb304dab" />

And now it's like this:

<img width="506" height="128" alt="image" src="https://github.com/user-attachments/assets/1842d53e-c431-4d3b-a318-d53f199c8fab" />

