### PR TITLE
parseKeyPairsIntoRecord()

### DIFF
--- a/packages/opentelemetry-core/src/baggage/utils.ts
+++ b/packages/opentelemetry-core/src/baggage/utils.ts
@@ -70,7 +70,7 @@ export function parsePairKeyValue(
   const rawKey = keyPairPart.substring(0, separatorIndex).trim();
   const rawValue = keyPairPart.substring(separatorIndex + 1).trim();
 
-  if (!rawKey || !rawValue) return;
+  if (!rawKey) return;
   let key: string;
   let value: string;
   try {
@@ -105,7 +105,7 @@ export function parseKeyPairsIntoRecord(
     value.split(BAGGAGE_ITEMS_SEPARATOR).forEach(entry => {
       const keyPair = parsePairKeyValue(entry);
 
-      if (keyPair !== undefined && keyPair.value.length > 0) {
+      if (keyPair !== undefined && keyPair.value !== undefined) {
         result[keyPair.key] = keyPair.value;
       }
     });

--- a/packages/opentelemetry-core/test/common/baggage/utils.test.ts
+++ b/packages/opentelemetry-core/test/common/baggage/utils.test.ts
@@ -54,9 +54,10 @@ describe('parseKeyPairsIntoRecord()', () => {
     });
   });
 
-  it('filters out empty values', () => {
-    assert.deepStrictEqual(parseKeyPairsIntoRecord('key1=,key2=value2'), {
-      key2: 'value2',
+  it('prevents empty baggage values', () => {
+    assert.deepStrictEqual(parseKeyPairsIntoRecord('key1=value1,key2='), {
+      key1: 'value1',
+      key2: '',
     });
   });
 });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This PR fixes an issue where parseKeyPairsIntoRecord() dropped baggage key-value pairs with empty values.

According to the W3C Baggage specification, empty values are valid, but the current implementation filtered them out during parsing. This caused valid baggage entries to be lost.

Fixes  #6138

## Short description of the changes

Updated parsePairKeyValue to allow empty baggage values while rejecting invalid pairs.

Ensured parseKeyPairsIntoRecord() preserves entries with empty values.

Added unit tests to cover empty baggage value handling and prevent regressions.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added unit tests for parseKeyPairsIntoRecord covering empty baggage values.

Tests were executed locally using:
npx mocha test/common/baggage/utils.test.ts

All existing and new tests pass.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
