### PR TITLE
fix(opentelemetry-context-async-hooks): Add `exports` field in package.json

### DIFF
--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -4,6 +4,10 @@
   "description": "OpenTelemetry AsyncHooks-based Context Manager",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
+  "exports": {
+    "default": "./build/src/index.js",
+    "types": "./build/src/index.d.ts"
+  },
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "prepublishOnly": "npm run compile",


### PR DESCRIPTION
## Which problem is this PR solving?

This PR adds an `exports` definition (`default` and `types`) to ensure the package resolves
correctly. Otherwise it fails with the following message:

> Did you mean to import "@opentelemetry/context-async-hooks/build/src/index.js"?

- Added an `exports` field to `@opentelemetry/context-async-hooks/package.json`
  - `default` entry pointing to `./build/src/index.js`
  - `types` entry pointing to `./build/src/index.d.ts`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Test suite

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
