### PR TITLE
chore(renovate): enable pinDigests for github actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,10 @@
   "extends": ["config:recommended"],
   "packageRules": [
     {
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    },
+    {
       "groupName": "all patch versions",
       "groupSlug": "all-patch",
       "matchUpdateTypes": ["patch"],
@@ -16,7 +20,7 @@
     {
       "groupName": "typedoc packages",
       "matchUpdateTypes": ["minor", "major"],
-      "matchPackageNames": ["/^typedoc/"]
+      "matchPackageNames": ["/^typedoc(-|$)/"]
     },
     {
       "matchUpdateTypes": ["minor"],


### PR DESCRIPTION
## Which problem is this PR solving?

Our security tab is full of warnings due to unpinned workflow actions. 

That's a security problem for two reasons:
- in case of compromised actions being re-tagged and ran in our workflows
- makes it more difficult to see when new severe problems pop up because the number is so high (notification fatigue)

Should also improve our OSSF score