### PR TITLE
chore(api): re-categorize changelog entries

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -9,14 +9,12 @@ All notable changes to this project will be documented in this file.
 
 ### :rocket: (Enhancement)
 
-* feat(api): improve isValidSpanId, isValidTraceId performance [#5714](https://github.com/open-telemetry/opentelemetry-js/pull/5714) @seemk
-* feat(diag): change types in `DiagComponentLogger` from `any` to `unknown`[#5478](https://github.com/open-telemetry/opentelemetry-js/pull/5478) @loganrosen
-
 ### :bug: (Bug Fix)
 
 * fix(api): prioritize `esnext` export condition as it is more specific [#5458](https://github.com/open-telemetry/opentelemetry-js/pull/5458)
 * fix(api): update diag `consoleLogger` to use original console methods to prevent infinite loop when a console instrumentation is present [#6395](https://github.com/open-telemetry/opentelemetry-js/pull/6395)
 * fix(api): use `Attributes` instead of deprecated `SpanAttributes` in `SpanOptions` [#6478](https://github.com/open-telemetry/opentelemetry-js/pull/6478) @overbalance
+* fix(diag): change types in `DiagComponentLogger` from `any` to `unknown`[#5478](https://github.com/open-telemetry/opentelemetry-js/pull/5478) @loganrosen
 
 ### :books: (Refine Doc)
 
@@ -29,6 +27,7 @@ All notable changes to this project will be documented in this file.
 * refactor(api): remove platform-specific globalThis, use globalThis directly [#6208](https://github.com/open-telemetry/opentelemetry-js/pull/6208) @overbalance
 * chore(api): mark ProxyTracerProvider as deprecated [#6328](https://github.com/open-telemetry/opentelemetry-js/pull/6328) @cjihrig
 * chore: enforce `import type` for type-only imports via ESLint [#6467](https://github.com/open-telemetry/opentelemetry-js/pull/6467) @overbalance
+* perf(api): improve isValidSpanId, isValidTraceId performance [#5714](https://github.com/open-telemetry/opentelemetry-js/pull/5714) @seemk
 
 ## 1.9.0
 


### PR DESCRIPTION
## Which problem is this PR solving?

Some changelog entries ended up in `feat`. After thinking about it for a bit, I think they're better suited for fix (the type change on `DiagConsoleLogger` #5478 is a type-level bugfix) and `perf` the performance improvement for `isValidSpanId` and `isValidTraceId` #5714, since it's an internal change.

This was we can avoid having a feature release that does not include any new features, which can cause some incompatibility with SDK versions that people have already installed.