### PR TITLE
refactor(otlp-exporter-base): promisify sendWithHttp

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -24,6 +24,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
+* refactor(otlp-exporter-base): promisify sendWithHttp() [#????](https://github.com/open-telemetry/opentelemetry-js/pull/6412) @pichlermarc
+
 ## 0.212.0
 
 ### :boom: Breaking Changes

--- a/experimental/packages/otlp-exporter-base/src/transport/http-exporter-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/http-exporter-transport.ts
@@ -29,21 +29,16 @@ class HttpExporterTransport implements IExporterTransport {
     const { agent, request } = await this._loadUtils();
     const headers = await this._parameters.headers();
 
-    return new Promise<ExportResponse>(resolve => {
-      sendWithHttp(
-        request,
-        this._parameters.url,
-        headers,
-        this._parameters.compression,
-        this._parameters.userAgent,
-        agent,
-        data,
-        result => {
-          resolve(result);
-        },
-        timeoutMillis
-      );
-    });
+    return sendWithHttp(
+      request,
+      this._parameters.url,
+      headers,
+      this._parameters.compression,
+      this._parameters.userAgent,
+      agent,
+      data,
+      timeoutMillis
+    );
   }
 
   shutdown() {

--- a/experimental/packages/otlp-exporter-base/test/node/http-transport-utils.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/node/http-transport-utils.test.ts
@@ -39,9 +39,8 @@ describe('sendWithHttp', function () {
     sentUserAgent = '';
   });
 
-  it('sends a request setting the default user-agent header', function (done) {
-    let firstCallback = true;
-    sendWithHttp(
+  it('sends a request setting the default user-agent header', async function () {
+    await sendWithHttp(
       requestFn,
       'http://localhost:8080',
       {},
@@ -49,26 +48,16 @@ describe('sendWithHttp', function () {
       undefined,
       new http.Agent(),
       Buffer.from([1, 2, 3]),
-      // TODO: the `onDone` callback is called twice because there are two error handlers
-      // - first is attached on the request created in `sendWithHttp`
-      // - second is attached on the pipe within `compressAndSend`
-      () => {
-        if (firstCallback) {
-          firstCallback = false;
-          assert.strictEqual(
-            sentUserAgent,
-            `OTel-OTLP-Exporter-JavaScript/${VERSION}`
-          );
-          done();
-        }
-      },
       100
+    );
+    assert.strictEqual(
+      sentUserAgent,
+      `OTel-OTLP-Exporter-JavaScript/${VERSION}`
     );
   });
 
-  it('sends a request prepending the provided user-agent to the default one', function (done) {
-    let firstCallback = true;
-    sendWithHttp(
+  it('sends a request prepending the provided user-agent to the default one', async function () {
+    await sendWithHttp(
       requestFn,
       'http://localhost:8080',
       {},
@@ -76,20 +65,11 @@ describe('sendWithHttp', function () {
       'Transport-User-Agent/1.2.3',
       new http.Agent(),
       Buffer.from([1, 2, 3]),
-      // TODO: the `onDone` callback is called twice because there are two error handlers
-      // - first is attached on the request created in `sendWithHttp`
-      // - second is attached on the pipe within `compressAndSend`
-      () => {
-        if (firstCallback) {
-          firstCallback = false;
-          assert.strictEqual(
-            sentUserAgent,
-            `Transport-User-Agent/1.2.3 OTel-OTLP-Exporter-JavaScript/${VERSION}`
-          );
-          done();
-        }
-      },
       100
+    );
+    assert.strictEqual(
+      sentUserAgent,
+      `Transport-User-Agent/1.2.3 OTel-OTLP-Exporter-JavaScript/${VERSION}`
     );
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

This change refactors sendWithHttp() to directly use a Promise instead of going through another callback, which reduces indirection and simplifies testing.

Fixes #5990 
