### PR TITLE
fix(opentelemetry-resources): remove extraneous identity utils

### DIFF
--- a/packages/opentelemetry-resources/src/utils.ts
+++ b/packages/opentelemetry-resources/src/utils.ts
@@ -21,7 +21,3 @@ export const isPromiseLike = <R>(val: unknown): val is PromiseLike<R> => {
     typeof (val as Partial<PromiseLike<R>>).then === 'function'
   );
 };
-
-export function identity<T>(_: T): T {
-  return _;
-}


### PR DESCRIPTION

## Which problem is this PR solving?

Hi.

While skimming through the codebase in my IDE, I stumbled this `identity` function that has no reference. I've grepped the package to ensure this was indeed not used anymore and it's now dead code.

It was introduced in this commit but never actually used https://github.com/open-telemetry/opentelemetry-js/commit/595d0e9c0d3ee871fde09d7f2cfe1d8cf209d99b

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
