### PR TITLE
fix: resolve relative URLs before ignoreUrls check in XHR

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -371,7 +371,8 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
     url: string,
     method: string
   ): api.Span | undefined {
-    if (isUrlIgnored(url, this.getConfig().ignoreUrls)) {
+    const resolvedUrl = parseUrl(url).href;
+    if (isUrlIgnored(resolvedUrl, this.getConfig().ignoreUrls)) {
       this._diag.debug('ignoring span as url matches ignored url');
       return;
     }


### PR DESCRIPTION
## Summary
Fixes #5810.
**Root cause:** XHR instrumentation matched relative URLs against `ignoreUrls` patterns as-is, while fetch instrumentation resolved them to absolute URLs first. This caused domain-based `ignoreUrls` patterns (e.g. `/.*myapp/`) to never match XHR requests using relative paths.
**Fix:** Resolved relative URLs to absolute URLs before checking against `ignoreUrls`, matching the behavior of fetch instrumentation.
## Changes
- Updated XHR instrumentation to resolve URLs before ignoreUrls check
## Testing
- Verified fix aligns XHR and fetch ignoreUrls behavior
- Change follows existing patterns in fetch instrumentation

Made with [Cursor](https://cursor.com)