### PR TITLE
feat(instrumentation): add support for '_latest_experimental' semantic conventions opt-in value

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -22,6 +22,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * feat(opentelemetry-sdk-node): set instrumentation and propagators for experimental start [#6148](https://github.com/open-telemetry/opentelemetry-js/pull/6148) @maryliag
 * refactor(configuration): set console exporter as empty object [#6164](https://github.com/open-telemetry/opentelemetry-js/pull/6164) @maryliag
 * feat(instrumentation-http, instrumentation-fetch, instrumentation-xml-http-request): support "QUERY" as a known HTTP method
+* feat(instrumentation): add support for "_latest_experimental" semantic conventions opt-in value [6224](https://github.com/open-telemetry/opentelemetry-js/pull/6224) @pichlermarc
 
 ### :bug: Bug Fixes
 


### PR DESCRIPTION
## Which problem is this PR solving?

> [!IMPORTANT]
> Part of a prototype for https://github.com/open-telemetry/semantic-conventions/issues/2928

Implements a utility for a new semconv stability opt-in value `LATEST_EXPERIMENTAL` that contains both stable, and in-development telemetry according to the latest semconv. 

See https://github.com/open-telemetry/semantic-conventions/issues/2928
This is based on the current state of https://github.com/open-telemetry/semantic-conventions/pull/3173

This should help with two things:
- lifting existing instrumentation **closer** to a stable state by allowing them to move forward with the in-development specification, reducing the effort needed when the semantic conventions for that area become stable
- allowing prototyping of in-development semantic conventions so that they can eventually be marked as stable, without emitting that telemetry by default.

Disclosure of AI use: I used Github Copilot and Claude Sonnet 4.5 to fill in some of the tests.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Added unit tests
