### PR TITLE
feat(otlp-transformer): add custom protobuf logs serializer

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -22,6 +22,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * feat(opentelemetry-sdk-node): set instrumentation and propagators for experimental start [#6148](https://github.com/open-telemetry/opentelemetry-js/pull/6148) @maryliag
 * refactor(configuration): set console exporter as empty object [#6164](https://github.com/open-telemetry/opentelemetry-js/pull/6164) @maryliag
 * feat(instrumentation-http, instrumentation-fetch, instrumentation-xml-http-request): support "QUERY" as a known HTTP method
+* feat(otlp-transformer): add custom protobuf logs serializer [#6228](https://github.com/open-telemetry/opentelemetry-js/pull/6228) @pichlermarc
 
 ### :bug: Bug Fixes
 

--- a/experimental/packages/otlp-transformer/src/common/protobuf/common-serializer.ts
+++ b/experimental/packages/otlp-transformer/src/common/protobuf/common-serializer.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ProtobufWriter } from './protobuf-writer';
+import type { Attributes, HrTime } from '@opentelemetry/api';
+import type { AnyValue, LogAttributes } from '@opentelemetry/api-logs';
+
+/**
+ * Write HrTime [seconds, nanoseconds] directly as fixed64 to the serializer.
+ * Converts to nanoseconds and writes as 64-bit little-endian integer without allocations.
+ *
+ * HrTime represents: total_nanos = seconds * 1_000_000_000 + nanoseconds
+ * We need to split this into low (bits 0-31) and high (bits 32-63).
+ *
+ * @param serializer - The protobuf writer
+ * @param hrTime - HrTime tuple [seconds, nanoseconds]
+ */
+export function writeHrTimeAsFixed64(
+  serializer: ProtobufWriter,
+  hrTime: HrTime
+): void {
+  const seconds = hrTime[0];
+  const nanos = hrTime[1];
+
+  // Calculate total nanoseconds split into 32-bit parts
+  // We use the fact that 1e9 < 2^30, so multiplication is safe for reasonable timestamps
+
+  // For the low 32 bits: (seconds * 1e9 + nanos) & 0xFFFFFFFF
+  // For the high 32 bits: floor((seconds * 1e9 + nanos) / 2^32)
+
+  // Calculate seconds * 1e9 split into parts
+  const secNanos = seconds * 1e9;
+  const secNanosLow = secNanos >>> 0; // Low 32 bits of seconds * 1e9
+  const secNanosHigh = (secNanos / 0x100000000) >>> 0; // High bits from seconds * 1e9
+
+  // Add nanoseconds to the low part
+  const totalLow = (secNanosLow + nanos) >>> 0;
+
+  // Check for overflow from low to high (carry bit)
+  const carry = secNanosLow + nanos >= 0x100000000 ? 1 : 0;
+  const totalHigh = (secNanosHigh + carry) >>> 0;
+
+  serializer.writeFixed64(totalLow, totalHigh);
+}
+
+/**
+ * Write Attributes directly to protobuf as repeated KeyValue
+ */
+export function writeAttributes(
+  writer: ProtobufWriter,
+  attributes: Attributes | LogAttributes,
+  fieldNumber: number
+): void {
+  for (const [key, value] of Object.entries(attributes)) {
+    writer.writeTag(fieldNumber, 2);
+    const kvStart = writer.startLengthDelimited();
+    const startPos = writer.pos;
+    writeKeyValue(writer, key, value);
+    writer.finishLengthDelimited(kvStart, writer.pos - startPos);
+  }
+}
+
+/**
+ * Write a KeyValue pair directly to protobuf
+ */
+export function writeKeyValue(
+  writer: ProtobufWriter,
+  key: string,
+  value: AnyValue
+): void {
+  writer.writeTag(1, 2);
+  writer.writeString(key);
+  writer.writeTag(2, 2);
+  const valueStart = writer.startLengthDelimited();
+  const startPos = writer.pos;
+  writeAnyValue(writer, value);
+  writer.finishLengthDelimited(valueStart, writer.pos - startPos);
+}
+
+/**
+ * Write an AnyValue directly from raw attribute value to protobuf
+ */
+export function writeAnyValue(writer: ProtobufWriter, value: AnyValue): void {
+  const t = typeof value;
+  if (t === 'string') {
+    writer.writeTag(1, 2);
+    writer.writeString(value as string);
+  } else if (t === 'boolean') {
+    writer.writeTag(2, 0);
+    writer.writeVarint((value as boolean) ? 1 : 0);
+  } else if (t === 'number') {
+    // Use isSafeInteger to avoid precision loss with large integers
+    // Numbers outside the safe integer range should be serialized as doubles
+    if (!Number.isSafeInteger(value as number)) {
+      writer.writeTag(4, 1);
+      writer.writeDouble(value as number);
+    } else {
+      writer.writeTag(3, 0);
+      writer.writeVarint(value as number);
+    }
+  } else if (value instanceof Uint8Array) {
+    writer.writeTag(7, 2);
+    writer.writeBytes(value);
+  } else if (Array.isArray(value)) {
+    writer.writeTag(5, 2);
+    const arrayStart = writer.startLengthDelimited();
+    const arrayStartPos = writer.pos;
+    for (const item of value) {
+      writer.writeTag(1, 2);
+      const itemStart = writer.startLengthDelimited();
+      const itemStartPos = writer.pos;
+      writeAnyValue(writer, item);
+      writer.finishLengthDelimited(itemStart, writer.pos - itemStartPos);
+    }
+    writer.finishLengthDelimited(arrayStart, writer.pos - arrayStartPos);
+  } else if (t === 'object' && value != null) {
+    writer.writeTag(6, 2);
+    const kvlistStart = writer.startLengthDelimited();
+    const kvlistStartPos = writer.pos;
+    for (const [k, v] of Object.entries(value as object)) {
+      writer.writeTag(1, 2);
+      const kvStart = writer.startLengthDelimited();
+      const kvStartPos = writer.pos;
+      writer.writeTag(1, 2);
+      writer.writeString(k);
+      writer.writeTag(2, 2);
+      const valueStart = writer.startLengthDelimited();
+      const valueStartPos = writer.pos;
+      writeAnyValue(writer, v);
+      writer.finishLengthDelimited(valueStart, writer.pos - valueStartPos);
+      writer.finishLengthDelimited(kvStart, writer.pos - kvStartPos);
+    }
+    writer.finishLengthDelimited(kvlistStart, writer.pos - kvlistStartPos);
+  }
+  // Else: unsupported type, write nothing
+}

--- a/experimental/packages/otlp-transformer/src/common/protobuf/protobuf-writer.ts
+++ b/experimental/packages/otlp-transformer/src/common/protobuf/protobuf-writer.ts
@@ -1,0 +1,265 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Primitive protobuf writer, optimized to avoid small object allocations.
+ */
+export class ProtobufWriter {
+  private _buffer: Uint8Array;
+  private readonly _textEncoder: TextEncoder;
+  private _dataView: DataView;
+
+  public pos: number = 0;
+
+  constructor(initialSize = 65536) {
+    this._buffer = new Uint8Array(initialSize);
+    this._textEncoder = new TextEncoder();
+    this._dataView = new DataView(this._buffer.buffer, this._buffer.byteOffset);
+  }
+
+  /**
+   * Ensure buffer has capacity for at least size more bytes
+   */
+  private ensureCapacity(size: number): void {
+    const needed = this.pos + size;
+    if (needed <= this._buffer.length) {
+      return;
+    }
+
+    // Double buffer size until we have enough space
+    let newSize = this._buffer.length * 2;
+    while (newSize < needed) {
+      newSize *= 2;
+    }
+
+    const newBuffer = new Uint8Array(newSize);
+    newBuffer.set(this._buffer);
+    this._buffer = newBuffer;
+    // Recreate DataView for the new buffer
+    this._dataView = new DataView(this._buffer.buffer, this._buffer.byteOffset);
+  }
+
+  /**
+   * Get the written bytes as a Uint8Array
+   */
+  finish(): Uint8Array {
+    return this._buffer.subarray(0, this.pos);
+  }
+
+  /**
+   * Insert placeholder for length. Update later with {@link finishLengthDelimited}
+   * Returns the position where to write the length.
+   */
+  startLengthDelimited(): number {
+    const lengthPos = this.pos;
+    // Reserve 5 bytes for the length varint (max size for 32-bit value)
+    this.ensureCapacity(5);
+    this.pos += 5;
+    return lengthPos;
+  }
+
+  /**
+   * Update length placeholder at given position with actual length.
+   * Shifts content if the actual varint is smaller than reserved space.
+   */
+  finishLengthDelimited(pos: number, length: number): void {
+    const currentPos = this.pos;
+    const reservedBytes = 5;
+    const contentStart = pos + reservedBytes;
+
+    // Calculate varint size inline and write directly
+    const v = length >>> 0;
+    let varintSize;
+    let writePos = pos;
+
+    if (v < 0x80) {
+      this._buffer[writePos++] = v;
+      varintSize = 1;
+    } else if (v < 0x4000) {
+      this._buffer[writePos++] = (v & 0x7f) | 0x80;
+      this._buffer[writePos++] = v >>> 7;
+      varintSize = 2;
+    } else if (v < 0x200000) {
+      this._buffer[writePos++] = (v & 0x7f) | 0x80;
+      this._buffer[writePos++] = ((v >>> 7) & 0x7f) | 0x80;
+      this._buffer[writePos++] = v >>> 14;
+      varintSize = 3;
+    } else if (v < 0x10000000) {
+      this._buffer[writePos++] = (v & 0x7f) | 0x80;
+      this._buffer[writePos++] = ((v >>> 7) & 0x7f) | 0x80;
+      this._buffer[writePos++] = ((v >>> 14) & 0x7f) | 0x80;
+      this._buffer[writePos++] = v >>> 21;
+      varintSize = 4;
+    } else {
+      this._buffer[writePos++] = (v & 0x7f) | 0x80;
+      this._buffer[writePos++] = ((v >>> 7) & 0x7f) | 0x80;
+      this._buffer[writePos++] = ((v >>> 14) & 0x7f) | 0x80;
+      this._buffer[writePos++] = ((v >>> 21) & 0x7f) | 0x80;
+      this._buffer[writePos++] = v >>> 28;
+      varintSize = 5;
+    }
+
+    // Shift content if we used fewer bytes than reserved
+    if (varintSize < reservedBytes) {
+      const shift = reservedBytes - varintSize;
+      const contentLength = currentPos - contentStart;
+      this._buffer.copyWithin(
+        pos + varintSize,
+        contentStart,
+        contentStart + contentLength
+      );
+      this.pos = currentPos - shift;
+    }
+  }
+
+  /**
+   * Write a varint (variable-length integer)
+   */
+  writeVarint(value: number): void {
+    this.ensureCapacity(10); // Max 10 bytes for varint64
+    // Check if value fits in 32-bit range
+    if (value >= 0 && value <= 0xffffffff) {
+      // 32-bit or small integer
+      let v = value >>> 0; // Convert to unsigned 32-bit
+      while (v > 0x7f) {
+        this._buffer[this.pos++] = (v & 0x7f) | 0x80;
+        v >>>= 7;
+      }
+      this._buffer[this.pos++] = v;
+    } else {
+      // Needs 64-bit handling - convert to [low, high]
+      let low: number;
+      let high: number;
+
+      if (value >= 0) {
+        // Positive number
+        low = value >>> 0;
+        high = (value / 0x100000000) >>> 0;
+      } else {
+        // Negative number - use two's complement
+        const abs = Math.abs(value);
+        low = abs >>> 0;
+        high = (abs / 0x100000000) >>> 0;
+
+        // Two's complement: invert bits and add 1
+        low = ~low >>> 0;
+        high = ~high >>> 0;
+        low = (low + 1) >>> 0;
+        if (low === 0) {
+          high = (high + 1) >>> 0;
+        }
+      }
+
+      // Write as 64-bit varint
+      while (high > 0 || low > 0x7f) {
+        this._buffer[this.pos++] = (low & 0x7f) | 0x80;
+        low = ((low >>> 7) | (high << 25)) >>> 0;
+        high >>>= 7;
+      }
+      this._buffer[this.pos++] = low & 0x7f;
+    }
+  }
+
+  /**
+   * Write a 32-bit fixed integer (little-endian)
+   */
+  writeFixed32(value: number): void {
+    this.ensureCapacity(4);
+    const v = value >>> 0;
+    this._buffer[this.pos++] = v & 0xff;
+    this._buffer[this.pos++] = (v >>> 8) & 0xff;
+    this._buffer[this.pos++] = (v >>> 16) & 0xff;
+    this._buffer[this.pos++] = (v >>> 24) & 0xff;
+  }
+
+  /**
+   * Write a 64-bit fixed integer (little-endian)
+   * @param low - Low 32 bits
+   * @param high - High 32 bits
+   */
+  writeFixed64(low: number, high: number): void {
+    this.ensureCapacity(8);
+    const l = low >>> 0;
+    const h = high >>> 0;
+
+    // Write low 32 bits
+    this._buffer[this.pos++] = l & 0xff;
+    this._buffer[this.pos++] = (l >>> 8) & 0xff;
+    this._buffer[this.pos++] = (l >>> 16) & 0xff;
+    this._buffer[this.pos++] = (l >>> 24) & 0xff;
+
+    // Write high 32 bits
+    this._buffer[this.pos++] = h & 0xff;
+    this._buffer[this.pos++] = (h >>> 8) & 0xff;
+    this._buffer[this.pos++] = (h >>> 16) & 0xff;
+    this._buffer[this.pos++] = (h >>> 24) & 0xff;
+  }
+
+  /**
+   * Write length-delimited data (varint length + bytes)
+   */
+  writeBytes(bytes: Uint8Array): void {
+    this.writeVarint(bytes.length);
+    this.ensureCapacity(bytes.length);
+    this._buffer.set(bytes, this.pos);
+    this.pos += bytes.length;
+  }
+
+  /**
+   * Write a field key (field number + wire type)
+   */
+  writeTag(fieldNumber: number, wireType: number): void {
+    this.writeVarint((fieldNumber << 3) | wireType);
+  }
+
+  /**
+   * Write a double (64-bit IEEE 754)
+   */
+  writeDouble(value: number): void {
+    this.ensureCapacity(8);
+    this._dataView.setFloat64(this.pos, value, true); // true = little-endian
+    this.pos += 8;
+  }
+
+  /**
+   * Write a string as UTF-8 bytes (length-delimited)
+   */
+  writeString(str: string): void {
+    // Fast path for ASCII strings (most common case)
+    let isAscii = true;
+    const len = str.length;
+    for (let i = 0; i < len; i++) {
+      if (str.charCodeAt(i) > 127) {
+        isAscii = false;
+        break;
+      }
+    }
+
+    if (isAscii) {
+      // Write length varint
+      this.writeVarint(len);
+      this.ensureCapacity(len);
+      // Write ASCII bytes directly
+      for (let i = 0; i < len; i++) {
+        this._buffer[this.pos++] = str.charCodeAt(i);
+      }
+    } else {
+      // Use TextEncoder for non-ASCII strings
+      const bytes = this._textEncoder.encode(str);
+      this.writeBytes(bytes);
+    }
+  }
+}

--- a/experimental/packages/otlp-transformer/src/logs/protobuf/logs-serializer.ts
+++ b/experimental/packages/otlp-transformer/src/logs/protobuf/logs-serializer.ts
@@ -1,0 +1,250 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ReadableLogRecord } from '@opentelemetry/sdk-logs';
+import { ProtobufWriter } from '../../common/protobuf/protobuf-writer';
+import { hexToBinary } from '../../common/hex-to-binary';
+import type { Resource } from '@opentelemetry/resources';
+import type { InstrumentationScope } from '@opentelemetry/core';
+import { SeverityNumber } from '@opentelemetry/api-logs';
+import {
+  writeAnyValue,
+  writeAttributes,
+  writeHrTimeAsFixed64,
+} from '../../common/protobuf/common-serializer';
+
+/**
+ * Serialize a single LogRecord directly from ReadableLogRecord
+ */
+function serializeLogRecord(
+  writer: ProtobufWriter,
+  logRecord: ReadableLogRecord
+): void {
+  const logStart = writer.startLengthDelimited();
+  const logStartPos = writer.pos;
+
+  // time_unix_nano (field 1, fixed64)
+  writer.writeTag(1, 1); // wire type 1 (fixed64)
+  writeHrTimeAsFixed64(writer, logRecord.hrTime);
+
+  // severity_number (field 2, enum/varint) - skip if unspecified
+  if (
+    logRecord.severityNumber !== undefined &&
+    logRecord.severityNumber !== SeverityNumber.UNSPECIFIED
+  ) {
+    writer.writeTag(2, 0);
+    writer.writeVarint(logRecord.severityNumber);
+  }
+
+  // severity_text (field 3, string) - skip if empty
+  if (logRecord.severityText) {
+    writer.writeTag(3, 2);
+    writer.writeString(logRecord.severityText);
+  }
+
+  // body (field 5, AnyValue) - skip if undefined
+  if (logRecord.body !== undefined) {
+    writer.writeTag(5, 2);
+    const bodyStart = writer.startLengthDelimited();
+    const bodyStartPos = writer.pos;
+    writeAnyValue(writer, logRecord.body);
+    writer.finishLengthDelimited(bodyStart, writer.pos - bodyStartPos);
+  }
+
+  // attributes (field 6, repeated KeyValue)
+  if (logRecord.attributes) {
+    writeAttributes(writer, logRecord.attributes, 6);
+  }
+
+  // dropped_attributes_count (field 7, uint32)
+  writer.writeTag(7, 0);
+  writer.writeVarint(logRecord.droppedAttributesCount);
+
+  // flags (field 8, fixed32) - skip if 0 or undefined
+  if (logRecord.spanContext?.traceFlags) {
+    writer.writeTag(8, 5); // wire type 5 (fixed32)
+    writer.writeFixed32(logRecord.spanContext.traceFlags);
+  }
+
+  // trace_id (field 9, bytes) - skip if empty
+  if (logRecord.spanContext?.traceId) {
+    writer.writeTag(9, 2);
+    writer.writeBytes(hexToBinary(logRecord.spanContext.traceId));
+  }
+
+  // span_id (field 10, bytes) - skip if empty
+  if (logRecord.spanContext?.spanId) {
+    writer.writeTag(10, 2);
+    writer.writeBytes(hexToBinary(logRecord.spanContext.spanId));
+  }
+
+  // observed_time_unix_nano (field 11, fixed64)
+  writer.writeTag(11, 1); // wire type 1 (fixed64)
+  writeHrTimeAsFixed64(writer, logRecord.hrTimeObserved);
+
+  // event_name (field 12, string) - skip if empty
+  if (logRecord.eventName) {
+    writer.writeTag(12, 2);
+    writer.writeString(logRecord.eventName);
+  }
+
+  writer.finishLengthDelimited(logStart, writer.pos - logStartPos);
+}
+
+/**
+ * Serialize ScopeLogs directly from SDK types
+ */
+function serializeScopeLogs(
+  writer: ProtobufWriter,
+  scope: InstrumentationScope,
+  logRecords: ReadableLogRecord[]
+): void {
+  const scopeLogsStart = writer.startLengthDelimited();
+  const scopeLogsStartPos = writer.pos;
+
+  // scope (field 1, InstrumentationScope)
+  writer.writeTag(1, 2);
+  const scopeStart = writer.startLengthDelimited();
+  const scopeStartPos = writer.pos;
+
+  // Write InstrumentationScope fields directly
+  writer.writeTag(1, 2);
+  writer.writeString(scope.name);
+
+  if (scope.version) {
+    writer.writeTag(2, 2);
+    writer.writeString(scope.version);
+  }
+
+  writer.finishLengthDelimited(scopeStart, writer.pos - scopeStartPos);
+
+  // log_records (field 2, repeated LogRecord)
+  for (const logRecord of logRecords) {
+    writer.writeTag(2, 2);
+    serializeLogRecord(writer, logRecord);
+  }
+
+  // schema_url (field 3, string) - skip if empty
+  if (scope.schemaUrl) {
+    writer.writeTag(3, 2);
+    writer.writeString(scope.schemaUrl);
+  }
+
+  writer.finishLengthDelimited(scopeLogsStart, writer.pos - scopeLogsStartPos);
+}
+
+function serializeResource(
+  writer: ProtobufWriter,
+  resource: Resource,
+  fieldNumber: number
+) {
+  writer.writeTag(fieldNumber, 2);
+  const resourceStart = writer.startLengthDelimited();
+  const resourceStartPos = writer.pos;
+
+  // Write Resource attributes directly
+  if (resource.attributes) {
+    writeAttributes(writer, resource.attributes, 1);
+  }
+
+  // dropped_attributes_count (field 2, uint32) - set to 0 as we don't track this
+  writer.writeTag(2, 0);
+  writer.writeVarint(0);
+
+  writer.finishLengthDelimited(resourceStart, writer.pos - resourceStartPos);
+}
+
+/**
+ * Serialize ResourceLogs directly from SDK Resource type
+ */
+function serializeResourceLogs(
+  writer: ProtobufWriter,
+  resource: Resource,
+  scopeMap: Map<string, ReadableLogRecord[]>
+): void {
+  const resourceLogsStart = writer.startLengthDelimited();
+  const resourceLogsStartPos = writer.pos;
+
+  // resource (field 1, Resource)
+  serializeResource(writer, resource, 1);
+
+  // scope_logs (field 2, repeated ScopeLogs)
+  for (const scopeLogs of scopeMap.values()) {
+    writer.writeTag(2, 2);
+    const scope = scopeLogs[0].instrumentationScope;
+    serializeScopeLogs(writer, scope, scopeLogs);
+  }
+
+  // schema_url (field 3, string) - skip if empty
+  if (resource.schemaUrl) {
+    writer.writeTag(3, 2);
+    writer.writeString(resource.schemaUrl);
+  }
+
+  writer.finishLengthDelimited(
+    resourceLogsStart,
+    writer.pos - resourceLogsStartPos
+  );
+}
+
+/**
+ * Group log records by resource and instrumentation scope
+ */
+function createResourceMap(
+  logRecords: ReadableLogRecord[]
+): Map<Resource, Map<string, ReadableLogRecord[]>> {
+  const resourceMap: Map<
+    Resource,
+    Map<string, ReadableLogRecord[]>
+  > = new Map();
+
+  for (const record of logRecords) {
+    const resource = record.resource;
+    const scope = record.instrumentationScope;
+
+    let ismMap = resourceMap.get(resource);
+    if (!ismMap) {
+      ismMap = new Map();
+      resourceMap.set(resource, ismMap);
+    }
+
+    const ismKey = `${scope.name}@${scope.version}:${scope.schemaUrl}`;
+    let records = ismMap.get(ismKey);
+    if (!records) {
+      records = [];
+      ismMap.set(ismKey, records);
+    }
+    records.push(record);
+  }
+  return resourceMap;
+}
+
+/**
+ * Serialize ExportLogsServiceRequest directly from ReadableLogRecord[]
+ */
+export function serializeLogsExportRequest(
+  logRecords: ReadableLogRecord[]
+): Uint8Array {
+  const resourceMap = createResourceMap(logRecords);
+  const writer = new ProtobufWriter();
+
+  // resource_logs (field 1, repeated ResourceLogs)
+  for (const [resource, scopeMap] of resourceMap) {
+    writer.writeTag(1, 2);
+    serializeResourceLogs(writer, resource, scopeMap);
+  }
+
+  return writer.finish();
+}

--- a/experimental/packages/otlp-transformer/src/logs/protobuf/logs.ts
+++ b/experimental/packages/otlp-transformer/src/logs/protobuf/logs.ts
@@ -15,19 +15,15 @@
  */
 import * as root from '../../generated/root';
 
-import { IExportLogsServiceRequest } from '../internal-types';
 import { IExportLogsServiceResponse } from '../export-response';
 
-import { createExportLogsServiceRequest } from '../internal';
 import { ReadableLogRecord } from '@opentelemetry/sdk-logs';
 import { ExportType } from '../../common/protobuf/protobuf-export-type';
 import { ISerializer } from '../../i-serializer';
+import { serializeLogsExportRequest } from './logs-serializer';
 
 const logsResponseType = root.opentelemetry.proto.collector.logs.v1
   .ExportLogsServiceResponse as ExportType<IExportLogsServiceResponse>;
-
-const logsRequestType = root.opentelemetry.proto.collector.logs.v1
-  .ExportLogsServiceRequest as ExportType<IExportLogsServiceRequest>;
 
 /*
  * @experimental this serializer may receive breaking changes in minor versions, pin this package's version when using this constant
@@ -37,8 +33,7 @@ export const ProtobufLogsSerializer: ISerializer<
   IExportLogsServiceResponse
 > = {
   serializeRequest: (arg: ReadableLogRecord[]) => {
-    const request = createExportLogsServiceRequest(arg);
-    return logsRequestType.encode(request).finish();
+    return serializeLogsExportRequest(arg);
   },
   deserializeResponse: (arg: Uint8Array) => {
     return logsResponseType.decode(arg);

--- a/experimental/packages/otlp-transformer/test/performance/benchmark/index.js
+++ b/experimental/packages/otlp-transformer/test/performance/benchmark/index.js
@@ -20,35 +20,15 @@ const {
 } = require('../../../build/src/trace/internal');
 const { BasicTracerProvider } = require('@opentelemetry/sdk-trace-base');
 const { ProtobufTraceSerializer } = require('../../../build/src');
+const { ProtobufLogsSerializer } = require('../../../build/src/logs/protobuf');
+const { JsonLogsSerializer } = require('../../../build/src/logs/json');
+const { resourceFromAttributes } = require('@opentelemetry/resources');
+const { TraceFlags } = require('@opentelemetry/api');
+const { SeverityNumber } = require('@opentelemetry/api-logs');
 
+// setup traces
 const tracerProvider = new BasicTracerProvider();
 const tracer = tracerProvider.getTracer('test');
-
-const suite = new Benchmark.Suite();
-
-const span = createSpan();
-const spans = [];
-for (let i = 0; i < 100; i++) {
-  spans.push(createSpan());
-}
-
-suite.on('cycle', event => {
-  console.log(String(event.target));
-});
-
-suite.add('transform 1 span', function () {
-  createExportTraceServiceRequest([span]);
-});
-
-suite.add('transform 100 spans', function () {
-  createExportTraceServiceRequest(spans);
-});
-
-suite.add('transform 100 spans to protobuf', function () {
-  ProtobufTraceSerializer.serializeRequest(spans);
-});
-
-suite.run();
 
 function createSpan() {
   const span = tracer.startSpan('span');
@@ -66,3 +46,89 @@ function createSpan() {
 
   return span;
 }
+
+const span = createSpan();
+const spans = [];
+for (let i = 0; i < 100; i++) {
+  spans.push(createSpan());
+}
+
+// setup logs
+const resource = resourceFromAttributes({
+  'service.name': 'benchmark-service',
+  'service.version': '1.0.0',
+});
+
+const instrumentationScope = {
+  name: 'benchmark-logger',
+  version: '1.0.0',
+  schemaUrl: 'https://opentelemetry.io/schemas/1.24.0',
+};
+
+function createLogRecord() {
+  const now = Date.now();
+  const seconds = Math.floor(now / 1000);
+  const nanos = (now % 1000) * 1000000;
+
+  return {
+    hrTime: [seconds, nanos],
+    hrTimeObserved: [seconds, nanos],
+    severityNumber: SeverityNumber.INFO,
+    severityText: 'INFO',
+    body: 'This is a log message with some content for benchmarking purposes',
+    attributes: {
+      'attribute.string': 'some string value',
+      'attribute.number': 12345,
+      'attribute.boolean': true,
+      'attribute.array': ['value1', 'value2', 'value3'],
+      'http.method': 'GET',
+      'http.url': 'https://example.com/api/endpoint',
+      'http.status_code': 200,
+      'user.id': 'user-12345',
+      'request.id': 'req-67890',
+      'session.id': 'sess-abcdef',
+    },
+    droppedAttributesCount: 0,
+    resource: resource,
+    instrumentationScope: instrumentationScope,
+    spanContext: {
+      traceId: '00000000000000000000000000000001',
+      spanId: '0000000000000002',
+      traceFlags: TraceFlags.SAMPLED,
+    },
+  };
+}
+
+const logs = [];
+for (let i = 0; i < 512; i++) {
+  logs.push(createLogRecord());
+}
+
+// setup benchmark suite
+const suite = new Benchmark.Suite();
+
+suite.on('cycle', event => {
+  console.log(String(event.target));
+});
+
+suite.add('transform 1 span', function () {
+  createExportTraceServiceRequest([span]);
+});
+
+suite.add('transform 100 spans', function () {
+  createExportTraceServiceRequest(spans);
+});
+
+suite.add('transform 100 spans to protobuf', function () {
+  ProtobufTraceSerializer.serializeRequest(spans);
+});
+
+suite.add('transform 512 logs (protobuf)', function () {
+  ProtobufLogsSerializer.serializeRequest(logs);
+});
+
+suite.add('transform 512 logs (json)', function () {
+  JsonLogsSerializer.serializeRequest(logs);
+});
+
+suite.run();

--- a/experimental/packages/otlp-transformer/test/protobuf/common-serializer.test.ts
+++ b/experimental/packages/otlp-transformer/test/protobuf/common-serializer.test.ts
@@ -1,0 +1,551 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as assert from 'assert';
+import { ProtobufWriter } from '../../src/common/protobuf/protobuf-writer';
+import {
+  writeAnyValue,
+  writeKeyValue,
+} from '../../src/common/protobuf/common-serializer';
+import * as root from '../../src/generated/root';
+import { AnyValue } from '@opentelemetry/api-logs';
+import { uint8ArrayToBase64 } from '../utils';
+
+/**
+ * Helper function to serialize an AnyValue and decode it using generated protobuf code.
+ * Uses longs: Number, bytes: String as results differ across platforms otherwise.
+ */
+function serializeAndDecodeAnyValue(value: AnyValue): any {
+  const writer = new ProtobufWriter();
+  writeAnyValue(writer, value);
+  const buffer = writer.finish();
+
+  const decoded = root.opentelemetry.proto.common.v1.AnyValue.decode(buffer);
+  return root.opentelemetry.proto.common.v1.AnyValue.toObject(decoded, {
+    longs: Number,
+    bytes: String,
+  });
+}
+
+/**
+ * Helper function to serialize a KeyValue and decode it using generated protobuf code.
+ * Uses longs: Number, bytes: String as results differ across platforms otherwise.
+ */
+function serializeAndDecodeKeyValue(key: string, value: AnyValue): any {
+  const writer = new ProtobufWriter();
+  writeKeyValue(writer, key, value);
+  const buffer = writer.finish();
+
+  const decoded = root.opentelemetry.proto.common.v1.KeyValue.decode(buffer);
+  return root.opentelemetry.proto.common.v1.KeyValue.toObject(decoded, {
+    longs: Number,
+    bytes: String,
+  });
+}
+
+describe('common-serializer', function () {
+  describe('writeAnyValue', function () {
+    describe('string values', function () {
+      it('serializes a string value', function () {
+        const obj = serializeAndDecodeAnyValue('hello world');
+        assert.strictEqual(obj.stringValue, 'hello world');
+      });
+
+      it('serializes an empty string', function () {
+        const obj = serializeAndDecodeAnyValue('');
+        assert.strictEqual(obj.stringValue, '');
+      });
+
+      it('serializes a string with special characters', function () {
+        const obj = serializeAndDecodeAnyValue('hello\nworld\t"test"');
+        assert.strictEqual(obj.stringValue, 'hello\nworld\t"test"');
+      });
+
+      it('serializes a string with unicode characters', function () {
+        const obj = serializeAndDecodeAnyValue('你好世界 🌍');
+        assert.strictEqual(obj.stringValue, '你好世界 🌍');
+      });
+    });
+
+    describe('boolean values', function () {
+      it('serializes true', function () {
+        const obj = serializeAndDecodeAnyValue(true);
+        assert.strictEqual(obj.boolValue, true);
+      });
+
+      it('serializes false', function () {
+        const obj = serializeAndDecodeAnyValue(false);
+        assert.strictEqual(obj.boolValue, false);
+      });
+    });
+
+    describe('integer values', function () {
+      it('serializes zero', function () {
+        const obj = serializeAndDecodeAnyValue(0);
+        assert.strictEqual(obj.intValue, 0);
+      });
+
+      it('serializes positive integers', function () {
+        const obj = serializeAndDecodeAnyValue(42);
+        assert.strictEqual(obj.intValue, 42);
+      });
+
+      it('serializes negative integers', function () {
+        const obj = serializeAndDecodeAnyValue(-42);
+        assert.strictEqual(obj.intValue, -42);
+      });
+
+      it('serializes large positive integers', function () {
+        const obj = serializeAndDecodeAnyValue(1000000);
+        assert.strictEqual(obj.intValue, 1000000);
+      });
+
+      it('serializes Number.MAX_SAFE_INTEGER', function () {
+        const obj = serializeAndDecodeAnyValue(Number.MAX_SAFE_INTEGER);
+        assert.strictEqual(obj.intValue, Number.MAX_SAFE_INTEGER);
+      });
+
+      it('serializes Number.MIN_SAFE_INTEGER', function () {
+        const obj = serializeAndDecodeAnyValue(Number.MIN_SAFE_INTEGER);
+        assert.strictEqual(obj.intValue, Number.MIN_SAFE_INTEGER);
+      });
+
+      it('serializes integers beyond MAX_SAFE_INTEGER as doubles', function () {
+        const largeInt = Number.MAX_SAFE_INTEGER + 1;
+        const obj = serializeAndDecodeAnyValue(largeInt);
+        // Integers beyond MAX_SAFE_INTEGER should serialize as double to avoid precision loss
+        assert.strictEqual(obj.doubleValue, largeInt);
+      });
+    });
+
+    describe('double values', function () {
+      it('serializes floating point numbers', function () {
+        const obj = serializeAndDecodeAnyValue(3.14);
+        assert.strictEqual(obj.doubleValue, 3.14);
+      });
+
+      it('serializes small decimal numbers', function () {
+        const obj = serializeAndDecodeAnyValue(0.1);
+        assert.strictEqual(obj.doubleValue, 0.1);
+      });
+
+      it('serializes negative decimal numbers', function () {
+        const obj = serializeAndDecodeAnyValue(-2.5);
+        assert.strictEqual(obj.doubleValue, -2.5);
+      });
+
+      it('serializes very small numbers', function () {
+        const obj = serializeAndDecodeAnyValue(1e-10);
+        assert.strictEqual(obj.doubleValue, 1e-10);
+      });
+
+      it('serializes Number.MAX_VALUE', function () {
+        const obj = serializeAndDecodeAnyValue(Number.MAX_VALUE);
+        // Number.MAX_VALUE is beyond MAX_SAFE_INTEGER, so it should serialize as double
+        assert.strictEqual(obj.doubleValue, Number.MAX_VALUE);
+      });
+
+      it('serializes Number.MIN_VALUE', function () {
+        const obj = serializeAndDecodeAnyValue(Number.MIN_VALUE);
+        assert.strictEqual(obj.doubleValue, Number.MIN_VALUE);
+      });
+
+      it('serializes Infinity', function () {
+        const obj = serializeAndDecodeAnyValue(Infinity);
+        assert.strictEqual(obj.doubleValue, Infinity);
+      });
+
+      it('serializes -Infinity', function () {
+        const obj = serializeAndDecodeAnyValue(-Infinity);
+        assert.strictEqual(obj.doubleValue, -Infinity);
+      });
+
+      it('serializes NaN', function () {
+        const obj = serializeAndDecodeAnyValue(NaN);
+        assert.strictEqual(obj.doubleValue, NaN);
+      });
+    });
+
+    describe('bytes values', function () {
+      it('serializes a Uint8Array', function () {
+        const bytes = new Uint8Array([0, 1, 2, 3, 4]);
+        const obj = serializeAndDecodeAnyValue(bytes);
+
+        const expectedBase64 = uint8ArrayToBase64(bytes);
+        assert.strictEqual(obj.bytesValue, expectedBase64);
+      });
+
+      it('serializes an empty Uint8Array', function () {
+        const bytes = new Uint8Array([]);
+        const obj = serializeAndDecodeAnyValue(bytes);
+
+        const expectedBase64 = uint8ArrayToBase64(bytes);
+        assert.strictEqual(obj.bytesValue, expectedBase64);
+      });
+
+      it('serializes a Uint8Array with all byte values', function () {
+        const bytes = new Uint8Array(256);
+        for (let i = 0; i < 256; i++) {
+          bytes[i] = i;
+        }
+        const obj = serializeAndDecodeAnyValue(bytes);
+
+        const expectedBase64 = uint8ArrayToBase64(bytes);
+        assert.strictEqual(obj.bytesValue, expectedBase64);
+      });
+    });
+
+    describe('array values', function () {
+      it('serializes an empty array', function () {
+        const obj = serializeAndDecodeAnyValue([]);
+
+        // Empty arrays serialize with an arrayValue, but the values field is omitted when empty
+        assert.deepStrictEqual(obj.arrayValue, {});
+      });
+
+      it('serializes an array with mixed types', function () {
+        const obj = serializeAndDecodeAnyValue([
+          1,
+          'two',
+          false,
+          2.5,
+          new Uint8Array([0, 1, 2]),
+        ]);
+
+        const expectedBase64 = uint8ArrayToBase64(new Uint8Array([0, 1, 2]));
+
+        assert.deepStrictEqual(obj.arrayValue.values, [
+          { intValue: 1 },
+          { stringValue: 'two' },
+          { boolValue: false },
+          { doubleValue: 2.5 },
+          { bytesValue: expectedBase64 },
+        ]);
+      });
+
+      it('serializes nested arrays', function () {
+        const obj = serializeAndDecodeAnyValue([1, [2, 3], [[4]]]);
+
+        assert.deepStrictEqual(obj.arrayValue.values, [
+          { intValue: 1 },
+          {
+            arrayValue: {
+              values: [{ intValue: 2 }, { intValue: 3 }],
+            },
+          },
+          {
+            arrayValue: {
+              values: [
+                {
+                  arrayValue: {
+                    values: [{ intValue: 4 }],
+                  },
+                },
+              ],
+            },
+          },
+        ]);
+      });
+
+      it('serializes arrays with objects', function () {
+        const obj = serializeAndDecodeAnyValue([
+          { key: 'value' },
+          { nested: { key: 'value' } },
+        ]);
+
+        assert.deepStrictEqual(obj.arrayValue.values, [
+          {
+            kvlistValue: {
+              values: [
+                {
+                  key: 'key',
+                  value: { stringValue: 'value' },
+                },
+              ],
+            },
+          },
+          {
+            kvlistValue: {
+              values: [
+                {
+                  key: 'nested',
+                  value: {
+                    kvlistValue: {
+                      values: [
+                        {
+                          key: 'key',
+                          value: { stringValue: 'value' },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ]);
+      });
+    });
+
+    describe('object/kvlist values', function () {
+      it('serializes an empty object', function () {
+        const obj = serializeAndDecodeAnyValue({});
+
+        // Empty objects serialize with a kvlistValue, but the values field is omitted when empty
+        assert.deepStrictEqual(obj.kvlistValue, {});
+      });
+
+      it('serializes a simple object', function () {
+        const obj = serializeAndDecodeAnyValue({ key: 'value', number: 42 });
+
+        assert.deepStrictEqual(obj.kvlistValue.values, [
+          {
+            key: 'key',
+            value: { stringValue: 'value' },
+          },
+          {
+            key: 'number',
+            value: { intValue: 42 },
+          },
+        ]);
+      });
+
+      it('serializes nested objects', function () {
+        const obj = serializeAndDecodeAnyValue({
+          outer: {
+            inner: {
+              deepKey: 'deepValue',
+            },
+          },
+        });
+
+        assert.deepStrictEqual(obj.kvlistValue.values, [
+          {
+            key: 'outer',
+            value: {
+              kvlistValue: {
+                values: [
+                  {
+                    key: 'inner',
+                    value: {
+                      kvlistValue: {
+                        values: [
+                          {
+                            key: 'deepKey',
+                            value: { stringValue: 'deepValue' },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ]);
+      });
+
+      it('serializes objects with special characters in keys', function () {
+        const obj = serializeAndDecodeAnyValue({
+          'key-with-dashes': 'value1',
+          'key.with.dots': 'value2',
+          'key with spaces': 'value3',
+          key_with_underscores: 'value4',
+        });
+
+        assert.deepStrictEqual(obj.kvlistValue.values, [
+          { key: 'key-with-dashes', value: { stringValue: 'value1' } },
+          { key: 'key.with.dots', value: { stringValue: 'value2' } },
+          { key: 'key with spaces', value: { stringValue: 'value3' } },
+          { key: 'key_with_underscores', value: { stringValue: 'value4' } },
+        ]);
+      });
+
+      it('serializes objects with mixed value types', function () {
+        const obj = serializeAndDecodeAnyValue({
+          stringVal: 'text',
+          intVal: 123,
+          doubleVal: 3.14,
+          boolVal: true,
+          arrayVal: [1, 2, 3],
+          objectVal: { nested: 'value' },
+        });
+
+        assert.deepStrictEqual(obj.kvlistValue.values, [
+          {
+            key: 'stringVal',
+            value: { stringValue: 'text' },
+          },
+          {
+            key: 'intVal',
+            value: { intValue: 123 },
+          },
+          {
+            key: 'doubleVal',
+            value: { doubleValue: 3.14 },
+          },
+          {
+            key: 'boolVal',
+            value: { boolValue: true },
+          },
+          {
+            key: 'arrayVal',
+            value: {
+              arrayValue: {
+                values: [{ intValue: 1 }, { intValue: 2 }, { intValue: 3 }],
+              },
+            },
+          },
+          {
+            key: 'objectVal',
+            value: {
+              kvlistValue: {
+                values: [
+                  {
+                    key: 'nested',
+                    value: { stringValue: 'value' },
+                  },
+                ],
+              },
+            },
+          },
+        ]);
+      });
+    });
+
+    describe('null and undefined handling', function () {
+      it('handles null by writing nothing', function () {
+        const writer = new ProtobufWriter();
+        writeAnyValue(writer, null);
+        const buffer = writer.finish();
+
+        // Empty buffer or minimal message structure
+        assert.ok(buffer.length === 0 || buffer.length < 5);
+      });
+
+      it('handles undefined by writing nothing', function () {
+        const writer = new ProtobufWriter();
+        writeAnyValue(writer, undefined);
+        const buffer = writer.finish();
+
+        // Empty buffer or minimal message structure
+        assert.ok(buffer.length === 0 || buffer.length < 5);
+      });
+
+      it('handles null in arrays by writing nothing for that element', function () {
+        const obj = serializeAndDecodeAnyValue([1, null, 3]);
+
+        // Middle element should have no value set (empty AnyValue)
+        assert.deepStrictEqual(obj.arrayValue.values, [
+          { intValue: 1 },
+          {}, // Empty AnyValue for null
+          { intValue: 3 },
+        ]);
+      });
+
+      it('handles undefined in objects by writing nothing for that value', function () {
+        const obj = serializeAndDecodeAnyValue({
+          key1: 'value1',
+          key2: undefined,
+          key3: 'value3',
+        });
+
+        assert.deepStrictEqual(obj.kvlistValue.values, [
+          {
+            key: 'key1',
+            value: { stringValue: 'value1' },
+          },
+          {
+            key: 'key2',
+            value: {}, // Empty AnyValue for undefined
+          },
+          {
+            key: 'key3',
+            value: { stringValue: 'value3' },
+          },
+        ]);
+      });
+    });
+  });
+
+  describe('writeKeyValue', function () {
+    it('serializes a key-value pair with string value', function () {
+      const obj = serializeAndDecodeKeyValue('myKey', 'myValue');
+
+      assert.deepStrictEqual(obj, {
+        key: 'myKey',
+        value: { stringValue: 'myValue' },
+      });
+    });
+
+    it('serializes a key-value pair with integer value', function () {
+      const obj = serializeAndDecodeKeyValue('count', 42);
+
+      assert.deepStrictEqual(obj, {
+        key: 'count',
+        value: { intValue: 42 },
+      });
+    });
+
+    it('serializes a key-value pair with double value', function () {
+      const obj = serializeAndDecodeKeyValue('ratio', 3.14);
+
+      assert.deepStrictEqual(obj, {
+        key: 'ratio',
+        value: { doubleValue: 3.14 },
+      });
+    });
+
+    it('serializes a key-value pair with boolean value', function () {
+      const obj = serializeAndDecodeKeyValue('enabled', true);
+
+      assert.deepStrictEqual(obj, {
+        key: 'enabled',
+        value: { boolValue: true },
+      });
+    });
+
+    it('serializes a key-value pair with array value', function () {
+      const obj = serializeAndDecodeKeyValue('items', [1, 2, 3]);
+
+      assert.deepStrictEqual(obj, {
+        key: 'items',
+        value: {
+          arrayValue: {
+            values: [{ intValue: 1 }, { intValue: 2 }, { intValue: 3 }],
+          },
+        },
+      });
+    });
+
+    it('serializes a key-value pair with object value', function () {
+      const obj = serializeAndDecodeKeyValue('metadata', { version: '1.0' });
+
+      assert.deepStrictEqual(obj, {
+        key: 'metadata',
+        value: {
+          kvlistValue: {
+            values: [
+              {
+                key: 'version',
+                value: { stringValue: '1.0' },
+              },
+            ],
+          },
+        },
+      });
+    });
+  });
+});

--- a/experimental/packages/otlp-transformer/test/utils.ts
+++ b/experimental/packages/otlp-transformer/test/utils.ts
@@ -23,10 +23,14 @@ import { hexToBinary } from '../src/common/hex-to-binary';
  * @param hexStr
  */
 export function toBase64(hexStr: string) {
-  if (typeof btoa !== 'undefined') {
-    const decoder = new TextDecoder('utf8');
-    return btoa(decoder.decode(hexToBinary(hexStr)));
-  }
+  const decoder = new TextDecoder('utf8');
+  return btoa(decoder.decode(hexToBinary(hexStr)));
+}
 
-  return Buffer.from(hexToBinary(hexStr)).toString('base64');
+/**
+ * Cross-platform utility function to convert a Uint8Array to a base64 string.
+ * This works in both Node.js and browsers so that we can avoid using Buffer in tests.
+ */
+export function uint8ArrayToBase64(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
 }


### PR DESCRIPTION
## Which problem is this PR solving?

> [!IMPORTANT]
> **Draft PR**; things that are still missing:
> - comparing allocations.
> - the way it's growing the buffer may not be exactly the way we want it yet.
> **NOTE:** I'm ooo until Jan 7 2026, will not be able to drive this forward until then.

This PR replaces the generated code for serializing logs to OTLP/protobuf with hand-rolled code. The idea is to eliminate most intermediate steps we needed to conform to the generated code's layout and write directly to a `Uint8Array`. I made this to address the performance regression discovered in #6221.

I added some perf tests to show the differences:

**protobuf.js** (currently on `main` - this is the baseline we're comparing against)
```
--- Logs Serialization Benchmarks ---
serialize 1 log (protobuf) x 219,135 ops/sec ±0.14% (101 runs sampled)
serialize 100 logs (protobuf) x 3,051 ops/sec ±0.19% (100 runs sampled)
serialize 256 logs (protobuf) x 1,230 ops/sec ±0.16% (98 runs sampled)
serialize 512 logs (protobuf) x 468 ops/sec ±0.78% (74 runs sampled)
serialize 1024 logs (protobuf) x 237 ops/sec ±0.25% (87 runs sampled)
serialize 1 log (json) x 215,862 ops/sec ±0.17% (101 runs sampled)
serialize 100 logs (json) x 3,778 ops/sec ±0.46% (92 runs sampled)
serialize 256 logs (json) x 1,460 ops/sec ±0.43% (98 runs sampled)
serialize 512 logs (json) x 743 ops/sec ±0.14% (99 runs sampled)
serialize 1024 logs (json) x 368 ops/sec ±0.29% (95 runs sampled)
```

**custom implementation** (from this PR, turns out to be pretty-much on-par with the current OTLP/json serializer, better than what we had with `protobuf.js`)
```
--- Logs Serialization Benchmarks ---
serialize 1 log (protobuf) x 200,625 ops/sec ±0.15% (97 runs sampled)
serialize 100 logs (protobuf) x 4,196 ops/sec ±0.19% (100 runs sampled)
serialize 256 logs (protobuf) x 1,608 ops/sec ±0.54% (98 runs sampled)
serialize 512 logs (protobuf) x 807 ops/sec ±0.27% (94 runs sampled)
serialize 1024 logs (protobuf) x 397 ops/sec ±0.41% (92 runs sampled)
serialize 1 log (json) x 217,570 ops/sec ±0.14% (97 runs sampled)
serialize 100 logs (json) x 3,874 ops/sec ±0.17% (100 runs sampled)
serialize 256 logs (json) x 1,470 ops/sec ±0.26% (100 runs sampled)
serialize 512 logs (json) x 745 ops/sec ±0.14% (99 runs sampled)
serialize 1024 logs (json) x 371 ops/sec ±0.30% (96 runs sampled)
```

Disclosure of AI use: I used GitHub copilot with Claude Sonnet 4.5 to fill in most of the logic from an interface that I initially set up. I did apply a bunch of optimizations on afterwards to make it my own, but it was a significant help to get the basics up and running.

Ref #6100 
Ref #6221 

## Short description of the changes

## Type of change

- [x] Refactor

## How Has This Been Tested?

- [x] existing unit tests
- [x] existing e2e tests
- [x] added unit tests
