### PR TITLE
feat: implement on ending in span processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :rocket: Features
 
+* feat(sdk-trace-base): implement on ending in span processor [#6024](https://github.com/open-telemetry/opentelemetry-js/pull/6024) @majanjua-amzn
+  * note: this feature is experimental and subject to change
+
 ### :bug: Bug Fixes
 
 ### :books: Documentation

--- a/packages/opentelemetry-sdk-trace-base/src/MultiSpanProcessor.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/MultiSpanProcessor.ts
@@ -53,6 +53,14 @@ export class MultiSpanProcessor implements SpanProcessor {
     }
   }
 
+  onEnding(span: Span): void {
+    for (const spanProcessor of this._spanProcessors) {
+      if (spanProcessor.onEnding) {
+        spanProcessor.onEnding(span);
+      }
+    }
+  }
+
   onEnd(span: ReadableSpan): void {
     for (const spanProcessor of this._spanProcessors) {
       spanProcessor.onEnd(span);

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -270,8 +270,6 @@ export class SpanImpl implements Span {
       );
       return;
     }
-    this._ended = true;
-
     this.endTime = this._getTime(endTime);
     this._duration = hrTimeDuration(this.startTime, this.endTime);
 
@@ -290,7 +288,11 @@ export class SpanImpl implements Span {
         `Dropped ${this._droppedEventsCount} events because eventCountLimit reached`
       );
     }
+    if (this._spanProcessor.onEnding) {
+      this._spanProcessor.onEnding(this);
+    }
 
+    this._ended = true;
     this._spanProcessor.onEnd(this);
   }
 

--- a/packages/opentelemetry-sdk-trace-base/src/SpanProcessor.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/SpanProcessor.ts
@@ -36,6 +36,15 @@ export interface SpanProcessor {
   onStart(span: Span, parentContext: Context): void;
 
   /**
+   * Called when a {@link Span} is ending, if the `span.isRecording()`
+   * returns true.
+   * @param span the Span that is ending.
+   *
+   * @experimental This method is experimental and may break in minor versions of this package
+   */
+  onEnding?(span: Span): void;
+
+  /**
    * Called when a {@link ReadableSpan} is ended, if the `span.isRecording()`
    * returns true.
    * @param span the Span that just ended.

--- a/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
@@ -1346,6 +1346,29 @@ describe('Span', () => {
       const s = provider.getTracer('default').startSpan('test') as Span;
       assert.ok(s.attributes.attr);
     });
+
+    it('should call onEnding with a writeable span', () => {
+      const processor: SpanProcessor = {
+        onStart: span => {
+          span.setAttribute('attr', true);
+        },
+        forceFlush: () => Promise.resolve(),
+        onEnding: span => {
+          span.setAttribute('attr2', true);
+        },
+        onEnd() {},
+        shutdown: () => Promise.resolve(),
+      };
+
+      const provider = new BasicTracerProvider({
+        spanProcessors: [processor],
+      });
+
+      const s = provider.getTracer('default').startSpan('test') as Span;
+      s.end();
+      assert.ok(s.attributes.attr);
+      assert.ok(s.attributes.attr2);
+    });
   });
 
   describe('recordException', () => {


### PR DESCRIPTION
## Which problem is this PR solving?
Implementation of in-development feature [onEnding of the opentelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#onending). This will allow users to modify spans before they become immutable as they are in the process of being ended

Fixes #5836 

## Short description of the changes
- Implementation of `onEnding` as optional and `@experimental`
- Added onEnding to `MultiSpanProcessor`
- Added unit tests to test `onStart`, `onEnding`, and `onStart` are called in the correct order


## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Unit Testing

## Checklist:
- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
