### PR TITLE
fix(instrumentation-http): better solution for avoiding double-wrapping of http

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -17,6 +17,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(instrumentation-http): better solution for avoiding double-wrapping of http [#6491](https://github.com/open-telemetry/opentelemetry-js/pull/6491) @trentm
 * fix(opentelemetry-instrumentation): access `require` via `globalThis` to avoid webpack analysis [#6481](https://github.com/open-telemetry/opentelemetry-js/pull/6481) @overbalance
 * fix(sdk-logs): fix inflated `droppedAttributesCount` when updating existing attribute keys [#6479](https://github.com/open-telemetry/opentelemetry-js/pull/6479) @overbalance
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -39,6 +39,7 @@ import { VERSION } from './version';
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
+  isWrapped,
   SemconvStability,
   semconvStabilityFromStr,
   safeExecuteInTheMiddle,
@@ -83,8 +84,6 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
   /** keep track on spans not ended */
   private readonly _spanNotEnded: WeakSet<Span> = new WeakSet<Span>();
   private _headerCapture;
-  private _httpPatched: boolean = false;
-  private _httpsPatched: boolean = false;
   declare private _oldHttpServerDurationHistogram: Histogram;
   declare private _stableHttpServerDurationHistogram: Histogram;
   declare private _oldHttpClientDurationHistogram: Histogram;
@@ -99,6 +98,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
       process.env.OTEL_SEMCONV_STABILITY_OPT_IN
     );
     this._headerCapture = this._createHeaderCapture(this._semconvStability);
+    console.log('XXX [instr-http] done the ctor');
   }
 
   protected override _updateMetricInstruments() {
@@ -203,17 +203,20 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
       'http',
       ['*'],
       (moduleExports: Http): Http => {
-        // Guard against double-instrumentation, if loaded by both `require`
-        // and `import`.
-        if (this._httpPatched) {
-          return moduleExports;
-        }
-        this._httpPatched = true;
-
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const isESM = (moduleExports as any)[Symbol.toStringTag] === 'Module';
+        console.log(
+          'XXX patch http: isEsm=%s',
+          isESM,
+          moduleExports?.request,
+          (moduleExports as any).default?.request
+        );
 
-        if (!this.getConfig().disableOutgoingRequestInstrumentation) {
+        if (
+          !this.getConfig().disableOutgoingRequestInstrumentation &&
+          !isWrapped(moduleExports.request)
+        ) {
+          console.log('XXX [instr-http] hooking moduleExports.*');
           const patchedRequest = this._wrap(
             moduleExports,
             'request',
@@ -225,6 +228,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
             this._getPatchOutgoingGetFunction(patchedRequest)
           );
           if (isESM) {
+            console.log('XXX [instr-http] hooking moduleExports.default.*');
             // To handle `import http from 'http'`, which returns the default
             // export, we need to set `module.default.*`.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -233,7 +237,10 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
             (moduleExports as any).default.get = patchedGet;
           }
         }
-        if (!this.getConfig().disableIncomingRequestInstrumentation) {
+        if (
+          !this.getConfig().disableIncomingRequestInstrumentation &&
+          !isWrapped(moduleExports.Server.prototype.emit)
+        ) {
           this._wrap(
             moduleExports.Server.prototype,
             'emit',
@@ -243,7 +250,6 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
         return moduleExports;
       },
       (moduleExports: Http) => {
-        this._httpPatched = false;
         if (moduleExports === undefined) return;
 
         if (!this.getConfig().disableOutgoingRequestInstrumentation) {
@@ -262,17 +268,13 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
       'https',
       ['*'],
       (moduleExports: Https): Https => {
-        // Guard against double-instrumentation, if loaded by both `require`
-        // and `import`.
-        if (this._httpsPatched) {
-          return moduleExports;
-        }
-        this._httpsPatched = true;
-
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const isESM = (moduleExports as any)[Symbol.toStringTag] === 'Module';
 
-        if (!this.getConfig().disableOutgoingRequestInstrumentation) {
+        if (
+          !this.getConfig().disableOutgoingRequestInstrumentation &&
+          !isWrapped(moduleExports.request)
+        ) {
           const patchedRequest = this._wrap(
             moduleExports,
             'request',
@@ -292,7 +294,10 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
             (moduleExports as any).default.get = patchedGet;
           }
         }
-        if (!this.getConfig().disableIncomingRequestInstrumentation) {
+        if (
+          !this.getConfig().disableIncomingRequestInstrumentation &&
+          !isWrapped(moduleExports.Server.prototype.emit)
+        ) {
           this._wrap(
             moduleExports.Server.prototype,
             'emit',
@@ -302,7 +307,6 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
         return moduleExports;
       },
       (moduleExports: Https) => {
-        this._httpsPatched = false;
         if (moduleExports === undefined) return;
 
         if (!this.getConfig().disableOutgoingRequestInstrumentation) {

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -98,7 +98,6 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
       process.env.OTEL_SEMCONV_STABILITY_OPT_IN
     );
     this._headerCapture = this._createHeaderCapture(this._semconvStability);
-    console.log('XXX [instr-http] done the ctor');
   }
 
   protected override _updateMetricInstruments() {
@@ -205,18 +204,11 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
       (moduleExports: Http): Http => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const isESM = (moduleExports as any)[Symbol.toStringTag] === 'Module';
-        console.log(
-          'XXX patch http: isEsm=%s',
-          isESM,
-          moduleExports?.request,
-          (moduleExports as any).default?.request
-        );
 
         if (
           !this.getConfig().disableOutgoingRequestInstrumentation &&
           !isWrapped(moduleExports.request)
         ) {
-          console.log('XXX [instr-http] hooking moduleExports.*');
           const patchedRequest = this._wrap(
             moduleExports,
             'request',
@@ -228,7 +220,6 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
             this._getPatchOutgoingGetFunction(patchedRequest)
           );
           if (isESM) {
-            console.log('XXX [instr-http] hooking moduleExports.default.*');
             // To handle `import http from 'http'`, which returns the default
             // export, we need to set `module.default.*`.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-package.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-package.test.ts
@@ -62,6 +62,7 @@ describe('Packages', () => {
       propagation.disable();
       nock.cleanAll();
       nock.enableNetConnect();
+      instrumentation.disable();
     });
 
     let resHeaders: http.IncomingHttpHeaders;

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-package.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-package.test.ts
@@ -62,6 +62,7 @@ describe('Packages', () => {
       nock.cleanAll();
       nock.enableNetConnect();
       propagation.disable();
+      instrumentation.disable();
     });
 
     let resHeaders: http.IncomingHttpHeaders;

--- a/experimental/packages/opentelemetry-instrumentation-http/test/integrations/double-instr.test.cjs
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/integrations/double-instr.test.cjs
@@ -1,17 +1,6 @@
 /*
  * Copyright The OpenTelemetry Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 // Test that http/https are not *double*-instrumented if http is loaded by


### PR DESCRIPTION
The previous fix (https://github.com/open-telemetry/opentelemetry-js/pull/6437)
would break in the case where:
1. ESM `import 'http'` executed before registration of IITM module
   loader, resulted in Node.js's ESM loader having a cache of the
   built-in 'http' module.
2. RITM hooked a `require('http')` -- setting the internal _httpPatched
   flag.
3. IITM hooked a `import 'http'`. Because of step 1, the `moduleExports`
   for this hook are the *unpatched* cached built-in. This needs to
   get patched.

Fixes: https://github.com/open-telemetry/opentelemetry-js/issues/6489
Refs: https://github.com/open-telemetry/opentelemetry-js/issues/6428

# Status

I think the fix is good. However, I haven't had a chance to add tests to `npm run test:double-instr` for the new case.
I'll be away for 1.5w, so if someone else wanted to take that one, that'd be helpful.

See my repro notes at https://github.com/open-telemetry/opentelemetry-js/issues/6489#issuecomment-4058846289 which shows scripts that could perhaps be the basis of a test case here. (If this repo had the https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/contrib-test-utils/src/test-fixtures.ts test support we have in the contrib repo, I'd just use that.)