### PR TITLE
chore(deps): pin @types/node@18.6.5 at the top-level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "bundler-tests/browser/*"
       ],
       "devDependencies": {
+        "@types/node": "18.6.5",
         "@typescript-eslint/eslint-plugin": "8.41.0",
         "@typescript-eslint/parser": "8.41.0",
         "assert": "2.1.0",
@@ -301,6 +302,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -423,13 +425,6 @@
         "ts-node": "^10.9.1"
       }
     },
-    "experimental/examples/logs/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "experimental/examples/opencensus-shim": {
       "version": "0.207.0",
       "license": "Apache-2.0",
@@ -528,13 +523,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "experimental/packages/exporter-logs-otlp-grpc/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "experimental/packages/exporter-logs-otlp-http": {
       "name": "@opentelemetry/exporter-logs-otlp-http",
       "version": "0.207.0",
@@ -578,13 +566,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "experimental/packages/exporter-logs-otlp-http/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "experimental/packages/exporter-logs-otlp-proto": {
       "name": "@opentelemetry/exporter-logs-otlp-proto",
       "version": "0.207.0",
@@ -627,13 +608,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "experimental/packages/exporter-logs-otlp-proto/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "experimental/packages/exporter-trace-otlp-grpc": {
       "name": "@opentelemetry/exporter-trace-otlp-grpc",
       "version": "0.207.0",
@@ -665,13 +639,6 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
-    },
-    "experimental/packages/exporter-trace-otlp-grpc/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "experimental/packages/exporter-trace-otlp-http": {
       "name": "@opentelemetry/exporter-trace-otlp-http",
@@ -715,13 +682,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "experimental/packages/exporter-trace-otlp-http/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "experimental/packages/exporter-trace-otlp-proto": {
       "name": "@opentelemetry/exporter-trace-otlp-proto",
       "version": "0.207.0",
@@ -762,13 +722,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "experimental/packages/exporter-trace-otlp-proto/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "experimental/packages/opentelemetry-browser-detector": {
       "name": "@opentelemetry/opentelemetry-browser-detector",
       "version": "0.207.0",
@@ -805,13 +758,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "experimental/packages/opentelemetry-browser-detector/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "experimental/packages/opentelemetry-configuration": {
       "name": "@opentelemetry/configuration",
       "version": "0.207.0",
@@ -837,13 +783,6 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0"
       }
-    },
-    "experimental/packages/opentelemetry-configuration/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc": {
       "name": "@opentelemetry/exporter-metrics-otlp-grpc",
@@ -877,13 +816,6 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
-    },
-    "experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-http": {
       "name": "@opentelemetry/exporter-metrics-otlp-http",
@@ -926,13 +858,6 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
-    },
-    "experimental/packages/opentelemetry-exporter-metrics-otlp-http/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "experimental/packages/opentelemetry-exporter-metrics-otlp-proto": {
       "name": "@opentelemetry/exporter-metrics-otlp-proto",
@@ -977,13 +902,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "experimental/packages/opentelemetry-exporter-metrics-otlp-proto/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "experimental/packages/opentelemetry-exporter-prometheus": {
       "name": "@opentelemetry/exporter-prometheus",
       "version": "0.207.0",
@@ -1010,13 +928,6 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
-    },
-    "experimental/packages/opentelemetry-exporter-prometheus/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "experimental/packages/opentelemetry-instrumentation": {
       "name": "@opentelemetry/instrumentation",
@@ -1105,13 +1016,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "experimental/packages/opentelemetry-instrumentation-fetch/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "experimental/packages/opentelemetry-instrumentation-grpc": {
       "name": "@opentelemetry/instrumentation-grpc",
       "version": "0.207.0",
@@ -1146,13 +1050,6 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
-    },
-    "experimental/packages/opentelemetry-instrumentation-grpc/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "experimental/packages/opentelemetry-instrumentation-http": {
       "name": "@opentelemetry/instrumentation-http",
@@ -1189,13 +1086,6 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
-    },
-    "experimental/packages/opentelemetry-instrumentation-http/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "experimental/packages/opentelemetry-instrumentation-xml-http-request": {
       "name": "@opentelemetry/instrumentation-xml-http-request",
