### PR TITLE
fix(sdk-trace-web): pass optimised parameter recursively in getElementXPath

### DIFF
--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -374,7 +374,7 @@ export function getElementXPath(target: any, optimised?: boolean): string {
   }
   let xpath = '';
   if (target.parentNode) {
-    xpath += getElementXPath(target.parentNode, false);
+    xpath += getElementXPath(target.parentNode, optimised);
   }
   xpath += targetValue;
 


### PR DESCRIPTION
Fixes #6323

## Problem

`getElementXPath` hardcodes `false` for the `optimised` parameter in the recursive call to traverse parent nodes:

```ts
xpath += getElementXPath(target.parentNode, false); // should be optimised
```

This means when `optimised=true`, ancestor nodes with IDs are not used as shortcuts, producing incorrect/longer XPaths.

## Fix

Pass the `optimised` parameter through the recursive call:

```ts
xpath += getElementXPath(target.parentNode, optimised);
```

## Example

Given `<body id="body-id"><div></div></body>`:

- Before: `getElementXPath(div, true)` → `/html/body/div` (ignores body's id)
- After: `getElementXPath(div, true)` → `//*[@id="body-id"]/div` (uses id shortcut)