### PR TITLE
feat(otlp-exporter-base): accept `fetch` parameter in `createFetchTransport`, and export `createFetchTransport`, `createRetryingTransport` and `FetchTransportParameters`

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :rocket: Features
 
+* feat(otlp-exporter-base): accept `fetch` parameter in `createFetchTransport`, and export `createFetchTransport`, `createRetryingTransport` and `FetchTransportParameters` [#6377](https://github.com/open-telemetry/opentelemetry-js/pull/6377) @zakcutner
+
 ### :bug: Bug Fixes
 
 * fix(instrumentation-http): guard against double-instrumentation if loaded with `require('http')` and `import 'http'` [#6428](https://github.com/open-telemetry/opentelemetry-js/issues/6428) @trentm

--- a/experimental/packages/otlp-exporter-base/src/index.ts
+++ b/experimental/packages/otlp-exporter-base/src/index.ts
@@ -25,6 +25,9 @@ export type {
 } from './export-response';
 
 export type { IExporterTransport } from './exporter-transport';
+export type { FetchTransportParameters } from './transport/fetch-transport';
+export { createRetryingTransport } from './retrying-transport';
+export { createFetchTransport } from './transport/fetch-transport';
 
 export {
   mergeOtlpSharedConfigurationWithDefaults,

--- a/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
@@ -52,6 +52,16 @@ let pendingBodySize = 0;
 let pendingKeepaliveCount = 0;
 
 export interface FetchTransportParameters {
+  /**
+   * Optional custom `fetch` implementation. Defaults to `globalThis.fetch`.
+   *
+   * Note: when providing a custom `fetch`, the retry behavior of the transport
+   * relies on errors being thrown as `TypeError` (without a `cause`) to detect
+   * retryable network errors, matching the browser `fetch` contract. A custom
+   * implementation that throws different error types may not be retried as
+   * expected by `createRetryingTransport`.
+   */
+  fetch?: typeof globalThis.fetch;
   url: string;
   headers: HeadersFactory;
 }
@@ -60,23 +70,38 @@ class FetchTransport implements IExporterTransport {
   private _parameters: FetchTransportParameters;
 
   constructor(parameters: FetchTransportParameters) {
+    if (
+      parameters.fetch !== undefined &&
+      typeof parameters.fetch !== 'function'
+    ) {
+      throw new TypeError(
+        'FetchTransport: `fetch` parameter must be a function'
+      );
+    }
     this._parameters = parameters;
   }
 
   async send(data: Uint8Array, timeoutMillis: number): Promise<ExportResponse> {
     const abortController = new AbortController();
     const timeout = setTimeout(() => abortController.abort(), timeoutMillis);
-    // Fetch API may be wrapped by an instrumentation like `@opentelemetry/instrumentation-fetch`.
-    // In that case the instrumentation would create a new Span for this request
-    // because the context manager cannot keep the context after `await` calls.
-    // This creates an indirect endless loop Export -> Span -> Export
-    // By using the `__original` function the instrumentation can't intercept the call
-    // and no Span will be created breaking the vicious cycle
-    let fetchApi = globalThis.fetch;
-    // @ts-expect-error -- fetch could be wrapped
-    if (typeof fetchApi.__original === 'function') {
+    let fetchApi: typeof globalThis.fetch;
+    if (this._parameters.fetch !== undefined) {
+      // Use the user-provided fetch as-is; do not unwrap `__original` because
+      // the caller has explicitly asked for this implementation.
+      fetchApi = this._parameters.fetch;
+    } else {
+      // Fetch API may be wrapped by an instrumentation like `@opentelemetry/instrumentation-fetch`.
+      // In that case the instrumentation would create a new Span for this request
+      // because the context manager cannot keep the context after `await` calls.
+      // This creates an indirect endless loop Export -> Span -> Export
+      // By using the `__original` function the instrumentation can't intercept the call
+      // and no Span will be created breaking the vicious cycle
+      fetchApi = globalThis.fetch;
       // @ts-expect-error -- fetch could be wrapped
-      fetchApi = fetchApi.__original;
+      if (typeof fetchApi.__original === 'function') {
+        // @ts-expect-error -- fetch could be wrapped
+        fetchApi = fetchApi.__original;
+      }
     }
 
     const requestSize = data.byteLength;

--- a/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
@@ -48,7 +48,7 @@ describe('FetchTransport', function () {
   });
 
   describe('send', function () {
-    it('it uses global fetch API and is not affected by patching', function (done) {
+    it('uses global fetch API and is not affected by patching', function (done) {
       // arrange
       const fetchStub = sinon
         .stub(globalThis, 'fetch')
@@ -72,6 +72,75 @@ describe('FetchTransport', function () {
         done();
       }, done /* catch any rejections */);
     });
+
+    it('uses provided fetch API and does not call global fetch', function (done) {
+      // arrange
+      const fetchStub = sinon
+        .stub(globalThis, 'fetch')
+        .resolves(new Response('test response', { status: 200 }));
+      const customStub = sinon
+        .stub()
+        .resolves(new Response('test response', { status: 200 }));
+      const transport = createFetchTransport({
+        ...testTransportParameters,
+        fetch: customStub as unknown as typeof globalThis.fetch,
+      });
+
+      //act
+      transport.send(testPayload, requestTimeout).then(response => {
+        // assert
+        try {
+          assert.strictEqual(response.status, 'success');
+          sinon.assert.called(customStub);
+          sinon.assert.notCalled(fetchStub);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      }, done /* catch any rejections */);
+    });
+
+    it('uses provided fetch API as-is and does not unwrap __original', function (done) {
+      // arrange
+      const originalStub = sinon
+        .stub()
+        .resolves(new Response('original response', { status: 200 }));
+      const customStub = sinon
+        .stub()
+        .resolves(new Response('custom response', { status: 200 }));
+      // We attach `__original` simulating an instrumented fetch that the user
+      // has chosen to provide explicitly
+      (customStub as any).__original = originalStub;
+      const transport = createFetchTransport({
+        ...testTransportParameters,
+        fetch: customStub as unknown as typeof globalThis.fetch,
+      });
+
+      //act
+      transport.send(testPayload, requestTimeout).then(response => {
+        // assert
+        try {
+          assert.strictEqual(response.status, 'success');
+          sinon.assert.calledOnce(customStub);
+          sinon.assert.notCalled(originalStub);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      }, done /* catch any rejections */);
+    });
+
+    it('throws when provided fetch is not a function', function () {
+      // arrange
+      const parameters = {
+        ...testTransportParameters,
+        fetch: 'not a function' as unknown as typeof globalThis.fetch,
+      };
+
+      //act + assert
+      assert.throws(() => createFetchTransport(parameters), TypeError);
+    });
+
     it('returns success when request succeeds', function (done) {
       // arrange
       const fetchStub = sinon


### PR DESCRIPTION
## Which problem is this PR solving?

I'm using OpenTelemetry JS in Cloudflare Workers and I need to send telemetry to a collector running in a private network via [Workers VPC](https://developers.cloudflare.com/workers-vpc/). Workers VPC provides a custom `fetch` function that can route requests through private networks, but there was no way to easily pass this to the OTLP exporters.

Before this change, the only way to achieve this was to create a custom version `FetchTransport`, which would require duplicating much of its implementation, or to monkey patch `globalThis.fetch`.

Specifying a custom `fetch` function could also be useful for other scenarios like adding request/response interceptors, using fetch polyfills, or testing with mocks.

## Short description of the changes

Adds a `fetch` configuration option to `createFetchTransport`, allowing users to provide a custom `fetch` implementation instead of using `globalThis.fetch`.

Exports `createFetchTransport`, `createRetryingTransport` and `FetchTransportParameters`, so these can be used in place of a `new OTLPTraceExporter()`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit tests for `FetchTransport` using custom fetch
- [x] Ran `npm test`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
