### PR TITLE
fix(instrumentation-fetch): handle string[][] format headers in _addH…

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -227,6 +227,13 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
       propagation.inject(context.active(), options.headers, {
         set: (h, k, v) => h.set(k, typeof v === 'string' ? v : String(v)),
       });
+    } else if (Array.isArray(options.headers)) {
+      const headers: Partial<Record<string, unknown>> = {};
+      propagation.inject(context.active(), headers);
+      const propagationEntries: [string, string][] = Object.entries(headers).map(
+        ([k, v]) => [k, typeof v === 'string' ? v : String(v)] as [string, string]
+      );
+      options.headers = [...options.headers, ...propagationEntries];
     } else {
       const headers: Partial<Record<string, unknown>> = {};
       propagation.inject(context.active(), headers);

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -845,6 +845,19 @@ describe('fetch', () => {
 
             assert.strictEqual(headers['foo'], 'bar');
           });
+
+          it('should keep custom headers with url, untyped request object and array headers', async () => {
+            const { response } = await tracedFetch({
+              callback: () =>
+                fetch('/api/echo-headers.json', {
+                  headers: [['foo', 'bar']],
+                }),
+            });
+
+            const headers = await assertPropagationHeaders(response);
+
+            assert.strictEqual(headers['foo'], 'bar');
+          });
         });
 
         describe('without global propagator', () => {
@@ -911,6 +924,19 @@ describe('fetch', () => {
                 fetch('/api/echo-headers.json', {
                   // @ts-expect-error relies on implicit coercion
                   headers: new Map().set('foo', 'bar'),
+                }),
+            });
+
+            const headers = await assertNoPropagationHeaders(response);
+
+            assert.strictEqual(headers['foo'], 'bar');
+          });
+
+          it('should keep custom headers with url, untyped request object and array headers', async () => {
+            const { response } = await tracedFetch({
+              callback: () =>
+                fetch('/api/echo-headers.json', {
+                  headers: [['foo', 'bar']],
                 }),
             });
 


### PR DESCRIPTION
## Which problem is this PR solving?

The `_addHeaders` method in `@opentelemetry/instrumentation-fetch` does not handle the `string[][]` (array of key-value pairs) format for `HeadersInit`, which is a valid format per the [Fetch API spec](https://fetch.spec.whatwg.org/#typedefdef-headersinit).

When another library (e.g., Datadog Browser RUM SDK) converts headers to `string[][]` format before OTel's fetch instrumentation processes them, the fallback `else` branch uses `Object.assign({}, otelHeaders, arrayHeaders)`. This converts array indices to object keys (`{0: [...], 1: [...]}`) instead of preserving header names, destroying headers like `Content-Type` and causing servers to return `415 Unsupported Media Type`.

here: https://github.com/DataDog/browser-sdk/blob/main/packages/rum-core/src/domain/tracing/tracer.ts#L77

## Short description of the changes

Added an `Array.isArray(options.headers)` check before the existing `else` fallback in `_addHeaders`. When headers are in array format, trace propagation headers are appended as additional array entries, preserving both the original headers and the array format.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added test cases for `string[][]` headers in both "with global propagator" and "without global propagator" sections, following the same pattern as existing tests for `Headers`, `Map`, and plain object formats.

- [x] `npm run test:browser` — 103/103 SUCCESS

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
