### PR TITLE
test(shim-opentracing): add comparison thresholds in flaky assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* test(shim-opentracing): add comparison thresholds in flaky assertions [#xxxx](https://github.com/open-telemetry/opentelemetry-js/pull/xxxx) @cjihrig
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
-* test(shim-opentracing): add comparison thresholds in flaky assertions [#xxxx](https://github.com/open-telemetry/opentelemetry-js/pull/xxxx) @cjihrig
+* test(shim-opentracing): add comparison thresholds in flaky assertions [#5974](https://github.com/open-telemetry/opentelemetry-js/pull/5974) @cjihrig
 
 ### :books: Documentation
 

--- a/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
+++ b/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
@@ -42,6 +42,17 @@ import {
   ATTR_EXCEPTION_TYPE,
 } from '@opentelemetry/semantic-conventions';
 
+function assertWithinThreshold(
+  actual: number,
+  expected: number,
+  threshold: number
+) {
+  assert.ok(
+    Math.abs(actual - expected) <= threshold,
+    `actual (${actual}) and expected (${expected}) not within threshold of ${threshold}`
+  );
+}
+
 describe('OpenTracing Shim', () => {
   const compositePropagator = new CompositePropagator({
     propagators: [new W3CTraceContextPropagator(), new W3CBaggagePropagator()],
@@ -263,9 +274,10 @@ describe('OpenTracing Shim', () => {
         const adjustment = (otSpan as any)['_performanceOffset'];
 
         assert.strictEqual(otSpan.links.length, 1);
-        assert.deepStrictEqual(
+        assertWithinThreshold(
           hrTimeToMilliseconds(otSpan.startTime),
-          now + adjustment + performance.timeOrigin
+          now + adjustment + performance.timeOrigin,
+          0.001
         );
         assert.deepStrictEqual(otSpan.attributes, opentracingOptions.tags);
       });
@@ -497,9 +509,10 @@ describe('OpenTracing Shim', () => {
       const now = performance.now();
       span.finish(now);
       const adjustment = (otSpan as any)['_performanceOffset'];
-      assert.deepStrictEqual(
+      assertWithinThreshold(
         hrTimeToMilliseconds(otSpan.endTime),
-        now + adjustment + performance.timeOrigin
+        now + adjustment + performance.timeOrigin,
+        0.001
       );
     });
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

These equality assertions can be flaky due to floating point math.

Fixes: https://github.com/open-telemetry/opentelemetry-js/actions/runs/18082260606/job/51447397928?pr=5962

## Short description of the changes

This commit updates the assertions to allow a small threshold.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Existing test suite

## Checklist:

- [x] Followed the style guidelines of this project
