### PR TITLE
fix(sdk-metrics): repair ExponentialHistogram tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ fix(opentelemetry-resources): do not discard OTEL_RESOURCE_ATTRIBUTES when it co
 
 ### :house: Internal
 
+* fix(sdk-metrics): repair ExponentialHistogram tests [#6565](https://github.com/open-telemetry/opentelemetry-js/pull/6565) @overbalance
+
 ## 2.6.1
 
 ### :bug: Bug Fixes

--- a/packages/sdk-metrics/test/aggregator/ExponentialHistogram.test.ts
+++ b/packages/sdk-metrics/test/aggregator/ExponentialHistogram.test.ts
@@ -179,13 +179,13 @@ describe('ExponentialHistogramAccumulation', () => {
                   maxFill = i;
                 }
               }
-              assert.ok(maxFill >= maxSize / 2);
+              assert.ok(maxFill >= accumulation.positive.length / 2);
 
               // count is correct
-              assert.ok(maxSize + 1 >= totalCount);
-              assert.ok(maxSize + 1 >= accumulation.count);
+              assert.strictEqual(totalCount, maxSize + 1);
+              assert.strictEqual(accumulation.count, maxSize + 1);
               // sum is correct
-              assert.ok(sum >= accumulation.sum);
+              assert.strictEqual(sum, accumulation.sum);
 
               // the offset is correct at the computed scale
               mapper = getMapping(accumulation.scale);

--- a/packages/sdk-metrics/test/aggregator/ExponentialHistogram.test.ts
+++ b/packages/sdk-metrics/test/aggregator/ExponentialHistogram.test.ts
@@ -107,103 +107,101 @@ describe('ExponentialHistogramAccumulation', () => {
         assert.strictEqual(accumulation.positive.at(0), 1);
         assert.strictEqual(accumulation.positive.at(1), 2);
       });
+    });
 
