### PR TITLE
fix(otlp-exporter-base): avoid adding new userAgent option for browser exporters

### DIFF
--- a/experimental/packages/otlp-exporter-base/src/configuration/otlp-http-configuration.ts
+++ b/experimental/packages/otlp-exporter-base/src/configuration/otlp-http-configuration.ts
@@ -24,7 +24,6 @@ import { validateAndNormalizeHeaders } from '../util';
 export interface OtlpHttpConfiguration extends OtlpSharedConfiguration {
   url: string;
   headers: () => Record<string, string>;
-  userAgent?: string;
 }
 
 function mergeHeaders(
@@ -93,7 +92,6 @@ export function mergeOtlpHttpConfigurationWithDefaults(
       validateUserProvidedUrl(userProvidedConfiguration.url) ??
       fallbackConfiguration.url ??
       defaultConfiguration.url,
-    userAgent: userProvidedConfiguration.userAgent,
   };
 }
 

--- a/experimental/packages/otlp-exporter-base/src/configuration/otlp-node-http-configuration.ts
+++ b/experimental/packages/otlp-exporter-base/src/configuration/otlp-node-http-configuration.ts
@@ -77,6 +77,7 @@ export function mergeOtlpNodeHttpConfigurationWithDefaults(
       userProvidedConfiguration.agentFactory ??
       fallbackConfiguration.agentFactory ??
       defaultConfiguration.agentFactory,
+    userAgent: userProvidedConfiguration.userAgent,
   };
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

Follow-up to #5928, as I missed it while doing the review. I noticed this while working on #5994.

The `userAgent` option is not used in any of the browser transports. This PR removes it from the `OtlpHttpConfiguration` interface so that it's only present on `OtlpNodeHttpConfiguration` and `OtlpGrpcConfiguration` where it's actually used. 🙂 

Skipping changelog since the change from #5928 is unreleased.

cc @david-luna 