### PR TITLE
fix(instrumentation-fetch): handle HeadersInit tuple arrays correctly

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -216,22 +216,23 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
       return;
     }
 
+    const headersSetter = {
+      set: (h: Headers, k: string, v: string) =>
+        h.set(k, typeof v === 'string' ? v : String(v)),
+    };
+
     if (options instanceof Request) {
-      propagation.inject(context.active(), options.headers, {
-        set: (h, k, v) => h.set(k, typeof v === 'string' ? v : String(v)),
-      });
-    } else if (options.headers instanceof Headers) {
-      propagation.inject(context.active(), options.headers, {
-        set: (h, k, v) => h.set(k, typeof v === 'string' ? v : String(v)),
-      });
-    } else if (options.headers instanceof Map) {
-      propagation.inject(context.active(), options.headers, {
-        set: (h, k, v) => h.set(k, typeof v === 'string' ? v : String(v)),
-      });
+      // Request.headers is already a Headers object
+      propagation.inject(context.active(), options.headers, headersSetter);
     } else {
-      const headers: Partial<Record<string, unknown>> = {};
-      propagation.inject(context.active(), headers);
-      options.headers = Object.assign({}, headers, options.headers || {});
+      // The Headers constructor handles all valid HeadersInit types:
+      // - undefined/null
+      // - Headers object
+      // - Record<string, string>
+      // - Iterable<[string, string]> (including array of tuples)
+      const headers = new Headers(options.headers);
+      propagation.inject(context.active(), headers, headersSetter);
+      options.headers = headers;
     }
   }
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -845,6 +845,23 @@ describe('fetch', () => {
 
             assert.strictEqual(headers['foo'], 'bar');
           });
+
+          it('should keep custom headers with url, untyped request object and tuple array headers', async () => {
+            const { response } = await tracedFetch({
+              callback: () =>
+                fetch('/api/echo-headers.json', {
+                  headers: [
+                    ['foo', 'bar'],
+                    ['baz', 'qux'],
+                  ],
+                }),
+            });
+
+            const headers = await assertPropagationHeaders(response);
+
+            assert.strictEqual(headers['foo'], 'bar');
+            assert.strictEqual(headers['baz'], 'qux');
+          });
         });
 
         describe('without global propagator', () => {
@@ -917,6 +934,23 @@ describe('fetch', () => {
             const headers = await assertNoPropagationHeaders(response);
 
             assert.strictEqual(headers['foo'], 'bar');
+          });
+
+          it('should keep custom headers with url, untyped request object and tuple array headers', async () => {
+            const { response } = await tracedFetch({
+              callback: () =>
+                fetch('/api/echo-headers.json', {
+                  headers: [
+                    ['foo', 'bar'],
+                    ['baz', 'qux'],
+                  ],
+                }),
+            });
+
+            const headers = await assertNoPropagationHeaders(response);
+
+            assert.strictEqual(headers['foo'], 'bar');
+            assert.strictEqual(headers['baz'], 'qux');
           });
         });
       });
@@ -1787,15 +1821,15 @@ describe('fetch', () => {
                 request !== null &&
                   typeof request === 'object' &&
                   !(request instanceof Request),
-                '`requestHook` should get the `RequestInit` object passed to `fetch()`'
+                '`requestHook` should get a `RequestInit` object'
               );
 
               assert.ok(
-                request.headers !== null && typeof request.headers === 'object',
-                '`requestHook` should get the `headers` object passed to `fetch()`'
+                request.headers instanceof Headers,
+                '`requestHook` should get headers as a `Headers` object'
               );
 
-              (request.headers as Record<string, string>)['custom-foo'] = 'foo';
+              (request.headers as Headers).set('custom-foo', 'foo');
             },
           },
           callback: () =>


### PR DESCRIPTION
## Which problem is this PR solving?

When `HeadersInit` is passed as an array of tuples (e.g., `[["Content-Type", "application/json"]]`), the `_addHeaders` method falls through to an else branch that uses `Object.assign()`. This corrupts the headers into an object with numeric keys like `{"0": "Content-Type", "1": "application/json"}`.

## Short description of the changes

Simplifies the logic by using `new Headers()` which correctly handles all valid `HeadersInit` types:
- `undefined`/`null`
- `Headers` object  
- `Record<string, string>`
- `Iterable<[string, string]>` (including array of tuples)

Also updates an existing test to use `Headers.set()` API since headers are now normalized to `Headers` objects.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added unit tests for tuple array headers (with and without propagator)
- [x] All 95 existing tests pass