### PR TITLE
feat(sampler-composite)!: rename createComposableTraceIDRatioBasedSampler to createComposableProbabilitySampler

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -9,10 +9,6 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :boom: Breaking Changes
 
 * feat(api-logs, sdk-logs)!: add Logger#enabled() [#6371](https://github.com/open-telemetry/opentelemetry-js/pull/6371) @david-luna
-
-### :rocket: Features
-
-* feat(api-logs, sdk-logs)!: add Logger#enabled() [#6371](https://github.com/open-telemetry/opentelemetry-js/pull/6371) @david-luna
 * feat(sampler-composite)!: rename `createComposableTraceIDRatioBasedSampler` to `createComposableProbabilitySampler` [#6541](https://github.com/open-telemetry/opentelemetry-js/pull/6541) @ravitheja4531-cell
 
 ### :rocket: Features

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,7 +12,11 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :rocket: Features
 
+* feat(api-logs, sdk-logs)!: add Logger#enabled() [#6371](https://github.com/open-telemetry/opentelemetry-js/pull/6371) @david-luna
 * feat(sampler-composite)!: rename `createComposableTraceIDRatioBasedSampler` to `createComposableProbabilitySampler` [#6541](https://github.com/open-telemetry/opentelemetry-js/pull/6541) @ravitheja4531-cell
+
+### :rocket: Features
+
 * feat(otlp-transformer): add custom protobuf logs serializer [#6228](https://github.com/open-telemetry/opentelemetry-js/pull/6228) @pichlermarc
 
 ### :bug: Bug Fixes

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,7 +12,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :rocket: Features
 
-* feat(sampler-composite): rename `createComposableTraceIDRatioBasedSampler` to `createComposableProbabilitySampler` [#6541](https://github.com/open-telemetry/opentelemetry-js/pull/6541) @ravitheja4531-cell
+* feat(sampler-composite)!: rename `createComposableTraceIDRatioBasedSampler` to `createComposableProbabilitySampler` [#6541](https://github.com/open-telemetry/opentelemetry-js/pull/6541) @ravitheja4531-cell
 * feat(otlp-transformer): add custom protobuf logs serializer [#6228](https://github.com/open-telemetry/opentelemetry-js/pull/6228) @pichlermarc
 
 ### :bug: Bug Fixes

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :rocket: Features
 
+* feat(sampler-composite): rename `createComposableTraceIDRatioBasedSampler` to `createComposableProbabilitySampler` [#6541](https://github.com/open-telemetry/opentelemetry-js/pull/6541) @ravitheja4531-cell
 * feat(otlp-transformer): add custom protobuf logs serializer [#6228](https://github.com/open-telemetry/opentelemetry-js/pull/6228) @pichlermarc
 
 ### :bug: Bug Fixes

--- a/experimental/packages/sampler-composite/README.md
+++ b/experimental/packages/sampler-composite/README.md
@@ -24,7 +24,7 @@ import {
   createComposableAlwaysOffSampler,
   createComposableAlwaysOnSampler,
   createComposableParentThresholdSampler,
-  createComposableTraceIDRatioBasedSampler,
+  createComposableProbabilitySampler,
   createComposableRuleBasedSampler
 } from '@opentelemetry/sampler-composite';
 
@@ -34,7 +34,7 @@ const sampler = createCompositeSampler(createComposableAlwaysOffSampler());
 const sampler = createCompositeSampler(createComposableAlwaysOnSampler());
 // follow the parent, or otherwise sample with a probability if root
 const sampler = createCompositeSampler(
-    createComposableParentThresholdSampler(createComposableTraceIDRatioBasedSampler(0.3)));
+    createComposableParentThresholdSampler(createComposableProbabilitySampler(0.3)));
 
 // An example of a rule-based sampler implementing the example at
 // https://opentelemetry.io/docs/specs/otel/trace/sdk/#composablerulebased
@@ -53,7 +53,7 @@ const sampler = createCompositeSampler(
       // ...always sample `/checkout` requests.
       [isCheckout, createComposableAlwaysOnSampler()],
       // ...sample 10% of all other requests.
-      [() => true, createComposableTraceIDRatioBasedSampler(0.1)]
+      [() => true, createComposableProbabilitySampler(0.1)]
     ])
   )
 );

--- a/experimental/packages/sampler-composite/src/index.ts
+++ b/experimental/packages/sampler-composite/src/index.ts
@@ -5,7 +5,7 @@
 
 export { createComposableAlwaysOffSampler } from './alwaysoff';
 export { createComposableAlwaysOnSampler } from './alwayson';
-export { createComposableTraceIDRatioBasedSampler } from './traceidratio';
+export { createComposableProbabilitySampler } from './probability';
 export { createComposableParentThresholdSampler } from './parentthreshold';
 export { createComposableAnnotatingSampler } from './annotating';
 export { createComposableRuleBasedSampler } from './rulebased';

--- a/experimental/packages/sampler-composite/src/probability.ts
+++ b/experimental/packages/sampler-composite/src/probability.ts
@@ -7,7 +7,7 @@ import type { ComposableSampler, SamplingIntent } from './types';
 import { INVALID_THRESHOLD, MAX_THRESHOLD } from './util';
 import { serializeTh } from './tracestate';
 
-class ComposableTraceIDRatioBasedSampler implements ComposableSampler {
+class ComposableProbabilitySampler implements ComposableSampler {
   private readonly intent: SamplingIntent;
   private readonly description: string;
 
@@ -34,7 +34,7 @@ class ComposableTraceIDRatioBasedSampler implements ComposableSampler {
         thresholdReliable: false,
       });
     }
-    this.description = `ComposableTraceIDRatioBasedSampler(threshold=${thresholdStr}, ratio=${ratio})`;
+    this.description = `ComposableProbabilitySampler(threshold=${thresholdStr}, ratio=${ratio})`;
   }
 
   getSamplingIntent(): SamplingIntent {
@@ -49,10 +49,10 @@ class ComposableTraceIDRatioBasedSampler implements ComposableSampler {
 /**
  * Returns a composable sampler that samples each span with a fixed ratio.
  */
-export function createComposableTraceIDRatioBasedSampler(
+export function createComposableProbabilitySampler(
   ratio: number
 ): ComposableSampler {
-  return new ComposableTraceIDRatioBasedSampler(ratio);
+  return new ComposableProbabilitySampler(ratio);
 }
 
 const probabilityThresholdScale = Math.pow(2, 56);

--- a/experimental/packages/sampler-composite/test/probability.test.ts
+++ b/experimental/packages/sampler-composite/test/probability.test.ts
@@ -9,13 +9,13 @@ import { SamplingDecision } from '@opentelemetry/sdk-trace-base';
 
 import {
   createCompositeSampler,
-  createComposableTraceIDRatioBasedSampler,
+  createComposableProbabilitySampler,
 } from '../src';
 import { traceIdGenerator } from './util';
 import { parseOtelTraceState } from '../src/tracestate';
 import { INVALID_RANDOM_VALUE } from '../src/util';
 
-describe('ComposableTraceIDRatioBasedSampler', () => {
+describe('ComposableProbabilitySampler', () => {
   [
     { ratio: 1.0, thresholdStr: '0' },
     { ratio: 0.5, thresholdStr: '8' },
@@ -24,10 +24,10 @@ describe('ComposableTraceIDRatioBasedSampler', () => {
     { ratio: 0, thresholdStr: 'max' },
   ].forEach(({ ratio, thresholdStr }) => {
     it(`should have a description for ratio ${ratio}`, () => {
-      const sampler = createComposableTraceIDRatioBasedSampler(ratio);
+      const sampler = createComposableProbabilitySampler(ratio);
       assert.strictEqual(
         sampler.toString(),
-        `ComposableTraceIDRatioBasedSampler(threshold=${thresholdStr}, ratio=${ratio})`
+        `ComposableProbabilitySampler(threshold=${thresholdStr}, ratio=${ratio})`
       );
     });
   });
@@ -45,7 +45,7 @@ describe('ComposableTraceIDRatioBasedSampler', () => {
   ].forEach(({ ratio, threshold }) => {
     it(`should sample spans with ratio ${ratio}`, () => {
       const sampler = createCompositeSampler(
-        createComposableTraceIDRatioBasedSampler(ratio)
+        createComposableProbabilitySampler(ratio)
       );
 
       const generator = traceIdGenerator();

--- a/experimental/packages/sampler-composite/test/sampler.test.ts
+++ b/experimental/packages/sampler-composite/test/sampler.test.ts
@@ -14,7 +14,7 @@ import {
   createComposableAlwaysOffSampler,
   createComposableAlwaysOnSampler,
   createComposableParentThresholdSampler,
-  createComposableTraceIDRatioBasedSampler,
+  createComposableProbabilitySampler,
 } from '../src';
 import { INVALID_RANDOM_VALUE, INVALID_THRESHOLD } from '../src/util';
 import {
@@ -84,7 +84,7 @@ describe('ConsistentSampler', () => {
       testId: 'parent based in legacy mode',
     },
     {
-      sampler: createComposableTraceIDRatioBasedSampler(0.5),
+      sampler: createComposableProbabilitySampler(0.5),
       parentSampled: true,
       parentThreshold: undefined,
       parentRandomValue: 0x7fffffffffffffn,
@@ -94,7 +94,7 @@ describe('ConsistentSampler', () => {
       testId: 'half threshold not sampled',
     },
     {
-      sampler: createComposableTraceIDRatioBasedSampler(0.5),
+      sampler: createComposableProbabilitySampler(0.5),
       parentSampled: false,
       parentThreshold: undefined,
       parentRandomValue: 0x80000000000000n,
@@ -104,7 +104,7 @@ describe('ConsistentSampler', () => {
       testId: 'half threshold sampled',
     },
     {
-      sampler: createComposableTraceIDRatioBasedSampler(1.0),
+      sampler: createComposableProbabilitySampler(1.0),
       parentSampled: false,
       parentThreshold: 0x80000000000000n,
       parentRandomValue: 0x80000000000000n,


### PR DESCRIPTION
## Summary

- Renames `createComposableTraceIDRatioBasedSampler` → `createComposableProbabilitySampler` in `@opentelemetry/sampler-composite` per issue #6540
- Renames internal class `ComposableTraceIDRatioBasedSampler` → `ComposableProbabilitySampler`
- Replaces `src/traceidratio.ts` with `src/probability.ts` and `test/traceidratio.test.ts` with `test/probability.test.ts`
- Updates `README.md` and `experimental/CHANGELOG.md`

Closes #6540

## Test plan

- [x] All 69 tests pass in `experimental/packages/sampler-composite`
- [x] New `probability.test.ts` covers description strings and sampling ratios