### PR TITLE
fix(deps): update dependency @grpc/grpc-js to v1.8.22 [security]

### DIFF
--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -64,7 +64,7 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.7.1",
+    "@grpc/grpc-js": "^1.8.22",
     "@opentelemetry/core": "2.5.0",
     "@opentelemetry/otlp-exporter-base": "0.211.0",
     "@opentelemetry/otlp-grpc-exporter-base": "0.211.0",

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -61,7 +61,7 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.7.1",
+    "@grpc/grpc-js": "^1.8.22",
     "@opentelemetry/core": "2.5.0",
     "@opentelemetry/otlp-exporter-base": "0.211.0",
     "@opentelemetry/otlp-grpc-exporter-base": "0.211.0",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -61,7 +61,7 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.7.1",
+    "@grpc/grpc-js": "^1.8.22",
     "@opentelemetry/core": "2.5.0",
     "@opentelemetry/exporter-metrics-otlp-http": "0.211.0",
     "@opentelemetry/otlp-exporter-base": "0.211.0",

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@bufbuild/buf": "1.53.0",
-    "@grpc/grpc-js": "^1.7.1",
+    "@grpc/grpc-js": "^1.8.22",
     "@grpc/proto-loader": "^0.7.10",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/context-async-hooks": "2.5.0",

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -61,7 +61,7 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.7.1",
+    "@grpc/grpc-js": "^1.8.22",
     "@opentelemetry/core": "2.5.0",
     "@opentelemetry/otlp-exporter-base": "0.211.0",
     "@opentelemetry/otlp-transformer": "0.211.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -261,6 +261,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -433,7 +434,7 @@
       "version": "0.211.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.7.1",
+        "@grpc/grpc-js": "^1.8.22",
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/otlp-exporter-base": "0.211.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.211.0",
@@ -551,7 +552,7 @@
       "version": "0.211.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.7.1",
+        "@grpc/grpc-js": "^1.8.22",
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/otlp-exporter-base": "0.211.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.211.0",
@@ -701,7 +702,7 @@
       "version": "0.211.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.7.1",
+        "@grpc/grpc-js": "^1.8.22",
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.211.0",
         "@opentelemetry/otlp-exporter-base": "0.211.0",
