### PR TITLE
chore(otlp-transformer): update public benchmarks to reflect common case

### DIFF
--- a/experimental/packages/otlp-transformer/test/performance/benchmark/transform.js
+++ b/experimental/packages/otlp-transformer/test/performance/benchmark/transform.js
@@ -15,54 +15,125 @@
  */
 
 const Benchmark = require('benchmark');
-const {
-  createExportTraceServiceRequest,
-} = require('../../../build/src/trace/internal');
 const { BasicTracerProvider } = require('@opentelemetry/sdk-trace-base');
-const { ProtobufTraceSerializer } = require('../../../build/src');
+const {
+  ProtobufTraceSerializer,
+  JsonTraceSerializer,
+  ProtobufLogsSerializer,
+  JsonLogsSerializer,
+} = require('../../../build/src');
+const { resourceFromAttributes } = require('@opentelemetry/resources');
+const { TraceFlags } = require('@opentelemetry/api');
+const { SeverityNumber } = require('@opentelemetry/api-logs');
 
-const tracerProvider = new BasicTracerProvider();
-const tracer = tracerProvider.getTracer('test');
+// shared concepts
+const resource = resourceFromAttributes({
+  'service.name': 'benchmark-service',
+  'service.version': '1.0.0',
+});
 
-const suite = new Benchmark.Suite();
+const instrumentationScope = {
+  name: 'benchmark-otlp-transformer',
+  version: '1.0.0',
+  schemaUrl: 'https://opentelemetry.io/schemas/1.24.0',
+};
 
-const span = createSpan();
+// setup traces
+const tracerProvider = new BasicTracerProvider({
+  resource,
+});
+const tracer = tracerProvider.getTracer(
+  instrumentationScope.name,
+  instrumentationScope.version,
+  {
+    schemaUrl: 'https://opentelemetry.io/schemas/1.24.0',
+  }
+);
+
+function createSpan() {
+  const span = tracer.startSpan('span');
+  span.setAttributes({
+    'attribute.string': 'some string value',
+    'attribute.number': 12345,
+    'attribute.boolean': true,
+    'attribute.array': ['value1', 'value2', 'value3'],
+    'http.method': 'GET',
+    'http.url': 'https://example.com/api/endpoint',
+    'http.status_code': 200,
+    'user.id': 'user-12345',
+    'request.id': 'req-67890',
+    'session.id': 'sess-abcdef',
+  });
+  span.end();
+  return span;
+}
+
 const spans = [];
-for (let i = 0; i < 100; i++) {
+for (let i = 0; i < 512; i++) {
   spans.push(createSpan());
 }
+
+// setup logs
+function createLogRecord() {
+  const now = Date.now();
+  const seconds = Math.floor(now / 1000);
+  const nanos = (now % 1000) * 1000000;
+
+  return {
+    hrTime: [seconds, nanos],
+    hrTimeObserved: [seconds, nanos],
+    severityNumber: SeverityNumber.INFO,
+    severityText: 'INFO',
+    body: 'This is a log message with some content for benchmarking purposes',
+    attributes: {
+      'attribute.string': 'some string value',
+      'attribute.number': 12345,
+      'attribute.boolean': true,
+      'attribute.array': ['value1', 'value2', 'value3'],
+      'http.method': 'GET',
+      'http.url': 'https://example.com/api/endpoint',
+      'http.status_code': 200,
+      'user.id': 'user-12345',
+      'request.id': 'req-67890',
+      'session.id': 'sess-abcdef',
+    },
+    droppedAttributesCount: 0,
+    resource: resource,
+    instrumentationScope: instrumentationScope,
+    spanContext: {
+      traceId: '00000000000000000000000000000001',
+      spanId: '0000000000000002',
+      traceFlags: TraceFlags.SAMPLED,
+    },
+  };
+}
+
+const logs = [];
+for (let i = 0; i < 512; i++) {
+  logs.push(createLogRecord());
+}
+
+// setup benchmark suite
+const suite = new Benchmark.Suite();
 
 suite.on('cycle', event => {
   console.log(String(event.target));
 });
 
-suite.add('transform 1 span', function () {
-  createExportTraceServiceRequest([span]);
-});
-
-suite.add('transform 100 spans', function () {
-  createExportTraceServiceRequest(spans);
-});
-
-suite.add('transform 100 spans to protobuf', function () {
+suite.add('transform 512 spans (protobuf)', function () {
   ProtobufTraceSerializer.serializeRequest(spans);
 });
 
+suite.add('transform 512 spans (json)', function () {
+  JsonTraceSerializer.serializeRequest(spans);
+});
+
+suite.add('transform 512 logs (protobuf)', function () {
+  ProtobufLogsSerializer.serializeRequest(logs);
+});
+
+suite.add('transform 512 logs (json)', function () {
+  JsonLogsSerializer.serializeRequest(logs);
+});
+
 suite.run();
-
-function createSpan() {
-  const span = tracer.startSpan('span');
-  span.setAttribute('aaaaaaaaaaaaaaaaaaaa', 'aaaaaaaaaaaaaaaaaaaa');
-  span.setAttribute('bbbbbbbbbbbbbbbbbbbb', 'bbbbbbbbbbbbbbbbbbbb');
-  span.setAttribute('cccccccccccccccccccc', 'cccccccccccccccccccc');
-  span.setAttribute('dddddddddddddddddddd', 'dddddddddddddddddddd');
-  span.setAttribute('eeeeeeeeeeeeeeeeeeee', 'eeeeeeeeeeeeeeeeeeee');
-  span.setAttribute('ffffffffffffffffffff', 'ffffffffffffffffffff');
-  span.setAttribute('gggggggggggggggggggg', 'gggggggggggggggggggg');
-  span.setAttribute('hhhhhhhhhhhhhhhhhhhh', 'hhhhhhhhhhhhhhhhhhhh');
-  span.setAttribute('iiiiiiiiiiiiiiiiiiii', 'iiiiiiiiiiiiiiiiiiii');
-  span.setAttribute('jjjjjjjjjjjjjjjjjjjj', 'jjjjjjjjjjjjjjjjjjjj');
-  span.end();
-
-  return span;
-}


### PR DESCRIPTION
## Which problem is this PR solving?

In preparation for #6228, this PR introduces benchmarks made to reflect common batch sizes (default batch size for spans and logs is `512`) and the full impact of OTLP serialization.

Previously, our tests primarily focused on 
- internal transformation logic
- smaller batch sizes
which don’t accurately represent real-world usage. 

By focusing on larger batches closer to the maximum size of 512, we can better assess performance under typical conditions. Additionally, this will make it easier to compare JSON and protobuf serialization.

For now, metrics have been intentionally excluded. The focus is on logs and spans first, as they share a similar layout.