### PR TITLE
fix: instrument ESM package export submodule

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@opentelemetry/api-logs": "0.210.0",
-    "import-in-the-middle": "^2.0.0",
+    "import-in-the-middle": "^2.0.1",
     "require-in-the-middle": "^8.0.0"
   },
   "peerDependencies": {

--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -220,12 +220,13 @@ export abstract class InstrumentationBase<
       }
       return exports;
     }
-    // internal file
+    // internal file or submodule export
     const files = module.files ?? [];
     const normalizedName = path.normalize(name);
+    const normalizedModuleName = path.normalize(module.name);
     const supportedFileInstrumentations = files.filter(
       f =>
-        f.name === normalizedName &&
+        (f.name === normalizedName || f.name === normalizedModuleName) &&
         isSupported(f.supportedVersions, version, module.includePrerelease)
     );
     return supportedFileInstrumentations.reduce<T>((patchedExports, file) => {

--- a/experimental/packages/opentelemetry-instrumentation/test/node/EsmSubmoduleInstrumentation.test.mjs
+++ b/experimental/packages/opentelemetry-instrumentation/test/node/EsmSubmoduleInstrumentation.test.mjs
@@ -1,0 +1,110 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+
+import {
+  InstrumentationBase,
+  InstrumentationNodeModuleDefinition,
+  InstrumentationNodeModuleFile,
+} from '../../build/src/index.js';
+
+class TestInstrumentationSimple extends InstrumentationBase {
+  constructor(config) {
+    super('test-esm-submodule-exports', '0.0.1', config);
+  }
+  init() {
+    return [
+      new InstrumentationNodeModuleDefinition(
+        '@opentelemetry/esm-submodule-exports',
+        ['*'],
+        moduleExports => {
+          moduleExports.propertyOnMainModule = 'modified string in main module';
+          return moduleExports;
+        },
+        moduleExports => {
+          return moduleExports;
+        },
+        [
+          new InstrumentationNodeModuleFile(
+            '@opentelemetry/esm-submodule-exports/src/index.js',
+            ['*'],
+            moduleExports => {
+            moduleExports.propertyOnMainModule = 'modified string in main module';
+            return moduleExports;
+
+            },
+            moduleExports => {
+              return moduleExports;
+            }
+          ),
+        ]
+      ),
+      new InstrumentationNodeModuleDefinition(
+        '@opentelemetry/esm-submodule-exports/sub',
+        ['*'],
+        moduleExports => {
+          moduleExports.propertyOnSubModule = 'modified string in sub module';
+          return moduleExports;
+        },
+        moduleExports => {
+          return moduleExports;
+        },
+        [
+          new InstrumentationNodeModuleFile(
+            '@opentelemetry/esm-submodule-exports/sub',
+            ['*'],
+            moduleExports => {
+              moduleExports.propertyOnSubModule = 'modified string in sub module';
+              return moduleExports;
+            },
+            moduleExports => {
+              return moduleExports;
+            }
+          ),
+        ]
+      )
+    ];
+  }
+}
+
+describe('instrumenting an esm scoped submodule package', function () {
+  it('should patch main module', async function () {
+    const instrumentation = new TestInstrumentationSimple({
+      enabled: false,
+    });
+    instrumentation.enable();
+
+    const {
+      propertyOnMainModule,
+    } = await import('@opentelemetry/esm-submodule-exports');
+
+    assert.strictEqual(propertyOnMainModule, 'modified string in main module');
+  });
+
+  it('should patch sub module', async function () {
+    const instrumentation = new TestInstrumentationSimple({
+      enabled: false,
+    });
+    instrumentation.enable();
+
+    const {
+      propertyOnSubModule,
+    } = await import('@opentelemetry/esm-submodule-exports/sub');
+
+    assert.strictEqual(propertyOnSubModule, 'modified string in sub module');
+  });
+});

--- a/experimental/packages/opentelemetry-instrumentation/test/node/node_modules/@opentelemetry/esm-submodule-exports/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/test/node/node_modules/@opentelemetry/esm-submodule-exports/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@opentelemetry/esm-submodule-exports",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.js",
+    "./sub": "./src/sub.js"
+  }
+}

--- a/experimental/packages/opentelemetry-instrumentation/test/node/node_modules/@opentelemetry/esm-submodule-exports/src/index.js
+++ b/experimental/packages/opentelemetry-instrumentation/test/node/node_modules/@opentelemetry/esm-submodule-exports/src/index.js
@@ -1,0 +1,5 @@
+import { testString } from './internal.js'
+
+export const getString = () => "from index.js: " + testString;
+
+export const propertyOnMainModule = 'string in main module';

--- a/experimental/packages/opentelemetry-instrumentation/test/node/node_modules/@opentelemetry/esm-submodule-exports/src/internal.js
+++ b/experimental/packages/opentelemetry-instrumentation/test/node/node_modules/@opentelemetry/esm-submodule-exports/src/internal.js
@@ -1,0 +1,1 @@
+export const testString = "internal string";

--- a/experimental/packages/opentelemetry-instrumentation/test/node/node_modules/@opentelemetry/esm-submodule-exports/src/sub.js
+++ b/experimental/packages/opentelemetry-instrumentation/test/node/node_modules/@opentelemetry/esm-submodule-exports/src/sub.js
@@ -1,0 +1,5 @@
+import { testString } from "./internal.js";
+
+export const getString = () => `from /sub: ${testString}`;
+
+export const propertyOnSubModule = 'string in sub module';

--- a/package-lock.json
+++ b/package-lock.json
@@ -867,7 +867,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.210.0",
-        "import-in-the-middle": "^2.0.0",
+        "import-in-the-middle": "^2.0.1",
         "require-in-the-middle": "^8.0.0"
       },
       "devDependencies": {


### PR DESCRIPTION
Add support for patching an ESM internal module that is exported with a submodule path name in the `package.json` exports object.

## Which problem is this PR solving?

It is not currently possible to patch an ESM submodule export.

Fixes # (issue)

## Short description of the changes

When determining whether to apply a patch, the `file.name` is compared against the `normalizedPath`. However, this makes it impossible to get import-in-the-middle to consider the module a valid hook target.

Allow passing in the submodule specifier as the file name, treating it as the effective "path" to be hooked.

This is the continuation (one level higher in the stack) of https://github.com/nodejs/import-in-the-middle/pull/215

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update (maybe?)

I believe it could be argued that this is a new feature, and perhaps even not the most elegant approach. It does feel a bit clunky, tbh, since the "filename" being passed in is actually a virtual path defined in `package.json`, not an actual path on disk, since those are fully abstracted away by the ESM module loading semantics. But, I can't see how it would break any existing use cases.

## How Has This Been Tested?

Test included in the patch, at `experimental/packages/opentelemetry-instrumentation/test/node/EsmSubmoduleInstrumentation.test.mjs`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
