### PR TITLE
perf(sdk-trace-base): avoid _getTime for default Span.startTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
+* perf(sdk-trace-base): avoid `_getTime` for default `Span.startTime` [#6528](https://github.com/open-telemetry/opentelemetry-js/pull/6528) @daniellockyer
+
 ## 2.6.1
 
 ### :bug: Bug Fixes

--- a/packages/opentelemetry-sdk-trace-base/src/Span.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Span.ts
@@ -126,7 +126,9 @@ export class SpanImpl implements Span {
         this.addLink(link);
       }
     }
-    this.startTime = this._getTime(opts.startTime ?? now);
+    this.startTime = this._startTimeProvided
+      ? this._getTime(opts.startTime)
+      : millisToHrTime(now);
     this.resource = opts.resource;
     this.instrumentationScope = opts.scope;
     this._recordEndMetrics = opts.recordEndMetrics;

--- a/packages/opentelemetry-sdk-trace-base/test/browser/Span.bench.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/browser/Span.bench.ts
@@ -30,6 +30,20 @@ const benchLinkContext: SpanContext = {
 describe('Span benchmark (browser)', function () {
   this.timeout(60000);
 
+  it('creates spans', done => {
+    const suite = new Benchmark.Suite();
+    suite
+      .add('creates spans', () => {
+        const span = tracer.startSpan('span');
+        span.end();
+      })
+      .on('cycle', (event: Benchmark.Event) =>
+        console.log(String(event.target))
+      )
+      .on('complete', () => done())
+      .run({ async: true });
+  });
+
   it('create spans (10 attributes) (browser)', done => {
     const suite = new Benchmark.Suite();
     suite

--- a/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/common/Span.test.ts
@@ -21,6 +21,7 @@ import {
   hrTimeDuration,
   hrTimeToMilliseconds,
   hrTimeToNanoseconds,
+  millisToHrTime,
   otperformance as performance,
 } from '@opentelemetry/core';
 import {
@@ -101,6 +102,53 @@ describe('Span', () => {
       hrTimeToMilliseconds(span.startTime) >
         hrTimeToMilliseconds(performanceTimeOrigin)
     );
+  });
+
+  describe('default vs explicit startTime', () => {
+    const baseOpts = () => ({
+      scope: tracer.instrumentationScope,
+      resource: tracer['_resource'],
+      context: ROOT_CONTEXT,
+      spanContext,
+      name,
+      kind: SpanKind.SERVER,
+      spanLimits: tracer.getSpanLimits(),
+      spanProcessor: tracer['_spanProcessor'],
+    });
+
+    it('should set startTime to millisToHrTime(Date.now()) when startTime is omitted', () => {
+      const epochMs = 1234567890123;
+      sinon.stub(Date, 'now').returns(epochMs);
+      const span = new SpanImpl(baseOpts());
+      assert.deepStrictEqual(span.startTime, millisToHrTime(epochMs));
+      assert.strictEqual(span['_startTimeProvided'], false);
+    });
+
+    it('should use _getTime when startTime is provided as epoch millis', () => {
+      const clockNow = 1111111111111;
+      const explicitStart = 2222222222222;
+      sinon.stub(Date, 'now').returns(clockNow);
+      const span = new SpanImpl({
+        ...baseOpts(),
+        startTime: explicitStart,
+      });
+      assert.deepStrictEqual(span.startTime, millisToHrTime(explicitStart));
+      assert.strictEqual(span['_startTimeProvided'], true);
+    });
+
+    it('should treat startTime 0 as explicit (not default clock time)', () => {
+      sinon.stub(Date, 'now').returns(1234567890123);
+      const span = new SpanImpl({
+        ...baseOpts(),
+        startTime: 0,
+      });
+      assert.strictEqual(span['_startTimeProvided'], true);
+      assert.notDeepStrictEqual(
+        span.startTime,
+        millisToHrTime(1234567890123),
+        'explicit 0 must use performance-relative path, not default epoch millis'
+      );
+    });
   });
 
   it('should have valid endTime', () => {

--- a/packages/opentelemetry-sdk-trace-base/test/node/Span.bench.ts
+++ b/packages/opentelemetry-sdk-trace-base/test/node/Span.bench.ts
@@ -30,6 +30,20 @@ const benchLinkContext: SpanContext = {
 describe('Span benchmark', function () {
   this.timeout(60000);
 
+  it('creates spans', done => {
+    const suite = new Benchmark.Suite();
+    suite
+      .add('creates spans', () => {
+        const span = tracer.startSpan('span');
+        span.end();
+      })
+      .on('cycle', (event: Benchmark.Event) =>
+        console.log(String(event.target))
+      )
+      .on('complete', () => done())
+      .run({ async: true });
+  });
+
   it('create spans (10 attributes)', done => {
     const suite = new Benchmark.Suite();
     suite


### PR DESCRIPTION
## Which problem is this PR solving?

This PR optimizes the new Span creation benchmark by ~8-10% when no `startTime` is not provided.

When we create a Span, and we don't provide a `startTime` (I'd imagine this is the vast majority of cases), we currently pass a `number` (`Date.now()`) into `_getTime`.

Because `_getTime` doesn't know if this is a `Date.now()` or a `performance.now()` `number`, it has to do an extra `performance.now()` call (and it's not even a `performance.now()` so it's wasted). This extra work is eating up some of our performance.

You can see this in the flamegraph from my benchmark:

<img width="1068" height="344" alt="CleanShot 2026-03-27 at 07 37 06@2x" src="https://github.com/user-attachments/assets/a6b19f85-3e13-4e92-a01a-efbc3bfd8e91" />

And after this PR:

<img width="796" height="340" alt="CleanShot 2026-03-27 at 07 37 46@2x" src="https://github.com/user-attachments/assets/b097cbea-2cd9-43f4-b6ec-03e9ebda917e" />

This PR improves performance here by checking whether we passed a `startTime`, and shortcuts `_getTime` by just going straight to `millisToHrTime(now)`.

I'm not _entirely_ happy about pulling time-related logic outside of `_getTime` but figure it's worth it given the improvement. Happy to switch to something else if we can maintain the improvement.

refs https://github.com/open-telemetry/opentelemetry-js/issues/6100

## Short description of the changes

When no `startTime` is provided to a new Span, shortcut `_getTime` and avoid an extra `performance.now()`.

## Type of change

Please delete options that are not relevant.

- [ ] ~Bug fix (non-breaking change which fixes an issue)~
- [ ] ~New feature (non-breaking change which adds functionality)~
- [ ] ~Breaking change (fix or feature that would cause existing functionality to not work as expected)~
- [ ] ~This change requires a documentation update~

## How Has This Been Tested?

New tests have been added, existing tests pass, and benchmarks show the results.

The tests mostly are to check the conditional is working as expected.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] ~Documentation has been updated~
