### PR TITLE
refactor(opentelemetry-sdk-node): simplify calculation of `validPropagators`

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -32,6 +32,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * refactor(opentelemetry-sdk-node): simplify calculation of traceExportersList [#6132](https://github.com/open-telemetry/opentelemetry-js/pull/6132) @cjihrig
 * refactor(instrumentation): combine filter() calls in \_onRequire [#6142](https://github.com/open-telemetry/opentelemetry-js/pull/6142) @cjihrig
 * test(instrumentation-http): make timing dependent test more robust [#6144](https://github.com/open-telemetry/opentelemetry-js/pull/6144) @cjihrig
+* refactor(opentelemetry-sdk-node): simplify calculation of validPropagators [#6143](https://github.com/open-telemetry/opentelemetry-js/pull/6143) @cjihrig
 
 ## 0.208.0
 

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -204,28 +204,19 @@ export function getPropagatorFromEnv(): TextMapPropagator | null | undefined {
 
   // Values MUST be deduplicated in order to register a Propagator only once.
   const uniquePropagatorNames = Array.from(new Set(propagatorsEnvVarValue));
+  const validPropagators: TextMapPropagator[] = [];
 
-  const propagators = uniquePropagatorNames.map(name => {
+  uniquePropagatorNames.forEach(name => {
     const propagator = propagatorsFactory.get(name)?.();
     if (!propagator) {
       diag.warn(
         `Propagator "${name}" requested through environment variable is unavailable.`
       );
-      return undefined;
+      return;
     }
 
-    return propagator;
+    validPropagators.push(propagator);
   });
-
-  const validPropagators = propagators.reduce<TextMapPropagator[]>(
-    (list, item) => {
-      if (item) {
-        list.push(item);
-      }
-      return list;
-    },
-    []
-  );
 
   if (validPropagators.length === 0) {
     // null to signal that the default should **not** be used in its place.


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

`validPropagators` is computed via a combination of `map()` and `reduce()`. This can be simplified. The `reduce()` probably should have been a `filter()` anyway.

Fixes # N/A

## Short description of the changes

Instead of using a `map()` followed by a `reduce()` that only filters out falsey values, do the same work in a single `forEach()`. This removes an intermediate array and an extra loop over the array.

## Type of change

None of these. Performance related refactor.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test suite

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