@@ -1240,20 +1130,6 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
-    },
-    "experimental/packages/opentelemetry-instrumentation-xml-http-request/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "experimental/packages/opentelemetry-instrumentation/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "experimental/packages/opentelemetry-sdk-node": {
       "name": "@opentelemetry/sdk-node",
@@ -1302,13 +1178,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "experimental/packages/opentelemetry-sdk-node/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "experimental/packages/otlp-exporter-base": {
       "name": "@opentelemetry/otlp-exporter-base",
       "version": "0.207.0",
@@ -1346,13 +1215,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "experimental/packages/otlp-exporter-base/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "experimental/packages/otlp-grpc-exporter-base": {
       "name": "@opentelemetry/otlp-grpc-exporter-base",
       "version": "0.207.0",
@@ -1382,13 +1244,6 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
-    },
-    "experimental/packages/otlp-grpc-exporter-base/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "experimental/packages/otlp-transformer": {
       "name": "@opentelemetry/otlp-transformer",
@@ -1449,13 +1304,6 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
-    },
-    "experimental/packages/sampler-composite/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "experimental/packages/sampler-composite/node_modules/glob": {
       "version": "10.4.5",
@@ -1558,13 +1406,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "experimental/packages/sampler-jaeger-remote/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "experimental/packages/sdk-logs": {
       "name": "@opentelemetry/sdk-logs",
       "version": "0.207.0",
@@ -1603,13 +1444,6 @@
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
-    "experimental/packages/sdk-logs/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "experimental/packages/shim-opencensus": {
       "name": "@opentelemetry/shim-opencensus",
       "version": "0.207.0",
@@ -1640,13 +1474,6 @@
         "@opencensus/core": "^0.1.0",
         "@opentelemetry/api": "^1.3.0"
       }
-    },
-    "experimental/packages/shim-opencensus/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "experimental/packages/web-common": {
       "name": "@opentelemetry/web-common",
@@ -1688,13 +1515,6 @@
         "@opentelemetry/api": ">=1.4.0 <1.10.0"
       }
     },
-    "experimental/packages/web-common/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "integration-tests/api": {
       "name": "@opentelemetry/integration-tests-api",
       "version": "2.6.0",
@@ -1710,13 +1530,6 @@
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       }
-    },
-    "integration-tests/api/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "integration-tests/propagation-validation-server": {
       "version": "2.6.0",
@@ -1802,6 +1615,7 @@
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -3681,6 +3495,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.0.tgz",
       "integrity": "sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -4809,18 +4624,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@lerna/create/node_modules/@types/node": {
-      "version": "24.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
-      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
     },
     "node_modules/@lerna/create/node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -6253,6 +6056,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -7304,6 +7108,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -7417,6 +7222,7 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -7472,10 +7278,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "license": "MIT"
+      "version": "18.6.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
+      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.14",
@@ -7743,6 +7550,7 @@
       "integrity": "sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.41.0",
         "@typescript-eslint/types": "8.41.0",
@@ -8294,6 +8102,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8383,6 +8192,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9294,6 +9104,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -10935,7 +10746,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
       "integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -11295,17 +11107,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/end-of-stream": {
@@ -11699,6 +11500,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11771,6 +11573,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -15112,6 +14915,7 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -16167,18 +15971,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/lerna/node_modules/@types/node": {
-      "version": "24.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
-      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
     },
     "node_modules/lerna/node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -17352,6 +17144,7 @@
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -18852,18 +18645,6 @@
         }
       }
     },
-    "node_modules/msw/node_modules/@types/node": {
-      "version": "24.10.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
-      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
     "node_modules/msw/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -19567,6 +19348,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -21085,6 +20867,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -21267,6 +21050,7 @@
       "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -22808,6 +22592,7 @@
       "integrity": "sha512-2kpQq2DD/pRpx3Tal/qRW1SYwcIeQ0iq8li5CJHQgOC+FtPn2BVmuDtzUCgNnpCrbgtfEHqh+iWzxK+Tq6C+RQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "chokidar": "^4.0.3",
@@ -23956,6 +23741,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -24210,6 +23996,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -24526,7 +24313,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "3.1.0",
@@ -24740,6 +24528,7 @@
       "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -24801,15 +24590,6 @@
       "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -25167,6 +24947,7 @@
       "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -25324,6 +25105,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -25495,6 +25277,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -25873,6 +25656,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -26601,13 +26385,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "packages/opentelemetry-context-async-hooks/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/opentelemetry-context-zone": {
       "name": "@opentelemetry/context-zone",
       "version": "2.2.0",
@@ -26661,13 +26438,6 @@
         "zone.js": "^0.10.2 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0"
       }
     },
