### PR TITLE
ci: use --ignore-scripts wherever possible

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,7 +44,7 @@ jobs:
       - run: npm install -g npm@latest
 
       - name: Bootstrap
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build 🔧
         run: npm run compile

--- a/.github/workflows/bundler-tests.yml
+++ b/.github/workflows/bundler-tests.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 24
       - run: npm install -g npm@latest
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Build TypeScript packages
         run: npm run compile
       - name: Run bundler tests

--- a/.github/workflows/create-or-update-release-pr.yml
+++ b/.github/workflows/create-or-update-release-pr.yml
@@ -43,7 +43,7 @@ jobs:
           node-version: 22
       - run: npm install -g npm@latest
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - name: Create/Update Release PR
         run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install and Build 🔧
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run compile
 
       - name: Build Docs

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,7 +48,7 @@ jobs:
           }}
 
       - name: Bootstrap
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build 🔧
         run: npm run compile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: '22'
 
       - name: Bootstrap
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Lint
         run: |

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       # NOTE: in the past, we've had situations where the compiled files were missing as the `prepublishOnly` script was
       # missing in some packages. `npx lerna publish` *should* also run compile, but this is intended as a safeguard
       # when that does not happen for whatever reason.

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -19,7 +19,7 @@ jobs:
       - run: npm install -g npm@latest
 
       - name: Bootstrap
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Generate SBOM for core packages
         if: ${{ ! startsWith(github.ref, 'refs/tags/experimental') && ! startsWith(github.ref, 'refs/tags/api') }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -50,7 +50,7 @@ jobs:
           }}
 
       - name: Bootstrap
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build 🔧
         run: npm run compile
@@ -86,7 +86,7 @@ jobs:
       - run: npm install -g npm@latest
 
       - name: Bootstrap
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build 🔧
         run: |
@@ -111,7 +111,7 @@ jobs:
           node-version: 22
 
       - name: Bootstrap
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build 🔧
         run: npm run compile
@@ -137,7 +137,7 @@ jobs:
           node-version: 22
 
       - name: Bootstrap
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build 🔧
         run: npm run compile

--- a/.github/workflows/w3c-integration-test.yml
+++ b/.github/workflows/w3c-integration-test.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 22
 
       - name: Install and Bootstrap 🔧
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Generate version.ts files
         run: npm run version:update


### PR DESCRIPTION
## Which problem is this PR solving?

Similar to the PR in the contrib repo. We can use `--ignore-scripts` wherever possible to avoid postinstall scripts from running in CI that are not strictly needed.