### PR TITLE
chore(sdk-logs): remove resource@1.9.0 dev dependency

### DIFF
--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -73,7 +73,6 @@
     "@babel/core": "7.27.1",
     "@babel/preset-env": "7.27.2",
     "@opentelemetry/api": ">=1.4.0 <1.10.0",
-    "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1537,7 +1537,6 @@
         "@babel/core": "7.27.1",
         "@babel/preset-env": "7.27.2",
         "@opentelemetry/api": ">=1.4.0 <1.10.0",
-        "@opentelemetry/resources_1.9.0": "npm:@opentelemetry/resources@1.9.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.4",
@@ -1571,50 +1570,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "experimental/packages/sdk-logs/node_modules/@opentelemetry/resources_1.9.0": {
-      "name": "@opentelemetry/resources",
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.9.0.tgz",
-      "integrity": "sha512-zCyien0p3XWarU6zv72c/JZ6QlG5QW/hc61Nh5TSR1K9ndnljzAGrH55x4nfyQdubfoh9QxLNh9FXH0fWK6vcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.9.0",
-        "@opentelemetry/semantic-conventions": "1.9.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "experimental/packages/sdk-logs/node_modules/@opentelemetry/resources_1.9.0/node_modules/@opentelemetry/core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.9.0.tgz",
-      "integrity": "sha512-Koy1ApRUp5DB5KpOqhDk0JjO9x6QeEkmcePl8qQDsXZGF4MuHUBShXibd+J2tRNckTsvgEHi1uEuUckDgN+c/A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.9.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "experimental/packages/sdk-logs/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.0.tgz",
-      "integrity": "sha512-po7penSfQ/Z8352lRVDpaBrd9znwA5mHGqXR7nDEiVnxkDFkBIhVf/tKeAJDIq/erFpcRowKFeCsr5eqqcSyFQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "experimental/packages/shim-opencensus": {


### PR DESCRIPTION
## Which problem is this PR solving?

Found this while working on another issue. `resource@1.9.0` might've been used for backward compatibility tests that are now obsolete (no compatibility is provided for 1.x packages in the 2.x line) 