### PR TITLE
perf: reduce loop overhead in sdk hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ fix(opentelemetry-resources): do not discard OTEL_RESOURCE_ATTRIBUTES when it co
 
 * test(exporter-zipkin): fix broken browser test assertions and add missing coverage [#6566](https://github.com/open-telemetry/opentelemetry-js/pull/6566) @overbalance
 * fix(sdk-metrics): repair ExponentialHistogram tests [#6565](https://github.com/open-telemetry/opentelemetry-js/pull/6565) @overbalance
+* perf(sdk-metrics): reduce loop overhead in sdk hot paths [#6593](https://github.com/open-telemetry/opentelemetry-js/pull/6593) @mcollina
 
 ## 2.6.1
 

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -400,9 +400,14 @@ export function getKeyListFromObjectArray(
   if (!obj || obj.length === 0) {
     return undefined;
   }
-  return obj
-    .map(item => Object.keys(item))
-    .reduce((prev, curr) => prev.concat(curr), []);
+
+  const keys: string[] = [];
+  for (const item of obj) {
+    for (const key of Object.keys(item)) {
+      keys.push(key);
+    }
+  }
+  return keys;
 }
 
 export function getNonNegativeNumberFromEnv(

--- a/packages/opentelemetry-core/src/propagation/composite.ts
+++ b/packages/opentelemetry-core/src/propagation/composite.ts
@@ -34,14 +34,16 @@ export class CompositePropagator implements TextMapPropagator {
   constructor(config: CompositePropagatorConfig = {}) {
     this._propagators = config.propagators ?? [];
 
-    this._fields = Array.from(
-      new Set(
-        this._propagators
-          // older propagators may not have fields function, null check to be sure
-          .map(p => (typeof p.fields === 'function' ? p.fields() : []))
-          .reduce((x, y) => x.concat(y), [])
-      )
-    );
+    const fields = new Set<string>();
+    for (const propagator of this._propagators) {
+      // older propagators may not have fields function, null check to be sure
+      const propagatorFields =
+        typeof propagator.fields === 'function' ? propagator.fields() : [];
+      for (const field of propagatorFields) {
+        fields.add(field);
+      }
+    }
+    this._fields = Array.from(fields);
   }
 
   /**

--- a/packages/sdk-metrics/src/exemplar/ExemplarReservoir.ts
+++ b/packages/sdk-metrics/src/exemplar/ExemplarReservoir.ts
@@ -59,11 +59,14 @@ class ExemplarBucket {
     if (!this._offered) return null;
     const currentAttributes = this.attributes;
     // filter attributes
-    Object.keys(pointAttributes).forEach(key => {
-      if (pointAttributes[key] === currentAttributes[key]) {
+    for (const key in pointAttributes) {
+      if (
+        Object.prototype.hasOwnProperty.call(pointAttributes, key) &&
+        pointAttributes[key] === currentAttributes[key]
+      ) {
         delete currentAttributes[key];
       }
-    });
+    }
     const retVal: Exemplar = {
       filteredAttributes: currentAttributes,
       value: this.value,
@@ -113,12 +116,12 @@ export abstract class FixedSizeExemplarReservoirBase
 
   collect(pointAttributes: Attributes): Exemplar[] {
     const exemplars: Exemplar[] = [];
-    this._reservoirStorage.forEach(storageItem => {
+    for (const storageItem of this._reservoirStorage) {
       const res = storageItem.collect(pointAttributes);
       if (res !== null) {
         exemplars.push(res);
       }
-    });
+    }
     this.reset();
     return exemplars;
   }

--- a/packages/sdk-metrics/src/state/AsyncMetricStorage.ts
+++ b/packages/sdk-metrics/src/state/AsyncMetricStorage.ts
@@ -52,9 +52,9 @@ export class AsyncMetricStorage<T extends Maybe<Accumulation>>
 
   record(measurements: AttributeHashMap<number>, observationTime: HrTime) {
     const processed = new AttributeHashMap<number>();
-    Array.from(measurements.entries()).forEach(([attributes, value]) => {
+    for (const [attributes, value] of measurements.entries()) {
       processed.set(this._attributesProcessor.process(attributes), value);
-    });
+    }
     this._deltaMetricStorage.batchCumulate(processed, observationTime);
   }
 

--- a/packages/sdk-metrics/src/state/DeltaMetricProcessor.ts
+++ b/packages/sdk-metrics/src/state/DeltaMetricProcessor.ts
@@ -61,53 +61,50 @@ export class DeltaMetricProcessor<T extends Maybe<Accumulation>> {
     measurements: AttributeHashMap<number>,
     collectionTime: HrTime
   ) {
-    Array.from(measurements.entries()).forEach(
-      ([attributes, value, hashCode]) => {
-        const accumulation =
-          this._aggregator.createAccumulation(collectionTime);
-        accumulation?.record(value);
-        let delta = accumulation;
-        // Diff with recorded cumulative memo.
-        if (this._cumulativeMemoStorage.has(attributes, hashCode)) {
-          // has() returned true, previous is present.
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const previous = this._cumulativeMemoStorage.get(
-            attributes,
-            hashCode
-          )!;
-          delta = this._aggregator.diff(previous, accumulation);
-        } else {
-          // If the cardinality limit is reached, we need to change the attributes
-          if (this._cumulativeMemoStorage.size >= this._cardinalityLimit) {
-            attributes = this._overflowAttributes;
-            hashCode = this._overflowHashCode;
-            if (this._cumulativeMemoStorage.has(attributes, hashCode)) {
-              // has() returned true, previous is present.
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              const previous = this._cumulativeMemoStorage.get(
-                attributes,
-                hashCode
-              )!;
-              delta = this._aggregator.diff(previous, accumulation);
-            }
+    for (const [
+      originalAttributes,
+      value,
+      originalHashCode,
+    ] of measurements.entries()) {
+      let attributes = originalAttributes;
+      let hashCode = originalHashCode;
+      const accumulation = this._aggregator.createAccumulation(collectionTime);
+      accumulation?.record(value);
+      let delta = accumulation;
+      // Diff with recorded cumulative memo.
+      if (this._cumulativeMemoStorage.has(attributes, hashCode)) {
+        // has() returned true, previous is present.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const previous = this._cumulativeMemoStorage.get(attributes, hashCode)!;
+        delta = this._aggregator.diff(previous, accumulation);
+      } else {
+        // If the cardinality limit is reached, we need to change the attributes
+        if (this._cumulativeMemoStorage.size >= this._cardinalityLimit) {
+          attributes = this._overflowAttributes;
+          hashCode = this._overflowHashCode;
+          if (this._cumulativeMemoStorage.has(attributes, hashCode)) {
+            // has() returned true, previous is present.
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            const previous = this._cumulativeMemoStorage.get(
+              attributes,
+              hashCode
+            )!;
+            delta = this._aggregator.diff(previous, accumulation);
           }
         }
-        // Merge with uncollected active delta.
-        if (this._activeCollectionStorage.has(attributes, hashCode)) {
-          // has() returned true, active is present.
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const active = this._activeCollectionStorage.get(
-            attributes,
-            hashCode
-          )!;
-          delta = this._aggregator.merge(active, delta);
-        }
-
-        // Save the current record and the delta record.
-        this._cumulativeMemoStorage.set(attributes, accumulation, hashCode);
-        this._activeCollectionStorage.set(attributes, delta, hashCode);
       }
-    );
+      // Merge with uncollected active delta.
+      if (this._activeCollectionStorage.has(attributes, hashCode)) {
+        // has() returned true, active is present.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const active = this._activeCollectionStorage.get(attributes, hashCode)!;
+        delta = this._aggregator.merge(active, delta);
+      }
+
+      // Save the current record and the delta record.
+      this._cumulativeMemoStorage.set(attributes, accumulation, hashCode);
+      this._activeCollectionStorage.set(attributes, delta, hashCode);
+    }
   }
 
   /**

--- a/packages/sdk-metrics/src/state/MultiWritableMetricStorage.ts
+++ b/packages/sdk-metrics/src/state/MultiWritableMetricStorage.ts
@@ -21,8 +21,9 @@ export class MultiMetricStorage implements WritableMetricStorage {
     context: Context,
     recordTime: HrTime
   ) {
-    this._backingStorages.forEach(it => {
-      it.record(value, attributes, context, recordTime);
-    });
+    const storages = this._backingStorages;
+    for (let i = 0; i < storages.length; i++) {
+      storages[i].record(value, attributes, context, recordTime);
+    }
   }
 }

--- a/packages/sdk-metrics/src/view/AttributesProcessor.ts
+++ b/packages/sdk-metrics/src/view/AttributesProcessor.ts
@@ -42,35 +42,41 @@ class MultiAttributesProcessor implements IAttributesProcessor {
 }
 
 class AllowListProcessor implements IAttributesProcessor {
-  private _allowedAttributeNames: string[];
+  private readonly _allowedAttributeNames: Set<string>;
   constructor(allowedAttributeNames: string[]) {
-    this._allowedAttributeNames = allowedAttributeNames;
+    this._allowedAttributeNames = new Set(allowedAttributeNames);
   }
 
   process(incoming: Attributes, _context?: Context): Attributes {
     const filteredAttributes: Attributes = {};
-    Object.keys(incoming).forEach(attributeName => {
-      if (this._allowedAttributeNames.includes(attributeName)) {
+    for (const attributeName in incoming) {
+      if (
+        Object.prototype.hasOwnProperty.call(incoming, attributeName) &&
+        this._allowedAttributeNames.has(attributeName)
+      ) {
         filteredAttributes[attributeName] = incoming[attributeName];
       }
-    });
+    }
     return filteredAttributes;
   }
 }
 
 class DenyListProcessor implements IAttributesProcessor {
-  private _deniedAttributeNames: string[];
+  private readonly _deniedAttributeNames: Set<string>;
   constructor(deniedAttributeNames: string[]) {
-    this._deniedAttributeNames = deniedAttributeNames;
+    this._deniedAttributeNames = new Set(deniedAttributeNames);
   }
 
   process(incoming: Attributes, _context?: Context): Attributes {
     const filteredAttributes: Attributes = {};
-    Object.keys(incoming).forEach(attributeName => {
-      if (!this._deniedAttributeNames.includes(attributeName)) {
+    for (const attributeName in incoming) {
+      if (
+        Object.prototype.hasOwnProperty.call(incoming, attributeName) &&
+        !this._deniedAttributeNames.has(attributeName)
+      ) {
         filteredAttributes[attributeName] = incoming[attributeName];
       }
-    });
+    }
     return filteredAttributes;
   }
 }

--- a/packages/sdk-metrics/test/performance/benchmarks/otel-sdk-metrics-paths.cjs
+++ b/packages/sdk-metrics/test/performance/benchmarks/otel-sdk-metrics-paths.cjs
@@ -1,20 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const os = require('node:os');
 const { performance } = require('node:perf_hooks');
 const { ROOT_CONTEXT } = require('@opentelemetry/api');
 
-const { AsyncMetricStorage } = require('../../packages/sdk-metrics/build/src/state/AsyncMetricStorage.js');
-const { MultiMetricStorage } = require('../../packages/sdk-metrics/build/src/state/MultiWritableMetricStorage.js');
-const { AttributeHashMap } = require('../../packages/sdk-metrics/build/src/state/HashMap.js');
+const { AsyncMetricStorage } = require('../../../build/src/state/AsyncMetricStorage.js');
+const { MultiMetricStorage } = require('../../../build/src/state/MultiWritableMetricStorage.js');
+const { AttributeHashMap } = require('../../../build/src/state/HashMap.js');
 const {
   createAllowListAttributesProcessor,
-} = require('../../packages/sdk-metrics/build/src/view/AttributesProcessor.js');
-const { SumAggregator } = require('../../packages/sdk-metrics/build/src/aggregator/Sum.js');
+} = require('../../../build/src/view/AttributesProcessor.js');
+const { SumAggregator } = require('../../../build/src/aggregator/Sum.js');
 const {
   createInstrumentDescriptor,
-} = require('../../packages/sdk-metrics/build/src/InstrumentDescriptor.js');
+} = require('../../../build/src/InstrumentDescriptor.js');
 const {
   InstrumentType,
-} = require('../../packages/sdk-metrics/build/src/export/MetricData.js');
+} = require('../../../build/src/export/MetricData.js');
 
 let sink = 0;
 
@@ -74,7 +90,9 @@ const attributeProcessor = createAllowListAttributesProcessor([
   'region',
 ]);
 
-const processorInput = Array.from({ length: 4_000 }, (_, i) => createAttributes(i));
+const processorInput = Array.from({ length: 4_000 }, (_, i) =>
+  createAttributes(i)
+);
 
 const allowListProcessorBench = benchmark(
   'AllowListProcessor.process x 4k',

--- a/scripts/benchmarks/otel-sdk-metrics-paths.cjs
+++ b/scripts/benchmarks/otel-sdk-metrics-paths.cjs
@@ -1,0 +1,156 @@
+const os = require('node:os');
+const { performance } = require('node:perf_hooks');
+const { ROOT_CONTEXT } = require('@opentelemetry/api');
+
+const { AsyncMetricStorage } = require('../../packages/sdk-metrics/build/src/state/AsyncMetricStorage.js');
+const { MultiMetricStorage } = require('../../packages/sdk-metrics/build/src/state/MultiWritableMetricStorage.js');
+const { AttributeHashMap } = require('../../packages/sdk-metrics/build/src/state/HashMap.js');
+const {
+  createAllowListAttributesProcessor,
+} = require('../../packages/sdk-metrics/build/src/view/AttributesProcessor.js');
+const { SumAggregator } = require('../../packages/sdk-metrics/build/src/aggregator/Sum.js');
+const {
+  createInstrumentDescriptor,
+} = require('../../packages/sdk-metrics/build/src/InstrumentDescriptor.js');
+const {
+  InstrumentType,
+} = require('../../packages/sdk-metrics/build/src/export/MetricData.js');
+
+let sink = 0;
+
+function median(values) {
+  const copy = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(copy.length / 2);
+  return copy.length % 2 === 0
+    ? (copy[mid - 1] + copy[mid]) / 2
+    : copy[mid];
+}
+
+function benchmark(name, fn, { warmup = 5, rounds = 7, iterations = 20 }) {
+  for (let i = 0; i < warmup; i++) {
+    sink ^= fn() & 0xffff;
+  }
+
+  const perIterationMs = [];
+
+  for (let round = 0; round < rounds; round++) {
+    let checksum = 0;
+    const start = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      checksum += fn();
+    }
+    const elapsed = performance.now() - start;
+    sink ^= checksum & 0xffff;
+    perIterationMs.push(elapsed / iterations);
+  }
+
+  const medianMs = median(perIterationMs);
+  return { name, medianMs, opsPerSec: 1000 / medianMs };
+}
+
+function printResult(title, result) {
+  console.log(`\n${title}`);
+  console.log(`  ${result.name.padEnd(34)} ${result.medianMs.toFixed(3)} ms/op`);
+  console.log(`  ${result.opsPerSec.toFixed(2)} ops/sec`);
+}
+
+function createAttributes(index) {
+  return {
+    service: `svc-${index % 16}`,
+    route: `/users/${index}`,
+    method: index % 2 === 0 ? 'GET' : 'POST',
+    region: `us-${index % 4}`,
+    ignoredA: `a-${index}`,
+    ignoredB: `b-${index % 32}`,
+    ignoredC: `c-${index % 8}`,
+    ignoredD: `d-${index % 64}`,
+  };
+}
+
+const attributeProcessor = createAllowListAttributesProcessor([
+  'service',
+  'route',
+  'method',
+  'region',
+]);
+
+const processorInput = Array.from({ length: 4_000 }, (_, i) => createAttributes(i));
+
+const allowListProcessorBench = benchmark(
+  'AllowListProcessor.process x 4k',
+  () => {
+    let count = 0;
+    for (const attributes of processorInput) {
+      count += Object.keys(attributeProcessor.process(attributes)).length;
+    }
+    return count;
+  },
+  { iterations: 10 }
+);
+
+const asyncMeasurements = new AttributeHashMap();
+for (let i = 0; i < 4_000; i++) {
+  asyncMeasurements.set(createAttributes(i), i + 1);
+}
+const asyncStorage = new AsyncMetricStorage(
+  createInstrumentDescriptor(
+    'bench.async.storage',
+    InstrumentType.OBSERVABLE_GAUGE
+  ),
+  new SumAggregator(false),
+  attributeProcessor,
+  [],
+  10_000
+);
+let observationNanos = 0;
+const asyncStorageBench = benchmark(
+  'AsyncMetricStorage.record x 4k',
+  () => {
+    observationNanos += 1;
+    asyncStorage.record(asyncMeasurements, [0, observationNanos]);
+    return asyncMeasurements.size;
+  },
+  { iterations: 10 }
+);
+
+class FakeWritableMetricStorage {
+  constructor() {
+    this.total = 0;
+  }
+
+  record(value, attributes) {
+    this.total += value + attributes.service.length + attributes.method.length;
+  }
+}
+
+const fanoutStorages = Array.from(
+  { length: 8 },
+  () => new FakeWritableMetricStorage()
+);
+const multiStorage = new MultiMetricStorage(fanoutStorages);
+const fanoutAttributes = {
+  service: 'checkout',
+  method: 'POST',
+  region: 'us-east-1',
+};
+const multiStorageBench = benchmark(
+  'MultiMetricStorage.record x 50k',
+  () => {
+    for (const storage of fanoutStorages) {
+      storage.total = 0;
+    }
+    for (let i = 0; i < 50_000; i++) {
+      multiStorage.record(i, fanoutAttributes, ROOT_CONTEXT, [0, i]);
+    }
+    return fanoutStorages[0].total;
+  },
+  { iterations: 5 }
+);
+
+console.log('OpenTelemetry SDK benchmark');
+console.log(`Node: ${process.version}`);
+console.log(`CPU: ${os.cpus()[0]?.model ?? 'unknown'}`);
+printResult('sdk-metrics allow-list attribute processing', allowListProcessorBench);
+printResult('sdk-metrics async observable accumulation', asyncStorageBench);
+printResult('sdk-metrics sync fan-out recording', multiStorageBench);
+console.log(`\nIgnore this checksum: ${sink}`);


### PR DESCRIPTION
## Summary

- reduce callback and intermediate-allocation overhead in `sdk-metrics` hot paths
- switch attribute allow/deny filtering to `Set` lookups with plain loops
- add an SDK-focused benchmark at `scripts/benchmarks/otel-sdk-metrics-paths.cjs`
- replace a couple of lower-priority `map(...).reduce(concat)` patterns with direct loops

## Details

This updates the following paths:

- `packages/sdk-metrics/src/view/AttributesProcessor.ts`
- `packages/sdk-metrics/src/state/DeltaMetricProcessor.ts`
- `packages/sdk-metrics/src/state/AsyncMetricStorage.ts`
- `packages/sdk-metrics/src/state/MultiWritableMetricStorage.ts`
- `packages/sdk-metrics/src/exemplar/ExemplarReservoir.ts`
- `experimental/packages/opentelemetry-sdk-node/src/utils.ts`
- `packages/opentelemetry-core/src/propagation/composite.ts`
- `scripts/benchmarks/otel-sdk-metrics-paths.cjs`

The `MultiMetricStorage.record` change intentionally uses an indexed loop with a local alias rather than `for...of`, since the benchmark showed `for...of` regressing on that small fixed fan-out case.

## Benchmark notes

Observed on Node `v24.13.0` / `Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz`:

- `AllowListProcessor.process x 4k`: `0.972 ms/op` -> about `0.64-0.67 ms/op`
- `AsyncMetricStorage.record x 4k`: `9.147 ms/op` -> about `8.0-8.3 ms/op`
- `MultiMetricStorage.record x 50k`: original `forEach` reran at `0.663 ms/op`; final indexed loop with a local alias ran at about `0.65-0.68 ms/op`

## Validation

- `NX_DAEMON=false npm test`
- `NX_DAEMON=false npm run lint`
