### PR TITLE
test(exporter-jaeger): clean up `OTEL_EXPORTER_JAEGER_AGENT_PORT` between tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :house: Internal
 
 * test(shim-opentracing): add comparison thresholds in flaky assertions [#5974](https://github.com/open-telemetry/opentelemetry-js/pull/5974) @cjihrig
+* test(exporter-jaeger): clean up OTEL_EXPORTER_JAEGER_AGENT_PORT between tests [#xxxx](https://github.com/open-telemetry/opentelemetry-js/pull/xxxx) @cjihrig
 
 ## 2.1.0
 

--- a/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
+++ b/packages/opentelemetry-exporter-jaeger/test/jaeger.test.ts
@@ -60,6 +60,7 @@ describe('JaegerExporter', () => {
   describe('constructor', () => {
     afterEach(() => {
       delete process.env.OTEL_EXPORTER_JAEGER_AGENT_HOST;
+      delete process.env.OTEL_EXPORTER_JAEGER_AGENT_PORT;
     });
 
     it('should construct an exporter', () => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

`process.env.OTEL_EXPORTER_JAEGER_AGENT_PORT` is not cleaned up between tests like `process.env.OTEL_EXPORTER_JAEGER_AGENT_HOST` is.

Fixes # N/A

## Short description of the changes

`OTEL_EXPORTER_JAEGER_AGENT_HOST` is already cleaned up between tests. This commit also cleans up `OTEL_EXPORTER_JAEGER_AGENT_PORT`, which is used in several tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Existing test suite.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