-    "packages/opentelemetry-context-zone-peer-dep/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/opentelemetry-core": {
       "name": "@opentelemetry/core",
       "version": "2.2.0",
@@ -26702,13 +26472,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "packages/opentelemetry-core/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/opentelemetry-exporter-jaeger": {
       "name": "@opentelemetry/exporter-jaeger",
       "version": "2.2.0",
@@ -26737,13 +26500,6 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
       }
-    },
-    "packages/opentelemetry-exporter-jaeger/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/opentelemetry-exporter-zipkin": {
       "name": "@opentelemetry/exporter-zipkin",
@@ -26787,13 +26543,6 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "packages/opentelemetry-exporter-zipkin/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/opentelemetry-propagator-b3": {
       "name": "@opentelemetry/propagator-b3",
       "version": "2.2.0",
@@ -26816,13 +26565,6 @@
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
-    },
-    "packages/opentelemetry-propagator-b3/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/opentelemetry-propagator-jaeger": {
       "name": "@opentelemetry/propagator-jaeger",
@@ -26857,13 +26599,6 @@
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
-    },
-    "packages/opentelemetry-propagator-jaeger/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/opentelemetry-resources": {
       "name": "@opentelemetry/resources",
@@ -26900,13 +26635,6 @@
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
-    },
-    "packages/opentelemetry-resources/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/opentelemetry-sdk-trace-base": {
       "name": "@opentelemetry/sdk-trace-base",
@@ -26945,13 +26673,6 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "packages/opentelemetry-sdk-trace-base/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/opentelemetry-sdk-trace-node": {
       "name": "@opentelemetry/sdk-trace-node",
       "version": "2.2.0",
@@ -26979,13 +26700,6 @@
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
-    },
-    "packages/opentelemetry-sdk-trace-node/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/opentelemetry-sdk-trace-web": {
       "name": "@opentelemetry/sdk-trace-web",
@@ -27032,13 +26746,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "packages/opentelemetry-sdk-trace-web/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/opentelemetry-shim-opentracing": {
       "name": "@opentelemetry/shim-opentracing",
       "version": "2.2.0",
@@ -27065,13 +26772,6 @@
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
-    },
-    "packages/opentelemetry-shim-opentracing/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/sdk-metrics": {
       "name": "@opentelemetry/sdk-metrics",
@@ -27110,13 +26810,6 @@
         "@opentelemetry/api": ">=1.9.0 <1.10.0"
       }
     },
-    "packages/sdk-metrics/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/template": {
       "name": "@opentelemetry/template",
       "version": "2.2.0",
@@ -27128,13 +26821,6 @@
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       }
-    },
-    "packages/template/node_modules/@types/node": {
-      "version": "18.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
-      "integrity": "sha512-Xjt5ZGUa5WusGZJ4WJPbOT8QOqp6nDynVFRKcUt32bOgvXEoc6o085WNkYTMO7ifAj2isEfQQ2cseE+wT6jsRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "semantic-conventions": {
       "name": "@opentelemetry/semantic-conventions",
@@ -27158,6 +26844,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "semantic-conventions/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "8.41.0",
     "@typescript-eslint/parser": "8.41.0",
+    "@types/node": "18.6.5",
     "assert": "2.1.0",
     "benchmark": "2.1.4",
     "eslint": "8.57.1",


### PR DESCRIPTION
## Which problem is this PR solving?

Looks like resolution is not working the same between old an new `npm` versions - `npm@10.9.4` expects `@types/node@24` to be pulled into package-lock for some reason, while the new `npm@11.6.0` is fine with whatever it resolved.

I played around with this locally, and pinning a version for `@types/node` at the top-level seems to solve the situation for now.

See working `npm ci` (11.6.0): https://github.com/open-telemetry/opentelemetry-js/actions/runs/19102343709/job/54577182743?pr=6046
Failing `npm ci` (10.9.4): https://github.com/open-telemetry/opentelemetry-js/actions/runs/19102343709/job/54577182741?pr=6046

I'm hoping that once https://github.com/npm/cli/issues/8628 is solved (likely with npm@11.6.3), we'll be able to undo this again.
