### PR TITLE
doc: add a doc for OTel JS users migrating to stable HTTP and database semconv

### DIFF
--- a/doc/semconv-stable-http-and-database.md
+++ b/doc/semconv-stable-http-and-database.md
@@ -36,7 +36,7 @@ Some HTTP-related instrumentations are for use in the browser:
 - 2024-09-10 to 2025-09-19: All OTel JS instrumentations producing `http.*` were updated to support stable semconv and `OTEL_SEMCONV_STABILITY_OPT_IN`.
 - Ongoing: [OTel JS instrumentations producing **`net.*` semconv** are being updated](https://github.com/open-telemetry/opentelemetry-js/issues/5663) to support stable semconv and `OTEL_SEMCONV_STABILITY_OPT_IN`
 - Ongoing: [OTel JS instrumentations producing **`db.*` semconv** are being updated](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2953) to support stable semconv and `OTEL_SEMCONV_STABILITY_OPT_IN`
-- Projected 2025-06: As part of OTel JS SDK 3.0, instrumentations will emit *stable* HTTP and database semantic conventions by default, and drop support for old names.
+- Projected 2026-06: As part of OTel JS SDK 3.0, instrumentations will emit *stable* HTTP and database semantic conventions by default, and drop support for old names.
 
 ## Q&A
 


### PR DESCRIPTION
This process can be pretty confusing because there are multiple sets of
semconv namespaces (http, net, db), two tokens in OTEL_SEMCONV_STABILITY_OPT_IN,
(http, database), and OTel JS instrumentations are *part* way through
supporting the migration process for these. As well, what config to use
to control migration of 'net.*' attributes isn't obvious.

Refs: https://github.com/open-telemetry/opentelemetry-js/issues/5663
Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2953

---

The rendered doc (to view before this PR is merged): https://github.com/trentm/opentelemetry-js/blob/trentm-semconv-up-doc/doc/semconv-stable-http-and-database.md