### PR TITLE
feat(configuration): refactoring config loader to print warning message

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -20,7 +20,6 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * feat(configuration): export interfaces required in other packages [#6507](https://github.com/open-telemetry/opentelemetry-js/pull/6507) @maryliag
 * feat(configuration): refactoring config loader to print warning message [#6524](https://github.com/open-telemetry/opentelemetry-js/pull/6524) @maxday
 
-
 ### :bug: Bug Fixes
 
 * fix(opentelemetry-instrumentation): access `require` via `globalThis` to avoid webpack analysis [#6481](https://github.com/open-telemetry/opentelemetry-js/pull/6481) @overbalance

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -18,6 +18,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * feat(configuration): export interfaces required in other packages [#6462](https://github.com/open-telemetry/opentelemetry-js/pull/6462) @maryliag
 * feat(configuration): set MeterProvider on sdk start [#6463](https://github.com/open-telemetry/opentelemetry-js/pull/6463) @maryliag
 * feat(configuration): export interfaces required in other packages [#6507](https://github.com/open-telemetry/opentelemetry-js/pull/6507) @maryliag
+* feat(configuration): refactoring config loader to print warning message [#6524](https://github.com/open-telemetry/opentelemetry-js/pull/6524) @maxday
+
 
 ### :bug: Bug Fixes
 

--- a/experimental/packages/configuration/src/EnvDefinition.ts
+++ b/experimental/packages/configuration/src/EnvDefinition.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { StringEnvVar } from "./EnvReader";
 
 export enum SamplerType {

--- a/experimental/packages/configuration/src/EnvDefinition.ts
+++ b/experimental/packages/configuration/src/EnvDefinition.ts
@@ -1,0 +1,25 @@
+import { StringEnvVar } from "./EnvReader";
+
+export enum SamplerType {
+  AlwaysOn = 'always_on',
+  AlwaysOff = 'always_off',
+  TraceIdRatio = 'traceidratio',
+  ParentBasedAlwaysOn = 'parentbased_always_on',
+  ParentBasedAlwaysOff = 'parentbased_always_off',
+  ParentBasedTraceIdRatio = 'parentbased_traceidratio',
+}
+
+export const ENV_DEFS = {
+  OTEL_TRACES_SAMPLER: {
+    key: 'OTEL_TRACES_SAMPLER',
+    type: 'string',
+    description: 'Traces sampler',
+    allowedValues: Object.values(SamplerType),
+  } as StringEnvVar,
+
+  OTEL_TRACES_SAMPLER_ARG: {
+    key: 'OTEL_TRACES_SAMPLER_ARG',
+    type: 'string',
+    description: 'Traces sampler argument',
+  } as StringEnvVar,
+} as const;

--- a/experimental/packages/configuration/src/EnvDefinition.ts
+++ b/experimental/packages/configuration/src/EnvDefinition.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { StringEnvVar } from "./EnvReader";
+import type { StringEnvVar } from './EnvReader';
 
 export enum SamplerType {
   AlwaysOn = 'always_on',

--- a/experimental/packages/configuration/src/EnvReader.ts
+++ b/experimental/packages/configuration/src/EnvReader.ts
@@ -4,11 +4,8 @@
  */
 
 import { diag } from '@opentelemetry/api';
-import {
-  getStringFromEnv,
-} from '@opentelemetry/core';
+import { getStringFromEnv } from '@opentelemetry/core';
 import { ENV_DEFS } from './EnvDefinition';
-
 
 /** Base definition shared by all env var types. */
 interface EnvVarBase<T> {
@@ -22,14 +19,14 @@ export interface StringEnvVar extends EnvVarBase<string> {
   allowedValues?: readonly string[];
 }
 
-export type EnvVarDefinition = StringEnvVar
+export type EnvVarDefinition = StringEnvVar;
 
 type ResolvedType<D extends EnvVarDefinition> = D extends StringEnvVar
   ? string | undefined
   : never;
 
 function readStringEnv(def: StringEnvVar): string | undefined {
-  let value = getStringFromEnv(def.key);
+  const value = getStringFromEnv(def.key);
   if (value == null) {
     return def.defaultValue;
   }

--- a/experimental/packages/configuration/src/EnvReader.ts
+++ b/experimental/packages/configuration/src/EnvReader.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { diag } from '@opentelemetry/api';
+import {
+  getStringFromEnv,
+} from '@opentelemetry/core';
+import { ENV_DEFS } from './EnvDefinition';
+
+
+/** Base definition shared by all env var types. */
+interface EnvVarBase<T> {
+  key: string;
+  description: string;
+  defaultValue?: T;
+}
+
+export interface StringEnvVar extends EnvVarBase<string> {
+  type: 'string';
+  allowedValues?: readonly string[];
+}
+
+export type EnvVarDefinition = StringEnvVar
+
+type ResolvedType<D extends EnvVarDefinition> = D extends StringEnvVar
+  ? string | undefined
+  : never;
+
+function readStringEnv(def: StringEnvVar): string | undefined {
+  let value = getStringFromEnv(def.key);
+  if (value == null) {
+    return def.defaultValue;
+  }
+  if (def.allowedValues && !def.allowedValues.includes(value)) {
+    diag.warn(
+      `Invalid value "${value}" for ${def.description} (env: ${def.key}). ` +
+        `Expected one of: ${def.allowedValues.join(', ')}. ` +
+        (def.defaultValue != null
+          ? `Falling back to "${def.defaultValue}".`
+          : 'Value will be ignored.')
+    );
+    return def.defaultValue;
+  }
+  return value;
+}
+
+export function readEnvVar<D extends EnvVarDefinition>(
+  def: D
+): ResolvedType<D> {
+  switch (def.type) {
+    case 'string':
+      return readStringEnv(def) as ResolvedType<D>;
+  }
+}
+
+export type EnvValues = {
+  [K in keyof typeof ENV_DEFS]: ResolvedType<(typeof ENV_DEFS)[K]>;
+};
+
+export function readAllEnvVars(): EnvValues {
+  const result = {} as Record<string, unknown>;
+  for (const [name, def] of Object.entries(ENV_DEFS)) {
+    result[name] = readEnvVar(def);
+  }
+  return result as EnvValues;
+}

--- a/experimental/packages/configuration/src/EnvironmentConfigFactory.ts
+++ b/experimental/packages/configuration/src/EnvironmentConfigFactory.ts
@@ -625,13 +625,13 @@ export function setMeterProvider(config: ConfigurationModel): void {
     getStringFromEnv('OTEL_METRICS_EXEMPLAR_FILTER') ?? 'trace_based';
   if (exemplarFilter) {
     switch (exemplarFilter) {
-      case ExemplarFilter.TraceBased:
+      case 'trace_based':
         config.meter_provider.exemplar_filter = ExemplarFilter.TraceBased;
         break;
-      case ExemplarFilter.AlwaysOn:
+      case 'always_on':
         config.meter_provider.exemplar_filter = ExemplarFilter.AlwaysOn;
         break;
-      case ExemplarFilter.AlwaysOff:
+      case 'always_off':
         config.meter_provider.exemplar_filter = ExemplarFilter.AlwaysOff;
         break;
       default:

--- a/experimental/packages/configuration/src/EnvironmentConfigFactory.ts
+++ b/experimental/packages/configuration/src/EnvironmentConfigFactory.ts
@@ -31,6 +31,9 @@ import type { BatchLogRecordProcessor } from './models/loggerProviderModel';
 import { initializeDefaultLoggerProviderConfiguration } from './models/loggerProviderModel';
 import { getGrpcTlsConfig, getHttpTlsConfig } from './utils';
 import type { ExperimentalResourceDetector } from './models/resourceModel';
+import type { EnvValues } from './EnvReader';
+import { readAllEnvVars } from './EnvReader';
+import { SamplerType } from './EnvDefinition';
 
 /**
  * EnvironmentConfigProvider provides a configuration based on environment variables.
@@ -47,10 +50,12 @@ export class EnvironmentConfigFactory implements ConfigFactory {
       this._config.log_level = logLevel;
     }
 
+    const envValues = readAllEnvVars();
+
     setResources(this._config);
     setAttributeLimits(this._config);
     setPropagators(this._config);
-    setTracerProvider(this._config);
+    setTracerProvider(this._config, envValues);
     setMeterProvider(this._config);
     setLoggerProvider(this._config);
   }
@@ -164,9 +169,12 @@ export function setPropagators(config: ConfigurationModel): void {
   }
 }
 
-export function setSampler(config: ConfigurationModel): void {
-  const sampler = getStringFromEnv('OTEL_TRACES_SAMPLER');
-  const arg = getStringFromEnv('OTEL_TRACES_SAMPLER_ARG');
+export function setSampler(
+  config: ConfigurationModel,
+  env: EnvValues
+): void {
+  const sampler = env.OTEL_TRACES_SAMPLER;
+  const arg = env.OTEL_TRACES_SAMPLER_ARG;
 
   if (!sampler || !config.tracer_provider) {
     return;
@@ -175,45 +183,45 @@ export function setSampler(config: ConfigurationModel): void {
   const ratio = arg ? parseFloat(arg) : 1.0;
 
   switch (sampler) {
-    case 'always_on':
+    case SamplerType.AlwaysOn:
       config.tracer_provider.sampler = { always_on: {} };
       break;
 
-    case 'always_off':
+    case SamplerType.AlwaysOff:
       config.tracer_provider.sampler = { always_off: {} };
       break;
 
-    case 'traceidratio':
+    case SamplerType.TraceIdRatio:
       config.tracer_provider.sampler = {
         trace_id_ratio_based: { ratio },
       };
       break;
 
-    case 'parentbased_always_on':
+    case SamplerType.ParentBasedAlwaysOn:
       config.tracer_provider.sampler = {
         parent_based: { root: { always_on: {} } },
       };
       break;
 
-    case 'parentbased_always_off':
+    case SamplerType.ParentBasedAlwaysOff:
       config.tracer_provider.sampler = {
         parent_based: { root: { always_off: {} } },
       };
       break;
 
-    case 'parentbased_traceidratio':
+    case SamplerType.ParentBasedTraceIdRatio:
       config.tracer_provider.sampler = {
         parent_based: { root: { trace_id_ratio_based: { ratio } } },
       };
       break;
 
     default:
-      diag.warn(`Unknown sampler type: ${sampler}`);
+      // readEnvVar already warns for invalid values via allowedValues
       break;
   }
 }
 
-export function setTracerProvider(config: ConfigurationModel): void {
+export function setTracerProvider(config: ConfigurationModel, env: EnvValues): void {
   const exportersType = Array.from(
     new Set(getStringListFromEnv('OTEL_TRACES_EXPORTER'))
   );
@@ -227,7 +235,7 @@ export function setTracerProvider(config: ConfigurationModel): void {
     return;
   }
   config.tracer_provider = initializeDefaultTracerProviderConfiguration();
-  setSampler(config);
+  setSampler(config, env);
 
   const attributeValueLengthLimit = getNumberFromEnv(
     'OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT'
@@ -617,13 +625,13 @@ export function setMeterProvider(config: ConfigurationModel): void {
     getStringFromEnv('OTEL_METRICS_EXEMPLAR_FILTER') ?? 'trace_based';
   if (exemplarFilter) {
     switch (exemplarFilter) {
-      case 'trace_based':
+      case ExemplarFilter.TraceBased:
         config.meter_provider.exemplar_filter = ExemplarFilter.TraceBased;
         break;
-      case 'always_on':
+      case ExemplarFilter.AlwaysOn:
         config.meter_provider.exemplar_filter = ExemplarFilter.AlwaysOn;
         break;
-      case 'always_off':
+      case ExemplarFilter.AlwaysOff:
         config.meter_provider.exemplar_filter = ExemplarFilter.AlwaysOff;
         break;
       default:

--- a/experimental/packages/configuration/src/EnvironmentConfigFactory.ts
+++ b/experimental/packages/configuration/src/EnvironmentConfigFactory.ts
@@ -169,10 +169,7 @@ export function setPropagators(config: ConfigurationModel): void {
   }
 }
 
-export function setSampler(
-  config: ConfigurationModel,
-  env: EnvValues
-): void {
+export function setSampler(config: ConfigurationModel, env: EnvValues): void {
   const sampler = env.OTEL_TRACES_SAMPLER;
   const arg = env.OTEL_TRACES_SAMPLER_ARG;
 
@@ -221,7 +218,10 @@ export function setSampler(
   }
 }
 
-export function setTracerProvider(config: ConfigurationModel, env: EnvValues): void {
+export function setTracerProvider(
+  config: ConfigurationModel,
+  env: EnvValues
+): void {
   const exportersType = Array.from(
     new Set(getStringListFromEnv('OTEL_TRACES_EXPORTER'))
   );

--- a/experimental/packages/configuration/test/ConfigFactory.test.ts
+++ b/experimental/packages/configuration/test/ConfigFactory.test.ts
@@ -1460,7 +1460,7 @@ describe('ConfigFactory', function () {
       process.env.OTEL_TRACES_EXPORTER = 'otlp';
       process.env.OTEL_TRACES_SAMPLER = 'unknown_sampler';
       createConfigFactory();
-      Sinon.assert.calledWith(warnSpy, 'Unknown sampler type: unknown_sampler');
+      Sinon.assert.calledWith(warnSpy, 'Invalid value "unknown_sampler" for Traces sampler (env: OTEL_TRACES_SAMPLER). Expected one of: always_on, always_off, traceidratio, parentbased_always_on, parentbased_always_off, parentbased_traceidratio. Value will be ignored.');
     });
 
     it('should return config with custom tracer_provider', function () {

--- a/experimental/packages/configuration/test/ConfigFactory.test.ts
+++ b/experimental/packages/configuration/test/ConfigFactory.test.ts
@@ -1460,7 +1460,10 @@ describe('ConfigFactory', function () {
       process.env.OTEL_TRACES_EXPORTER = 'otlp';
       process.env.OTEL_TRACES_SAMPLER = 'unknown_sampler';
       createConfigFactory();
-      Sinon.assert.calledWith(warnSpy, 'Invalid value "unknown_sampler" for Traces sampler (env: OTEL_TRACES_SAMPLER). Expected one of: always_on, always_off, traceidratio, parentbased_always_on, parentbased_always_off, parentbased_traceidratio. Value will be ignored.');
+      Sinon.assert.calledWith(
+        warnSpy,
+        'Invalid value "unknown_sampler" for Traces sampler (env: OTEL_TRACES_SAMPLER). Expected one of: always_on, always_off, traceidratio, parentbased_always_on, parentbased_always_off, parentbased_traceidratio. Value will be ignored.'
+      );
     });
 
     it('should return config with custom tracer_provider', function () {

--- a/experimental/packages/configuration/test/EnvReader.test.ts
+++ b/experimental/packages/configuration/test/EnvReader.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import * as Sinon from 'sinon';
+import { diag } from '@opentelemetry/api';
+import { readEnvVar, readAllEnvVars } from '../src/EnvReader';
+import type { StringEnvVar } from '../src/EnvReader';
+import { SamplerType } from '../src/EnvDefinition';
+
+describe('EnvReader', function () {
+  const _origEnvVariables = { ...process.env };
+
+  afterEach(function () {
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key];
+    }
+    for (const [key, value] of Object.entries(_origEnvVariables)) {
+      process.env[key] = value;
+    }
+    Sinon.restore();
+  });
+
+  describe('readEnvVar', function () {
+    it('should return undefined when env var is not set', function () {
+      const def: StringEnvVar = {
+        key: 'TEST_UNSET_VAR',
+        type: 'string',
+        description: 'test var',
+      };
+      assert.strictEqual(readEnvVar(def), undefined);
+    });
+
+    it('should return the value when env var is set', function () {
+      process.env.TEST_VAR = 'hello';
+      const def: StringEnvVar = {
+        key: 'TEST_VAR',
+        type: 'string',
+        description: 'test var',
+      };
+      assert.strictEqual(readEnvVar(def), 'hello');
+    });
+
+    it('should return defaultValue when env var is not set and defaultValue is provided', function () {
+      const def: StringEnvVar = {
+        key: 'TEST_MISSING_VAR',
+        type: 'string',
+        description: 'test var',
+        defaultValue: 'fallback',
+      };
+      assert.strictEqual(readEnvVar(def), 'fallback');
+    });
+
+    it('should return the value when it matches allowedValues', function () {
+      process.env.TEST_ALLOWED = 'b';
+      const def: StringEnvVar = {
+        key: 'TEST_ALLOWED',
+        type: 'string',
+        description: 'test var',
+        allowedValues: ['a', 'b', 'c'],
+      };
+      assert.strictEqual(readEnvVar(def), 'b');
+    });
+
+    it('should warn and return undefined for invalid value with no defaultValue', function () {
+      const warnSpy = Sinon.spy(diag, 'warn');
+      process.env.TEST_INVALID = 'bad';
+      const def: StringEnvVar = {
+        key: 'TEST_INVALID',
+        type: 'string',
+        description: 'My setting',
+        allowedValues: ['good', 'fine'],
+      };
+      const result = readEnvVar(def);
+      assert.strictEqual(result, undefined);
+      Sinon.assert.calledOnce(warnSpy);
+      Sinon.assert.calledWith(
+        warnSpy,
+        'Invalid value "bad" for My setting (env: TEST_INVALID). Expected one of: good, fine. Value will be ignored.'
+      );
+    });
+
+    it('should warn and return defaultValue for invalid value with defaultValue', function () {
+      const warnSpy = Sinon.spy(diag, 'warn');
+      process.env.TEST_INVALID_DEFAULT = 'bad';
+      const def: StringEnvVar = {
+        key: 'TEST_INVALID_DEFAULT',
+        type: 'string',
+        description: 'My setting',
+        allowedValues: ['good', 'fine'],
+        defaultValue: 'good',
+      };
+      const result = readEnvVar(def);
+      assert.strictEqual(result, 'good');
+      Sinon.assert.calledOnce(warnSpy);
+      Sinon.assert.calledWith(
+        warnSpy,
+        'Invalid value "bad" for My setting (env: TEST_INVALID_DEFAULT). Expected one of: good, fine. Falling back to "good".'
+      );
+    });
+
+    it('should not warn when no allowedValues is defined', function () {
+      const warnSpy = Sinon.spy(diag, 'warn');
+      process.env.TEST_NO_ALLOWED = 'anything';
+      const def: StringEnvVar = {
+        key: 'TEST_NO_ALLOWED',
+        type: 'string',
+        description: 'test var',
+      };
+      assert.strictEqual(readEnvVar(def), 'anything');
+      Sinon.assert.notCalled(warnSpy);
+    });
+  });
+
+  describe('readAllEnvVars', function () {
+    it('should read OTEL_TRACES_SAMPLER when set to a valid value', function () {
+      process.env.OTEL_TRACES_SAMPLER = 'always_off';
+      const env = readAllEnvVars();
+      assert.strictEqual(env.OTEL_TRACES_SAMPLER, SamplerType.AlwaysOff);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -5602,9 +5602,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5619,9 +5616,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5636,9 +5630,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5653,9 +5644,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6313,6 +6301,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5602,6 +5602,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5616,6 +5619,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5630,6 +5636,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5644,6 +5653,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6301,7 +6313,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       }


### PR DESCRIPTION
Part Of #6107 

While I wanted to add some simple debug logs, I noticed that it might require a bigger change.
I started small with only two env variables `OTEL_TRACES_SAMPLER` and  `OTEL_TRACES_SAMPLER_ARG` to make sure we all agree on the approach.

The new approach for loading the config (and adding warning logs) is the following:
1. Have a map of env variable + possible values
1. The env reading happens only one time (it will auto-loop over all defined env variables)
1. Since we now know the list of allowed values, it can print generic warning message without any additional work

Note that everything is strongly typed, I just did `String` for now, but it can be super easily extended to `Bool`, `Number` and `StringList`. I also added unit test around new functions.

Very open to any feedback, my plan was to start small to validate the approach, and if you like it, I can do follow-up PRs to adopt this mechanism in all the `EnvironmentConfigFactory.ts`

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] Followed the style guidelines of this project
- [x]  Unit tests have been added
- [N/A] Documentation has been updated

Output of local unit test running
```
  EnvReader
    readEnvVar
      ✔ should return undefined when env var is not set
      ✔ should return the value when env var is set
      ✔ should return defaultValue when env var is not set and defaultValue is provided
      ✔ should return the value when it matches allowedValues
      ✔ should warn and return undefined for invalid value with no defaultValue
      ✔ should warn and return defaultValue for invalid value with defaultValue
      ✔ should not warn when no allowedValues is defined
    readAllEnvVars
      ✔ should read OTEL_TRACES_SAMPLER when set to a valid value
```
