### PR TITLE
fix(instrumentation): lazily initialize require-in-the-middle for empty instrumentations

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts
@@ -35,8 +35,7 @@ export abstract class InstrumentationBase<
 {
   private _modules: InstrumentationModuleDefinition[];
   private _hooks: (Hooked | HookRequire)[] = [];
-  private _requireInTheMiddleSingleton: RequireInTheMiddleSingleton =
-    RequireInTheMiddleSingleton.getInstance();
+  private _requireInTheMiddleSingleton?: RequireInTheMiddleSingleton;
   private _enabled = false;
 
   constructor(
@@ -166,6 +165,14 @@ export abstract class InstrumentationBase<
     return undefined;
   }
 
+  private _getRequireInTheMiddleSingleton(): RequireInTheMiddleSingleton {
+    return (
+      this._requireInTheMiddleSingleton ??
+      (this._requireInTheMiddleSingleton =
+        RequireInTheMiddleSingleton.getInstance())
+    );
+  }
+
   private _onRequire<T>(
     module: InstrumentationModuleDefinition,
     exports: T,
@@ -276,6 +283,10 @@ export abstract class InstrumentationBase<
       return;
     }
 
+    if (this._modules.length === 0) {
+      return;
+    }
+
     this._warnOnPreloadedModules();
     for (const module of this._modules) {
       const hookFn: HookFn = (exports, name, baseDir) => {
@@ -298,7 +309,9 @@ export abstract class InstrumentationBase<
       // require-in-the-middle `Hook`.
       const hook = path.isAbsolute(module.name)
         ? new HookRequire([module.name], { internals: true }, onRequire)
-        : this._requireInTheMiddleSingleton.register(module.name, onRequire);
+        : this
+            ._getRequireInTheMiddleSingleton()
+            .register(module.name, onRequire);
 
       this._hooks.push(hook);
       const esmHook = new HookImport(

--- a/experimental/packages/opentelemetry-instrumentation/test/node/InstrumentationBase.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation/test/node/InstrumentationBase.test.ts
@@ -8,6 +8,7 @@ import * as sinon from 'sinon';
 import * as path from 'path';
 import { InstrumentationBase } from '../../src';
 import type { InstrumentationModuleDefinition } from '../../src/';
+import { RequireInTheMiddleSingleton } from '../../src/platform/node/RequireInTheMiddleSingleton';
 import {
   InstrumentationNodeModuleDefinition,
   InstrumentationNodeModuleFile,
@@ -29,6 +30,37 @@ class TestInstrumentation extends InstrumentationBase {
 }
 
 describe('InstrumentationBase', function () {
+  describe('constructor/enable without module definitions', function () {
+    let getInstanceStub: sinon.SinonStub;
+
+    class EmptyInstrumentation extends InstrumentationBase {
+      constructor(config = {}) {
+        super('@opentelemetry/instrumentation-empty-test', '0.0.0', config);
+      }
+
+      init() {}
+    }
+
+    beforeEach(() => {
+      getInstanceStub = sinon.stub(RequireInTheMiddleSingleton, 'getInstance');
+    });
+
+    afterEach(() => {
+      getInstanceStub.restore();
+    });
+
+    it('should not initialize require-in-the-middle in the constructor', function () {
+      new EmptyInstrumentation();
+      sinon.assert.notCalled(getInstanceStub);
+    });
+
+    it('should not initialize require-in-the-middle on enable', function () {
+      const instrumentation = new EmptyInstrumentation({ enabled: false });
+      instrumentation.enable();
+      sinon.assert.notCalled(getInstanceStub);
+    });
+  });
+
   describe('_onRequire - core module', function () {
     let instrumentation: TestInstrumentation;
     let modulePatchSpy: sinon.SinonSpy;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6304,6 +6304,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       }


### PR DESCRIPTION
## Which problem is this PR solving?

`InstrumentationBase` currently creates `RequireInTheMiddleSingleton` eagerly during construction.

That means simply instantiating a Node instrumentation can install the global `require-in-the-middle` hook, even when that instrumentation does not declare any modules to patch in `init()`.

This is a problem for bundled ESM applications, including Electron main-process apps, which use `createRequire(import.meta.url)` for native `.node` addons.

In this case, an instrumentation which only uses `diagnostics_channel` and does not need module patching can still cause `require-in-the-middle` to be installed. In bundled ESM environments, that unnecessary hook can lead to runtime failures when the app later uses `createRequire()`, for example `ReferenceError: require is not defined`.

This PR makes `RequireInTheMiddleSingleton` lazy. It is now only initialized when an instrumentation actually has module definitions to register.

That keeps module-patching instrumentations working as before, while avoiding an unnecessary global side effect for instrumentations that do not use `require-in-the-middle`.

## Short description of the changes

- Make `RequireInTheMiddleSingleton` lazy in `InstrumentationBase`
- Skip `require-in-the-middle` initialization entirely when `init()` returns no module definitions
- Add unit tests covering instrumentations with empty `init()` results

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Targeted tests run in `experimental/packages/opentelemetry-instrumentation`:

- [x] `npx mocha -r ts-node/register test/node/InstrumentationBase.test.ts`
- [x] `npx mocha -r ts-node/register test/node/RequireInTheMiddleSingleton.test.ts`

Added coverage verifies that `RequireInTheMiddleSingleton.getInstance()` is not called:
- during construction of an instrumentation whose `init()` returns no module definitions
- during `enable()` for that same kind of instrumentation

I also smoke-tested this change against a local Electron repro using Sentry + bundled ESM + `createRequire(import.meta.url)`. With this patch applied, the repro no longer throws `require is not defined`, and the diagnostics-channel-based fetch instrumentation still remains enabled.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated