### PR TITLE
fix(instr-fetch): avoid unwrap fetch API

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -21,6 +21,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 * fix(instrumentation-fetch): preserve init overrides when input is a Request object [#6421](https://github.com/open-telemetry/opentelemetry-js/issues/6421) @akandic47
 * fix(otlp-exporter-base): limit Node.js HTTP transport response body to 4 MiB [#6552](https://github.com/open-telemetry/opentelemetry-js/pull/6552) @kartikgola
+* fix(instrumentation-fetch): avoid unwrapping fetch API when disabling [#6575](https://github.com/open-telemetry/opentelemetry-js/issues/6575) @david-luna
 
 ### :books: Documentation
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -21,7 +21,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 * fix(instrumentation-fetch): preserve init overrides when input is a Request object [#6421](https://github.com/open-telemetry/opentelemetry-js/issues/6421) @akandic47
 * fix(otlp-exporter-base): limit Node.js HTTP transport response body to 4 MiB [#6552](https://github.com/open-telemetry/opentelemetry-js/pull/6552) @kartikgola
-* fix(instrumentation-fetch): avoid unwrapping fetch API when disabling [#6575](https://github.com/open-telemetry/opentelemetry-js/issues/6575) @david-luna
+* fix(instrumentation-fetch): avoid unwrapping fetch API when disabling [#6575](https://github.com/open-telemetry/opentelemetry-js/pull/6575) @david-luna
 
 ### :books: Documentation
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -15,7 +15,6 @@ import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import {
   SemconvStability,
   semconvStabilityFromStr,
-  isWrapped,
   InstrumentationBase,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
@@ -110,6 +109,12 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
   private _tasksCount = 0;
 
   private _semconvStability: SemconvStability;
+
+  // Note: Intentionally *not* using `_enabled` as the field name to avoid
+  // any possible confusion with the `_enabled` field used on the *Node.js*
+  // InstrumentationBase class.
+  declare private _isEnabled: boolean;
+  declare private _isFetchPatched: boolean;
 
   constructor(config: FetchInstrumentationConfig = {}) {
     super('@opentelemetry/instrumentation-fetch', VERSION, config);
@@ -611,10 +616,17 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
       );
       return;
     }
-    if (isWrapped(fetch)) {
-      this._unwrap(globalThis, 'fetch');
-      this._diag.debug('removing previous patch for constructor');
+
+    if (this._isEnabled) {
+      return;
     }
+    this._isEnabled = true;
+
+    if (this._isFetchPatched) {
+      this._diag.debug('fetch constructor already patched');
+      return;
+    }
+    this._isFetchPatched = true;
     this._wrap(globalThis, 'fetch', this._patchConstructor());
   }
 
@@ -625,7 +637,10 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
     if (!hasBrowserPerformanceAPI) {
       return;
     }
-    this._unwrap(globalThis, 'fetch');
+    if (!this._isEnabled) {
+      return;
+    }
+    this._isEnabled = false;
     this._usedResources = new WeakSet<PerformanceResourceTiming>();
   }
 }

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -637,7 +637,7 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
   }
 
   /**
-   * implements unpatch function
+   * deactivates fetch instrumentation
    */
   override disable(): void {
     if (!hasBrowserPerformanceAPI) {

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -389,7 +389,7 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
       ): Promise<Response> {
         if (!plugin._isEnabled) {
           return original.apply(this, args);
-        }  
+        }
         const self = this;
         const url = web.parseUrl(
           args[0] instanceof Request ? args[0].url : String(args[0])

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -113,6 +113,9 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
   // Note: Intentionally *not* using `_enabled` as the field name to avoid
   // any possible confusion with the `_enabled` field used on the *Node.js*
   // InstrumentationBase class.
+  // Also not initializing the fields to `false` because the base class
+  // constructor already call `enable` modifying their values and it will
+  // set the instrumentaitons in a bas state (enabled, patched but with flags set to false)
   declare private _isEnabled: boolean;
   declare private _isFetchPatched: boolean;
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -387,6 +387,9 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
         this: typeof globalThis,
         ...args: Parameters<typeof fetch>
       ): Promise<Response> {
+        if (!plugin._isEnabled) {
+          return original.apply(this, args);
+        }  
         const self = this;
         const url = web.parseUrl(
           args[0] instanceof Request ? args[0].url : String(args[0])

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -122,6 +122,7 @@ function waitFor(timeout: number): Promise<void> {
 }
 
 describe('fetch', () => {
+  const originalFetch = globalThis.fetch;
   let workerStarted = false;
 
   const startWorker = async (
@@ -202,17 +203,18 @@ describe('fetch', () => {
       );
     } finally {
       sinon.restore();
+      globalThis.fetch = originalFetch;
     }
   });
 
   describe('enabling/disabling', () => {
-    const originalFetch = globalThis.fetch;
+    // const originalFetch = globalThis.fetch;
     let fetchInstrumentation: FetchInstrumentation | undefined;
 
     afterEach(() => {
       fetchInstrumentation?.disable();
       fetchInstrumentation = undefined;
-      globalThis.fetch = originalFetch;
+      // globalThis.fetch = originalFetch;
     });
 
     it('should wrap global fetch when instantiated', () => {

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -206,11 +206,13 @@ describe('fetch', () => {
   });
 
   describe('enabling/disabling', () => {
+    const originalFetch = globalThis.fetch;
     let fetchInstrumentation: FetchInstrumentation | undefined;
 
     afterEach(() => {
       fetchInstrumentation?.disable();
       fetchInstrumentation = undefined;
+      globalThis.fetch = originalFetch;
     });
 
     it('should wrap global fetch when instantiated', () => {

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -227,11 +227,11 @@ describe('fetch', () => {
       assert.ok(isWrapped(window.fetch));
     });
 
-    it('should unwrap global fetch when disabled', () => {
+    it('should not unwrap global fetch when disabled', () => {
       fetchInstrumentation = new FetchInstrumentation();
       assert.ok(isWrapped(window.fetch));
       fetchInstrumentation.disable();
-      assert.ok(!isWrapped(window.fetch));
+      assert.ok(isWrapped(window.fetch));
 
       // Avoids ERROR in the logs when calling `disable()` again during cleanup
       fetchInstrumentation = undefined;


### PR DESCRIPTION
## Which problem is this PR solving?

When fetch adn XHR instrumentations are unwrapping the browser APIs they may also remove any other patch added by another instrumentation. This PR makes the `fetch` instrumentation to avoid the unwrap and check on the enabled state of the instrumentation to decide to generate telemetry or not

Refs: https://github.com/open-telemetry/opentelemetry-browser/issues/204

## Short description of the changes

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] ran unit tests

## Checklist:

- [X] Followed the style guidelines of this project
- [ ] Unit tests have been added
