### PR TITLE
ci: pin to npm@11.6.0

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,7 +41,7 @@ jobs:
             package-lock.json
           node-version: ${{ matrix.node_version }}
 
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11.6.0
 
       - name: Bootstrap
         run: npm ci --ignore-scripts

--- a/.github/workflows/bundler-tests.yml
+++ b/.github/workflows/bundler-tests.yml
@@ -20,7 +20,7 @@ jobs:
           cache-dependency-path: |
             package-lock.json
           node-version: 24
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11.6.0
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Build TypeScript packages

--- a/.github/workflows/create-or-update-release-pr.yml
+++ b/.github/workflows/create-or-update-release-pr.yml
@@ -41,7 +41,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: package-lock.json
           node-version: 22
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11.6.0
 
       - run: npm ci --ignore-scripts
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,7 +40,7 @@ jobs:
           matrix.node_version == '18' ||
           matrix.node_version == '20.6.0'
           }}
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11.6.0
         if: ${{
           matrix.node_version == '20' ||
           matrix.node_version == '22' ||

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 22
 
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11.6.0
 
       - name: Bootstrap
         run: npm ci --ignore-scripts

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -42,7 +42,7 @@ jobs:
           matrix.node_version == '18' ||
           matrix.node_version == '20.6.0'
           }}
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11.6.0
         if: ${{
           matrix.node_version == '20' ||
           matrix.node_version == '22' ||
@@ -83,7 +83,7 @@ jobs:
             package-lock.json
           node-version: '22'
 
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11.6.0
 
       - name: Bootstrap
         run: npm ci --ignore-scripts

--- a/renovate.json
+++ b/renovate.json
@@ -42,7 +42,7 @@
     "@types/node"
   ],
   "constraints": {
-    "npm": ">10.8.0"
+    "npm": "11.6.0"
   },
   "assignees": ["@dyladan", "@legendecas", "@pichlermarc", "@trentm"],
   "labels": ["dependencies"],


### PR DESCRIPTION
## Which problem is this PR solving?

Pins to `npm@11.6.0` to avoid https://github.com/npm/cli/issues/8628. When updating the lockfile to v3, I was met with quite a few missing "optional" dependencies for both `@bufbuild/buf` and `nx` that were previously installed.

I'm not sure if it's the same change in `npm` that caused it, but I've also seen an out-of-sync `package-lock.json` for older `npm` versions in #5976