### PR TITLE
test(instrumentation): drop deprecated codecov package

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -88,7 +88,6 @@
     "@types/webpack-env": "1.16.3",
     "babel-loader": "10.0.0",
     "babel-plugin-istanbul": "7.0.1",
-    "codecov": "3.8.3",
     "karma": "6.4.4",
     "karma-chrome-launcher": "3.1.0",
     "karma-coverage": "2.2.1",

--- a/experimental/packages/opentelemetry-instrumentation/test/node/RequireInTheMiddleSingleton.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation/test/node/RequireInTheMiddleSingleton.test.ts
@@ -37,39 +37,42 @@ describe('RequireInTheMiddleSingleton', function () {
   describe('register', function () {
     const onRequireFsStub = makeOnRequiresStub('fs');
     const onRequireFsPromisesStub = makeOnRequiresStub('fs-promises');
-    const onRequireCodecovStub = makeOnRequiresStub('codecov');
-    const onRequireCodecovLibStub = makeOnRequiresStub('codecov-lib');
-    const onRequireCpxStub = makeOnRequiresStub('test-non-core-module');
-    const onRequireCpxLibStub = makeOnRequiresStub('test-non-core-module-lib');
+    const onRequireNonCoreModuleStub = makeOnRequiresStub(
+      'test-non-core-module'
+    );
+    const onRequireNonCoreModuleLibStub = makeOnRequiresStub(
+      'test-non-core-module-lib'
+    );
 
-    before(() => {
+    before(function () {
       requireInTheMiddleSingleton.register('fs', onRequireFsStub);
       requireInTheMiddleSingleton.register(
         'fs/promises',
         onRequireFsPromisesStub
       );
-      requireInTheMiddleSingleton.register('codecov', onRequireCodecovStub);
-      requireInTheMiddleSingleton.register(
-        'codecov/lib/codecov.js',
-        onRequireCodecovLibStub
-      );
       requireInTheMiddleSingleton.register(
         'test-non-core-module',
-        onRequireCpxStub
+        onRequireNonCoreModuleStub
       );
       requireInTheMiddleSingleton.register(
         'test-non-core-module/lib/copy-sync.js',
-        onRequireCpxLibStub
+        onRequireNonCoreModuleLibStub
       );
     });
 
-    beforeEach(() => {
+    afterEach(function () {
+      // delete cached modules to allow re-require
+      delete require.cache[require.resolve('fs/promises')];
+      delete require.cache[require.resolve('test-non-core-module')];
+      delete require.cache[
+        require.resolve('test-non-core-module/lib/copy-sync')
+      ];
+
+      // reset stubs
       onRequireFsStub.resetHistory();
       onRequireFsPromisesStub.resetHistory();
-      onRequireCodecovStub.resetHistory();
-      onRequireCodecovLibStub.resetHistory();
-      onRequireCpxStub.resetHistory();
-      onRequireCpxLibStub.resetHistory();
+      onRequireNonCoreModuleStub.resetHistory();
+      onRequireNonCoreModuleLibStub.resetHistory();
     });
 
     it('should return a hooked object', function () {
@@ -124,29 +127,44 @@ describe('RequireInTheMiddleSingleton', function () {
     describe('non-core module', function () {
       describe('AND module name matches', function () {
         const baseDir = path.normalize(
-          path.dirname(require.resolve('codecov'))
+          path.resolve(
+            path.dirname(require.resolve('test-non-core-module')),
+            '..'
+          )
         );
         const modulePath = path.normalize(
-          path.join('codecov', 'lib', 'codecov.js')
+          path.join('test-non-core-module', 'lib', 'copy-sync.js')
         );
         it('should call `onRequire`', function () {
-          const exports = require('codecov');
-          assert.deepStrictEqual(exports.__ritmOnRequires, ['codecov']);
+          const exports = require('test-non-core-module');
+          assert.deepStrictEqual(exports.__ritmOnRequires, [
+            'test-non-core-module',
+          ]);
           sinon.assert.calledWithExactly(
-            onRequireCodecovStub,
+            onRequireNonCoreModuleStub,
             exports,
-            'codecov',
+            'test-non-core-module',
             baseDir
           );
           sinon.assert.calledWithMatch(
-            onRequireCodecovStub,
-            { __ritmOnRequires: ['codecov', 'codecov-lib'] },
+            onRequireNonCoreModuleStub,
+            {
+              __ritmOnRequires: [
+                'test-non-core-module',
+                'test-non-core-module-lib',
+              ],
+            },
             modulePath,
             baseDir
           );
           sinon.assert.calledWithMatch(
-            onRequireCodecovLibStub,
-            { __ritmOnRequires: ['codecov', 'codecov-lib'] },
+            onRequireNonCoreModuleLibStub,
+            {
+              __ritmOnRequires: [
+                'test-non-core-module',
+                'test-non-core-module-lib',
+              ],
+            },
             modulePath,
             baseDir
           );
@@ -154,7 +172,7 @@ describe('RequireInTheMiddleSingleton', function () {
       });
     });
 
-    describe('non-core module with sub-path', function () {
+    describe('non-core module with sub-path (deep require)', function () {
       describe('AND module name matches', function () {
         const baseDir = path.normalize(
           path.resolve(
@@ -172,7 +190,7 @@ describe('RequireInTheMiddleSingleton', function () {
             'test-non-core-module-lib',
           ]);
           sinon.assert.calledWithMatch(
-            onRequireCpxStub,
+            onRequireNonCoreModuleStub,
             {
               __ritmOnRequires: [
                 'test-non-core-module',
@@ -183,13 +201,13 @@ describe('RequireInTheMiddleSingleton', function () {
             baseDir
           );
           sinon.assert.calledWithExactly(
-            onRequireCpxStub,
+            onRequireNonCoreModuleStub,
             exports,
             modulePath,
             baseDir
           );
           sinon.assert.calledWithExactly(
-            onRequireCpxLibStub,
+            onRequireNonCoreModuleLibStub,
             exports,
             modulePath,
             baseDir

--- a/experimental/packages/opentelemetry-instrumentation/test/node/node_modules/test-non-core-module/lib/index.js
+++ b/experimental/packages/opentelemetry-instrumentation/test/node/node_modules/test-non-core-module/lib/index.js
@@ -1,4 +1,3 @@
 module.exports = {
-    copy: require('./lib/copy-sync')  // matches the original API
+    copy: require('./copy-sync')  // matches the original API
   };
-  

--- a/package-lock.json
+++ b/package-lock.json
@@ -928,7 +928,6 @@
         "@types/webpack-env": "1.16.3",
         "babel-loader": "10.0.0",
         "babel-plugin-istanbul": "7.0.1",
-        "codecov": "3.8.3",
         "karma": "6.4.4",
         "karma-chrome-launcher": "3.1.0",
         "karma-coverage": "2.2.1",
@@ -6625,16 +6624,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -8018,16 +8007,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/argv": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
-      "integrity": "sha512-dEamhpPEwRUBpLNHeuCm/v+g0anFByHahxodVO/BbAarHVBBg2MccCwf9K+o1Pof+2btdnkJelYVUWjW/VrATw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.10"
-      }
-    },
     "node_modules/array-differ": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
@@ -9361,41 +9340,6 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/codecov": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.3.tgz",
-      "integrity": "sha512-Y8Hw+V3HgR7V71xWH2vQ9lyS358CbGCldWlJFR0JirqoGtOoas3R3/OclRTvgUYFK29mmJICDPauVKmpqbwhOA==",
-      "deprecated": "https://about.codecov.io/blog/codecov-uploader-deprecation-plan/",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argv": "0.0.2",
-        "ignore-walk": "3.0.4",
-        "js-yaml": "3.14.1",
-        "teeny-request": "7.1.1",
-        "urlgrey": "1.0.0"
-      },
-      "bin": {
-        "codecov": "bin/codecov"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/codecov/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/color-convert": {
@@ -11840,16 +11784,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fast-url-parser": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^1.3.2"
-      }
-    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -13371,40 +13305,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/ignore-walk": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.4.tgz",
-      "integrity": "sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minimatch": "^3.0.4"
-      }
-    },
-    "node_modules/ignore-walk/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/ignore-walk/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/import-fresh": {
@@ -17525,9 +17425,9 @@
       }
     },
     "node_modules/mocha/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -17896,27 +17796,6 @@
       },
       "engines": {
         "node": ">= 10.13"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-forge": {
@@ -22133,16 +22012,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/stream-events": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
-      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stubs": "^3.0.0"
-      }
-    },
     "node_modules/streamroller": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
@@ -22399,13 +22268,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/stubs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/superagent": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.1.1.tgz",
@@ -22642,75 +22504,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/teeny-request": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.1.tgz",
-      "integrity": "sha512-iwY6rkW5DDGq8hE2YgNQlKbptYpY5Nn2xecjQiNjOXWbKzPGUfmeUBCSQbbr306d7Z7U2N0TPl+/SwYRfua1Dg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.1",
-        "stream-events": "^1.0.5",
-        "uuid": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/teeny-request/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/teeny-request/node_modules/http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/teeny-request/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/teeny-request/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/temp-dir": {
       "version": "1.0.0",
@@ -23110,13 +22903,6 @@
       "engines": {
         "node": ">= 4.0.0"
       }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/tree-dump": {
       "version": "1.1.0",
@@ -23745,16 +23531,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "node_modules/urlgrey": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-1.0.0.tgz",
-      "integrity": "sha512-hJfIzMPJmI9IlLkby8QrsCykQ+SXDeO2W5Q9QTW3QpqZVTx4a/K7p8/5q+/isD8vsbVaFgql/gvAoQCRQ2Cb5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "fast-url-parser": "^1.1.3"
-      }
-    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -23901,13 +23677,6 @@
       "integrity": "sha512-Y9E1/oi4XMxcR8AT0ZC4OvYntl34SPgwjmELH+owjBr0korAX4jKgZULBWILGCVGdVCQ0dodTToIETozhG8zvA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
       "version": "5.101.3",
@@ -24749,17 +24518,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {


### PR DESCRIPTION
## Which problem is this PR solving?

We depend on the deprecated `codecov` uploader in some ritm singleton tests. This was probably used because the package was already there back in the day. We've since switched to another way of uploading `codecov` reports so this now pulls in old dependencies and holds back package updates. 

Something similar was done in #5077 for dropping `cpx2`

Related: #6115 (codecov depends on an old version of `js-yaml`)