### PR TITLE
style(api): fix indentation in api.test.ts

### DIFF
--- a/api/test/common/api/api.test.ts
+++ b/api/test/common/api/api.test.ts
@@ -219,35 +219,34 @@ describe('API', function () {
   });
 
   describe('Global diag', function () {
-   it('initialization', function () {
-    const inst = DiagAPI.instance();
-    assert.deepStrictEqual(diag, inst);
-   });
-
-  diagLoggerFunctions.forEach(fName => {
-    it(`no argument logger ${fName} message doesn't throw`, function () {
-      // @ts-expect-error an undefined logger is not allowed
-      diag.setLogger();
-      diag[fName](`${fName} message`);
+    it('initialization', function () {
+      const inst = DiagAPI.instance();
+      assert.deepStrictEqual(diag, inst);
     });
 
-    it(`null logger ${fName} message doesn't throw`, function () {
-      diag.setLogger(null as any);
-      diag[fName](`${fName} message`);
-    });
+    diagLoggerFunctions.forEach(fName => {
+      it(`no argument logger ${fName} message doesn't throw`, function () {
+        // @ts-expect-error an undefined logger is not allowed
+        diag.setLogger();
+        diag[fName](`${fName} message`);
+      });
 
-    it(`undefined logger ${fName} message doesn't throw`, function () {
-      diag.setLogger(undefined as any);
-      diag[fName](`${fName} message`);
-    });
+      it(`null logger ${fName} message doesn't throw`, function () {
+        diag.setLogger(null as any);
+        diag[fName](`${fName} message`);
+      });
 
-    it(`empty logger ${fName} message doesn't throw`, function () {
-      diag.setLogger({} as any);
-      diag[fName](`${fName} message`);
+      it(`undefined logger ${fName} message doesn't throw`, function () {
+        diag.setLogger(undefined as any);
+        diag[fName](`${fName} message`);
+      });
+
+      it(`empty logger ${fName} message doesn't throw`, function () {
+        diag.setLogger({} as any);
+        diag[fName](`${fName} message`);
+      });
     });
   });
-});
-
 
   describe('Global metrics', function () {
     it('should expose a meter provider via getMeterProvider', function () {


### PR DESCRIPTION
## Summary
- Fix indentation in the "Global diag" test block in `api/test/common/api/api.test.ts`

## Test plan
- [x] Linting passes