### PR TITLE
perf(sdk-metrics): improve performance of hashAttributes() util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :house: Internal
 
 * chore: enforce `import type` for type-only imports via ESLint [#6467](https://github.com/open-telemetry/opentelemetry-js/pull/6467) @overbalance
+* perf(sdk-metrics): improve performance of hashAttributes() util [#6515][https://github.com/open-telemetry/opentelemetry-js/pull/6515] @gunjam
 
 ## 2.6.0
 

--- a/packages/sdk-metrics/src/utils.ts
+++ b/packages/sdk-metrics/src/utils.ts
@@ -3,22 +3,59 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Attributes } from '@opentelemetry/api';
+import type { Attributes, AttributeValue } from '@opentelemetry/api';
 import type { InstrumentationScope } from '@opentelemetry/core';
 
 export type Maybe<T> = T | undefined;
+
+function stringifyValue (value: AttributeValue | null | undefined): string {
+  if (typeof value === 'string') {
+    return `"${value}"`;
+  }
+  if (value === undefined) {
+    return 'u';
+  }
+  if (value === null) {
+    return 'n';
+  }
+  if (value === true) {
+    return 't';
+  }
+  if (value === false) {
+    return 'f';
+  }
+  return value.toString();
+}
+
+function stringifyAttribue (value: AttributeValue | undefined): string {
+  if (!Array.isArray(value)) {
+    return stringifyValue(value);
+  }
+  let str = 'A';
+  str += stringifyValue(value[0]);
+  for (let i = 1, len = value.length; i < len; i++) {
+    str += `,${stringifyValue(value[i])}`;
+  }
+  return str;
+}
 
 /**
  * Converting the unordered attributes into unique identifier string.
  * @param attributes user provided unordered Attributes.
  */
-export function hashAttributes(attributes: Attributes): string {
-  let keys = Object.keys(attributes);
-  if (keys.length === 0) return '';
+export function hashAttributes (attributes: Attributes): string {
+  const keys = Object.keys(attributes);
+  const length = keys.length;
+  if (length === 0) return '';
 
   // Return a string that is stable on key orders.
-  keys = keys.sort();
-  return JSON.stringify(keys.map(key => [key, attributes[key]]));
+  keys.sort();
+
+  let str = `${keys[0]}=${stringifyAttribue(attributes[keys[0]])}`;
+  for (let i = 1; i < length; i++) {
+    str += `;${keys[i]}=${stringifyAttribue(attributes[keys[i]])}`;
+  }
+  return str;
 }
 
 /**

--- a/packages/sdk-metrics/src/utils.ts
+++ b/packages/sdk-metrics/src/utils.ts
@@ -8,7 +8,7 @@ import type { InstrumentationScope } from '@opentelemetry/core';
 
 export type Maybe<T> = T | undefined;
 
-function stringifyValue (value: AttributeValue | null | undefined): string {
+function stringifyValue(value: AttributeValue | null | undefined): string {
   if (typeof value === 'string') {
     return `"${value}"`;
   }
@@ -27,7 +27,7 @@ function stringifyValue (value: AttributeValue | null | undefined): string {
   return value.toString();
 }
 
-function stringifyAttribue (value: AttributeValue | undefined): string {
+function stringifyAttribue(value: AttributeValue | undefined): string {
   if (!Array.isArray(value)) {
     return stringifyValue(value);
   }
@@ -43,7 +43,7 @@ function stringifyAttribue (value: AttributeValue | undefined): string {
  * Converting the unordered attributes into unique identifier string.
  * @param attributes user provided unordered Attributes.
  */
-export function hashAttributes (attributes: Attributes): string {
+export function hashAttributes(attributes: Attributes): string {
   const keys = Object.keys(attributes);
   const length = keys.length;
   if (length === 0) return '';

--- a/packages/sdk-metrics/test/utils.test.ts
+++ b/packages/sdk-metrics/test/utils.test.ts
@@ -36,17 +36,23 @@ describe('utils', () => {
   describe('hashAttributes', () => {
     it('should hash all types of attribute values', () => {
       const cases: [Attributes, string][] = [
-        [{ string: 'bar' }, '[["string","bar"]]'],
-        [{ number: 1 }, '[["number",1]]'],
-        [{ false: false, true: true }, '[["false",false],["true",true]]'],
+        [{ string: 'bar' }, 'string="bar"'],
+        [{ number: 1 }, 'number=1'],
+        [{ number: '1' }, 'number="1"'],
+        [{ false: false, true: true }, 'false=f;true=t'],
+        [{ false: 'false', true: 'true' }, 'false="false";true="true"'],
         [
           { arrayOfString: ['foo', 'bar'] },
-          '[["arrayOfString",["foo","bar"]]]',
+          'arrayOfString=A"foo","bar"',
         ],
-        [{ arrayOfNumber: [1, 2] }, '[["arrayOfNumber",[1,2]]]'],
-        [{ arrayOfBool: [false, true] }, '[["arrayOfBool",[false,true]]]'],
-        [{ undefined: undefined }, '[["undefined",null]]'],
-        [{ arrayOfHoles: [undefined, null] }, '[["arrayOfHoles",[null,null]]]'],
+        [{ arrayOfNumber: [1, 2] }, 'arrayOfNumber=A1,2'],
+        [{ arrayOfBool: [false, true] }, 'arrayOfBool=Af,t'],
+        [{ undefined: undefined }, 'undefined=u'],
+        [{ arrayOfHoles: [undefined, null] }, 'arrayOfHoles=Au,n'],
+
+        // Should hash to the same value regardless of key order
+        [{ a: 'a', b: 'b' }, 'a="a";b="b"'],
+        [{ b: 'b', a: 'a' }, 'a="a";b="b"'],
       ];
 
       for (const [idx, it] of cases.entries()) {

--- a/packages/sdk-metrics/test/utils.test.ts
+++ b/packages/sdk-metrics/test/utils.test.ts
@@ -41,10 +41,7 @@ describe('utils', () => {
         [{ number: '1' }, 'number="1"'],
         [{ false: false, true: true }, 'false=f;true=t'],
         [{ false: 'false', true: 'true' }, 'false="false";true="true"'],
-        [
-          { arrayOfString: ['foo', 'bar'] },
-          'arrayOfString=A"foo","bar"',
-        ],
+        [{ arrayOfString: ['foo', 'bar'] }, 'arrayOfString=A"foo","bar"'],
         [{ arrayOfNumber: [1, 2] }, 'arrayOfNumber=A1,2'],
         [{ arrayOfBool: [false, true] }, 'arrayOfBool=Af,t'],
         [{ undefined: undefined }, 'undefined=u'],


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

After reading @daniellockyer [comments](https://github.com/open-telemetry/opentelemetry-js/issues/4372#issuecomment-4102754442) in [#6100]( https://github.com/open-telemetry/opentelemetry-js/issues/6100l) I thought I'd have a go at improving the performance of the `hashAttributes()` util function, and have made the following performance improvements:

| Attributes | Before | After | Improvement |
| ----------- | ------- | ----- | ----------------| 
| `{ string: 'bar' }`|  199.67 ns/iter|  19.85 ns/iter |10.06x |
|`{ number: 1 }`|   199.73 ns/iter | 43.96 ns/iter |  4.54x |
|`{ false: false, true: true }`|  388.45 ns/iter |  182.89 ns/iter |2.12x |
|`{ arrayOfString: ['foo', 'bar'] }`|   263.32 ns/iter|  93.54 ns/iter  | 2.82x|
|`{ arrayOfNumber: [1, 2] }`|   227.72 ns/iter|  71.23 ns/iter | 3.2x  |
|`{ arrayOfBool: [false, true] }`|  221.49 ns/iter  |  65.56 ns/iter    |    3.38x|
|`{ undefined: undefined }`|  193.78 ns/iter |  42.78 ns/iter  | 4.53x |
|`{ arrayOfHoles: [undefined, null] }`|   235.97 ns/iter |  69.62 ns/iter   |   3.39x  |

refs [#6100]( https://github.com/open-telemetry/opentelemetry-js/issues/6100l)

## Short description of the changes

Improve `hasAttributes()` performance by avoiding `Array.map()` and `JSON.stringify()` calls.

## Type of change

Please delete options that are not relevant.

- ~~[ ] Bug fix (non-breaking change which fixes an issue)~~
- ~~[ ] New feature (non-breaking change which adds functionality)~~
- ~~[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)~~
- ~~[ ] This change requires a documentation update~~

## How Has This Been Tested?

Existing unit tests pass, benchmarks for unit test example values included above.
Added unit tests to check stringifying `true` and `"true"` and `1` and `"1"` are not the same.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- ~~[ ] Documentation has been updated~~
