### PR TITLE
chore: move catch-all rule to top of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,9 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
+# All files
+* @open-telemetry/javascript-approvers
+
 # Only maintainers can approve changes in .github/ - including this file here, workflows and issue templates
 .github/ @open-telemetry/javascript-maintainers
 
@@ -27,6 +30,3 @@ experimental/packages/opentelemetry-instrumentation-fetch/ @open-telemetry/brows
 experimental/packages/opentelemetry-instrumentation-xml-http-request/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
 experimental/packages/opentelemetry-web-common/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
 packages/opentelemetry-sdk-trace-web/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
-
-# All other files
-* @open-telemetry/javascript-approvers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
+* chore: fix CODEOWNERS rule ordering [#6297](https://github.com/open-telemetry/opentelemetry-js/pull/6297) @overbalance
+
 ## 2.4.0
 
 ### :bug: Bug Fixes


### PR DESCRIPTION
## Summary
- Moves the catch-all `* @open-telemetry/javascript-approvers` rule from the bottom to the top of CODEOWNERS
- CODEOWNERS rules are matched top-to-bottom with later rules taking precedence, so the catch-all must be first for specific rules to properly override it

## Test plan
- [ ] Verify that PRs touching `.github/` files require javascript-maintainers approval
- [ ] Verify that PRs touching browser packages require browser-maintainers approval

# Verification
Observe that this PR modifies `.github/` but only `@open-telemetry/javascript-approvers` are tagged for review.

<img width="380" height="206" alt="Screenshot 2026-01-14 at 12 02 24 PM" src="https://github.com/user-attachments/assets/28c8b773-2500-4b6f-a20e-268dcb2f6902" />
