### PR TITLE
feat(configuration): refactoring config loader to print warning message for booleans

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -43,6 +43,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * feat(configuration): set MeterProvider on sdk start [#6463](https://github.com/open-telemetry/opentelemetry-js/pull/6463) @maryliag
 * feat(configuration): export interfaces required in other packages [#6507](https://github.com/open-telemetry/opentelemetry-js/pull/6507) @maryliag
 * feat(configuration): refactoring config loader to print warning message [#6524](https://github.com/open-telemetry/opentelemetry-js/pull/6524) @maxday
+* feat(configuration): refactoring config loader to print warning message for booleans
+ [#6583](https://github.com/open-telemetry/opentelemetry-js/pull/6583) @maxday
 
 ### :bug: Bug Fixes
 

--- a/experimental/packages/configuration/src/EnvDefinition.ts
+++ b/experimental/packages/configuration/src/EnvDefinition.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { StringEnvVar } from './EnvReader';
+import type { BooleanEnvVar, StringEnvVar } from './EnvReader';
 
 export enum SamplerType {
   AlwaysOn = 'always_on',
@@ -15,6 +15,13 @@ export enum SamplerType {
 }
 
 export const ENV_DEFS = {
+  OTEL_SDK_DISABLED: {
+    key: 'OTEL_SDK_DISABLED',
+    type: 'boolean',
+    description: 'Disable the SDK',
+    defaultValue: false,
+  } as BooleanEnvVar,
+
   OTEL_TRACES_SAMPLER: {
     key: 'OTEL_TRACES_SAMPLER',
     type: 'string',

--- a/experimental/packages/configuration/src/EnvReader.ts
+++ b/experimental/packages/configuration/src/EnvReader.ts
@@ -19,11 +19,18 @@ export interface StringEnvVar extends EnvVarBase<string> {
   allowedValues?: readonly string[];
 }
 
-export type EnvVarDefinition = StringEnvVar;
+export interface BooleanEnvVar extends EnvVarBase<boolean> {
+  type: 'boolean';
+  defaultValue: boolean;
+}
+
+export type EnvVarDefinition = StringEnvVar | BooleanEnvVar;
 
 type ResolvedType<D extends EnvVarDefinition> = D extends StringEnvVar
   ? string | undefined
-  : never;
+  : D extends BooleanEnvVar
+    ? boolean
+    : never;
 
 function readStringEnv(def: StringEnvVar): string | undefined {
   const value = getStringFromEnv(def.key);
@@ -43,12 +50,34 @@ function readStringEnv(def: StringEnvVar): string | undefined {
   return value;
 }
 
+function readBooleanEnv(def: BooleanEnvVar): boolean {
+  const raw = getStringFromEnv(def.key)?.trim().toLowerCase();
+  // Handle the case where the env var is not set (no warning).
+  if (raw == null || raw === '') {
+    return def.defaultValue;
+  }
+  if (raw === 'true') {
+    return true;
+  }
+  if (raw === 'false') {
+    return false;
+  }
+  // If set to an unrecognized value, warn and fall back to the default.
+  diag.warn(
+    `Invalid value "${raw}" for ${def.description} (env: ${def.key}). ` +
+      `Expected 'true' or 'false'. Falling back to "${def.defaultValue}".`
+  );
+  return def.defaultValue;
+}
+
 export function readEnvVar<D extends EnvVarDefinition>(
   def: D
 ): ResolvedType<D> {
   switch (def.type) {
     case 'string':
       return readStringEnv(def) as ResolvedType<D>;
+    case 'boolean':
+      return readBooleanEnv(def) as ResolvedType<D>;
   }
 }
 

--- a/experimental/packages/configuration/src/EnvironmentConfigFactory.ts
+++ b/experimental/packages/configuration/src/EnvironmentConfigFactory.ts
@@ -6,7 +6,6 @@
 import type { ConfigurationModel } from './models/configModel';
 import { initializeDefaultConfiguration } from './models/configModel';
 import {
-  getBooleanFromEnv,
   getStringFromEnv,
   getStringListFromEnv,
   diagLogLevelFromString,
@@ -43,14 +42,13 @@ export class EnvironmentConfigFactory implements ConfigFactory {
 
   constructor() {
     this._config = initializeDefaultConfiguration();
-    this._config.disabled = getBooleanFromEnv('OTEL_SDK_DISABLED');
+    const envValues = readAllEnvVars();
+    this._config.disabled = envValues.OTEL_SDK_DISABLED;
 
     const logLevel = diagLogLevelFromString(getStringFromEnv('OTEL_LOG_LEVEL'));
     if (logLevel) {
       this._config.log_level = logLevel;
     }
-
-    const envValues = readAllEnvVars();
 
     setResources(this._config);
     setAttributeLimits(this._config);

--- a/experimental/packages/configuration/test/ConfigFactory.test.ts
+++ b/experimental/packages/configuration/test/ConfigFactory.test.ts
@@ -1021,6 +1021,18 @@ describe('ConfigFactory', function () {
       assert.deepStrictEqual(configFactory.getConfigModel(), expectedConfig);
     });
 
+    it('should warn and fall back to false when OTEL_SDK_DISABLED is set to an invalid value', function () {
+      const warnSpy = Sinon.spy(diag, 'warn');
+      process.env.OTEL_SDK_DISABLED = 'not_a_boolean_value';
+      const configFactory = createConfigFactory();
+      assert.deepStrictEqual(configFactory.getConfigModel(), defaultConfig);
+      Sinon.assert.calledOnce(warnSpy);
+      Sinon.assert.calledWith(
+        warnSpy,
+        'Invalid value "not_a_boolean_value" for Disable the SDK (env: OTEL_SDK_DISABLED). Expected \'true\' or \'false\'. Falling back to "false".'
+      );
+    });
+
     it('should return config with log level as debug', function () {
       process.env.OTEL_LOG_LEVEL = 'DEBUG';
       const expectedConfig: ConfigurationModel = {

--- a/experimental/packages/configuration/test/EnvReader.test.ts
+++ b/experimental/packages/configuration/test/EnvReader.test.ts
@@ -7,7 +7,7 @@ import * as assert from 'assert';
 import * as Sinon from 'sinon';
 import { diag } from '@opentelemetry/api';
 import { readEnvVar, readAllEnvVars } from '../src/EnvReader';
-import type { StringEnvVar } from '../src/EnvReader';
+import type { BooleanEnvVar, StringEnvVar } from '../src/EnvReader';
 import { SamplerType } from '../src/EnvDefinition';
 
 describe('EnvReader', function () {
@@ -112,6 +112,38 @@ describe('EnvReader', function () {
       assert.strictEqual(readEnvVar(def), 'anything');
       Sinon.assert.notCalled(warnSpy);
     });
+
+    it('should return true for boolean env var set to "true"', function () {
+      process.env.TEST_BOOL_TRUE = 'true';
+      const def: BooleanEnvVar = {
+        key: 'TEST_BOOL_TRUE',
+        type: 'boolean',
+        description: 'test bool var',
+        defaultValue: false,
+      };
+      assert.strictEqual(readEnvVar(def), true);
+    });
+
+    it('should return false for boolean env var set to "false"', function () {
+      process.env.TEST_BOOL_FALSE = 'false';
+      const def: BooleanEnvVar = {
+        key: 'TEST_BOOL_FALSE',
+        type: 'boolean',
+        description: 'test bool var',
+        defaultValue: true,
+      };
+      assert.strictEqual(readEnvVar(def), false);
+    });
+
+    it('should return defaultValue for boolean env var when not set', function () {
+      const def: BooleanEnvVar = {
+        key: 'TEST_BOOL_UNSET',
+        type: 'boolean',
+        description: 'test bool var',
+        defaultValue: false,
+      };
+      assert.strictEqual(readEnvVar(def), false);
+    });
   });
 
   describe('readAllEnvVars', function () {
@@ -119,6 +151,24 @@ describe('EnvReader', function () {
       process.env.OTEL_TRACES_SAMPLER = 'always_off';
       const env = readAllEnvVars();
       assert.strictEqual(env.OTEL_TRACES_SAMPLER, SamplerType.AlwaysOff);
+    });
+
+    it('should read OTEL_SDK_DISABLED as true when set to "true"', function () {
+      process.env.OTEL_SDK_DISABLED = 'true';
+      const env = readAllEnvVars();
+      assert.strictEqual(env.OTEL_SDK_DISABLED, true);
+    });
+
+    it('should read OTEL_SDK_DISABLED as false when set to "false"', function () {
+      process.env.OTEL_SDK_DISABLED = 'false';
+      const env = readAllEnvVars();
+      assert.strictEqual(env.OTEL_SDK_DISABLED, false);
+    });
+
+    it('should read OTEL_SDK_DISABLED as false when not set', function () {
+      delete process.env.OTEL_SDK_DISABLED;
+      const env = readAllEnvVars();
+      assert.strictEqual(env.OTEL_SDK_DISABLED, false);
     });
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

Follow-up of #6524
Part Of #6107
This adresses the `boolean` story.
Next follow-up is to remove usage of `getBooleanFromEnv` from `environment.ts` at other places.

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
