### PR TITLE
chore: re-order changelog

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,9 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-logs): allow AnyValue attributes for logs and handle circular references [#6210](https://github.com/open-telemetry/opentelemetry-js/pull/6210) @david-luna
+  * based on [#5765](https://github.com/open-telemetry/opentelemetry-js/pull/5765) from @alec2435
+
 ### :books: Documentation
 
 ### :house: Internal
@@ -75,8 +78,6 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * test(otlp-transformer): remove obsolete compat code from toBase64() [#6242](https://github.com/open-telemetry/opentelemetry-js/pull/6242) @cjihrig
 * refactor(otlp-exporter-base): simplify isExportHTTPErrorRetryable() [#6249](https://github.com/open-telemetry/opentelemetry-js/pull/6249) @cjihrig
 * refactor(sdk-logs): remove wrapper Promise in \_flushOneBatch() [#6253](https://github.com/open-telemetry/opentelemetry-js/pull/6253) @cjihrig
-* fix(sdk-logs): allow AnyValue attributes for logs and handle circular references [#6210](https://github.com/open-telemetry/opentelemetry-js/pull/6210) @david-luna
-  * based on [#5765](https://github.com/open-telemetry/opentelemetry-js/pull/5765) from @alec2435
 
 ## 0.208.0
 


### PR DESCRIPTION
## Which problem is this PR solving?

#6210's changelog unintentionally went into `0.209.0`, should be under `Unreleased`