### PR TITLE
fix(opentelemetry-core): add extra checks on internal merge function for safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 * feat(sdk-metrics): adds the cardinalitySelector argument to PeriodicExportingMetricReaders
   [#6460](https://github.com/open-telemetry/opentelemetry-js/pull/6460) @starzlocker
+* feat(opentelemetry-core): add extra checks on internal merge function for safety [#x](https://github.com/open-telemetry/opentelemetry-js/pull/x) @maryliag
 
 ### :boom: Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 * feat(sdk-metrics): adds the cardinalitySelector argument to PeriodicExportingMetricReaders
   [#6460](https://github.com/open-telemetry/opentelemetry-js/pull/6460) @starzlocker
-* feat(opentelemetry-core): add extra checks on internal merge function for safety [#x](https://github.com/open-telemetry/opentelemetry-js/pull/x) @maryliag
+* feat(opentelemetry-core): add extra checks on internal merge function for safety [#6587](https://github.com/open-telemetry/opentelemetry-js/pull/6587) @maryliag
 
 ### :boom: Breaking Changes
 

--- a/packages/opentelemetry-core/src/utils/merge.ts
+++ b/packages/opentelemetry-core/src/utils/merge.ts
@@ -69,6 +69,13 @@ function mergeTwoObjects(
       const keys = Object.keys(two);
       for (let i = 0, j = keys.length; i < j; i++) {
         const key = keys[i];
+        if (
+          key === '__proto__' ||
+          key === 'constructor' ||
+          key === 'prototype'
+        ) {
+          continue;
+        }
         result[key] = takeValue(two[key]);
       }
     }
@@ -82,6 +89,13 @@ function mergeTwoObjects(
 
       for (let i = 0, j = keys.length; i < j; i++) {
         const key = keys[i];
+        if (
+          key === '__proto__' ||
+          key === 'constructor' ||
+          key === 'prototype'
+        ) {
+          continue;
+        }
         const twoValue = two[key];
 
         if (isPrimitive(twoValue)) {


### PR DESCRIPTION
The `mergeTwoObjects` function iterates over keys from untrusted objects without filtering __proto__, constructor, or prototype, which would allow someone controlling a config object to pollute Object.prototype.

Fix: Add a key check before processing