### PR TITLE
chore(context-async-hooks): remove deprecated AsyncHooksContextManager export

### DIFF
--- a/packages/opentelemetry-context-async-hooks/src/index.ts
+++ b/packages/opentelemetry-context-async-hooks/src/index.ts
@@ -14,5 +14,4 @@
  * limitations under the License.
  */
 
-export { AsyncHooksContextManager } from './AsyncHooksContextManager';
 export { AsyncLocalStorageContextManager } from './AsyncLocalStorageContextManager';


### PR DESCRIPTION
This removes the deprecated AsyncHooksContextManager from the public exports as part of the planned cleanup for the next major version.

Related to #6299.