### PR TITLE
chore(deps): Update `import-in-the-middle`

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@opentelemetry/api-logs": "0.206.0",
-    "import-in-the-middle": "^1.8.1",
+    "import-in-the-middle": "^2.0.0",
     "require-in-the-middle": "^8.0.0"
   },
   "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -965,7 +965,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.206.0",
-        "import-in-the-middle": "^1.8.1",
+        "import-in-the-middle": "^2.0.0",
         "require-in-the-middle": "^8.0.0"
       },
       "devDependencies": {
@@ -13880,9 +13880,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.4.tgz",
-      "integrity": "sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.0.tgz",
+      "integrity": "sha512-yNZhyQYqXpkT0AKq3F3KLasUSK4fHvebNH5hOsKQw2dhGSALvQ4U0BqUc5suziKvydO5u5hgN2hy1RJaho8U5A==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.14.0",


### PR DESCRIPTION
`import-in-the-middle` has a new v2.0.0 release. 

This was only a new major out of an abundance of caution. The hook code has been converted to ESM to work around some loader issues. There should actually be no breaking changes when using `import-in-the-middle/hook.mjs` or the exported `Hook` API.

