### PR TITLE
fix(instrumentation-fetch): preserve init overrides when input is a Request object

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(instrumentation-fetch): preserve init overrides when input is a Request object [#6421](https://github.com/open-telemetry/opentelemetry-js/issues/6421) @akandic47
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -387,7 +387,18 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
           args[0] instanceof Request ? args[0].url : String(args[0])
         ).href;
 
-        const options = args[0] instanceof Request ? args[0] : args[1] || {};
+        // Per the Fetch spec, when fetch() is called with a Request object
+        // and a separate init object, the init properties override the
+        // Request's properties. Merge them into a new Request so that
+        // downstream consumers (hooks, header injection, the actual fetch
+        // call) see the correct final values.
+        // See: https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#parameters
+        let options: Request | RequestInit;
+        if (args[0] instanceof Request) {
+          options = args[1] != null ? new Request(args[0], args[1]) : args[0];
+        } else {
+          options = args[1] || {};
+        }
         const createdSpan = plugin._createSpan(url, options);
         if (!createdSpan) {
           return original.apply(this, args);

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -824,6 +824,73 @@ describe('fetch', () => {
             assert.strictEqual(headers['foo'], 'bar');
           });
 
+          it('should keep custom headers from init overrides when first arg is a Request object', async () => {
+            const { response } = await tracedFetch({
+              callback: () =>
+                fetch(new Request('/api/echo-headers.json'), {
+                  headers: { foo: 'bar' },
+                }),
+            });
+
+            const headers = await assertPropagationHeaders(response);
+
+            assert.strictEqual(
+              headers['foo'],
+              'bar',
+              'headers from init overrides should be preserved when first arg is a Request'
+            );
+          });
+
+          it('should keep custom headers from init overrides with typed Headers when first arg is a Request object', async () => {
+            const { response } = await tracedFetch({
+              callback: () =>
+                fetch(new Request('/api/echo-headers.json'), {
+                  headers: new Headers({ foo: 'bar' }),
+                }),
+            });
+
+            const headers = await assertPropagationHeaders(response);
+
+            assert.strictEqual(
+              headers['foo'],
+              'bar',
+              'typed headers from init overrides should be preserved when first arg is a Request'
+            );
+          });
+
+          it('should merge headers from Request and init overrides with init taking precedence', async () => {
+            const { response } = await tracedFetch({
+              callback: () =>
+                fetch(
+                  new Request('/api/echo-headers.json', {
+                    headers: {
+                      'x-from-request': 'request-value',
+                      shared: 'from-request',
+                    },
+                  }),
+                  {
+                    headers: {
+                      'x-from-init': 'init-value',
+                      shared: 'from-init',
+                    },
+                  }
+                ),
+            });
+
+            const headers = await assertPropagationHeaders(response);
+
+            assert.strictEqual(
+              headers['x-from-init'],
+              'init-value',
+              'headers from init overrides should be present'
+            );
+            assert.strictEqual(
+              headers['shared'],
+              'from-init',
+              'init overrides should take precedence over Request headers'
+            );
+          });
+
           it('should keep custom headers with url, untyped request object and typed (Headers) headers object', async () => {
             const { response } = await tracedFetch({
               callback: () =>


### PR DESCRIPTION
## Which problem is this PR solving?

When `fetch()` is called as `fetch(request, init)` — with a `Request` object as the first argument and a `RequestInit` as the second — the instrumentation discards `args[1]` entirely:

```ts
const options = args[0] instanceof Request ? args[0] : args[1] || {};
```

This means all properties from the `init` argument (headers, credentials, signal, etc.) are silently dropped. The instrumentation then calls `original.apply(self, [options])` with only the bare `Request`, violating the [Fetch API specification](https://fetch.spec.whatwg.org/#dom-global-fetch) which states that `init` properties should override `Request` properties.

**Real-world impact**: This breaks any SDK that uses the `fetch(Request, init)` pattern. We discovered this with a third-party authentication SDK where Grafana Faro's `TracingInstrumentation` (which uses this fetch instrumentation) caused all custom headers and credentials to be stripped from requests, resulting in 400 errors.

Headers comparison — **without** OTel fetch instrumentation (working):
```
accept: application/json
content-type: application/json
x-custom-auth: [present]
cookie: [present]
```

**With** OTel fetch instrumentation (broken — all init overrides lost):
```
accept: */*
(x-custom-auth missing)
(content-type missing)
(cookie missing — credentials: include was dropped)
```

Fixes #6421
Supersedes #6422 (adds tests and changelog entry)

## Short description of the changes

When `args[0]` is a `Request` and `args[1]` is present, merge them via `new Request(args[0], args[1])` — which is exactly what the native `fetch()` does per spec. When `args[1]` is not present, behavior is unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Three new browser tests added and verified:

1. **Without fix**: 3 FAILED, 104 SUCCESS — the new tests catch the bug
2. **With fix**: 107 SUCCESS — all tests pass

Tests cover:
- `fetch(Request, { headers: plainObject })` — verifies plain header objects in init are preserved
- `fetch(Request, { headers: Headers })` — verifies typed `Headers` in init are preserved
- `fetch(Request with headers, { headers })` — verifies init headers take precedence over Request headers (per spec)

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated