### PR TITLE
feat(exporter-prometheus): support withoutTargetInfo option

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,6 +16,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * feat(opentelemetry-configuration): Parse of Configuration File [#5875](https://github.com/open-telemetry/opentelemetry-js/pull/5875) @maryliag
 * feat(opentelemetry-configuration): parse of array objects on configuration file [#5947](https://github.com/open-telemetry/opentelemetry-js/pull/5947) @maryliag
 * feat(opentelemetry-configuration): parse of environment variables on configuration file [#5947](https://github.com/open-telemetry/opentelemetry-js/pull/5947) @maryliag
+* feat(exporter-prometheus): support withoutTargetInfo option [#xxxx](https://github.com/open-telemetry/opentelemetry-js/pull/xxxx) @cjihrig
 
 ### :bug: Bug Fixes
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -35,6 +35,7 @@ export class PrometheusExporter extends MetricReader {
     prefix: '',
     appendTimestamp: false,
     withResourceConstantLabels: undefined,
+    withoutTargetInfo: false,
   };
 
   private readonly _host?: string;
@@ -86,12 +87,16 @@ export class PrometheusExporter extends MetricReader {
     const _withResourceConstantLabels =
       config.withResourceConstantLabels ||
       PrometheusExporter.DEFAULT_OPTIONS.withResourceConstantLabels;
+    const _withoutTargetInfo =
+      config.withoutTargetInfo ||
+      PrometheusExporter.DEFAULT_OPTIONS.withoutTargetInfo;
     // unref to prevent prometheus exporter from holding the process open on exit
     this._server = createServer(this._requestHandler).unref();
     this._serializer = new PrometheusSerializer(
       this._prefix,
       this._appendTimestamp,
-      _withResourceConstantLabels
+      _withResourceConstantLabels,
+      _withoutTargetInfo
     );
 
     this._baseUrl = `http://${this._host}:${this._port}/`;

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -173,17 +173,20 @@ export class PrometheusSerializer {
   private _appendTimestamp: boolean;
   private _additionalAttributes: Attributes | undefined;
   private _withResourceConstantLabels: RegExp | undefined;
+  private _withoutTargetInfo: boolean | undefined;
 
   constructor(
     prefix?: string,
     appendTimestamp = false,
-    withResourceConstantLabels?: RegExp
+    withResourceConstantLabels?: RegExp,
+    withoutTargetInfo?: boolean
   ) {
     if (prefix) {
       this._prefix = prefix + '_';
     }
     this._appendTimestamp = appendTimestamp;
     this._withResourceConstantLabels = withResourceConstantLabels;
+    this._withoutTargetInfo = !!withoutTargetInfo;
   }
 
   serialize(resourceMetrics: ResourceMetrics): string {
@@ -353,6 +356,10 @@ export class PrometheusSerializer {
   }
 
   protected _serializeResource(resource: Resource): string {
+    if (this._withoutTargetInfo === true) {
+      return '';
+    }
+
     const name = 'target_info';
     const help = `# HELP ${name} Target metadata`;
     const type = `# TYPE ${name} gauge`;

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/export/types.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/export/types.ts
@@ -74,4 +74,10 @@ export interface ExporterConfig {
    * @default undefined (no resource attributes are applied)
    */
   withResourceConstantLabels?: RegExp;
+
+  /**
+   * If true, the target_info metric is not included in scraped metrics.
+   * @default false (target_info metric is included)
+   */
+  withoutTargetInfo?: boolean;
 }

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -587,6 +587,14 @@ describe('PrometheusExporter', () => {
         '',
       ]);
     });
+
+    it('should omit target_info if withoutTargetInfo is true', async () => {
+      exporter = new PrometheusExporter({ withoutTargetInfo: true });
+      setup(exporter);
+      const body = await request('http://localhost:9464/metrics');
+
+      assert.deepStrictEqual(body.includes('target_info'), false);
+    });
   });
 });
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -830,5 +830,25 @@ describe('PrometheusSerializer', () => {
           'target_info{env="prod",hostname="myhost",datacenter="sdc",region="europe",owner="frontend"} 1\n'
       );
     });
+
+    it('omits target_info if withoutTargetInfo is true', () => {
+      const serializer = new PrometheusSerializer(
+        undefined,
+        true,
+        undefined,
+        true
+      );
+      const result = serializer['_serializeResource'](
+        resourceFromAttributes({
+          env: 'prod',
+          hostname: 'myhost',
+          datacenter: 'sdc',
+          region: 'europe',
+          owner: 'frontend',
+        })
+      );
+
+      assert.strictEqual(result.includes('target_info'), false);
+    });
   });
 });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This commit adds support for the `without_target_info` option (converted to camelCase to match other options) from the spec.

Fixes # N/A

## Short description of the changes

This commit adds support for the `without_target_info` option (converted to camelCase to match other options) from the spec.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Existing tests
- [x] Tests added

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
