### PR TITLE
feat: add packageManager and devEngines to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,5 +98,17 @@
     "examples/http",
     "examples/https",
     "examples/esm-http-ts"
-  ]
+  ],
+  "packageManager": "npm@11.1.0",
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": "^11.9.0",
+      "onFail": "error"
+    },
+    "runtime": {
+      "name": "node",
+      "version": "^18.19.0 || >=20.6.0 <22.22.1 || >=22.22.2"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Add `packageManager: npm@11.1.0` to enforce npm as the package manager (11.1.0 is the last version before the peerDeps/overrides regression introduced in 11.2.0)
- Add `devEngines` to enforce npm >=11.9.0 and Node.js `^18.19.0 || >=20.6.0 <22.22.1 || >=22.22.2` (excludes Node 22.22.1 due to a known bug)

## Test plan
- [ ] Verify `npm install` works on supported Node.js versions
- [ ] Verify contributors on Node 22.22.1 get a clear error