### PR TITLE
fix(sdk-trace-web): pass optimised parameter recursively in getElementXPath

### DIFF
--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -374,7 +374,7 @@ export function getElementXPath(target: any, optimised?: boolean): string {
   }
   let xpath = '';
   if (target.parentNode) {
-    xpath += getElementXPath(target.parentNode, false);
+    xpath += getElementXPath(target.parentNode, optimised);
   }
   xpath += targetValue;
 

--- a/packages/opentelemetry-sdk-trace-web/test/window/utils.test.ts
+++ b/packages/opentelemetry-sdk-trace-web/test/window/utils.test.ts
@@ -140,6 +140,17 @@ describe('utils', function () {
       assert.strictEqual(textNode, getElementByXpath(element));
     });
 
+    it('should return optimised path for child of element with id when optimised = true', function () {
+      const element = getElementXPath(
+        $fixture.find('#btn22')[0].parentNode.children[0],
+        true
+      );
+      assert.ok(
+        element.indexOf('@id') > 0,
+        'expected optimised xpath to use @id shortcut for ancestor'
+      );
+    });
+
     it('should return correct path when element is comment node', function () {
       const comment = $fixture.find('#comment')[0];
       const node = document.createComment('foobar');


### PR DESCRIPTION
Fixes #6323

## Problem
`getElementXPath` hardcodes `false` for the `optimised` parameter when recursing to parent nodes:

```ts
xpath += getElementXPath(target.parentNode, false);
```

This means child elements of nodes with IDs produce non-optimised XPaths even when `optimised=true` is requested:
- **Expected:** `//*[@id="body-id"]/div`
- **Actual:** `//html/body/div`

## Fix
Changed `false` to `optimised` so the parameter is correctly passed through recursive calls:

```ts
xpath += getElementXPath(target.parentNode, optimised);
```

Also added a test case verifying that child elements of id-bearing ancestors use the optimised `@id` shortcut.