### PR TITLE
docs: drop the single-quotes from OTEL_RESOURCE_ATTRIBUTES usage

### DIFF
--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -153,7 +153,7 @@ export OTEL_NODE_RESOURCE_DETECTORS="host,env"
 ```
 
 NOTE: The order set on `OTEL_NODE_RESOURCE_DETECTORS` will be respected and the detectors will be executed in order.
-For example, if you have `OTEL_RESOURCE_ATTRIBUTES="service.instance.id='custom-name'"`, but also `serviceinstance` and `env` on `OTEL_NODE_RESOURCE_DETECTORS`, it can have 2 scenarios:
+For example, if you have `OTEL_RESOURCE_ATTRIBUTES="service.instance.id=custom-name"`, but also `serviceinstance` and `env` on `OTEL_NODE_RESOURCE_DETECTORS`, it can have 2 scenarios:
 
 - `OTEL_NODE_RESOURCE_DETECTORS="serviceinstance,env"` will have the `service.instance.id` as `custom-name`
 - `OTEL_NODE_RESOURCE_DETECTORS="env,serviceinstance"` will have the `service.instance.id` as a random UUID


### PR DESCRIPTION
This actually results in the single-quotes being part of the value.

      resource: Resource {
        attributes: [
          KeyValue { key: 'service.instance.id', value: AnyValue { stringValue: "'custom-name'" } },
          ...

Refs: https://github.com/open-telemetry/opentelemetry-js/pull/6345

---

/cc @maryliag 