@@ -937,7 +938,7 @@
       },
       "devDependencies": {
         "@bufbuild/buf": "1.53.0",
-        "@grpc/grpc-js": "^1.7.1",
+        "@grpc/grpc-js": "^1.8.22",
         "@grpc/proto-loader": "^0.7.10",
         "@opentelemetry/api": "1.9.0",
         "@opentelemetry/context-async-hooks": "2.5.0",
@@ -1134,7 +1135,7 @@
       "version": "0.211.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.7.1",
+        "@grpc/grpc-js": "^1.8.22",
         "@opentelemetry/core": "2.5.0",
         "@opentelemetry/otlp-exporter-base": "0.211.0",
         "@opentelemetry/otlp-transformer": "0.211.0"
@@ -1484,6 +1485,7 @@
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -3423,6 +3425,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -5550,6 +5553,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -6452,6 +6456,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6820,6 +6825,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -6933,6 +6939,7 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -6992,6 +6999,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -7307,6 +7315,7 @@
       "integrity": "sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.41.0",
         "@typescript-eslint/types": "8.41.0",
@@ -7817,6 +7826,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8784,6 +8794,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10350,7 +10361,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
       "integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -11124,6 +11136,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11196,6 +11209,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -14520,6 +14534,7 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -15686,6 +15701,7 @@
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -15863,6 +15879,7 @@
       "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -17936,6 +17953,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -19254,6 +19272,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -19436,6 +19455,7 @@
       "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -20905,6 +20925,7 @@
       "integrity": "sha512-JBG8dioIs0m2kHOhs9jD6E/tZKD08vmbf2bfqj/rJyNWqJxk/ZcakixjhYtsqdbi+AKVbfPkt3g2RRZiKaizYA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes-iec": "^3.1.1",
         "lilconfig": "^3.1.3",
@@ -20951,6 +20972,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21884,6 +21906,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -22138,6 +22161,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -22447,7 +22471,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",
@@ -22544,6 +22569,7 @@
       "integrity": "sha512-/z585740YHURLl9DN2jCWe6OW7zKYm6VoQ93H0sxZ1cwHQEQrUn5BJrEnkWhfzUdyO+BLGjnKUZ9iz9hKloFDw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^1.24.0",
         "lunr": "^2.3.9",
@@ -22577,6 +22603,7 @@
       "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22995,6 +23022,7 @@
       "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -23152,6 +23180,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -23300,6 +23329,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -23686,6 +23716,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",


### PR DESCRIPTION
Copy from a renovate PR in another repo:

This MR contains the following updates:

| Package | Change | Age | Confidence |
|---|---|---|---|
| [@grpc/grpc-js](https://grpc.io/) ([source](https://github.com/grpc/grpc-node)) | [`1.7.1` -> `1.8.22`](https://renovatebot.com/diffs/npm/@grpc%2fgrpc-js/1.7.1/1.8.22) | [![age](https://developer.mend.io/api/mc/badges/age/npm/@grpc%2fgrpc-js/1.8.22?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/npm/@grpc%2fgrpc-js/1.7.1/1.8.22?slim=true)](https://docs.renovatebot.com/merge-confidence/) |

---

### @&#8203;grpc/grpc-js can allocate memory for incoming messages well above configured limits
[CVE-2024-37168](https://nvd.nist.gov/vuln/detail/CVE-2024-37168) / [GHSA-7v5v-9h63-cj86](https://github.com/advisories/GHSA-7v5v-9h63-cj86)

<details>
<summary>More information</summary>

#### Details
##### Impact
There are two separate code paths in which memory can be allocated per message in excess of the `grpc.max_receive_message_length` channel option:

 1. If an incoming message has a size on the wire greater than the configured limit, the entire message is buffered before it is discarded.
 2. If an incoming message has a size within the limit on the wire but decompresses to a size greater than the limit, the entire message is decompressed into memory, and on the server is not discarded.

##### Patches

This has been patched in versions 1.10.9, 1.9.15, and 1.8.22

#### Severity
- CVSS Score: 5.3 / 10 (Medium)
- Vector String: `CVSS:3.1/AV:N/AC:L/MR:N/UI:N/S:U/C:N/I:N/A:L`

#### References
- [https://github.com/grpc/grpc-node/security/advisories/GHSA-7v5v-9h63-cj86](https://github.com/grpc/grpc-node/security/advisories/GHSA-7v5v-9h63-cj86)
- [https://nvd.nist.gov/vuln/detail/CVE-2024-37168](https://nvd.nist.gov/vuln/detail/CVE-2024-37168)
- [https://github.com/grpc/grpc-node/commit/08b0422dae56467ecae1007e899efe66a8c4a650](https://github.com/grpc/grpc-node/commit/08b0422dae56467ecae1007e899efe66a8c4a650)
- [https://github.com/grpc/grpc-node/commit/674f4e351a619fd4532f84ae6dff96b8ee4e1ed3](https://github.com/grpc/grpc-node/commit/674f4e351a619fd4532f84ae6dff96b8ee4e1ed3)
- [https://github.com/grpc/grpc-node/commit/a8a020339c7eab1347a343a512ad17a4aea4bfdb](https://github.com/grpc/grpc-node/commit/a8a020339c7eab1347a343a512ad17a4aea4bfdb)
- [https://github.com/grpc/grpc-node](https://github.com/grpc/grpc-node)

This data is provided by [OSV](https://osv.dev/vulnerability/GHSA-7v5v-9h63-cj86) and the [GitHub Advisory Database](https://github.com/github/advisory-database) ([CC-BY 4.0](https://github.com/github/advisory-database/blob/main/LICENSE.md)).
</details>

---

### Release Notes

<details>
<summary>grpc/grpc-node (@&#8203;grpc/grpc-js)</summary>

### [`v1.8.22`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.22): @&#8203;grpc/grpc-js 1.8.22

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.21...@grpc/grpc-js@1.8.22)

- Avoid buffering significantly more than `grpc.max_receive_message_size` per received message.

### [`v1.8.21`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.21)

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.20...@grpc/grpc-js@1.8.21)

- Fix propagation of UNIMPLEMENTED error messages ([#&#8203;2528](https://github.com/grpc/grpc-node/issues/2528))

### [`v1.8.20`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.20): @&#8203;grpc/grpc-js 1.8.20

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.19...@grpc/grpc-js@1.8.20)

- Fix a crash when the channel option `grpc.keepalive_permit_without_calls` is set ([#&#8203;2519](https://github.com/grpc/grpc-node/issues/2519))

### [`v1.8.19`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.19): @&#8203;grpc/grpc-js 1.8.19

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.18...@grpc/grpc-js@1.8.19)

- Update keepalive behavior to more correctly handle short calls and long periods of inactivity ([#&#8203;2513](https://github.com/grpc/grpc-node/issues/2513))

### [`v1.8.18`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.18): @&#8203;grpc/grpc-js 1.8.18

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.17...@grpc/grpc-js@1.8.18)

- Fix reporting of call stacks in unary request errors ([#&#8203;2503](https://github.com/grpc/grpc-node/issues/2503))
- Fix reporting of proxy info in channelz socket responses ([#&#8203;2503](https://github.com/grpc/grpc-node/issues/2503))

### [`v1.8.17`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.17): @&#8203;grpc/grpc-js 1.8.17

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.16...@grpc/grpc-js@1.8.17)

- Disallow `pick_first` LB policy as the direct child of an `outlier_detection` LB policy ([#&#8203;2476](https://github.com/grpc/grpc-node/issues/2476))

### [`v1.8.16`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.16): @&#8203;grpc/grpc-js 1.8.16

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.15...@grpc/grpc-js@1.8.16)

- Fix missing `transport` trace logs ([#&#8203;2470](https://github.com/grpc/grpc-node/issues/2470))

### [`v1.8.15`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.15): @&#8203;grpc/grpc-js 1.8.15

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.14...@grpc/grpc-js@1.8.15)

- Fix a memory leak that could result from a specific pattern of recursive function calls ([#&#8203;2456](https://github.com/grpc/grpc-node/issues/2456))
- Ensure `status` and `error` events are consistently emitted asynchronously ([#&#8203;2456](https://github.com/grpc/grpc-node/issues/2456))

### [`v1.8.14`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.14): @&#8203;grpc/grpc-js 1.8.14

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.13...@grpc/grpc-js@1.8.14)

- Fix sequencing of some events related to connectivity state changes ([#&#8203;2421](https://github.com/grpc/grpc-node/issues/2421))

### [`v1.8.13`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.13): @&#8203;grpc/grpc-js 1.8.13

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.12...@grpc/grpc-js@1.8.13)

- Fix memory leak in channelz socket tracking ([#&#8203;2394](https://github.com/grpc/grpc-node/issues/2394))

### [`v1.8.12`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.12)

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.11...@grpc/grpc-js@1.8.12)

- Fix an occasional type error when receiving DNS updates ([#&#8203;2380](https://github.com/grpc/grpc-node/issues/2380))
- Fix ordering of events when handing requests on the server ([#&#8203;2376](https://github.com/grpc/grpc-node/issues/2376) contributed by [@&#8203;phoenix741](https://github.com/phoenix741))

### [`v1.8.11`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.11): @&#8203;grpc/grpc-js 1.8.11

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.10...@grpc/grpc-js@1.8.11)

- Avoid accumulating placeholder objects when sending many messages on a long-running stream ([#&#8203;2372](https://github.com/grpc/grpc-node/issues/2372))

### [`v1.8.10`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.10): @&#8203;grpc/grpc-js 1.8.10

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.9...@grpc/grpc-js@1.8.10)

- Fix bugs in "pick first" load balancing policy that caused incorrect reconnection behavior ([#&#8203;2369](https://github.com/grpc/grpc-node/issues/2369))

### [`v1.8.9`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.9): @&#8203;grpc/grpc-js 1.8.9

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.8...@grpc/grpc-js@1.8.9)

- Fix a bug where clients would continue to send pings at the original configured rate after receiving a backoff request from the server ([#&#8203;2363](https://github.com/grpc/grpc-node/issues/2363))

### [`v1.8.8`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.8): @&#8203;grpc/grpc-js 1.8.8

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.7...@grpc/grpc-js@1.8.8)

- Remove `progress` field in returned status object ([#&#8203;2350](https://github.com/grpc/grpc-node/issues/2350))
- Export `InterceptingListener` and `NextCall` types ([#&#8203;2351](https://github.com/grpc/grpc-node/issues/2351))
- Fix a bug that could cause a crash when sending messages that exceed the outgoing message buffer size while a retry is in progress ([#&#8203;2349](https://github.com/grpc/grpc-node/issues/2349))

### [`v1.8.7`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.7): @&#8203;grpc/grpc-js 1.8.7

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.6...@grpc/grpc-js@1.8.7)

- Make handling of HTTP2 session references work independent of keepalive settings ([#&#8203;2337](https://github.com/grpc/grpc-node/issues/2337))

### [`v1.8.6`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.6): @&#8203;grpc/grpc-js 1.8.6

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.5...@grpc/grpc-js@1.8.6)

- Hold a reference to transport from call to avoid premature garbage collection ([#&#8203;2336](https://github.com/grpc/grpc-node/issues/2336))

### [`v1.8.5`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.5): @&#8203;grpc/grpc-js 1.8.5

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.4...@grpc/grpc-js@1.8.5)

- Cancel deadline timer when the call ends ([#&#8203;2335](https://github.com/grpc/grpc-node/issues/2335))

### [`v1.8.4`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.4)

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.3...@grpc/grpc-js@1.8.4)

- Fix a bug that would sometimes allow the Node process to exit even though a gRPC request is active ([#&#8203;2322](https://github.com/grpc/grpc-node/issues/2322))

### [`v1.8.3`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.3): @&#8203;grpc/grpc-js 1.8.3

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.2...@grpc/grpc-js@1.8.3)

- Fix bug that caused streams to fail early when receiving a GOAWAY ([#&#8203;2319](https://github.com/grpc/grpc-node/issues/2319))

### [`v1.8.2`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.2)

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.1...@grpc/grpc-js@1.8.2)

- Continue keepalive pings after receiving a GOAWAY on the client ([#&#8203;2308](https://github.com/grpc/grpc-node/issues/2308))
- Fix handling of keepalive timers when the timeout is longer than the interval ([#&#8203;2304](https://github.com/grpc/grpc-node/issues/2304) contributed by [@&#8203;nicknotfun](https://github.com/nicknotfun), included in [#&#8203;2308](https://github.com/grpc/grpc-node/issues/2308))
- Ensure the last received message is fully handled before outputting status ([#&#8203;2316](https://github.com/grpc/grpc-node/issues/2316))

### [`v1.8.1`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.1)

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.8.0...@grpc/grpc-js@1.8.1)

- Implement support for the `grpc.service_config_disable_resolution` channel option ([#&#8203;2277](https://github.com/grpc/grpc-node/issues/2277) contributed by [@&#8203;kleinsch](https://github.com/kleinsch))
- Include standard headers in trailers-only responses ([#&#8203;2305](https://github.com/grpc/grpc-node/issues/2305))
- Fix a memory leak in the retry implementation ([#&#8203;2306](https://github.com/grpc/grpc-node/issues/2306))

### [`v1.8.0`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.8.0): @&#8203;grpc/grpc-js 1.8.0

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.7.3...@grpc/grpc-js@1.8.0)

- Implement retries ([specified in gRFC A6](https://github.com/grpc/proposal/blob/master/A6-client-retries.md)) ([#&#8203;2243](https://github.com/grpc/grpc-node/issues/2243), [#&#8203;2278](https://github.com/grpc/grpc-node/issues/2278))
- Enable servers to send trailers-only responses ([#&#8203;2278](https://github.com/grpc/grpc-node/issues/2278))
- Add server connection management options ([#&#8203;2272](https://github.com/grpc/grpc-node/issues/2272))

### [`v1.7.3`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.7.3): @&#8203;grpc/grpc-js 1.7.3

[Compare Source](https://github.com/grpc/grpc-node/compare/@grpc/grpc-js@1.7.2...@grpc/grpc-js@1.7.3)

- Server performance improvements ([#&#8203;2249](https://github.com/grpc/grpc-node/issues/2249) contributed by [@&#8203;AVVS](https://github.com/AVVS))

### [`v1.7.2`](https://github.com/grpc/grpc-node/releases/tag/%40grpc/grpc-js%401.7.2): @&#8203;grpc/grpc-js 1.7.2

[Compare Source](https://github.com/grpc/grpc-node/compare/v1.7.1...@grpc/grpc-js@1.7.2)

- Make the default value of the `grpc-node.max_session_memory` option `Number.MAX_SAFE_INTEGER` on the server ([#&#8203;2245](https://github.com/grpc/grpc-node/issues/2245))

</details>
