### PR TITLE
ci(move-to-emeritus): use otelbot-js over regular otelbot

### DIFF
--- a/.github/workflows/move-to-emeritus.yml
+++ b/.github/workflows/move-to-emeritus.yml
@@ -25,8 +25,8 @@ jobs:
       - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: otelbot-token
         with:
-          app-id: ${{ vars.OTELBOT_APP_ID }}
-          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          app-id: ${{ vars.OTELBOT_JS_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_JS_PRIVATE_KEY }}
 
       - name: Create/Update Move to Emeritus PR
         run: |


### PR DESCRIPTION
uses `otelbot-js` over the regular `otelbot` as the regular one is not allowed to create any PRs.

Ref: https://github.com/open-telemetry/opentelemetry-js/actions/runs/18096191118