### PR TITLE
fix(ci): pin to Node.js v22.22.1 to avoid bug in v22.22.2

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         node_version:
-          - "22"
+          - "22.22.1" # pin to avoid bug in 22.22.2
     runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     container:
       image: ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c

--- a/.github/workflows/create-or-update-release-pr.yml
+++ b/.github/workflows/create-or-update-release-pr.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           cache: 'npm'
           cache-dependency-path: package-lock.json
-          node-version: 22
+          node-version: "22.22.1" # pin to avoid bug in 22.22.2
       - run: npm install -g npm@latest
 
       - run: npm ci --ignore-scripts

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,7 +18,7 @@ jobs:
           - "18"
           - "20.6.0"
           - "20"
-          - "22"
+          - "22.22.1" # pin to avoid bug in 22.22.2
           - "24"
           - "25"
     runs-on: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
       - run: npm install -g npm@latest
         if: ${{
           matrix.node_version == '20' ||
-          matrix.node_version == '22' ||
+          matrix.node_version == '22.22.1' ||
           matrix.node_version == '24' ||
           matrix.node_version == '25'
           }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: 22
+          node-version: "22.22.1" # pin to avoid bug in 22.22.2
 
       - run: npm install -g npm@latest
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,7 +19,7 @@ jobs:
           - "18"
           - "20.6.0"
           - "20"
-          - "22.22.1" # pin to avoid bug in 22.22.2
+          - "22"
           - "24"
           - "25"
     runs-on: ubuntu-latest
@@ -43,10 +43,12 @@ jobs:
           matrix.node_version == '18' ||
           matrix.node_version == '20.6.0'
           }}
+      # Workaround: skip this install of npm@latest for Node.js v22 to
+      # workaround https://github.com/nodejs/node/issues/62425
+      # Npm@latest isn't typically *required*.
       - run: npm install -g npm@latest
         if: ${{
           matrix.node_version == '20' ||
-          matrix.node_version == '22.22.1' ||
           matrix.node_version == '24' ||
           matrix.node_version == '25'
           }}
@@ -76,7 +78,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: '22'
+          node-version: "22.22.1" # pin to avoid bug in 22.22.2
 
       - run: npm install -g npm@latest
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,7 +19,7 @@ jobs:
           - "18"
           - "20.6.0"
           - "20"
-          - "22"
+          - "22.22.1" # pin to avoid bug in 22.22.2
           - "24"
           - "25"
     runs-on: ubuntu-latest
@@ -46,7 +46,7 @@ jobs:
       - run: npm install -g npm@latest
         if: ${{
           matrix.node_version == '20' ||
-          matrix.node_version == '22' ||
+          matrix.node_version == '22.22.1' ||
           matrix.node_version == '24' ||
           matrix.node_version == '25'
           }}


### PR DESCRIPTION
'npm install -g npm@latest' fails with Node.js v22.22.2.
Pin to v22.22.1 for those workflows that install npm@latest.

Refs: https://github.com/nodejs/node/issues/62425
