### PR TITLE
## Summary
- propagate  through recursive  calls
- add regression test covering ancestor id optimization

## Context
Fixes #6323. When , ancestor ids were not used in the
computed XPath due to a false value in recursive calls.

## Test plan
- [ ] npm test -- packages/opentelemetry-sdk-trace-web/test/window/utils.test.ts

### DIFF
--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -374,7 +374,7 @@ export function getElementXPath(target: any, optimised?: boolean): string {
   }
   let xpath = '';
   if (target.parentNode) {
-    xpath += getElementXPath(target.parentNode, false);
+    xpath += getElementXPath(target.parentNode, optimised);
   }
   xpath += targetValue;
 

--- a/packages/opentelemetry-sdk-trace-web/test/window/utils.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/window/utils.test.ts
@@ -92,6 +92,27 @@ describe('utils', function () {
       );
     });
 
+    it('should use ancestor id when optimised recursively', function () {
+      const body = document.querySelector('body');
+      if (!body) {
+        throw new Error('Missing document body');
+      }
+
+      const container = document.createElement('div');
+      container.id = 'body-id';
+      const inner = document.createElement('div');
+      container.appendChild(inner);
+      body.appendChild(container);
+
+      try {
+        const element = getElementXPath(inner, true);
+        assert.strictEqual(element, '//*[@id="body-id"]/div');
+        assert.strictEqual(inner, getElementByXpath(element));
+      } finally {
+        body.removeChild(container);
+      }
+    });
+
     it(
       'should return correct path for element with id and surrounded by the' +
         ' same type',


### PR DESCRIPTION
## Summary
- propagate `optimised` through recursive `getElementXPath` calls
- add regression test covering ancestor id optimization

## Context
Fixes #6323. When `optimised=true`, ancestor ids were not used in the
computed XPath due to a false value in recursive calls.

## Test plan
- [ ] npm test -- packages/opentelemetry-sdk-trace-web/test/window/utils.test.ts