### PR TITLE
chore(api): mark ProxyTracerProvider as deprecated

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -24,6 +24,7 @@ fix(api): prioritize `esnext` export condition as it is more specific [#5458](ht
 * chore: enable tsconfig isolatedModules [#5697](https://github.com/open-telemetry/opentelemetry-js/pull/5697) @legendecas
 * chore: disallow constructor parameter property syntax [#6187](https://github.com/open-telemetry/opentelemetry-js/pull/6187) @legendecas
 * refactor(api): remove platform-specific globalThis, use globalThis directly [#6208](https://github.com/open-telemetry/opentelemetry-js/pull/6208) @overbalance
+* chore(api): mark ProxyTracerProvider as deprecated [#6328](https://github.com/open-telemetry/opentelemetry-js/pull/6328) @cjihrig
 
 ## 1.9.0
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -87,6 +87,7 @@ export type { PropagationAPI } from './api/propagation';
 export type { SpanAttributes, SpanAttributeValue } from './trace/attributes';
 export type { Link } from './trace/link';
 export { ProxyTracer, type TracerDelegator } from './trace/ProxyTracer';
+// TODO: Remove ProxyTracerProvider export in the next major version.
 export { ProxyTracerProvider } from './trace/ProxyTracerProvider';
 export type { Sampler } from './trace/Sampler';
 export { SamplingDecision, type SamplingResult } from './trace/SamplingResult';

--- a/api/src/trace/ProxyTracerProvider.ts
+++ b/api/src/trace/ProxyTracerProvider.ts
@@ -30,6 +30,7 @@ const NOOP_TRACER_PROVIDER = new NoopTracerProvider();
  *   When a delegate is set after tracers have already been provided,
  *   all tracers already provided will use the provided delegate implementation.
  *
+ * @deprecated This will be removed in the next major version.
  * @since 1.0.0
  */
 export class ProxyTracerProvider implements TracerProvider {

--- a/api/test/common/proxy-implementations/proxy-tracer.test.ts
+++ b/api/test/common/proxy-implementations/proxy-tracer.test.ts
@@ -19,7 +19,6 @@ import * as sinon from 'sinon';
 import {
   context,
   ProxyTracer,
-  ProxyTracerProvider,
   ROOT_CONTEXT,
   Span,
   SpanKind,
@@ -29,6 +28,7 @@ import {
 } from '../../../src';
 import { NonRecordingSpan } from '../../../src/trace/NonRecordingSpan';
 import { NoopTracer } from '../../../src/trace/NoopTracer';
+import { ProxyTracerProvider } from '../../../src/trace/ProxyTracerProvider';
 
 describe('ProxyTracer', function () {
   let provider: ProxyTracerProvider;


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

`ProxyTracerProvider` should not be exported from the API.

Fixes #6321

## Short description of the changes

This commit completes the checklist for `ProxyTracerProvider` in #6321.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test suite

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated
