### PR TITLE
fix(web-common): add check for possible unsafe json parse

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -21,6 +21,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 * fix(instrumentation-fetch): preserve init overrides when input is a Request object [#6421](https://github.com/open-telemetry/opentelemetry-js/issues/6421) @akandic47
 * fix(otlp-exporter-base): limit Node.js HTTP transport response body to 4 MiB [#6552](https://github.com/open-telemetry/opentelemetry-js/pull/6552) @kartikgola
+* fix(web-common): add check for possible unsafe json parse [#x](https://github.com/open-telemetry/opentelemetry-js/pull/x) @maryliag
 
 ### :books: Documentation
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -21,7 +21,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 * fix(instrumentation-fetch): preserve init overrides when input is a Request object [#6421](https://github.com/open-telemetry/opentelemetry-js/issues/6421) @akandic47
 * fix(otlp-exporter-base): limit Node.js HTTP transport response body to 4 MiB [#6552](https://github.com/open-telemetry/opentelemetry-js/pull/6552) @kartikgola
-* fix(web-common): add check for possible unsafe json parse [#x](https://github.com/open-telemetry/opentelemetry-js/pull/x) @maryliag
+* fix(web-common): add check for possible unsafe json parse [#6589](https://github.com/open-telemetry/opentelemetry-js/pull/6589) @maryliag
 
 ### :books: Documentation
 

--- a/experimental/packages/web-common/src/LocalStorageSessionStore.ts
+++ b/experimental/packages/web-common/src/LocalStorageSessionStore.ts
@@ -26,7 +26,11 @@ export class LocalStorageSessionStore implements SessionStore {
 
     const sessionData = localStorage.getItem(SESSION_STORAGE_KEY);
     if (sessionData) {
-      return Promise.resolve(JSON.parse(sessionData) as Session);
+      try {
+        return Promise.resolve(JSON.parse(sessionData) as Session);
+      } catch {
+        return Promise.resolve(null);
+      }
     }
     return Promise.resolve(null);
   }

--- a/experimental/packages/web-common/test/LocalStorageSessionStore.test.ts
+++ b/experimental/packages/web-common/test/LocalStorageSessionStore.test.ts
@@ -51,4 +51,16 @@ describe('LocalStorageSessionStore', () => {
 
     assert.deepStrictEqual(retrieved, session);
   });
+
+  it.only('return null if localStorage is not available', async () => {
+    sinon.stub(window, 'localStorage').value(undefined);
+    const retrieved = await store.get();
+    assert.strictEqual(retrieved, null);
+  });
+
+  it.only('return null if stored session is invalid', async () => {
+    getItemStub.returns('invalid-json');
+    const retrieved = await store.get();
+    assert.strictEqual(retrieved, null);
+  });
 });

--- a/experimental/packages/web-common/test/LocalStorageSessionStore.test.ts
+++ b/experimental/packages/web-common/test/LocalStorageSessionStore.test.ts
@@ -52,13 +52,13 @@ describe('LocalStorageSessionStore', () => {
     assert.deepStrictEqual(retrieved, session);
   });
 
-  it.only('return null if localStorage is not available', async () => {
+  it('return null if localStorage is not available', async () => {
     sinon.stub(window, 'localStorage').value(undefined);
     const retrieved = await store.get();
     assert.strictEqual(retrieved, null);
   });
 
-  it.only('return null if stored session is invalid', async () => {
+  it('return null if stored session is invalid', async () => {
     getItemStub.returns('invalid-json');
     const retrieved = await store.get();
     assert.strictEqual(retrieved, null);


### PR DESCRIPTION
`localStorage` data can be tampered with by other scripts on the same origin. Malformed data crashes the call.