### PR TITLE
[sdk-logs] Fix Not Exporting Upon `_maxExportBatchSize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-logs): Fix the `batchLogProcessor` exporting only upon `_scheduledDelayMillis` and ignoring `maxExportBatchSize`.
+
 ### :books: Documentation
 
 ### :house: Internal


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This pull request addresses a bug in the log batching processor so that logs are exported immediately when the batch size limit is reached, rather than waiting for the scheduled delay. It also adds and improves tests to ensure the correct export behavior for both full and partial batches, and clarifies the logic for queue size limits.

Bug Fixes and Core Logic:

* Fixed the `batchLogProcessor` so that it exports logs immediately when `maxExportBatchSize` is reached, instead of waiting for `_scheduledDelayMillis`. This ensures timely log delivery and corrects previous batching behavior. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR19-R20) [[2]](diffhunk://#diff-2aefd36a4016582492724ea21a66c80483c53b8c6c8e3023b321e5f0bd23dc40L150-R150) [[3]](diffhunk://#diff-2aefd36a4016582492724ea21a66c80483c53b8c6c8e3023b321e5f0bd23dc40L164-R169)

Fixes #5706

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

* Updated and expanded tests in `BatchLogRecordProcessor.test.ts` to cover immediate export on batch size, timer-based export for partial batches, multiple immediate exports, and correct handling of queue size limits. [[1]](diffhunk://#diff-9387962cfa15f1ab6adafb8aa142400f7f4a6c1904e2e0cd9f6662b0340acdefL144-R313) [[2]](diffhunk://#diff-9387962cfa15f1ab6adafb8aa142400f7f4a6c1904e2e0cd9f6662b0340acdefL268-R443)
* Improved test clarity by removing unnecessary fake timers where not needed, and by verifying the processor's behavior in a variety of batching and flushing scenarios. [[1]](diffhunk://#diff-9387962cfa15f1ab6adafb8aa142400f7f4a6c1904e2e0cd9f6662b0340acdefL144-R313) [[2]](diffhunk://#diff-9387962cfa15f1ab6adafb8aa142400f7f4a6c1904e2e0cd9f6662b0340acdefL268-R443)

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
