### PR TITLE
ci: drop useWorkspaces in lerna.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
   "version": "independent",
-  "npmClient": "npm",
-  "useWorkspaces": true
+  "npmClient": "npm"
 }


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-js/actions/runs/18274858515 - workflow is failing as we use an old, but now default option in our `lerna.json`