### PR TITLE
test: remove assert.doesNotThrow from tests

### DIFF
--- a/api/test/common/api/api.test.ts
+++ b/api/test/common/api/api.test.ts
@@ -219,43 +219,35 @@ describe('API', function () {
   });
 
   describe('Global diag', function () {
-    it('initialization', function () {
-      const inst = DiagAPI.instance();
+   it('initialization', function () {
+    const inst = DiagAPI.instance();
+    assert.deepStrictEqual(diag, inst);
+   });
 
-      assert.deepStrictEqual(diag, inst);
+  diagLoggerFunctions.forEach(fName => {
+    it(`no argument logger ${fName} message doesn't throw`, function () {
+      // @ts-expect-error an undefined logger is not allowed
+      diag.setLogger();
+      diag[fName](`${fName} message`);
     });
 
-    diagLoggerFunctions.forEach(fName => {
-      it(`no argument logger ${fName} message doesn't throw`, function () {
-        //@ts-expect-error an undefined logger is not allowed
-        diag.setLogger();
-        assert.doesNotThrow(() => {
-          diag[fName](`${fName} message`);
-        });
-      });
+    it(`null logger ${fName} message doesn't throw`, function () {
+      diag.setLogger(null as any);
+      diag[fName](`${fName} message`);
+    });
 
-      it(`null logger ${fName} message doesn't throw`, function () {
-        diag.setLogger(null as any);
-        assert.doesNotThrow(() => {
-          diag[fName](`${fName} message`);
-        });
-      });
+    it(`undefined logger ${fName} message doesn't throw`, function () {
+      diag.setLogger(undefined as any);
+      diag[fName](`${fName} message`);
+    });
 
-      it(`undefined logger ${fName} message doesn't throw`, function () {
-        diag.setLogger(undefined as any);
-        assert.doesNotThrow(() => {
-          diag[fName](`${fName} message`);
-        });
-      });
-
-      it(`empty logger ${fName} message doesn't throw`, function () {
-        diag.setLogger({} as any);
-        assert.doesNotThrow(() => {
-          diag[fName](`${fName} message`);
-        });
-      });
+    it(`empty logger ${fName} message doesn't throw`, function () {
+      diag.setLogger({} as any);
+      diag[fName](`${fName} message`);
     });
   });
+});
+
 
   describe('Global metrics', function () {
     it('should expose a meter provider via getMeterProvider', function () {

--- a/api/test/common/context/NoopContextManager.test.ts
+++ b/api/test/common/context/NoopContextManager.test.ts
@@ -23,24 +23,20 @@ describe('NoopContextManager', function () {
 
   describe('.enable()', function () {
     it('should work', function () {
-      assert.doesNotThrow(() => {
-        contextManager = new NoopContextManager();
-        assert.ok(
-          contextManager.enable() === contextManager,
-          'should return this'
-        );
-      });
+      contextManager = new NoopContextManager();
+      assert.ok(
+        contextManager.enable() === contextManager,
+        'should return this'
+      );
     });
   });
 
   describe('.disable()', function () {
     it('should work', function () {
-      assert.doesNotThrow(() => {
-        assert.ok(
-          contextManager.disable() === contextManager,
-          'should return this'
-        );
-      });
+      assert.ok(
+        contextManager.disable() === contextManager,
+        'should return this'
+      );
       contextManager.enable();
     });
   });


### PR DESCRIPTION
This PR removes usages of `assert.doesNotThrow()` from test cases.

Per the Node.js documentation and core lint rules, `assert.doesNotThrow()` provides no additional value in tests, since it only catches and rethrows errors without adding assertions.

The affected tests already fail naturally if an exception is thrown, so removing these wrappers keeps the tests simpler and more consistent with current Node.js testing practices.

No functional or behavioral changes are introduced — this is a test-only cleanup.

fixes #6333 