### PR TITLE
feat(sdk-node)!: drop dynamic loading of jaeger exporter

### DIFF
--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -22,7 +22,7 @@ $ npm install @opentelemetry/sdk-node
 
 $ # Install exporters and plugins
 $ npm install \
-    @opentelemetry/exporter-jaeger \ # add tracing exporters as needed
+    @opentelemetry/exporter-trace-otlp-proto \ # add tracing exporters as needed
     @opentelemetry/exporter-prometheus \ # add metrics exporters as needed
     @opentelemetry/instrumentation-http # add instrumentations as needed
 
@@ -38,23 +38,24 @@ $ npm install @opentelemetry/auto-instrumentations-node
 Before any other module in your application is loaded, you must initialize the SDK.
 If you fail to initialize the SDK or initialize it too late, no-op implementations will be provided to any library which acquires a tracer or meter from the API.
 
-This example uses Jaeger and Prometheus, but exporters exist for [other tracing backends][other-tracing-backends].
+This example uses Jaeger (via OTLP) and Prometheus, but exporters exist for [other tracing backends][other-tracing-backends].
+OTLP in particular is widely supported by a wide-variety of backends.
 As shown in the installation instructions, exporters passed to the SDK must be installed alongside `@opentelemetry/sdk-node`.
 
 ```javascript
 const opentelemetry = require("@opentelemetry/sdk-node");
-const { JaegerExporter } = require("@opentelemetry/exporter-jaeger");
+const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-proto");
 const { PrometheusExporter } = require("@opentelemetry/exporter-prometheus");
 const {
   getNodeAutoInstrumentations,
 } = require("@opentelemetry/auto-instrumentations-node");
 
-const jaegerExporter = new JaegerExporter();
+const otlpExporter = new OTLPTraceExporter();
 const prometheusExporter = new PrometheusExporter();
 
 const sdk = new opentelemetry.NodeSDK({
   // Optional - if omitted, the tracing SDK will be initialized from environment variables
-  traceExporter: jaegerExporter,
+  traceExporter: otlpExporter,
   // Optional - If omitted, the metrics SDK will not be initialized
   metricReader: prometheusExporter,
   // Optional - you can use the metapackage or load each instrumentation individually
@@ -199,28 +200,27 @@ This is an alternative to programmatically configuring an exporter or span proce
 
 ### Exporters
 
-| Environment variable | Description                                                                                                                                                                        |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| OTEL_TRACES_EXPORTER | List of exporters to be used for tracing, separated by commas. Options include `otlp`, `jaeger`, `zipkin`, and `none`. Default is `otlp`. `none` means no autoconfigured exporter. |
-| OTEL_LOGS_EXPORTER   | List of exporters to be used for logging, separated by commas. Options include `otlp`, `console` and `none`. Default is `otlp`. `none` means no autoconfigured exporter.           |
+| Environment variable | Description                                                                                                                                                              |
+|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| OTEL_TRACES_EXPORTER | List of exporters to be used for tracing, separated by commas. Options include `otlp`, `zipkin`, and `none`. Default is `otlp`. `none` means no autoconfigured exporter. |
+| OTEL_LOGS_EXPORTER   | List of exporters to be used for logging, separated by commas. Options include `otlp`, `console` and `none`. Default is `otlp`. `none` means no autoconfigured exporter. |
 
 ### OTLP Exporter
 
 | Environment variable                | Description                                                                                                                                                  |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|-------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | OTEL_EXPORTER_OTLP_PROTOCOL         | The transport protocol to use on OTLP trace, metric, and log requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`. |
 | OTEL_EXPORTER_OTLP_TRACES_PROTOCOL  | The transport protocol to use on OTLP trace requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`.                  |
 | OTEL_EXPORTER_OTLP_METRICS_PROTOCOL | The transport protocol to use on OTLP metric requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`.                 |
 | OTEL_EXPORTER_OTLP_LOGS_PROTOCOL    | The transport protocol to use on OTLP log requests. Options include `grpc`, `http/protobuf`, and `http/json`. Default is `http/protobuf`.                    |
