### PR TITLE
tests(sdk-node, sdk-trace-node, sdk-trace-web): 6077 refactor test global providers

### DIFF
--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -199,7 +199,10 @@ describe('Node SDK', () => {
       assertDefaultPropagatorRegistered();
 
       assert.strictEqual(setGlobalTracerProviderSpy.callCount, 1);
-      assert.ok(setGlobalTracerProviderSpy.lastCall.args[0] instanceof NodeTracerProvider)
+      assert.ok(
+        setGlobalTracerProviderSpy.lastCall.args[0] instanceof
+          NodeTracerProvider
+      );
       await sdk.shutdown();
     });
 
@@ -219,7 +222,10 @@ describe('Node SDK', () => {
         1,
         'tracer provider should have changed once'
       );
-      assert.ok(setGlobalTracerProviderSpy.lastCall.args[0] instanceof NodeTracerProvider)
+      assert.ok(
+        setGlobalTracerProviderSpy.lastCall.args[0] instanceof
+          NodeTracerProvider
+      );
       await sdk.shutdown();
     });
 
@@ -242,7 +248,7 @@ describe('Node SDK', () => {
 
       const nodeTracerProvider = setGlobalTracerProviderSpy.lastCall.args[0];
       assert.strictEqual(setGlobalTracerProviderSpy.callCount, 1);
-      assert.ok(nodeTracerProvider instanceof NodeTracerProvider)
+      assert.ok(nodeTracerProvider instanceof NodeTracerProvider);
 
       const spanProcessor = nodeTracerProvider['_activeSpanProcessor'] as any;
 
@@ -1124,7 +1130,7 @@ describe('Node SDK', () => {
       assert.ok(
         setGlobalLoggerProviderSpy.callCount === 0,
         'logger provider should not have changed'
-      )
+      );
       await sdk.shutdown();
     });
 

--- a/packages/opentelemetry-sdk-trace-node/test/registration.test.ts
+++ b/packages/opentelemetry-sdk-trace-node/test/registration.test.ts
@@ -18,11 +18,7 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { inspect } from 'util';
 
-import {
-  context,
-  propagation,
-  trace,
-} from '@opentelemetry/api';
+import { context, propagation, trace } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { CompositePropagator } from '@opentelemetry/core';
 import { NodeTracerProvider } from '../src';
@@ -39,7 +35,7 @@ const assertInstanceOf = (actual: object, ExpectedConstructor: Function) => {
 
 describe('API registration', function () {
   let setGlobalTracerProviderSpy: sinon.SinonSpy;
-  
+
   beforeEach(() => {
     context.disable();
     trace.disable();

--- a/packages/opentelemetry-sdk-trace-web/test/NodeGlobalsFoolProofing.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/NodeGlobalsFoolProofing.test.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  context,
-  propagation,
-  trace,
-} from '@opentelemetry/api';
+import { context, propagation, trace } from '@opentelemetry/api';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { StackContextManager, WebTracerProvider } from '../src';

--- a/packages/opentelemetry-sdk-trace-web/test/registration.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/registration.test.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  context,
-  propagation,
-  trace,
-} from '@opentelemetry/api';
+import { context, propagation, trace } from '@opentelemetry/api';
 import { CompositePropagator } from '@opentelemetry/core';
 import * as assert from 'assert';
 import * as sinon from 'sinon';


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Refactor SDK tests to not assert on `Proxy*Provider` but do it in `setGlobal*Provider` calls.

Closes #6077

## Short description of the changes

## Type of change

- [X] Test Refactor

## How Has This Been Tested?

- [X] ran tests with the new assertions

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been updated
