### PR TITLE
test(opentelemetry-configuration): simplify management of environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :house: Internal
 
 * test(shim-opentracing): add comparison thresholds in flaky assertions [#5974](https://github.com/open-telemetry/opentelemetry-js/pull/5974) @cjihrig
-* test(exporter-jaeger): clean up OTEL_EXPORTER_JAEGER_AGENT_PORT between tests [#xxxx](https://github.com/open-telemetry/opentelemetry-js/pull/xxxx) @cjihrig
+* test(exporter-jaeger): clean up OTEL_EXPORTER_JAEGER_AGENT_PORT between tests [#6003](https://github.com/open-telemetry/opentelemetry-js/pull/6003) @cjihrig
 
 ## 2.1.0
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -24,6 +24,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
+* test(opentelemetry-configuration): simplify management of environment variables [#6004](https://github.com/open-telemetry/opentelemetry-js/pull/6004) @cjihrig
+
 ## 0.206.0
 
 ### :rocket: Features

--- a/experimental/packages/opentelemetry-configuration/test/ConfigProvider.test.ts
+++ b/experimental/packages/opentelemetry-configuration/test/ConfigProvider.test.ts
@@ -353,61 +353,13 @@ const defaultConfigFromFileWithEnvVariables: Configuration = {
 };
 
 describe('ConfigProvider', function () {
-  describe('get values from environment variables', function () {
-    afterEach(function () {
-      delete process.env.OTEL_SDK_DISABLED;
-      delete process.env.OTEL_LOG_LEVEL;
-      delete process.env.OTEL_NODE_RESOURCE_DETECTORS;
-      delete process.env.OTEL_RESOURCE_ATTRIBUTES;
-      delete process.env.OTEL_SERVICE_NAME;
-      delete process.env.OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT;
-      delete process.env.OTEL_ATTRIBUTE_COUNT_LIMIT;
-      delete process.env.OTEL_PROPAGATORS;
-      delete process.env.OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT;
-      delete process.env.OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT;
-      delete process.env.OTEL_SPAN_EVENT_COUNT_LIMIT;
-      delete process.env.OTEL_SPAN_LINK_COUNT_LIMIT;
-      delete process.env.OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT;
-      delete process.env.OTEL_LINK_ATTRIBUTE_COUNT_LIMIT;
-      delete process.env.OTEL_BSP_SCHEDULE_DELAY;
-      delete process.env.OTEL_BSP_EXPORT_TIMEOUT;
-      delete process.env.OTEL_BSP_MAX_QUEUE_SIZE;
-      delete process.env.OTEL_BSP_MAX_EXPORT_BATCH_SIZE;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_COMPRESSION;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_HEADERS;
-      delete process.env.OTEL_METRIC_EXPORT_INTERVAL;
-      delete process.env.OTEL_METRIC_EXPORT_TIMEOUT;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_COMPRESSION;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_TIMEOUT;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_HEADERS;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE;
-      delete process.env
-        .OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION;
-      delete process.env.OTEL_METRICS_EXEMPLAR_FILTER;
-      delete process.env.OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT;
-      delete process.env.OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT;
-      delete process.env.OTEL_BLRP_SCHEDULE_DELAY;
-      delete process.env.OTEL_BLRP_EXPORT_TIMEOUT;
-      delete process.env.OTEL_BLRP_MAX_QUEUE_SIZE;
-      delete process.env.OTEL_BLRP_MAX_EXPORT_BATCH_SIZE;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_COMPRESSION;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_TIMEOUT;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_HEADERS;
-    });
+  const _origEnvVariables = { ...process.env };
 
+  afterEach(function () {
+    process.env = { ..._origEnvVariables };
+  });
+
+  describe('get values from environment variables', function () {
     it('should initialize config with default values', function () {
       const configProvider = createConfigProvider();
       assert.deepStrictEqual(
@@ -706,61 +658,6 @@ describe('ConfigProvider', function () {
   });
 
   describe('get values from config file', function () {
-    afterEach(function () {
-      delete process.env.OTEL_EXPERIMENTAL_CONFIG_FILE;
-      delete process.env.OTEL_NODE_RESOURCE_DETECTORS;
-      delete process.env.OTEL_SDK_DISABLED;
-      delete process.env.OTEL_LOG_LEVEL;
-      delete process.env.OTEL_SERVICE_NAME;
-      delete process.env.OTEL_RESOURCE_ATTRIBUTES;
-      delete process.env.OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT;
-      delete process.env.OTEL_ATTRIBUTE_COUNT_LIMIT;
-      delete process.env.OTEL_PROPAGATORS;
-      delete process.env.OTEL_BSP_SCHEDULE_DELAY;
-      delete process.env.OTEL_BSP_EXPORT_TIMEOUT;
-      delete process.env.OTEL_BSP_MAX_QUEUE_SIZE;
-      delete process.env.OTEL_BSP_MAX_EXPORT_BATCH_SIZE;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_COMPRESSION;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_TIMEOUT;
-      delete process.env.OTEL_EXPORTER_OTLP_TRACES_HEADERS;
-      delete process.env.OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT;
-      delete process.env.OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT;
-      delete process.env.OTEL_SPAN_EVENT_COUNT_LIMIT;
-      delete process.env.OTEL_SPAN_LINK_COUNT_LIMIT;
-      delete process.env.OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT;
-      delete process.env.OTEL_LINK_ATTRIBUTE_COUNT_LIMIT;
-      delete process.env.OTEL_METRIC_EXPORT_INTERVAL;
-      delete process.env.OTEL_METRIC_EXPORT_TIMEOUT;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_COMPRESSION;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_TIMEOUT;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_HEADERS;
-      delete process.env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE;
-      delete process.env
-        .OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION;
-      delete process.env.OTEL_METRICS_EXEMPLAR_FILTER;
-      delete process.env.OTEL_BLRP_SCHEDULE_DELAY;
-      delete process.env.OTEL_BLRP_EXPORT_TIMEOUT;
-      delete process.env.OTEL_BLRP_MAX_QUEUE_SIZE;
-      delete process.env.OTEL_BLRP_MAX_EXPORT_BATCH_SIZE;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_COMPRESSION;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_TIMEOUT;
-      delete process.env.OTEL_EXPORTER_OTLP_LOGS_HEADERS;
-      delete process.env.OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT;
-      delete process.env.OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT;
-    });
-
     it('should initialize config with default values from valid config file', function () {
       process.env.OTEL_EXPERIMENTAL_CONFIG_FILE =
         'test/fixtures/kitchen-sink.yaml';


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The `ConfigProvider` tests were deleting a number of environment variables after every test, and this logic was duplicated in a few places. This is a bit error prone.

Fixes # N/A

## Short description of the changes

The tests seem to pass with a clean `process.env` provided to each test, and Mocha's `afterEach()` hook is inherited, so the logic can be simplified a good bit while maintaining semantics.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) Not really a bug, but more of a simplification.

## How Has This Been Tested?

- [x] Existing test suite

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