-| OTEL_METRICS_EXPORTER    | Metrics exporter to be used. options are `otlp`, `prometheus`, `console` or `none`.                    |
-| OTEL_METRIC_EXPORT_INTERVAL    | The export interval when using a push Metric Reader. Default is `60000`.                     |
-| OTEL_METRIC_EXPORT_TIMEOUT    | The export timeout when using a push Metric Reader. Default is `30000`.                     |
+| OTEL_METRICS_EXPORTER               | Metrics exporter to be used. options are `otlp`, `prometheus`, `console` or `none`.                                                                          |
+| OTEL_METRIC_EXPORT_INTERVAL         | The export interval when using a push Metric Reader. Default is `60000`.                                                                                     |
+| OTEL_METRIC_EXPORT_TIMEOUT          | The export timeout when using a push Metric Reader. Default is `30000`.                                                                                      |
 
 Additionally, you can specify other applicable environment variables that apply to each exporter such as the following:
 
 - [OTLP exporter environment configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options)
 - [Zipkin exporter environment configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/6ce62202e5407518e19c56c445c13682ef51a51d/specification/sdk-environment-variables.md#zipkin-exporter)
-- [Jaeger exporter environment configuration](https://github.com/open-telemetry/opentelemetry-specification/blob/6ce62202e5407518e19c56c445c13682ef51a51d/specification/sdk-environment-variables.md#jaeger-exporter)
 
 ## Useful links
 

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -72,7 +72,6 @@
   "devDependencies": {
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/context-async-hooks": "2.1.0",
-    "@opentelemetry/exporter-jaeger": "2.1.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.6.5",
     "@types/sinon": "17.0.4",

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -113,27 +113,11 @@ function getOtlpExporterFromEnv(): SpanExporter {
   }
 }
 
-function getJaegerExporter() {
-  // The JaegerExporter does not support being required in bundled
-  // environments. By delaying the require statement to here, we only crash when
-  // the exporter is actually used in such an environment.
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { JaegerExporter } = require('@opentelemetry/exporter-jaeger');
-    return new JaegerExporter();
-  } catch (e) {
-    throw new Error(
-      `Could not instantiate JaegerExporter. This could be due to the JaegerExporter's lack of support for bundling. If possible, use @opentelemetry/exporter-trace-otlp-proto instead. Original Error: ${e}`
-    );
-  }
-}
-
 export function getSpanProcessorsFromEnv(): SpanProcessor[] {
   const exportersMap = new Map<string, () => SpanExporter>([
     ['otlp', () => getOtlpExporterFromEnv()],
     ['zipkin', () => new ZipkinExporter()],
     ['console', () => new ConsoleSpanExporter()],
-    ['jaeger', () => getJaegerExporter()],
   ]);
   const exporters: SpanExporter[] = [];
   const processors: SpanProcessor[] = [];

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -29,7 +29,6 @@ import {
   AsyncLocalStorageContextManager,
 } from '@opentelemetry/context-async-hooks';
 import { CompositePropagator } from '@opentelemetry/core';
-import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
 import {
   AggregationTemporality,
   ConsoleMetricExporter,
@@ -1676,67 +1675,6 @@ describe('setup exporter from env', () => {
     assert.ok(
       listOfProcessors[1]['_exporter'] instanceof OTLPGrpcTraceExporter
     );
-
-    delete env.OTEL_TRACES_EXPORTER;
-    delete env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL;
-    await sdk.shutdown();
-  });
-
-  it('should be able to setup jaeger exporter', async () => {
-    env.OTEL_TRACES_EXPORTER = 'jaeger';
-    env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = 'grpc';
-    const sdk = new NodeSDK();
-    sdk.start();
-
-    const listOfProcessors = getSdkSpanProcessors(sdk);
-
-    assert.ok(listOfProcessors.length === 1);
-    assert.ok(listOfProcessors[0] instanceof BatchSpanProcessor);
-    assert.ok(listOfProcessors[0]['_exporter'] instanceof JaegerExporter);
-
-    delete env.OTEL_TRACES_EXPORTER;
-    delete env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL;
-    await sdk.shutdown();
-  });
-
-  it('should be able to setup jaeger and otlp exporters', async () => {
-    env.OTEL_TRACES_EXPORTER = 'otlp, jaeger';
-    env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = 'grpc';
-    const sdk = new NodeSDK();
-    sdk.start();
-
-    const listOfProcessors = getSdkSpanProcessors(sdk);
-
-    assert.ok(listOfProcessors.length === 2);
-    assert.ok(listOfProcessors[0] instanceof BatchSpanProcessor);
-    assert.ok(
-      listOfProcessors[0]['_exporter'] instanceof OTLPGrpcTraceExporter
-    );
-    assert.ok(listOfProcessors[1] instanceof BatchSpanProcessor);
-    assert.ok(listOfProcessors[1]['_exporter'] instanceof JaegerExporter);
-
-    delete env.OTEL_TRACES_EXPORTER;
-    delete env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL;
-    await sdk.shutdown();
-  });
-
-  it('should be able to setup zipkin, jaeger and otlp exporters', async () => {
-    env.OTEL_TRACES_EXPORTER = 'zipkin, otlp, jaeger';
-    env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = 'grpc';
-    const sdk = new NodeSDK();
-    sdk.start();
-
-    const listOfProcessors = getSdkSpanProcessors(sdk);
-
-    assert.ok(listOfProcessors.length === 3);
-    assert.ok(listOfProcessors[0] instanceof BatchSpanProcessor);
-    assert.ok(listOfProcessors[0]['_exporter'] instanceof ZipkinExporter);
-    assert.ok(listOfProcessors[1] instanceof BatchSpanProcessor);
-    assert.ok(
-      listOfProcessors[1]['_exporter'] instanceof OTLPGrpcTraceExporter
-    );
-    assert.ok(listOfProcessors[2] instanceof BatchSpanProcessor);
-    assert.ok(listOfProcessors[2]['_exporter'] instanceof JaegerExporter);
 
     delete env.OTEL_TRACES_EXPORTER;
     delete env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL;

--- a/experimental/packages/opentelemetry-sdk-node/tsconfig.json
+++ b/experimental/packages/opentelemetry-sdk-node/tsconfig.json
@@ -19,9 +19,6 @@
       "path": "../../../packages/opentelemetry-core"
     },
     {
-      "path": "../../../packages/opentelemetry-exporter-jaeger"
-    },
-    {
       "path": "../../../packages/opentelemetry-exporter-zipkin"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1192,7 +1192,6 @@
       "devDependencies": {
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/context-async-hooks": "2.1.0",
-        "@opentelemetry/exporter-jaeger": "2.1.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.6.5",
         "@types/sinon": "17.0.4",


### PR DESCRIPTION
## Which problem is this PR solving?

A whole bunch of bundles are failing to build when `@opentelemetry/sdk-node` is used. The reason for it is that we dynamically try to lazy-load `@opentelemetry/exporter-jaeger` if present which we've marked as deprecated for a long time now and has been superseded by `@opentelemetry/exporter-trace-otlp-http` et al. since Jaeger now has native support for OTLP

This PR removes the lazy-loading in favor of the OTLP exporter, which remains fully supported.

Though deprecated, the Jaeger exporter will continue to be published from this repo until we mark `@opentelemetry/exporter-trace-otlp-http` as stable.

Fixes #4297