### PR TITLE
feat(sdk-logs,sdk-trace-base,sdk-metrics): add configuration for console.dir depth in ConsoleSpanExporter, ConsoleMetricExporter, and ConsoleLogRecordExporter

### DIFF
--- a/experimental/packages/sdk-logs/src/export/ConsoleLogRecordExporter.ts
+++ b/experimental/packages/sdk-logs/src/export/ConsoleLogRecordExporter.ts
@@ -23,6 +23,22 @@ import {
 import type { ReadableLogRecord } from './ReadableLogRecord';
 import type { LogRecordExporter } from './LogRecordExporter';
 
+function log(payload: unknown): void {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(
+      payload,
+      (_key, value) => (value === undefined ? null : value),
+      2
+    );
+  } catch {
+    serialized = String(payload);
+  }
+
+  /* eslint-disable-next-line no-console */
+  console.log(serialized);
+}
+
 /**
  * This is implementation of {@link LogRecordExporter} that prints LogRecords to the
  * console. This class can be used for diagnostic purposes.
@@ -82,7 +98,7 @@ export class ConsoleLogRecordExporter implements LogRecordExporter {
     done?: (result: ExportResult) => void
   ): void {
     for (const logRecord of logRecords) {
-      console.dir(this._exportInfo(logRecord), { depth: 3 });
+      log(this._exportInfo(logRecord));
     }
     done?.({ code: ExportResultCode.SUCCESS });
   }

--- a/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/ConsoleSpanExporter.ts
@@ -22,6 +22,22 @@ import {
   hrTimeToMicroseconds,
 } from '@opentelemetry/core';
 
+function log(payload: unknown): void {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(
+      payload,
+      (_key, value) => (value === undefined ? null : value),
+      2
+    );
+  } catch {
+    serialized = String(payload);
+  }
+
+  /* eslint-disable-next-line no-console */
+  console.log(serialized);
+}
+
 /**
  * This is implementation of {@link SpanExporter} that prints spans to the
  * console. This class can be used for diagnostic purposes.
@@ -93,7 +109,7 @@ export class ConsoleSpanExporter implements SpanExporter {
     done?: (result: ExportResult) => void
   ): void {
     for (const span of spans) {
-      console.dir(this._exportInfo(span), { depth: 3 });
+      log(this._exportInfo(span));
     }
     if (done) {
       return done({ code: ExportResultCode.SUCCESS });

--- a/packages/sdk-metrics/src/export/ConsoleMetricExporter.ts
+++ b/packages/sdk-metrics/src/export/ConsoleMetricExporter.ts
@@ -26,6 +26,35 @@ interface ConsoleMetricExporterOptions {
   temporalitySelector?: AggregationTemporalitySelector;
 }
 
+function log(payload: unknown): void {
+  /**
+   * String(payload) fallback path is currently redundant because
+   * hashAttributes invokes JSON.stringify during metric registration. Reinstate
+   * fallback logic below if hashAttributes logic is changed to standardise
+   * implementation with ConsoleSpanExporter and ConsoleLogRecordExporter, and
+   * unskip the test.
+   */
+  // let serialized: string;
+  // try {
+  //   serialized = JSON.stringify(
+  //     payload,
+  //     (_key, value) => (value === undefined ? null : value),
+  //     2
+  //   );
+  // } catch {
+  //   serialized = String(payload);
+  // }
+
+  const serialized = JSON.stringify(
+    payload,
+    (_key, value) => (value === undefined ? null : value),
+    2
+  );
+
+  /* eslint-disable-next-line no-console */
+  console.log(serialized);
+}
+
 /**
  * This is an implementation of {@link PushMetricExporter} that prints metrics to the
  * console. This class can be used for diagnostic purposes.
@@ -77,14 +106,11 @@ export class ConsoleMetricExporter implements PushMetricExporter {
   ): void {
     for (const scopeMetrics of metrics.scopeMetrics) {
       for (const metric of scopeMetrics.metrics) {
-        console.dir(
-          {
-            descriptor: metric.descriptor,
-            dataPointType: metric.dataPointType,
-            dataPoints: metric.dataPoints,
-          },
-          { depth: null }
-        );
+        log({
+          descriptor: metric.descriptor,
+          dataPointType: metric.dataPointType,
+          dataPoints: metric.dataPoints,
+        });
       }
     }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This PR makes console.dir depth configurable in ConsoleSpanExporter, ConsoleMetricExporter, and ConsoleLogRecordExporter to resolve problem using with Cloudflare (excessive depth), and Semantic Conventions for Generative AI (insufficient depth).

Fixes #[5800](https://github.com/open-telemetry/opentelemetry-js/issues/5800)

## Short description of the changes
1. An optional options parameter is added to the constructors of ConsoleSpanExporter and ConsoleLogRecordExporter.
2. An optional depth property is added to the options parameter of the constructors of ConsoleSpanExporter, ConsoleMetricExporter, and ConsoleLogRecordExporter that controls the depth setting of `console.dir()`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

NB: ConsoleSpanExporter, ConsoleMetricExporter, and ConsoleLogRecordExporter are not well documented, only used in examples, so there was no existing documentation to update.

## How Has This Been Tested?

- [x] packages/opentelemetry-sdk-trace-base/test/common/export/ConsoleSpanExporter.test.ts
- [x] packages/sdk-metrics/test/export/ConsoleMetricExporter.test.ts
- [x] experimental/packages/sdk-logs/test/common/export/ConsoleLogRecordExporter.test.ts

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
