### PR TITLE
fix: cancel retries on shutdown

### DIFF
--- a/experimental/packages/otlp-exporter-base/src/exporter-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/exporter-transport.ts
@@ -18,5 +18,10 @@ import { ExportResponse } from './export-response';
 
 export interface IExporterTransport {
   send(data: Uint8Array, timeoutMillis: number): Promise<ExportResponse>;
+
+  /**
+   * Finish pending requests as soon as possible, foregoing retries if possible.
+   */
+  forceFlush?(): void;
   shutdown(): void;
 }

--- a/experimental/packages/otlp-exporter-base/src/otlp-export-delegate.ts
+++ b/experimental/packages/otlp-exporter-base/src/otlp-export-delegate.ts
@@ -141,6 +141,8 @@ class OTLPExportDelegate<Internal, Response>
   }
 
   forceFlush(): Promise<void> {
+    // note: it is the responsibility of the caller to ensure not new exports are scheduled after this call.
+    this._transport.forceFlush?.();
     return this._promiseQueue.awaitAll();
   }
 

--- a/experimental/packages/otlp-exporter-base/test/common/otlp-export-delegate.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/common/otlp-export-delegate.test.ts
@@ -104,7 +104,6 @@ describe('OTLPExportDelegate', function () {
       };
       const mockSerializer = <FakeSerializer>serializerStubs;
 
-      // promise queue has not reached capacity yet
       const promiseQueueStubs = {
         pushPromise: sinon.stub(),
         hasReachedLimit: sinon.stub(),

--- a/experimental/packages/otlp-exporter-base/test/common/retrying-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/common/retrying-transport.test.ts
@@ -19,10 +19,15 @@ import * as assert from 'assert';
 import { IExporterTransport } from '../../src';
 import { createRetryingTransport } from '../../src/retrying-transport';
 import { ExportResponse } from '../../src';
+import { diag } from '@opentelemetry/api';
 
 const timeoutMillis = 1000000;
 
 describe('RetryingTransport', function () {
+  afterEach(function () {
+    sinon.restore();
+  });
+
   describe('send', function () {
     it('does not retry when underlying transport succeeds', async function () {
       // arrange
@@ -241,6 +246,235 @@ describe('RetryingTransport', function () {
         timeoutMillis
       );
       assert.strictEqual(result, retryResponse);
+    });
+  });
+
+  describe('forceFlush', function () {
+    it('cancels pending retries and returns retryable', async function () {
+      // arrange
+      const timer = sinon.useFakeTimers();
+      const retryResponse: ExportResponse = {
+        status: 'retryable',
+        retryInMillis: 100,
+      };
+      const mockData = Uint8Array.from([1, 2, 3]);
+
+      const transportStubs = {
+        send: sinon.stub().resolves(retryResponse),
+        shutdown: sinon.stub(),
+      };
+      const mockTransport = <IExporterTransport>transportStubs;
+      const transport = createRetryingTransport({ transport: mockTransport });
+
+      // Start a send that will retry
+      const sendPromise = transport.send(mockData, timeoutMillis);
+
+      // Break event loop to allow initial send to complete
+      await timer.tickAsync(1);
+
+      // act - forceFlush while retry is pending (this should cancel the pending timeout)
+      transport.forceFlush?.();
+
+      // assert - the send promise should resolve with retryable status immediately
+      await timer.runAllAsync();
+      const result = await sendPromise;
+      assert.strictEqual(result.status, 'retryable');
+      assert.strictEqual(
+        result.error?.message,
+        'Retry cancelled due to forceFlush()'
+      );
+      sinon.assert.calledOnce(transportStubs.send); // Only initial attempt, retry was cancelled
+    });
+
+    it('allows new retries after forceFlush', async function () {
+      // arrange
+      const timer = sinon.useFakeTimers();
+      const retryResponse: ExportResponse = {
+        status: 'retryable',
+      };
+      const successResponse: ExportResponse = {
+        status: 'success',
+      };
+      const mockData = Uint8Array.from([1, 2, 3]);
+
+      const transportStubs = {
+        send: sinon
+          .stub()
+          .onFirstCall()
+          .resolves(retryResponse)
+          .onSecondCall()
+          .resolves(successResponse),
+        shutdown: sinon.stub(),
+      };
+      const mockTransport = <IExporterTransport>transportStubs;
+      const transport = createRetryingTransport({ transport: mockTransport });
+
+      // act - forceFlush first
+      transport.forceFlush?.();
+
+      // Start a send after forceFlush()
+      const sendPromise = transport.send(mockData, timeoutMillis);
+
+      // Wait for first attempt to complete
+      await timer.runAllAsync();
+
+      // assert
+      const result = await sendPromise;
+      assert.strictEqual(result.status, 'success');
+      sinon.assert.calledTwice(transportStubs.send); // Initial attempt + one retry
+    });
+
+    it('cancels multiple pending retries', async function () {
+      // arrange
+      const timer = sinon.useFakeTimers();
+      const retryResponse: ExportResponse = {
+        status: 'retryable',
+        retryInMillis: 100, // Short retry delay
+      };
+      const mockData1 = Uint8Array.from([1, 2, 3]);
+      const mockData2 = Uint8Array.from([4, 5, 6]);
+
+      const transportStubs = {
+        send: sinon.stub().resolves(retryResponse),
+        shutdown: sinon.stub(),
+      };
+      const mockTransport = <IExporterTransport>transportStubs;
+      const transport = createRetryingTransport({ transport: mockTransport });
+
+      // Start multiple sends that will retry
+      const sendPromise1 = transport.send(mockData1, timeoutMillis);
+      const sendPromise2 = transport.send(mockData2, timeoutMillis);
+
+      // Break event loop to allow initial sends to complete
+      await timer.tickAsync(1);
+
+      // act - forceFlush while retries are pending (cancel pending retries)
+      transport.forceFlush?.();
+
+      // assert - the send promises should resolve with retryable status immediately
+      const result1 = await sendPromise1;
+      const result2 = await sendPromise2;
+
+      assert.strictEqual(result1.status, 'retryable');
+      assert.strictEqual(
+        result1.error?.message,
+        'Retry cancelled due to forceFlush()'
+      );
+      assert.strictEqual(result2.status, 'retryable');
+      assert.strictEqual(
+        result2.error?.message,
+        'Retry cancelled due to forceFlush()'
+      );
+
+      // Only 2 initial attempts (one for each send), all retries were cancelled
+      sinon.assert.calledTwice(transportStubs.send);
+    });
+
+    it('cancels retries that have not been scheduled yet', async function () {
+      // arrange
+      const timer = sinon.useFakeTimers();
+      const infoSpy = sinon.spy(diag, 'info');
+      const originalError = new Error();
+      const retryResponse: ExportResponse = {
+        status: 'retryable',
+        retryInMillis: 100, // Short retry delay
+        error: originalError, // include an error to verify it's retained in the response
+      };
+      const mockData = Uint8Array.from([1, 2, 3]);
+
+      const transportStubs = {
+        send: sinon.stub().resolves(retryResponse),
+        shutdown: sinon.stub(),
+      };
+      const mockTransport = <IExporterTransport>transportStubs;
+      const transport = createRetryingTransport({ transport: mockTransport });
+
+      // send, but do not break event loop yet, so retry is not yet scheduled
+      const sendPromise = transport.send(mockData, timeoutMillis);
+
+      // act - forceFlush, no retries are pending but send is still in progress
+      transport.forceFlush?.();
+
+      // assert
+      // let everything play out
+      await timer.runAllAsync();
+      const result = await sendPromise;
+      assert.strictEqual(result.status, 'retryable');
+      assert.strictEqual(result.error, originalError);
+      infoSpy.calledOnceWithExactly(
+        'foregoing retry as operation was forceFlushed'
+      );
+
+      // Only 1 attempt (initial send, no retry)
+      sinon.assert.calledOnce(transportStubs.send);
+    });
+
+    it('calls forceFlush on underlying transport', function () {
+      // arrange
+      const transportStubs = {
+        send: sinon.stub(),
+        shutdown: sinon.stub(),
+        forceFlush: sinon.stub().resolves(),
+      };
+      const mockTransport = <IExporterTransport>transportStubs;
+      const transport = createRetryingTransport({ transport: mockTransport });
+
+      // act
+      transport.forceFlush?.();
+
+      // assert
+      sinon.assert.calledOnce(transportStubs.forceFlush);
+    });
+  });
+
+  describe('shutdown', function () {
+    it('calls shutdown on underlying transport', function () {
+      // arrange
+      const transportStubs = {
+        send: sinon.stub(),
+        shutdown: sinon.stub(),
+      };
+      const mockTransport = <IExporterTransport>transportStubs;
+      const transport = createRetryingTransport({ transport: mockTransport });
+
+      // act
+      transport.shutdown();
+
+      // assert
+      sinon.assert.calledOnce(transportStubs.shutdown);
+    });
+
+    it('allows initial send attempt to complete even during shutdown', async function () {
+      // arrange
+      const successResponse: ExportResponse = {
+        status: 'success',
+      };
+      const mockData = Uint8Array.from([1, 2, 3]);
+
+      let resolveTransportSend: (value: ExportResponse) => void;
+      const transportSendPromise = new Promise<ExportResponse>(resolve => {
+        resolveTransportSend = resolve;
+      });
+
+      const transportStubs = {
+        send: sinon.stub().returns(transportSendPromise),
+        shutdown: sinon.stub(),
+      };
+      const mockTransport = <IExporterTransport>transportStubs;
+      const transport = createRetryingTransport({ transport: mockTransport });
+
+      // Start a send
+      const sendPromise = transport.send(mockData, timeoutMillis);
+
+      // Shutdown while initial send is in progress
+      transport.shutdown();
+
+      // Complete the initial send
+      resolveTransportSend!(successResponse);
+
+      // assert - initial send should complete successfully
+      const result = await sendPromise;
+      assert.strictEqual(result.status, 'success');
     });
   });
 });

--- a/experimental/packages/sdk-logs/src/export/LogRecordExporter.ts
+++ b/experimental/packages/sdk-logs/src/export/LogRecordExporter.ts
@@ -30,4 +30,6 @@ export interface LogRecordExporter {
 
   /** Stops the exporter. */
   shutdown(): Promise<void>;
+
+  forceFlush?(): Promise<void>;
 }

--- a/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
@@ -41,7 +41,6 @@ import {
 import { LogRecordImpl } from '../../../src/LogRecordImpl';
 
 class BatchLogRecordProcessor extends BatchLogRecordProcessorBase<BufferConfig> {
-  onInit() {}
   onShutdown() {}
 }
 
@@ -292,12 +291,15 @@ describe('BatchLogRecordProcessorBase', () => {
       await processor.shutdown();
     });
 
-    it('should force flush when timeout exceeded for partial batches', done => {
+    it('should force flush when timeout exceeded for partial batches', async function () {
+      // arrange
       const clock = sinon.useFakeTimers();
       const processor = new BatchLogRecordProcessor(
         exporter,
         defaultBufferConfig
       );
+
+      // act
       // Add only a partial batch (less than maxExportBatchSize)
       const partialBatchSize = Math.floor(
         defaultBufferConfig.maxExportBatchSize / 2
@@ -307,15 +309,14 @@ describe('BatchLogRecordProcessorBase', () => {
         processor.onEmit(logRecord);
         assert.strictEqual(exporter.getFinishedLogRecords().length, 0);
       }
-      setTimeout(() => {
-        // Should export the partial batch after timeout
-        assert.strictEqual(
-          exporter.getFinishedLogRecords().length,
-          partialBatchSize
-        );
-        done();
-      }, defaultBufferConfig.scheduledDelayMillis + 1000);
-      clock.tick(defaultBufferConfig.scheduledDelayMillis + 1000);
+      await clock.tickAsync(defaultBufferConfig.scheduledDelayMillis + 1000);
+
+      // assert
+      // Should export the partial batch after timeout
+      assert.strictEqual(
+        exporter.getFinishedLogRecords().length,
+        partialBatchSize
+      );
       clock.restore();
     });
 
@@ -365,7 +366,8 @@ describe('BatchLogRecordProcessorBase', () => {
       });
     });
 
-    it('should call globalErrorHandler when exporting fails', done => {
+    it('should call globalErrorHandler when exporting fails', async function () {
+      // arrange
       const clock = sinon.useFakeTimers();
       const expectedError = new Error('Exporter failed');
       sinon.stub(exporter, 'export').callsFake((_, callback) => {
@@ -379,23 +381,21 @@ describe('BatchLogRecordProcessorBase', () => {
         exporter,
         defaultBufferConfig
       );
+
+      // act
       for (let i = 0; i < defaultBufferConfig.maxExportBatchSize; i++) {
         const logRecord = createLogRecord();
         processor.onEmit(logRecord);
       }
-      clock.tick(defaultBufferConfig.scheduledDelayMillis + 1000);
-      clock.restore();
-      setTimeout(() => {
-        assert.strictEqual(errorHandlerSpy.callCount, 1);
-        const [[error]] = errorHandlerSpy.args;
-        assert.deepStrictEqual(error, expectedError);
-        // reset global error handler
-        setGlobalErrorHandler(loggingErrorHandler());
-        done();
-      });
+      await clock.tickAsync(defaultBufferConfig.scheduledDelayMillis + 1000);
+
+      // assert
+      sinon.assert.calledOnceWithExactly(errorHandlerSpy, expectedError);
+      // reset global error handler
+      setGlobalErrorHandler(loggingErrorHandler());
     });
 
-    it('should drop logRecords when there are more logRecords than "maxQueueSize"', () => {
+    it('should drop logRecords when there are more logRecords than "maxQueueSize"', function () {
       // Use a large batch size to prevent automatic exports during this test
       const maxQueueSize = 6;
       const maxExportBatchSize = 20; // Will be clamped to maxQueueSize (6) by constructor
@@ -505,6 +505,7 @@ describe('BatchLogRecordProcessorBase', () => {
 
   describe('Concurrency', () => {
     it('should only send a single batch at a time', async () => {
+      // arrange
       const callbacks: ((result: ExportResult) => void)[] = [];
       const logRecords: SdkLogRecord[] = [];
       const exporter: LogRecordExporter = {
@@ -521,11 +522,17 @@ describe('BatchLogRecordProcessorBase', () => {
         maxExportBatchSize: 5,
         maxQueueSize: 6,
       });
+
+      // act
       const totalLogRecords = 50;
       for (let i = 0; i < totalLogRecords; i++) {
         const logRecord = createLogRecord();
         processor.onEmit(logRecord);
       }
+
+      // yield to allow an export to start
+      await new Promise(resolve => setTimeout(resolve, 0));
+      // assert
       assert.equal(callbacks.length, 1);
       assert.equal(logRecords.length, 5);
       callbacks[0]({ code: ExportResultCode.SUCCESS });

--- a/packages/opentelemetry-sdk-trace-base/src/export/SpanExporter.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/export/SpanExporter.ts
@@ -21,7 +21,7 @@ import { ReadableSpan } from './ReadableSpan';
  * An interface that allows different tracing services to export recorded data
  * for sampled spans in their own format.
  *
- * To export data this MUST be register to the Tracer SDK using a optional
+ * To export data this MUST be registered to the Tracer SDK using an optional
  * config.
  */
 export interface SpanExporter {

--- a/packages/sdk-metrics/test/export/PeriodicExportingMetricReader.test.ts
+++ b/packages/sdk-metrics/test/export/PeriodicExportingMetricReader.test.ts
@@ -653,14 +653,16 @@ describe('PeriodicExportingMetricReader', () => {
 
     it('should throw on non-initialized instance.', async () => {
       const exporter = new TestMetricExporter();
-      exporter.throwFlush = true;
       const reader = new PeriodicExportingMetricReader({
         exporter: exporter,
         exportIntervalMillis: MAX_32_BIT_INT,
         exportTimeoutMillis: 80,
       });
 
-      await assert.rejects(() => reader.shutdown(), /Error during forceFlush/);
+      await assert.rejects(
+        () => reader.shutdown(),
+        /Error: MetricReader is not bound to a MetricProducer/
+      );
     });
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

With the fix from #6147, we started re-trying failed exports more aggressively. The result is that shutdown now hangs for a couple of seconds before it finishes. (ref: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/3349) 

This PR introduces several changes to address this:
- OTLP exporters now cancel in-flight retries when `exporter.forceFlush()` is called
- `BatchSpanProcessor#shutdown()` now schedules exports, but calls `SpanExporter#forceFlush()`  right after scheduling the export, signaling the exporter to speed up
- `BatchLogRecordProcessor#shutdown()` does the same
- `PeriodicExportingMetricReader#shutdown()` does the same

The diff for this is fairly large, and I don't expect anybody to review this PR, so I'll break this down into smaller chunks, keeping this PR in draft to show all changes working together.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Existing tests (had to make some changes as the previous tests were relying heavily on behvaior that was not guaranteed by the API)
- [x] Added test in `@opentelemetry/sdk-node` to test the same shutdown code path used in `@opentelemetry/auto-instrumentation-node`