-      // Tests that every permutation of {1, 1/2, 1/4} with maxSize=2
-      // results in the same scale=-1 histogram.
-      it('handles permutations of [1, 1/2, 1/4] with maxSize: 2', () => {
-        [
-          [1, 0.5, 0.25],
-          [1, 0.25, 0.5],
-          [0.5, 0.25, 1],
-          [0.5, 1, 0.25],
-          [0.25, 1, 0.5],
-          [0.25, 0.5, 1],
-        ].forEach(row => {
-          const accumulation = new ExponentialHistogramAccumulation([0, 0], 2);
-          row.forEach(value => {
-            accumulation.record(value);
-          });
-
-          assert.strictEqual(accumulation.scale, -1);
-          assert.strictEqual(accumulation.positive.offset, -2);
-          assert.strictEqual(accumulation.positive.length, 2);
-          assert.strictEqual(accumulation.positive.at(0), 1);
-          assert.strictEqual(accumulation.positive.at(1), 2);
+    // Tests that every permutation of {1, 1/2, 1/4} with maxSize=2
+    // results in the same scale=-1 histogram.
+    it('handles permutations of [1, 1/2, 1/4] with maxSize: 2', () => {
+      [
+        [1, 0.5, 0.25],
+        [1, 0.25, 0.5],
+        [0.5, 0.25, 1],
+        [0.5, 1, 0.25],
+        [0.25, 1, 0.5],
+        [0.25, 0.5, 1],
+      ].forEach(row => {
+        const accumulation = new ExponentialHistogramAccumulation([0, 0], 2);
+        row.forEach(value => {
+          accumulation.record(value);
         });
+
+        assert.strictEqual(accumulation.scale, -1);
+        assert.strictEqual(accumulation.positive.offset, -2);
+        assert.strictEqual(accumulation.positive.length, 2);
+        assert.strictEqual(accumulation.positive.at(0), 1);
+        assert.strictEqual(accumulation.positive.at(1), 2);
       });
+    });
 
-      // Tests a variety of ascending sequences, calculated using known
-      // index ranges.  For example, with maxSize=3, using scale=0 and
-      // offset -5, add a sequence of numbers. Because the numbers have
-      // known range, we know the expected scale.
-      it('handles ascending sequences', () => {
-        for (const maxSize of [3, 4, 6, 9]) {
-          for (let offset = -5; offset <= 5; offset++) {
-            for (const initScale of [0, 4]) {
-              for (let step = maxSize; step < 4 * maxSize; step++) {
-                const accumulation = new ExponentialHistogramAccumulation(
-                  [0, 0],
-                  maxSize
-                );
-                let mapper = getMapping(initScale);
+    // Tests a variety of ascending sequences, calculated using known
+    // index ranges. For example, with maxSize=3, using scale=0 and
+    // offset -5, add a sequence of numbers. Because the numbers have
+    // known range, we know the expected scale.
+    it('handles ascending sequences', () => {
+      for (const maxSize of [3, 4, 6, 9]) {
+        for (let offset = -5; offset <= 5; offset++) {
+          for (const initScale of [0, 4]) {
+            for (let step = maxSize; step < 4 * maxSize; step++) {
+              const accumulation = new ExponentialHistogramAccumulation(
+                [0, 0],
+                maxSize
+              );
+              let mapper = getMapping(initScale);
 
-                const minValue = centerValue(mapper, offset);
-                const maxValue = centerValue(mapper, offset + step);
-                let sum = 0.0;
+              const minValue = centerValue(mapper, offset);
+              const maxValue = centerValue(mapper, offset + step);
+              let sum = 0.0;
 
-                for (let i = 0; i < maxSize; i++) {
-                  const value = centerValue(mapper, offset + i);
-                  accumulation.record(value);
-                  sum += value;
-                }
-
-                assert.strictEqual(accumulation.scale, initScale);
-                assert.strictEqual(accumulation.positive.offset, offset);
-
-                accumulation.record(maxValue);
-                sum += maxValue;
-
-                // The zeroth bucket is not empty
-                assert.notStrictEqual(accumulation.positive.at(0), 0);
-
-                // The maximum-index is at or above the midpoint,
-                // otherwise we downscaled too much.
-
-                let maxFill = 0;
-                let totalCount = 0;
-
-                for (let i = 0; i < accumulation.positive.length; i++) {
-                  totalCount += accumulation.positive.at(i);
-                  if (accumulation.positive.at(i) !== 0) {
-                    maxFill = 0;
-                  }
-                }
-                assert.ok(maxFill >= maxSize / 2);
-
-                // count is correct
-                assert.ok(maxSize + 1 >= totalCount);
-                assert.ok(maxSize + 1 >= accumulation.count);
-                // sum is correct
-                assert.ok(sum >= accumulation.sum);
-
-                // the offset is correct at the computed scale
-                mapper = getMapping(accumulation.scale);
-                let index = mapper.mapToIndex(minValue);
-                assert.strictEqual(accumulation.positive.offset, index);
-
-                // the maximum range is correct at the computed scale
-                index = mapper.mapToIndex(maxValue);
-                assert.strictEqual(
-                  accumulation.positive.offset +
-                    accumulation.positive.length -
-                    1,
-                  index
-                );
+              for (let i = 0; i < maxSize; i++) {
+                const value = centerValue(mapper, offset + i);
+                accumulation.record(value);
+                sum += value;
               }
+
+              assert.strictEqual(accumulation.scale, initScale);
+              assert.strictEqual(accumulation.positive.offset, offset);
+
+              accumulation.record(maxValue);
+              sum += maxValue;
+
+              // The zeroth bucket is not empty
+              assert.notStrictEqual(accumulation.positive.at(0), 0);
+
+              // The maximum-index is at or above the midpoint,
+              // otherwise we downscaled too much.
+
+              let maxFill = 0;
+              let totalCount = 0;
+
+              for (let i = 0; i < accumulation.positive.length; i++) {
+                totalCount += accumulation.positive.at(i);
+                if (accumulation.positive.at(i) !== 0) {
+                  maxFill = i;
+                }
+              }
+              assert.ok(maxFill >= maxSize / 2);
+
+              // count is correct
+              assert.ok(maxSize + 1 >= totalCount);
+              assert.ok(maxSize + 1 >= accumulation.count);
+              // sum is correct
+              assert.ok(sum >= accumulation.sum);
+
+              // the offset is correct at the computed scale
+              mapper = getMapping(accumulation.scale);
+              let index = mapper.mapToIndex(minValue);
+              assert.strictEqual(accumulation.positive.offset, index);
+
+              // the maximum range is correct at the computed scale
+              index = mapper.mapToIndex(maxValue);
+              assert.strictEqual(
+                accumulation.positive.offset + accumulation.positive.length - 1,
+                index
+              );
             }
           }
         }
-      });
+      }
     });
 
     it('ignores NaN', () => {


### PR DESCRIPTION
## Summary

Fixes several bugs in the `ExponentialHistogramAccumulation` test suite. Two test cases were defined inside the body of another `it()` block, which Mocha silently ignores, making them dead code:

- `handles permutations of [1, 1/2, 1/4] with maxSize: 2`
- `handles ascending sequences`

These tests have been moved to the correct `describe('record', ...)` scope so they actually run. Once exposed, four bugs surfaced:

1. **`maxFill` was reset instead of tracked.** Every non-zero bucket reset `maxFill` to `0` instead of recording the index:
   ```diff
   - maxFill = 0;
   + maxFill = i;
   ```

2. **`maxFill >= maxSize / 2` fails for some parameter combos.** After downscaling, `positive.length` can be less than `maxSize` (e.g., 2 buckets when maxSize=3). The midpoint check should compare against the actual bucket array length, not the max capacity:
   ```diff
   - assert.ok(maxFill >= maxSize / 2);
   + assert.ok(maxFill >= accumulation.positive.length / 2);
   ```

3. **Count assertions only check an upper bound.** We record exactly `maxSize + 1` values (all positive, no NaN), so both `totalCount` and `accumulation.count` must be exactly that:
   ```diff
   - assert.ok(maxSize + 1 >= totalCount);
   - assert.ok(maxSize + 1 >= accumulation.count);
   + assert.strictEqual(totalCount, maxSize + 1);
   + assert.strictEqual(accumulation.count, maxSize + 1);
   ```

4. **Sum assertion only checks one direction.** The manual sum and `accumulation.sum` add the same values in the same order, so they are bit-identical:
   ```diff
   - assert.ok(sum >= accumulation.sum);
   + assert.strictEqual(sum, accumulation.sum);
   ```

## Test plan

- [x] `handles ascending sequences` passes across all parameter combinations (maxSize in [3,4,6,9], offset in [-5..5], initScale in [0,4], step in [maxSize..4*maxSize))
- [x] `handles permutations of [1, 1/2, 1/4] with maxSize: 2` passes
- [x] All 30 ExponentialHistogram tests pass