### PR TITLE
fix(sdk-trace-web): pass optimised parameter recursively in getElementXPath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-trace-web): pass `optimised` parameter recursively in `getElementXPath` [#6323](https://github.com/open-telemetry/opentelemetry-js/issues/6323) @ritesh
 * fix(opentelemetry-sdk-node): the custom value from env variable for service.instance.id should take priority over random uuid as backup [#6345](https://github.com/open-telemetry/opentelemetry-js/pull/6345) @maryliag
 
 ### :books: Documentation

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -374,7 +374,7 @@ export function getElementXPath(target: any, optimised?: boolean): string {
   }
   let xpath = '';
   if (target.parentNode) {
-    xpath += getElementXPath(target.parentNode, false);
+    xpath += getElementXPath(target.parentNode, optimised);
   }
   xpath += targetValue;
 

--- a/packages/opentelemetry-sdk-trace-web/test/window/utils.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/window/utils.test.ts
@@ -148,6 +148,25 @@ describe('utils', function () {
       assert.strictEqual(element, '//html/body/div/div[4]/div[8]/comment()');
       assert.strictEqual(node, getElementByXpath(element));
     });
+
+    it('should pass optimised parameter recursively to parent nodes', function () {
+      // Test the specific bug from issue #6323
+      // Create a structure: div#test-parent-id > div (no id)
+      const testContainer = document.createElement('div');
+      testContainer.id = 'test-parent-id';
+      const childDiv = document.createElement('div');
+      testContainer.appendChild(childDiv);
+      document.body.appendChild(testContainer);
+
+      try {
+        const xpath = getElementXPath(childDiv, true);
+        // With optimised=true, should use parent's id instead of full path
+        assert.strictEqual(xpath, '//*[@id="test-parent-id"]/div');
+        assert.strictEqual(childDiv, getElementByXpath(xpath));
+      } finally {
+        document.body.removeChild(testContainer);
+      }
+    });
   });
 
   describe('parseUrl', function () {


### PR DESCRIPTION
## Description

The `getElementXPath` function was not passing the `optimised` parameter recursively when traversing parent nodes. This caused child elements of parents with IDs to get full paths (e.g., `//html/body/div`) instead of optimised paths using the parent's ID (e.g., `//*[@id="parent-id"]/div`).

## Changes

- Fixed the recursive call in `getElementXPath` to pass `optimised` instead of `false`
- Added test case to verify the fix

## Fix

```diff
- xpath += getElementXPath(target.parentNode, false);
+ xpath += getElementXPath(target.parentNode, optimised);
```

Fixes #6323
