### PR TITLE
chore(renovate): ignore bundler-tests directory

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,5 +50,6 @@
   },
   "assignees": ["@dyladan", "@legendecas", "@pichlermarc", "@trentm"],
   "labels": ["dependencies"],
+  "ignorePaths": ["**/bundler-tests/**"],
   "postUpdateOptions": ["npmDedupe"]
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Ignores the `bundler-tests` directory as a good chunk of the tools we test against are outdated on purpose.

Idea is to prevent PRs like:
- #6312 
- #6311
- #6247
