### PR TITLE
chore(sdk-metrics): add comment to clarify intent of an error message

### DIFF
--- a/packages/sdk-metrics/src/export/MetricReader.ts
+++ b/packages/sdk-metrics/src/export/MetricReader.ts
@@ -146,8 +146,15 @@ export abstract class MetricReader implements IMetricReader {
 
   setMetricProducer(metricProducer: MetricProducer) {
     if (this._sdkMetricProducer) {
+      // This check ensures the following requirement from the spec
+      // (https://opentelemetry.io/docs/specs/otel/metrics/sdk/#metricreader):
+      // > The SDK MUST NOT allow a `MetricReader` instance to be registered
+      // > on more than one `MeterProvider` instance.
+      //
+      // So while the argument is a `MetricProducer`, the relevant user-level
+      // error message is about the **MeterProvider**.
       throw new Error(
-        'MetricReader can not be bound to a MeterProducer again.'
+        'MetricReader can not be bound to a MeterProvider again.'
       );
     }
     this._sdkMetricProducer = metricProducer;


### PR DESCRIPTION
**Update:** After my initial commit, I realized that this error message isn't a typo. While the local code is operating on a `MetricProducer`, the check is actually about ensuring a spec invariant about readers on `MeterProvider`s. I've added a (wordy) comment to explain, to avoid me making this same mistake in 2y.