### PR TITLE
fix(instr-xhr): do not unpatch XHR methods

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(instrumentation-xml-http-request): avoid unwrapping `XMLHttpRequest` API when disabling [#6611](https://github.com/open-telemetry/opentelemetry-js/pull/6611) @david-luna
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -126,7 +126,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
       'http',
       config?.semconvStabilityOptIn
     );
-    console.log('contructor', this._id);
+    console.log('constructor', this._id);
   }
 
   init() {}
@@ -138,7 +138,6 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
    * @private
    */
   private _addHeaders(xhr: XMLHttpRequest, spanUrl: string) {
-    console.log('_addHeaders', this._id);
     const url = parseUrl(spanUrl).href;
     if (
       !shouldPropagateTraceHeaders(
@@ -311,7 +310,6 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
     if (!spanUrl || !startTime || !endTime || !xhrMem.createdResources) {
       return;
     }
-
     let resources: PerformanceResourceTiming[] =
       xhrMem.createdResources.entries;
 
@@ -388,6 +386,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
       this._diag.debug('ignoring span as url matches ignored url');
       return;
     }
+    console.log('_createSpan', url, method);
 
     let name = '';
     const parsedUrl = parseUrl(url);
@@ -470,6 +469,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
    * @private
    */
   protected _patchSend() {
+    console.log('_patchSend');
     const plugin = this;
 
     function endSpanTimeout(
@@ -580,7 +580,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
 
     return (original: SendFunction): SendFunction => {
       return function patchSend(this: XMLHttpRequest, ...args): void {
-        console.log('plugin send', plugin._id, plugin._isEnabled);
+        console.log('patchSend', plugin._isEnabled);
         if (!plugin._isEnabled) {
           return original.apply(this, args);
         }
@@ -672,7 +672,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
    * implements disable function
    */
   override disable() {
-    console.log('disable', this._id);
+    // console.log('disable', this._id);
     this._isEnabled = false;
     // this._diag.debug('removing patch from', this.moduleName, this.version);
     // this._unwrap(XMLHttpRequest.prototype, 'open');

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -8,7 +8,7 @@ import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import {
   SemconvStability,
   semconvStabilityFromStr,
-  isWrapped,
+  // isWrapped,
   InstrumentationBase,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
@@ -109,12 +109,24 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
   private _usedResources = new WeakSet<PerformanceResourceTiming>();
   private _semconvStability: SemconvStability;
 
+  // Note: Intentionally *not* using `_enabled` as the field name to avoid
+  // any possible confusion with the `_enabled` field used on the *Node.js*
+  // InstrumentationBase class.
+  // Also not initializing the fields to `false` because the base class
+  // constructor already call `enable` modifying their values and it will
+  // set the instrumentaitons in a bas state (enabled, patched but with flags set to false)
+  declare private _isEnabled: boolean;
+  declare private _isXhrPatched: boolean;
+
+  private _id = Math.random();
+
   constructor(config: XMLHttpRequestInstrumentationConfig = {}) {
     super('@opentelemetry/instrumentation-xml-http-request', VERSION, config);
     this._semconvStability = semconvStabilityFromStr(
       'http',
       config?.semconvStabilityOptIn
     );
+    console.log('contructor', this._id);
   }
 
   init() {}
@@ -126,6 +138,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
    * @private
    */
   private _addHeaders(xhr: XMLHttpRequest, spanUrl: string) {
+    console.log('_addHeaders', this._id);
     const url = parseUrl(spanUrl).href;
     if (
       !shouldPropagateTraceHeaders(
@@ -440,6 +453,9 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
     return (original: OpenFunction): OpenFunction => {
       const plugin = this;
       return function patchOpen(this: XMLHttpRequest, ...args): void {
+        if (!plugin._isEnabled) {
+          return original.apply(this, args);
+        }
         const method: string = args[0];
         const url: string = args[1];
         plugin._createSpan(this, url, method);
@@ -564,6 +580,10 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
 
     return (original: SendFunction): SendFunction => {
       return function patchSend(this: XMLHttpRequest, ...args): void {
+        console.log('plugin send', plugin._id, plugin._isEnabled);
+        if (!plugin._isEnabled) {
+          return original.apply(this, args);
+        }
         const xhrMem = plugin._xhrMem.get(this);
         if (!xhrMem) {
           return original.apply(this, args);
@@ -623,18 +643,27 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
    * implements enable function
    */
   override enable() {
+    console.log('enable', this._id);
+    if (this._isEnabled) {
+      return;
+    }
+    this._isEnabled = true;
     this._diag.debug('applying patch to', this.moduleName, this.version);
 
-    if (isWrapped(XMLHttpRequest.prototype.open)) {
-      this._unwrap(XMLHttpRequest.prototype, 'open');
-      this._diag.debug('removing previous patch from method open');
-    }
+    // if (isWrapped(XMLHttpRequest.prototype.open)) {
+    //   this._unwrap(XMLHttpRequest.prototype, 'open');
+    //   this._diag.debug('removing previous patch from method open');
+    // }
 
-    if (isWrapped(XMLHttpRequest.prototype.send)) {
-      this._unwrap(XMLHttpRequest.prototype, 'send');
-      this._diag.debug('removing previous patch from method send');
-    }
+    // if (isWrapped(XMLHttpRequest.prototype.send)) {
+    //   this._unwrap(XMLHttpRequest.prototype, 'send');
+    //   this._diag.debug('removing previous patch from method send');
+    // }
 
+    if (this._isXhrPatched) {
+      return;
+    }
+    this._isXhrPatched = true;
     this._wrap(XMLHttpRequest.prototype, 'open', this._patchOpen());
     this._wrap(XMLHttpRequest.prototype, 'send', this._patchSend());
   }
@@ -643,10 +672,11 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
    * implements disable function
    */
   override disable() {
-    this._diag.debug('removing patch from', this.moduleName, this.version);
-
-    this._unwrap(XMLHttpRequest.prototype, 'open');
-    this._unwrap(XMLHttpRequest.prototype, 'send');
+    console.log('disable', this._id);
+    this._isEnabled = false;
+    // this._diag.debug('removing patch from', this.moduleName, this.version);
+    // this._unwrap(XMLHttpRequest.prototype, 'open');
+    // this._unwrap(XMLHttpRequest.prototype, 'send');
 
     this._tasksCount = 0;
     this._xhrMem = new WeakMap<XMLHttpRequest, XhrMem>();

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -118,15 +118,12 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
   declare private _isEnabled: boolean;
   declare private _isXhrPatched: boolean;
 
-  private _id = Math.random();
-
   constructor(config: XMLHttpRequestInstrumentationConfig = {}) {
     super('@opentelemetry/instrumentation-xml-http-request', VERSION, config);
     this._semconvStability = semconvStabilityFromStr(
       'http',
       config?.semconvStabilityOptIn
     );
-    console.log('constructor', this._id);
   }
 
   init() {}
@@ -386,8 +383,6 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
       this._diag.debug('ignoring span as url matches ignored url');
       return;
     }
-    console.log('_createSpan', url, method);
-
     let name = '';
     const parsedUrl = parseUrl(url);
     const attributes = {} as api.Attributes;
@@ -469,7 +464,6 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
    * @private
    */
   protected _patchSend() {
-    console.log('_patchSend');
     const plugin = this;
 
     function endSpanTimeout(
@@ -580,7 +574,6 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
 
     return (original: SendFunction): SendFunction => {
       return function patchSend(this: XMLHttpRequest, ...args): void {
-        console.log('patchSend', plugin._isEnabled);
         if (!plugin._isEnabled) {
           return original.apply(this, args);
         }
@@ -643,22 +636,11 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
    * implements enable function
    */
   override enable() {
-    console.log('enable', this._id);
     if (this._isEnabled) {
       return;
     }
     this._isEnabled = true;
     this._diag.debug('applying patch to', this.moduleName, this.version);
-
-    // if (isWrapped(XMLHttpRequest.prototype.open)) {
-    //   this._unwrap(XMLHttpRequest.prototype, 'open');
-    //   this._diag.debug('removing previous patch from method open');
-    // }
-
-    // if (isWrapped(XMLHttpRequest.prototype.send)) {
-    //   this._unwrap(XMLHttpRequest.prototype, 'send');
-    //   this._diag.debug('removing previous patch from method send');
-    // }
 
     if (this._isXhrPatched) {
       return;
@@ -672,12 +654,7 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
    * implements disable function
    */
   override disable() {
-    // console.log('disable', this._id);
     this._isEnabled = false;
-    // this._diag.debug('removing patch from', this.moduleName, this.version);
-    // this._unwrap(XMLHttpRequest.prototype, 'open');
-    // this._unwrap(XMLHttpRequest.prototype, 'send');
-
     this._tasksCount = 0;
     this._xhrMem = new WeakMap<XMLHttpRequest, XhrMem>();
     this._usedResources = new WeakSet<PerformanceResourceTiming>();

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -112,8 +112,8 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
   // any possible confusion with the `_enabled` field used on the *Node.js*
   // InstrumentationBase class.
   // Also not initializing the fields to `false` because the base class
-  // constructor already call `enable` modifying their values and it will
-  // set the instrumentaitons in a bas state (enabled, patched but with flags set to false)
+  // constructor already calls `enable` modifying their values and it will
+  // set the instrumentations in a bad state (enabled, patched but with flags set to false)
   declare private _isEnabled: boolean;
   declare private _isXhrPatched: boolean;
 

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -640,11 +640,12 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
       return;
     }
     this._isEnabled = true;
-    this._diag.debug('applying patch to', this.moduleName, this.version);
 
     if (this._isXhrPatched) {
+      this._diag.debug('reactivating existing patch on', this.moduleName, this.version);
       return;
     }
+    this._diag.debug('applying patch to', this.moduleName, this.version);
     this._isXhrPatched = true;
     this._wrap(XMLHttpRequest.prototype, 'open', this._patchOpen());
     this._wrap(XMLHttpRequest.prototype, 'send', this._patchSend());

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -641,7 +641,11 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
     this._isEnabled = true;
 
     if (this._isXhrPatched) {
-      this._diag.debug('reactivating existing patch on', this.moduleName, this.version);
+      this._diag.debug(
+        'reactivating existing patch on',
+        this.moduleName,
+        this.version
+      );
       return;
     }
     this._diag.debug('applying patch to', this.moduleName, this.version);

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -638,20 +638,32 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
     if (this._isEnabled) {
       return;
     }
-    this._isEnabled = true;
-
     if (this._isXhrPatched) {
       this._diag.debug(
         'reactivating existing patch on',
         this.moduleName,
         this.version
       );
+      this._isEnabled = true;
       return;
     }
-    this._diag.debug('applying patch to', this.moduleName, this.version);
-    this._isXhrPatched = true;
-    this._wrap(XMLHttpRequest.prototype, 'open', this._patchOpen());
-    this._wrap(XMLHttpRequest.prototype, 'send', this._patchSend());
+
+    try {
+      this._diag.debug('applying patch to', this.moduleName, this.version);
+      this._wrap(XMLHttpRequest.prototype, 'open', this._patchOpen());
+      this._wrap(XMLHttpRequest.prototype, 'send', this._patchSend());
+      this._isXhrPatched = true;
+      this._isEnabled = true;
+    } catch (err) {
+      // make sure there is no wrapped functions
+      this._unwrap(XMLHttpRequest.prototype, 'open');
+      this._unwrap(XMLHttpRequest.prototype, 'send');
+      this._diag.warn(
+        'Failed to patch globalThis.XMLHttpRequest; instrumentation will not be enabled. ' +
+          'Another script may have locked globalThis.XMLHttpRequest via Object.defineProperty.',
+        err
+      );
+    }
   }
 
   /**

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -653,6 +653,9 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
    * implements disable function
    */
   override disable() {
+    if (!this._isEnabled) {
+      return;
+    }
     this._isEnabled = false;
     this._tasksCount = 0;
     this._xhrMem = new WeakMap<XMLHttpRequest, XhrMem>();

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -8,7 +8,6 @@ import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import {
   SemconvStability,
   semconvStabilityFromStr,
-  // isWrapped,
   InstrumentationBase,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/unmocked.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/unmocked.test.ts
@@ -46,7 +46,11 @@ describe('unmocked xhr', () => {
     });
   });
   afterEach(() => {
-    // nop
+    // NOTE: need to unwrap here to restore the API for the other test file
+    // @ts-expect-error -- property added by instrumentation.wrap(...)
+    XMLHttpRequest.prototype.send.__unwrap();
+    // @ts-expect-error -- property added by instrumentation.wrap(...)
+    XMLHttpRequest.prototype.open.__unwrap();
   });
 
   it('should find resource with a relative url', done => {

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -194,18 +194,15 @@ function createFakePerformanceObs(url: string) {
       const absoluteUrl = url.startsWith('http') ? url : location.origin + url;
       const resources: PerformanceObserverEntryList = {
         getEntries(): PerformanceEntryList {
-          console.log('getEntries', absoluteUrl);
           return [
             createResource({ name: absoluteUrl }) as any,
             createMainResource({ name: absoluteUrl }) as any,
           ];
         },
         getEntriesByName(): PerformanceEntryList {
-          console.log('getEntriesByName');
           return [];
         },
         getEntriesByType(): PerformanceEntryList {
-          console.log('getEntriesByType');
           return [];
         },
       };
@@ -612,7 +609,6 @@ describe('xhr', () => {
           it('span should have correct events', () => {
             const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
             const events = span.events;
-            console.log(events.map(e => e.name));
 
             testForCorrectEvents(events, [
               EventNames.METHOD_OPEN,
@@ -662,11 +658,6 @@ describe('xhr', () => {
 
           it('should set trace headers', () => {
             const span: api.Span = exportSpy.args[0][0][0];
-            console.log(
-              span.spanContext().traceId,
-              '===',
-              requests[0].requestHeaders[X_B3_TRACE_ID]
-            );
 
             assert.strictEqual(
               requests[0].requestHeaders[X_B3_TRACE_ID],
@@ -839,7 +830,6 @@ describe('xhr', () => {
                 span: api.Span,
                 xhr: XMLHttpRequest
               ) {
-                console.log('applyCustomAttributesOnSpan');
                 const res = JSON.parse(xhr.response);
                 span.setAttribute('xhr-custom-attribute', res.foo);
               },
@@ -949,7 +939,7 @@ describe('xhr', () => {
       describe('when GET request is NOT successful', () => {
         const url =
           'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/master/package.json';
-        
+
         beforeEach(() => {
           clearData();
           prepareData(url);
@@ -1603,89 +1593,21 @@ describe('xhr', () => {
         });
       });
 
-      describe.skip('when POST request is successful', () => {
+      describe('when POST request is successful', () => {
         const url = 'http://localhost:8090/xml-http-request.js';
         const secureUrl = 'https://localhost:8090/xml-http-request.js';
-        let fakeNow = 0;
-        let xmlHttpRequestInstrumentation: XMLHttpRequestInstrumentation;
 
-        const clearData = () => {
-          sinon.restore();
-          timer = sinon.useFakeTimers();
-          requests = [];
-        };
-
-        const prepareData = (
+        function successfulPostRequest(
+          url: string,
           done: any,
-          fileUrl: string,
-          config?: XMLHttpRequestInstrumentationConfig
-        ) => {
-          const fakeXhr = sinon.useFakeXMLHttpRequest();
-          fakeXhr.onCreate = function (xhr: any) {
-            requests.push(xhr);
-          };
-          // @ts-expect-error -- custom property
-          if (typeof XMLHttpRequest.prototype.send.__unwrap === 'function') {
-            // @ts-expect-error -- custom property
-            XMLHttpRequest.prototype.send.__unwrap();
-          }
-          // @ts-expect-error -- custom property
-          if (typeof XMLHttpRequest.prototype.open.__unwrap === 'function') {
-            // @ts-expect-error -- custom property
-            XMLHttpRequest.prototype.open.__unwrap();
-          }
-
-          sinon.stub(performance, 'timeOrigin').value(0);
-          sinon.stub(performance, 'now').callsFake(() => fakeNow);
-
-          const resources: PerformanceResourceTiming[] = [];
-          resources.push(
-            createResource({
-              name: fileUrl,
-            }),
-            createMainResource({
-              name: fileUrl,
-            })
-          );
-
-          spyEntries = sinon.stub(
-            performance as unknown as Performance,
-            'getEntriesByType'
-          );
-          spyEntries.withArgs('resource').returns(resources);
-
-          sinon
-            .stub(window, 'PerformanceObserver')
-            .value(createFakePerformanceObs(fileUrl));
-
-          xmlHttpRequestInstrumentation = new XMLHttpRequestInstrumentation({
-            semconvStabilityOptIn: test.semconvStabilityOptIn,
-            ...config,
-          });
-          dummySpanExporter = new DummySpanExporter();
-          exportSpy = sinon.stub(dummySpanExporter, 'export');
-          webTracerProviderWithZone = new WebTracerProvider({
-            spanProcessors: [
-              new tracing.SimpleSpanProcessor(dummySpanExporter),
-            ],
-          });
-          registerInstrumentations({
-            instrumentations: [xmlHttpRequestInstrumentation],
-            tracerProvider: webTracerProviderWithZone,
-          });
-          webTracerWithZone = webTracerProviderWithZone.getTracer('xhr-test');
-          clearResourceTimingsSpy = sinon.stub(
-            performance as unknown as Performance,
-            'clearResourceTimings'
-          );
-
-          rootSpan = webTracerWithZone.startSpan('root');
+          xhr = new XMLHttpRequest()
+        ) {
           api.context.with(
             api.trace.setSpan(api.context.active(), rootSpan),
             () => {
               void postData(
-                new XMLHttpRequest(),
-                fileUrl,
+                xhr,
+                url,
                 '{"embedded":"data"}',
                 () => {
                   fakeNow = 100;
@@ -1696,229 +1618,233 @@ describe('xhr', () => {
                 timer.tick(1000);
                 done();
               });
-              assert.strictEqual(requests.length, 1, 'request not called');
+              assert.ok(requests.length >= 1, 'request not called');
 
-              requests[0].respond(
+              requests[requests.length - 1].respond(
                 200,
                 { 'Content-Type': 'application/json' },
                 '{"foo":"bar"}'
               );
             }
           );
-        };
+        }
 
-        beforeEach(done => {
-          clearData();
-          const propagateTraceHeaderCorsUrls = [window.location.origin];
-          prepareData(done, url, {
-            propagateTraceHeaderCorsUrls,
-            measureRequestSize: true,
+        describe('When making http requests', () => {
+          beforeEach(done => {
+            clearData();
+            const propagateTraceHeaderCorsUrls = [window.location.origin];
+            prepareData(url, {
+              propagateTraceHeaderCorsUrls,
+              measureRequestSize: true,
+            });
+            successfulPostRequest(url, done);
+          });
+
+          it('should patch to wrap XML HTTP Requests when enabled', () => {
+            const xhttp = new XMLHttpRequest();
+            assert.ok(isWrapped(xhttp.send));
+            xmlHttpRequestInstrumentation.enable();
+            assert.ok(isWrapped(xhttp.send));
+          });
+
+          it('should create a span with correct root span', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            assert.strictEqual(
+              span.parentSpanContext?.spanId,
+              rootSpan.spanContext().spanId,
+              'parent span is not root span'
+            );
+          });
+
+          it('span should have correct name', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            assert.strictEqual(span.name, 'POST', 'span has wrong name');
+          });
+
+          it('span should have correct kind', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            assert.strictEqual(
+              span.kind,
+              api.SpanKind.CLIENT,
+              'span has wrong kind'
+            );
+          });
+
+          it('span should have correct attributes and status', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const attributes = span.attributes;
+
+            let expectedNumAttrs = 0;
+            const semconvStability = semconvStabilityFromStr(
+              'http',
+              test.semconvStabilityOptIn
+            );
+
+            if (semconvStability & SemconvStability.OLD) {
+              expectedNumAttrs += 9;
+              assert.strictEqual(
+                attributes[ATTR_HTTP_METHOD],
+                'POST',
+                `attributes ${ATTR_HTTP_METHOD} is wrong`
+              );
+              assert.strictEqual(
+                attributes[ATTR_HTTP_URL],
+                url,
+                `attributes ${ATTR_HTTP_URL} is wrong`
+              );
+              const requestContentLength = attributes[
+                ATTR_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED
+              ] as number;
+              assert.strictEqual(
+                requestContentLength,
+                19,
+                `attributes ${ATTR_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED} !== 19`
+              );
+              const responseContentLength = attributes[
+                ATTR_HTTP_RESPONSE_CONTENT_LENGTH
+              ] as number;
+              assert.strictEqual(
+                responseContentLength,
+                60,
+                `attributes ${ATTR_HTTP_RESPONSE_CONTENT_LENGTH} <= 0`
+              );
+              assert.strictEqual(
+                attributes[ATTR_HTTP_STATUS_CODE],
+                200,
+                `attributes ${ATTR_HTTP_STATUS_CODE} is wrong`
+              );
+              assert.strictEqual(
+                attributes[AttributeNames.HTTP_STATUS_TEXT],
+                'OK',
+                `attributes ${AttributeNames.HTTP_STATUS_TEXT} is wrong`
+              );
+              assert.strictEqual(
+                attributes[ATTR_HTTP_HOST],
+                parseUrl(url).host,
+                `attributes ${ATTR_HTTP_HOST} is wrong`
+              );
+              const httpScheme = attributes[ATTR_HTTP_SCHEME];
+              assert.ok(
+                httpScheme === 'http' || httpScheme === 'https',
+                `attributes ${ATTR_HTTP_SCHEME} is wrong`
+              );
+              assert.notStrictEqual(
+                attributes[ATTR_HTTP_USER_AGENT],
+                '',
+                `attributes ${ATTR_HTTP_USER_AGENT} is not defined`
+              );
+            }
+
+            if (semconvStability & SemconvStability.STABLE) {
+              assert.strictEqual(span.status.code, api.SpanStatusCode.UNSET);
+
+              expectedNumAttrs += 6;
+              assert.strictEqual(attributes[ATTR_HTTP_REQUEST_METHOD], 'POST');
+              assert.strictEqual(attributes[ATTR_URL_FULL], url);
+              assert.strictEqual(
+                attributes[ATTR_HTTP_RESPONSE_STATUS_CODE],
+                200
+              );
+              assert.strictEqual(
+                attributes[ATTR_SERVER_ADDRESS],
+                parseUrl(url).hostname,
+                'server.address'
+              );
+              assert.strictEqual(
+                attributes[ATTR_SERVER_PORT],
+                Number(parseUrl(url).port),
+                'server.port'
+              );
+              assert.strictEqual(attributes[ATTR_HTTP_REQUEST_BODY_SIZE], 19);
+            }
+
+            assert.strictEqual(
+              Object.keys(attributes).length,
+              expectedNumAttrs,
+              'number of attributes is wrong'
+            );
+          });
+
+          it('span should have correct events', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const events = span.events;
+            testForCorrectEvents(events, [
+              EventNames.METHOD_OPEN,
+              EventNames.METHOD_SEND,
+              PTN.FETCH_START,
+              PTN.DOMAIN_LOOKUP_START,
+              PTN.DOMAIN_LOOKUP_END,
+              PTN.CONNECT_START,
+              PTN.CONNECT_END,
+              PTN.REQUEST_START,
+              PTN.RESPONSE_START,
+              PTN.RESPONSE_END,
+              EventNames.EVENT_LOAD,
+            ]);
+            assert.strictEqual(events.length, 11, 'number of events is wrong');
+          });
+
+          it('should create a span for preflight request', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+            const parentSpan: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            assert.strictEqual(
+              span.parentSpanContext?.spanId,
+              parentSpan.spanContext().spanId,
+              'parent span is not root span'
+            );
+          });
+
+          it('preflight request span should have correct name', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+            assert.strictEqual(
+              span.name,
+              'CORS Preflight',
+              'preflight request span has wrong name'
+            );
+          });
+
+          it('preflight request span should have correct kind', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+            assert.strictEqual(
+              span.kind,
+              api.SpanKind.INTERNAL,
+              'span has wrong kind'
+            );
+          });
+
+          it('preflight request span should have correct events', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+            const events = span.events;
+            assert.strictEqual(events.length, 8, 'number of events is wrong');
+            testForCorrectEvents(events, [
+              PTN.FETCH_START,
+              PTN.DOMAIN_LOOKUP_START,
+              PTN.DOMAIN_LOOKUP_END,
+              PTN.CONNECT_START,
+              PTN.CONNECT_END,
+              PTN.REQUEST_START,
+              PTN.RESPONSE_START,
+              PTN.RESPONSE_END,
+            ]);
+          });
+
+          it('should NOT clear the resources', () => {
+            assert.ok(
+              clearResourceTimingsSpy.notCalled,
+              'resources have been cleared'
+            );
           });
         });
 
-        afterEach(() => {
-          clearData();
-        });
-
-        it('should patch to wrap XML HTTP Requests when enabled', () => {
-          const xhttp = new XMLHttpRequest();
-          assert.ok(isWrapped(xhttp.send));
-          xmlHttpRequestInstrumentation.enable();
-          assert.ok(isWrapped(xhttp.send));
-        });
-
-        it('should create a span with correct root span', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
-          assert.strictEqual(
-            span.parentSpanContext?.spanId,
-            rootSpan.spanContext().spanId,
-            'parent span is not root span'
-          );
-        });
-
-        it('span should have correct name', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
-          assert.strictEqual(span.name, 'POST', 'span has wrong name');
-        });
-
-        it('span should have correct kind', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
-          assert.strictEqual(
-            span.kind,
-            api.SpanKind.CLIENT,
-            'span has wrong kind'
-          );
-        });
-
-        it('span should have correct attributes and status', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
-          const attributes = span.attributes;
-
-          let expectedNumAttrs = 0;
-          const semconvStability = semconvStabilityFromStr(
-            'http',
-            test.semconvStabilityOptIn
-          );
-
-          if (semconvStability & SemconvStability.OLD) {
-            expectedNumAttrs += 9;
-            assert.strictEqual(
-              attributes[ATTR_HTTP_METHOD],
-              'POST',
-              `attributes ${ATTR_HTTP_METHOD} is wrong`
-            );
-            assert.strictEqual(
-              attributes[ATTR_HTTP_URL],
-              url,
-              `attributes ${ATTR_HTTP_URL} is wrong`
-            );
-            const requestContentLength = attributes[
-              ATTR_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED
-            ] as number;
-            assert.strictEqual(
-              requestContentLength,
-              19,
-              `attributes ${ATTR_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED} !== 19`
-            );
-            const responseContentLength = attributes[
-              ATTR_HTTP_RESPONSE_CONTENT_LENGTH
-            ] as number;
-            assert.strictEqual(
-              responseContentLength,
-              60,
-              `attributes ${ATTR_HTTP_RESPONSE_CONTENT_LENGTH} <= 0`
-            );
-            assert.strictEqual(
-              attributes[ATTR_HTTP_STATUS_CODE],
-              200,
-              `attributes ${ATTR_HTTP_STATUS_CODE} is wrong`
-            );
-            assert.strictEqual(
-              attributes[AttributeNames.HTTP_STATUS_TEXT],
-              'OK',
-              `attributes ${AttributeNames.HTTP_STATUS_TEXT} is wrong`
-            );
-            assert.strictEqual(
-              attributes[ATTR_HTTP_HOST],
-              parseUrl(url).host,
-              `attributes ${ATTR_HTTP_HOST} is wrong`
-            );
-            const httpScheme = attributes[ATTR_HTTP_SCHEME];
-            assert.ok(
-              httpScheme === 'http' || httpScheme === 'https',
-              `attributes ${ATTR_HTTP_SCHEME} is wrong`
-            );
-            assert.notStrictEqual(
-              attributes[ATTR_HTTP_USER_AGENT],
-              '',
-              `attributes ${ATTR_HTTP_USER_AGENT} is not defined`
-            );
-          }
-
-          if (semconvStability & SemconvStability.STABLE) {
-            assert.strictEqual(span.status.code, api.SpanStatusCode.UNSET);
-
-            expectedNumAttrs += 6;
-            assert.strictEqual(attributes[ATTR_HTTP_REQUEST_METHOD], 'POST');
-            assert.strictEqual(attributes[ATTR_URL_FULL], url);
-            assert.strictEqual(attributes[ATTR_HTTP_RESPONSE_STATUS_CODE], 200);
-            assert.strictEqual(
-              attributes[ATTR_SERVER_ADDRESS],
-              parseUrl(url).hostname,
-              'server.address'
-            );
-            assert.strictEqual(
-              attributes[ATTR_SERVER_PORT],
-              Number(parseUrl(url).port),
-              'server.port'
-            );
-            assert.strictEqual(attributes[ATTR_HTTP_REQUEST_BODY_SIZE], 19);
-          }
-
-          assert.strictEqual(
-            Object.keys(attributes).length,
-            expectedNumAttrs,
-            'number of attributes is wrong'
-          );
-        });
-
-        it('span should have correct events', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
-          const events = span.events;
-          testForCorrectEvents(events, [
-            EventNames.METHOD_OPEN,
-            EventNames.METHOD_SEND,
-            PTN.FETCH_START,
-            PTN.DOMAIN_LOOKUP_START,
-            PTN.DOMAIN_LOOKUP_END,
-            PTN.CONNECT_START,
-            PTN.CONNECT_END,
-            PTN.REQUEST_START,
-            PTN.RESPONSE_START,
-            PTN.RESPONSE_END,
-            EventNames.EVENT_LOAD,
-          ]);
-          assert.strictEqual(events.length, 11, 'number of events is wrong');
-        });
-
-        it('should create a span for preflight request', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-          const parentSpan: tracing.ReadableSpan = exportSpy.args[1][0][0];
-          assert.strictEqual(
-            span.parentSpanContext?.spanId,
-            parentSpan.spanContext().spanId,
-            'parent span is not root span'
-          );
-        });
-
-        it('preflight request span should have correct name', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-          assert.strictEqual(
-            span.name,
-            'CORS Preflight',
-            'preflight request span has wrong name'
-          );
-        });
-
-        it('preflight request span should have correct kind', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-          assert.strictEqual(
-            span.kind,
-            api.SpanKind.INTERNAL,
-            'span has wrong kind'
-          );
-        });
-
-        it('preflight request span should have correct events', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-          const events = span.events;
-          assert.strictEqual(events.length, 8, 'number of events is wrong');
-          testForCorrectEvents(events, [
-            PTN.FETCH_START,
-            PTN.DOMAIN_LOOKUP_START,
-            PTN.DOMAIN_LOOKUP_END,
-            PTN.CONNECT_START,
-            PTN.CONNECT_END,
-            PTN.REQUEST_START,
-            PTN.RESPONSE_START,
-            PTN.RESPONSE_END,
-          ]);
-        });
-
-        it('should NOT clear the resources', () => {
-          assert.ok(
-            clearResourceTimingsSpy.notCalled,
-            'resources have been cleared'
-          );
-        });
         describe('When making https requests', () => {
           beforeEach(done => {
             clearData();
             // this won't generate a preflight span
             const propagateTraceHeaderCorsUrls = [secureUrl];
-            prepareData(done, secureUrl, {
+            prepareData(secureUrl, {
               propagateTraceHeaderCorsUrls,
             });
+            successfulPostRequest(secureUrl, done);
           });
 
           it('span should have correct events', () => {
@@ -1964,9 +1890,13 @@ describe('xhr', () => {
             clearData();
             // this won't generate a preflight span
             const propagateTraceHeaderCorsUrls = [url];
-            prepareData(done, window.location.origin + '/xml-http-request.js', {
+            prepareData(window.location.origin + '/xml-http-request.js', {
               propagateTraceHeaderCorsUrls,
             });
+            successfulPostRequest(
+              window.location.origin + '/xml-http-request.js',
+              done
+            );
           });
 
           it('should set trace headers', () => {
@@ -1994,12 +1924,13 @@ describe('xhr', () => {
             ' propagateTraceHeaderCorsUrls',
           () => {
             beforeEach(done => {
+              const ghUrl =
+                'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/master/package.json';
               clearData();
-              prepareData(
-                done,
-                'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/master/package.json',
-                { propagateTraceHeaderCorsUrls: /raw\.githubusercontent\.com/ }
-              );
+              prepareData(ghUrl, {
+                propagateTraceHeaderCorsUrls: /raw\.githubusercontent\.com/,
+              });
+              successfulPostRequest(ghUrl, done);
             });
             it('should set trace headers', () => {
               // span at exportSpy.args[0][0][0] is the preflight span
@@ -2022,6 +1953,7 @@ describe('xhr', () => {
             });
           }
         );
+
         describe(
           'AND origin does NOT match window.location And does NOT match' +
             ' with propagateTraceHeaderCorsUrls',
@@ -2029,15 +1961,16 @@ describe('xhr', () => {
             let spyDebug: sinon.SinonSpy;
             beforeEach(done => {
               clearData();
+              const ghUrl =
+                'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/master/package.json';
               const diagLogger = new api.DiagConsoleLogger();
               spyDebug = sinon.spy();
               diagLogger.debug = spyDebug;
               api.diag.setLogger(diagLogger, api.DiagLogLevel.ALL);
-              prepareData(
-                done,
-                'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/master/package.json'
-              );
+              prepareData(ghUrl);
+              successfulPostRequest(ghUrl, done);
             });
+
             it('should NOT set trace headers', () => {
               assert.strictEqual(
                 requests[0].requestHeaders[X_B3_TRACE_ID],
@@ -2069,10 +2002,11 @@ describe('xhr', () => {
           beforeEach(done => {
             clearData();
             const propagateTraceHeaderCorsUrls = url;
-            prepareData(done, url, {
+            prepareData(url, {
               propagateTraceHeaderCorsUrls,
               ignoreUrls: [propagateTraceHeaderCorsUrls],
             });
+            successfulPostRequest(url, done);
           });
 
           it('should NOT create any span', () => {
@@ -2084,10 +2018,11 @@ describe('xhr', () => {
           beforeEach(done => {
             clearData();
             const propagateTraceHeaderCorsUrls = url;
-            prepareData(done, url, {
+            prepareData(url, {
               propagateTraceHeaderCorsUrls,
               clearTimingResources: true,
             });
+            successfulPostRequest(url, done);
           });
 
           it('should clear the resources', () => {
@@ -2105,65 +2040,19 @@ describe('xhr', () => {
           beforeEach(done => {
             clearData();
             const propagateTraceHeaderCorsUrls = [firstUrl, secondUrl];
-            prepareData(done, firstUrl, {
+            prepareData(firstUrl, {
               propagateTraceHeaderCorsUrls,
             });
+            const xhr = new XMLHttpRequest();
+            successfulPostRequest(
+              firstUrl,
+              () => successfulPostRequest(secondUrl, done),
+              xhr
+            );
           });
 
-          // beforeEach(done => {
-          //   requests = [];
-          //   const reusableReq = new XMLHttpRequest();
-          //   api.context.with(
-          //     api.trace.setSpan(api.context.active(), rootSpan),
-          //     () => {
-          //       void postData(
-          //         reusableReq,
-          //         firstUrl,
-          //         '{"embedded":"data"}',
-          //         () => {
-          //           fakeNow = 100;
-          //         },
-          //         testAsync
-          //       ).then(() => {
-          //         fakeNow = 0;
-          //         timer.tick(1000);
-          //       });
-          //     }
-          //   );
-
-          //   api.context.with(
-          //     api.trace.setSpan(api.context.active(), rootSpan),
-          //     () => {
-          //       void postData(
-          //         reusableReq,
-          //         secondUrl,
-          //         '{"embedded":"data"}',
-          //         () => {
-          //           fakeNow = 100;
-          //         },
-          //         testAsync
-          //       ).then(() => {
-          //         fakeNow = 0;
-          //         timer.tick(1000);
-          //         done();
-          //       });
-
-          //       assert.strictEqual(
-          //         requests.length,
-          //         1,
-          //         'first request not called'
-          //       );
-
-          //       requests[0].respond(
-          //         200,
-          //         { 'Content-Type': 'application/json' },
-          //         '{"foo":"bar"}'
-          //       );
-          //     }
-          //   );
-          // });
-
           it('should clear previous span information', () => {
+            // span at exportSpy.args[0][0][0] is the preflight span
             const span: tracing.ReadableSpan = exportSpy.args[2][0][0];
             const attributes = span.attributes;
             const keys = Object.keys(attributes);
@@ -2180,7 +2069,7 @@ describe('xhr', () => {
           beforeEach(done => {
             clearData();
             const propagateTraceHeaderCorsUrls = [url];
-            prepareData(done, url, {
+            prepareData(url, {
               propagateTraceHeaderCorsUrls,
               applyCustomAttributesOnSpan: function (
                 span: api.Span,
@@ -2190,9 +2079,11 @@ describe('xhr', () => {
                 span.setAttribute('xhr-custom-attribute', res.foo);
               },
             });
+            successfulPostRequest(url, done);
           });
 
           it('span should have custom attribute', () => {
+            // span at exportSpy.args[0][0][0] is the preflight span
             const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
             const attributes = span.attributes;
             assert.ok(attributes['xhr-custom-attribute'] === 'bar');
@@ -2203,7 +2094,8 @@ describe('xhr', () => {
           beforeEach(done => {
             clearData();
             const propagateTraceHeaderCorsUrls = [window.location.origin];
-            prepareData(done, '/get', { propagateTraceHeaderCorsUrls });
+            prepareData('/get', { propagateTraceHeaderCorsUrls });
+            successfulPostRequest('/get', done);
           });
 
           it('should create correct span with events', () => {
@@ -2257,87 +2149,13 @@ describe('xhr', () => {
         });
       });
 
-      describe.skip('when POST request is NOT successful', () => {
-        let webTracerWithZoneProvider: WebTracerProvider;
-        let webTracerWithZone: api.Tracer;
-        let dummySpanExporter: DummySpanExporter;
-        let exportSpy: any;
-        let rootSpan: api.Span;
-        let spyEntries: any;
+      describe('when POST request is NOT successful', () => {
         const url =
           'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/master/package.json';
-        let fakeNow = 0;
-
-        const clearData = () => {
-          sinon.restore();
-          timer = sinon.useFakeTimers();
-          requests = [];
-        };
-
-        const prepareData = function (
-          config: XMLHttpRequestInstrumentationConfig = {}
-        ) {
-          const fakeXhr = sinon.useFakeXMLHttpRequest();
-          fakeXhr.onCreate = function (xhr: any) {
-            requests.push(xhr);
-          };
-          // @ts-expect-error -- custom property
-          if (typeof XMLHttpRequest.prototype.send.__unwrap === 'function') {
-            // @ts-expect-error -- custom property
-            XMLHttpRequest.prototype.send.__unwrap();
-          }
-          // @ts-expect-error -- custom property
-          if (typeof XMLHttpRequest.prototype.open.__unwrap === 'function') {
-            // @ts-expect-error -- custom property
-            XMLHttpRequest.prototype.open.__unwrap();
-          }
-
-          sinon.stub(performance, 'timeOrigin').value(0);
-          sinon.stub(performance, 'now').callsFake(() => fakeNow);
-
-          const resources: PerformanceResourceTiming[] = [];
-          resources.push(
-            createResource({
-              name: url,
-            })
-          );
-
-          spyEntries = sinon.stub(
-            performance as unknown as Performance,
-            'getEntriesByType'
-          );
-          spyEntries.withArgs('resource').returns(resources);
-
-          dummySpanExporter = new DummySpanExporter();
-          webTracerWithZoneProvider = new WebTracerProvider({
-            spanProcessors: [
-              new tracing.SimpleSpanProcessor(dummySpanExporter),
-            ],
-          });
-
-          registerInstrumentations({
-            instrumentations: [
-              new XMLHttpRequestInstrumentation({
-                semconvStabilityOptIn: test.semconvStabilityOptIn,
-                ...config,
-              }),
-            ],
-            tracerProvider: webTracerWithZoneProvider,
-          });
-
-          exportSpy = sinon.stub(dummySpanExporter, 'export');
-
-          webTracerWithZone = webTracerWithZoneProvider.getTracer('xhr-test');
-
-          rootSpan = webTracerWithZone.startSpan('root');
-        };
 
         beforeEach(() => {
-          prepareData();
-        });
-
-        afterEach(() => {
           clearData();
+          prepareData(url);
         });
 
         function timedOutRequest(done: any) {
@@ -2436,8 +2254,9 @@ describe('xhr', () => {
           beforeEach(done => {
             erroredRequest(done);
           });
+
           it('span should have correct attributes', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
             const attributes = span.attributes;
 
             let expectedNumAttrs = 0;
@@ -2472,7 +2291,7 @@ describe('xhr', () => {
               ] as number;
               assert.strictEqual(
                 responseContentLength,
-                30,
+                60,
                 `attributes ${ATTR_HTTP_RESPONSE_CONTENT_LENGTH} <= 0`
               );
               assert.strictEqual(
@@ -2533,7 +2352,7 @@ describe('xhr', () => {
           });
 
           it('span should have correct events', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
             const events = span.events;
 
             testForCorrectEvents(events, [
@@ -2555,6 +2374,7 @@ describe('xhr', () => {
         });
 
         describe('when request encounters a network error', () => {
+          // this won't generate a preflight span
           beforeEach(done => {
             networkErrorRequest(done);
           });
@@ -2674,6 +2494,7 @@ describe('xhr', () => {
             }
           });
 
+          // this won't generate a preflight span
           beforeEach(done => {
             abortedRequest(done);
           });
@@ -2793,6 +2614,7 @@ describe('xhr', () => {
             }
           });
 
+          // this won't generate a preflight span
           beforeEach(done => {
             timedOutRequest(done);
           });
@@ -2909,7 +2731,7 @@ describe('xhr', () => {
           describe('AND request loads and receives an error code', () => {
             beforeEach(done => {
               clearData();
-              prepareData({
+              prepareData(url, {
                 applyCustomAttributesOnSpan: function (span, xhr) {
                   span.setAttribute('xhr-custom-error-code', xhr.status);
                 },
@@ -2918,7 +2740,7 @@ describe('xhr', () => {
             });
 
             it('span should have custom attribute', () => {
-              const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+              const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
               const attributes = span.attributes;
               assert.ok(attributes['xhr-custom-error-code'] === 400);
             });
@@ -2927,7 +2749,7 @@ describe('xhr', () => {
           describe('AND request encounters a network error', () => {
             beforeEach(done => {
               clearData();
-              prepareData({
+              prepareData(url, {
                 applyCustomAttributesOnSpan: function (span, xhr) {
                   span.setAttribute('xhr-custom-error-code', xhr.status);
                 },
@@ -2952,7 +2774,7 @@ describe('xhr', () => {
 
             beforeEach(done => {
               clearData();
-              prepareData({
+              prepareData(url, {
                 applyCustomAttributesOnSpan: function (span, xhr) {
                   span.setAttribute('xhr-custom-error-code', xhr.status);
                 },
@@ -2977,7 +2799,7 @@ describe('xhr', () => {
 
             beforeEach(done => {
               clearData();
-              prepareData({
+              prepareData(url, {
                 applyCustomAttributesOnSpan: function (span, xhr) {
                   span.setAttribute('xhr-custom-error-code', xhr.status);
                 },

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -360,7 +360,7 @@ describe('xhr', () => {
         api.propagation.disable();
       });
 
-      describe.only('when GET request is successful', () => {
+      describe('when GET request is successful', () => {
         const url = 'http://localhost:8090/xml-http-request.js';
         const secureUrl = 'https://localhost:8090/xml-http-request.js';
 
@@ -947,82 +947,12 @@ describe('xhr', () => {
       });
 
       describe('when GET request is NOT successful', () => {
-        let webTracerWithZoneProvider: WebTracerProvider;
-        let webTracerWithZone: api.Tracer;
-        let dummySpanExporter: DummySpanExporter;
-        let exportSpy: any;
-        let rootSpan: api.Span;
-        let spyEntries: any;
         const url =
           'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/master/package.json';
-        let fakeNow = 0;
-
-        const clearData = () => {
-          sinon.restore();
-          timer = sinon.useFakeTimers();
-          requests = [];
-        };
-
-        const prepareData = function (
-          config: XMLHttpRequestInstrumentationConfig = {}
-        ) {
-          const fakeXhr = sinon.useFakeXMLHttpRequest();
-          fakeXhr.onCreate = function (xhr: any) {
-            requests.push(xhr);
-          };
-          // @ts-expect-error -- custom property
-          if (typeof XMLHttpRequest.prototype.send.__unwrap === 'function') {
-            // @ts-expect-error -- custom property
-            XMLHttpRequest.prototype.send.__unwrap();
-          }
-          // @ts-expect-error -- custom property
-          if (typeof XMLHttpRequest.prototype.open.__unwrap === 'function') {
-            // @ts-expect-error -- custom property
-            XMLHttpRequest.prototype.open.__unwrap();
-          }
-
-          sinon.stub(performance, 'timeOrigin').value(0);
-          sinon.stub(performance, 'now').callsFake(() => fakeNow);
-
-          const resources: PerformanceResourceTiming[] = [];
-          resources.push(
-            createResource({
-              name: url,
-            })
-          );
-
-          spyEntries = sinon.stub(
-            performance as unknown as Performance,
-            'getEntriesByType'
-          );
-          spyEntries.withArgs('resource').returns(resources);
-
-          dummySpanExporter = new DummySpanExporter();
-          webTracerWithZoneProvider = new WebTracerProvider({
-            spanProcessors: [
-              new tracing.SimpleSpanProcessor(dummySpanExporter),
-            ],
-          });
-
-          registerInstrumentations({
-            instrumentations: [
-              new XMLHttpRequestInstrumentation({
-                semconvStabilityOptIn: test.semconvStabilityOptIn,
-                ...config,
-              }),
-            ],
-            tracerProvider: webTracerWithZoneProvider,
-          });
-
-          exportSpy = sinon.stub(dummySpanExporter, 'export');
-          webTracerWithZone = webTracerWithZoneProvider.getTracer('xhr-test');
-
-          rootSpan = webTracerWithZone.startSpan('root');
-        };
-
+        
         beforeEach(() => {
           clearData();
-          prepareData();
+          prepareData(url);
         });
 
         function timedOutRequest(done: any) {
@@ -1107,13 +1037,13 @@ describe('xhr', () => {
           );
         }
 
-        describe('when request loads and receives an error code', () => {
+        describe.only('when request loads and receives an error code', () => {
           beforeEach(done => {
             erroredRequest(done);
           });
 
           it('span should have correct attributes and status', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
             const attributes = span.attributes;
             let expectedNumAttrs = 0;
             const semconvStability = semconvStabilityFromStr(
@@ -1147,7 +1077,7 @@ describe('xhr', () => {
               ] as number;
               assert.strictEqual(
                 responseContentLength,
-                30,
+                60,
                 `attributes ${ATTR_HTTP_RESPONSE_CONTENT_LENGTH} <= 0`
               );
               assert.strictEqual(
@@ -1209,7 +1139,7 @@ describe('xhr', () => {
           });
 
           it('span should have correct events', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
             const events = span.events;
 
             testForCorrectEvents(events, [
@@ -1588,7 +1518,7 @@ describe('xhr', () => {
           describe('AND request loads and receives an error code', () => {
             beforeEach(done => {
               clearData();
-              prepareData({
+              prepareData(url, {
                 applyCustomAttributesOnSpan: function (span, xhr) {
                   span.setAttribute('xhr-custom-error-code', xhr.status);
                 },
@@ -1606,7 +1536,7 @@ describe('xhr', () => {
           describe('AND request encounters a network error', () => {
             beforeEach(done => {
               clearData();
-              prepareData({
+              prepareData(url, {
                 applyCustomAttributesOnSpan: function (span, xhr) {
                   span.setAttribute('xhr-custom-error-code', xhr.status);
                 },
@@ -1631,7 +1561,7 @@ describe('xhr', () => {
 
             beforeEach(done => {
               clearData();
-              prepareData({
+              prepareData(url, {
                 applyCustomAttributesOnSpan: function (span, xhr) {
                   span.setAttribute('xhr-custom-error-code', xhr.status);
                 },
@@ -1656,7 +1586,7 @@ describe('xhr', () => {
 
             beforeEach(done => {
               clearData();
-              prepareData({
+              prepareData(url, {
                 applyCustomAttributesOnSpan: function (span, xhr) {
                   span.setAttribute('xhr-custom-error-code', xhr.status);
                 },
@@ -1673,7 +1603,7 @@ describe('xhr', () => {
         });
       });
 
-      describe('when POST request is successful', () => {
+      describe.skip('when POST request is successful', () => {
         const url = 'http://localhost:8090/xml-http-request.js';
         const secureUrl = 'https://localhost:8090/xml-http-request.js';
         let fakeNow = 0;
@@ -2327,7 +2257,7 @@ describe('xhr', () => {
         });
       });
 
-      describe('when POST request is NOT successful', () => {
+      describe.skip('when POST request is NOT successful', () => {
         let webTracerWithZoneProvider: WebTracerProvider;
         let webTracerWithZone: api.Tracer;
         let dummySpanExporter: DummySpanExporter;

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -252,6 +252,22 @@ describe('xhr', () => {
     sinon.restore();
   });
 
+  describe('enable', () => {
+    it('should patch to wrap XML HTTP Requests when enabled', () => {
+      const xhttp = new XMLHttpRequest();
+      assert.ok(!isWrapped(xhttp.send), 'should not be wrapped');
+      // NOTE: constructor already calls `enable()`
+      // @ts-expect-error -- constructor already enables, no need to use the var
+      const xhrInstrumentation = new XMLHttpRequestInstrumentation();
+      const xhttp2 = new XMLHttpRequest();
+      assert.ok(isWrapped(xhttp2.send), 'should be wrapped');
+      // @ts-expect-error -- property added by instrumentation.wrap(...)
+      XMLHttpRequest.prototype.send.__unwrap();
+      // @ts-expect-error -- property added by instrumentation.wrap(...)
+      XMLHttpRequest.prototype.open.__unwrap();
+    });
+  });
+
   asyncTests.forEach(test => {
     const testAsync = test.async;
     describe(`when async='${testAsync}', semconvStabilityOptIn=${test.semconvStabilityOptIn}`, () => {
@@ -281,14 +297,12 @@ describe('xhr', () => {
         fakeXhr.onCreate = function (xhr: any) {
           requests.push(xhr);
         };
-        // @ts-expect-error - disable no longer unpatches
-        if (typeof XMLHttpRequest.prototype.send.__unwrap === 'function') {
-          // @ts-expect-error -- custom property
+        if (isWrapped(XMLHttpRequest.prototype.send)) {
+          // @ts-expect-error -- property added by instrumentation.wrap(...)
           XMLHttpRequest.prototype.send.__unwrap();
         }
-        // @ts-expect-error -- custom property
-        if (typeof XMLHttpRequest.prototype.open.__unwrap === 'function') {
-          // @ts-expect-error -- custom property
+        if (isWrapped(XMLHttpRequest.prototype.open)) {
+          // @ts-expect-error -- property added by instrumentation.wrap(...)
           XMLHttpRequest.prototype.open.__unwrap();
         }
 
@@ -400,13 +414,6 @@ describe('xhr', () => {
               measureRequestSize: true,
             });
             successfulGetRequest(url, done);
-          });
-
-          it('should patch to wrap XML HTTP Requests when enabled', () => {
-            const xhttp = new XMLHttpRequest();
-            assert.ok(isWrapped(xhttp.send));
-            xmlHttpRequestInstrumentation.enable();
-            assert.ok(isWrapped(xhttp.send));
           });
 
           it('should create a span with correct root span', () => {
@@ -1652,13 +1659,6 @@ describe('xhr', () => {
               measureRequestSize: true,
             });
             successfulPostRequest(url, done);
-          });
-
-          it('should patch to wrap XML HTTP Requests when enabled', () => {
-            const xhttp = new XMLHttpRequest();
-            assert.ok(isWrapped(xhttp.send));
-            xmlHttpRequestInstrumentation.enable();
-            assert.ok(isWrapped(xhttp.send));
           });
 
           it('should create a span with correct root span', () => {

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -798,7 +798,7 @@ describe('xhr', () => {
           beforeEach(done => {
             clearData();
             prepareData(firstUrl);
-            // Must create xhr after prepareData call because it craetes the instrumentation
+            // Must create xhr after prepareData call because it creates the instrumentation
             const xhr = new XMLHttpRequest();
             successfulGetRequest(
               firstUrl,
@@ -2043,6 +2043,7 @@ describe('xhr', () => {
             prepareData(firstUrl, {
               propagateTraceHeaderCorsUrls,
             });
+            // Must create xhr after prepareData call because it creates the instrumentation
             const xhr = new XMLHttpRequest();
             successfulPostRequest(
               firstUrl,

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -238,11 +238,11 @@ function testForCorrectEvents(
 describe('xhr', () => {
   const asyncTests = [
     { async: true, semconvStabilityOptIn: undefined },
-    // { async: true, semconvStabilityOptIn: 'http' },
-    // { async: true, semconvStabilityOptIn: 'http/dup' },
-    // { async: false, semconvStabilityOptIn: undefined },
-    // { async: false, semconvStabilityOptIn: 'http' },
-    // { async: false, semconvStabilityOptIn: 'http/dup' },
+    { async: true, semconvStabilityOptIn: 'http' },
+    { async: true, semconvStabilityOptIn: 'http/dup' },
+    { async: false, semconvStabilityOptIn: undefined },
+    { async: false, semconvStabilityOptIn: 'http' },
+    { async: false, semconvStabilityOptIn: 'http/dup' },
   ];
 
   let timer: sinon.SinonFakeTimers;
@@ -1037,7 +1037,7 @@ describe('xhr', () => {
           );
         }
 
-        describe.only('when request loads and receives an error code', () => {
+        describe('when request loads and receives an error code', () => {
           beforeEach(done => {
             erroredRequest(done);
           });
@@ -1527,7 +1527,7 @@ describe('xhr', () => {
             });
 
             it('span should have custom attribute', () => {
-              const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+              const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
               const attributes = span.attributes;
               assert.ok(attributes['xhr-custom-error-code'] === 400);
             });

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -281,7 +281,7 @@ describe('xhr', () => {
         fakeXhr.onCreate = function (xhr: any) {
           requests.push(xhr);
         };
-        // @ts-expect-error -- custom property
+        // @ts-expect-error - disable no longer unpatches
         if (typeof XMLHttpRequest.prototype.send.__unwrap === 'function') {
           // @ts-expect-error -- custom property
           XMLHttpRequest.prototype.send.__unwrap();

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -194,15 +194,18 @@ function createFakePerformanceObs(url: string) {
       const absoluteUrl = url.startsWith('http') ? url : location.origin + url;
       const resources: PerformanceObserverEntryList = {
         getEntries(): PerformanceEntryList {
+          console.log('getEntries', absoluteUrl);
           return [
             createResource({ name: absoluteUrl }) as any,
             createMainResource({ name: absoluteUrl }) as any,
           ];
         },
         getEntriesByName(): PerformanceEntryList {
+          console.log('getEntriesByName');
           return [];
         },
         getEntriesByType(): PerformanceEntryList {
+          console.log('getEntriesByType');
           return [];
         },
       };
@@ -235,7 +238,7 @@ function testForCorrectEvents(
 describe('xhr', () => {
   const asyncTests = [
     { async: true, semconvStabilityOptIn: undefined },
-    { async: true, semconvStabilityOptIn: 'http' },
+    // { async: true, semconvStabilityOptIn: 'http' },
     // { async: true, semconvStabilityOptIn: 'http/dup' },
     // { async: false, semconvStabilityOptIn: undefined },
     // { async: false, semconvStabilityOptIn: 'http' },
@@ -256,8 +259,87 @@ describe('xhr', () => {
     const testAsync = test.async;
     describe(`when async='${testAsync}', semconvStabilityOptIn=${test.semconvStabilityOptIn}`, () => {
       let requests: any[] = [];
-      // let clearData: any;
       let contextManager: ZoneContextManager;
+      let webTracerWithZone: api.Tracer;
+      let webTracerProviderWithZone: WebTracerProvider;
+      let dummySpanExporter: DummySpanExporter;
+      let spyEntries: any;
+      let fakeNow = 0;
+      let xmlHttpRequestInstrumentation: XMLHttpRequestInstrumentation;
+      let exportSpy: any;
+      let clearResourceTimingsSpy: any;
+      let rootSpan: api.Span;
+
+      const clearData = () => {
+        sinon.restore();
+        timer = sinon.useFakeTimers();
+        requests = [];
+      };
+
+      const prepareData = (
+        fileUrl: string,
+        config?: XMLHttpRequestInstrumentationConfig
+      ) => {
+        const fakeXhr = sinon.useFakeXMLHttpRequest();
+        fakeXhr.onCreate = function (xhr: any) {
+          requests.push(xhr);
+        };
+        // @ts-expect-error -- custom property
+        if (typeof XMLHttpRequest.prototype.send.__unwrap === 'function') {
+          // @ts-expect-error -- custom property
+          XMLHttpRequest.prototype.send.__unwrap();
+        }
+        // @ts-expect-error -- custom property
+        if (typeof XMLHttpRequest.prototype.open.__unwrap === 'function') {
+          // @ts-expect-error -- custom property
+          XMLHttpRequest.prototype.open.__unwrap();
+        }
+
+        sinon.stub(performance, 'timeOrigin').value(0);
+        sinon.stub(performance, 'now').callsFake(() => fakeNow);
+
+        const resources: PerformanceResourceTiming[] = [];
+        resources.push(
+          createResource({
+            name: fileUrl,
+          }),
+          createMainResource({
+            name: fileUrl,
+          })
+        );
+
+        spyEntries = sinon.stub(
+          performance as unknown as Performance,
+          'getEntriesByType'
+        );
+        spyEntries.withArgs('resource').returns(resources);
+
+        sinon
+          .stub(window, 'PerformanceObserver')
+          .value(createFakePerformanceObs(fileUrl));
+
+        xmlHttpRequestInstrumentation = new XMLHttpRequestInstrumentation({
+          semconvStabilityOptIn: test.semconvStabilityOptIn,
+          ...config,
+        });
+        dummySpanExporter = new DummySpanExporter();
+        webTracerProviderWithZone = new WebTracerProvider({
+          spanProcessors: [new tracing.SimpleSpanProcessor(dummySpanExporter)],
+        });
+        registerInstrumentations({
+          instrumentations: [xmlHttpRequestInstrumentation],
+          tracerProvider: webTracerProviderWithZone,
+        });
+        webTracerWithZone = webTracerProviderWithZone.getTracer('xhr-test');
+
+        exportSpy = sinon.stub(dummySpanExporter, 'export');
+        clearResourceTimingsSpy = sinon.stub(
+          performance as unknown as Performance,
+          'clearResourceTimings'
+        );
+
+        rootSpan = webTracerWithZone.startSpan('root');
+      };
 
       beforeEach(() => {
         contextManager = new ZoneContextManager().enable();
@@ -278,97 +360,21 @@ describe('xhr', () => {
         api.propagation.disable();
       });
 
-      describe('when GET request is successful', () => {
-        let webTracerWithZone: api.Tracer;
-        let webTracerProviderWithZone: WebTracerProvider;
-        let dummySpanExporter: DummySpanExporter;
-        let exportSpy: any;
-        let clearResourceTimingsSpy: any;
-        let rootSpan: api.Span;
-        let spyEntries: any;
+      describe.only('when GET request is successful', () => {
         const url = 'http://localhost:8090/xml-http-request.js';
         const secureUrl = 'https://localhost:8090/xml-http-request.js';
-        let fakeNow = 0;
-        let xmlHttpRequestInstrumentation: XMLHttpRequestInstrumentation;
 
-        const clearData = () => {
-          sinon.restore();
-          timer = sinon.useFakeTimers();
-          requests = [];
-        };
-
-        const prepareData = (
+        function successfulGetRequest(
+          url: string,
           done: any,
-          fileUrl: string,
-          config?: XMLHttpRequestInstrumentationConfig
-        ) => {
-          const fakeXhr = sinon.useFakeXMLHttpRequest();
-          fakeXhr.onCreate = function (xhr: any) {
-            requests.push(xhr);
-          };
-          // @ts-expect-error -- custom property
-          if (typeof XMLHttpRequest.prototype.send.__unwrap === 'function') {
-            // @ts-expect-error -- custom property
-            XMLHttpRequest.prototype.send.__unwrap();
-          }
-          // @ts-expect-error -- custom property
-          if (typeof XMLHttpRequest.prototype.open.__unwrap === 'function') {
-            // @ts-expect-error -- custom property
-            XMLHttpRequest.prototype.open.__unwrap();
-          }
-
-          sinon.stub(performance, 'timeOrigin').value(0);
-          sinon.stub(performance, 'now').callsFake(() => fakeNow);
-
-          const resources: PerformanceResourceTiming[] = [];
-          resources.push(
-            createResource({
-              name: fileUrl,
-            }),
-            createMainResource({
-              name: fileUrl,
-            })
-          );
-
-          spyEntries = sinon.stub(
-            performance as unknown as Performance,
-            'getEntriesByType'
-          );
-          spyEntries.withArgs('resource').returns(resources);
-
-          sinon
-            .stub(window, 'PerformanceObserver')
-            .value(createFakePerformanceObs(fileUrl));
-
-          xmlHttpRequestInstrumentation = new XMLHttpRequestInstrumentation({
-            semconvStabilityOptIn: test.semconvStabilityOptIn,
-            ...config,
-          });
-          dummySpanExporter = new DummySpanExporter();
-          webTracerProviderWithZone = new WebTracerProvider({
-            spanProcessors: [
-              new tracing.SimpleSpanProcessor(dummySpanExporter),
-            ],
-          });
-          registerInstrumentations({
-            instrumentations: [xmlHttpRequestInstrumentation],
-            tracerProvider: webTracerProviderWithZone,
-          });
-          webTracerWithZone = webTracerProviderWithZone.getTracer('xhr-test');
-
-          exportSpy = sinon.stub(dummySpanExporter, 'export');
-          clearResourceTimingsSpy = sinon.stub(
-            performance as unknown as Performance,
-            'clearResourceTimings'
-          );
-
-          rootSpan = webTracerWithZone.startSpan('root');
+          xhr = new XMLHttpRequest()
+        ) {
           api.context.with(
             api.trace.setSpan(api.context.active(), rootSpan),
             () => {
               void getData(
-                new XMLHttpRequest(),
-                fileUrl,
+                xhr,
+                url,
                 () => {
                   fakeNow = 100;
                 },
@@ -379,7 +385,6 @@ describe('xhr', () => {
                 done();
               });
               assert.strictEqual(requests.length, 1, 'request not called');
-
               requests[0].respond(
                 200,
                 { 'Content-Type': 'application/json' },
@@ -387,19 +392,17 @@ describe('xhr', () => {
               );
             }
           );
-        };
+        }
 
         describe('AND the spans are exported', () => {
           beforeEach(function (done) {
             const propagateTraceHeaderCorsUrls = [window.location.origin];
-            prepareData(done, url, {
+            clearData();
+            prepareData(url, {
               propagateTraceHeaderCorsUrls,
               measureRequestSize: true,
             });
-          });
-
-          afterEach(() => {
-            clearData();
+            successfulGetRequest(url, done);
           });
 
           it('should patch to wrap XML HTTP Requests when enabled', () => {
@@ -600,14 +603,17 @@ describe('xhr', () => {
             clearData();
             // this won't generate a preflight span
             const propagateTraceHeaderCorsUrls = [secureUrl];
-            prepareData(done, secureUrl, {
+            prepareData(secureUrl, {
               propagateTraceHeaderCorsUrls,
             });
+            successfulGetRequest(secureUrl, done);
           });
 
           it('span should have correct events', () => {
             const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
             const events = span.events;
+            console.log(events.map(e => e.name));
+
             testForCorrectEvents(events, [
               EventNames.METHOD_OPEN,
               EventNames.METHOD_SEND,
@@ -648,9 +654,10 @@ describe('xhr', () => {
             clearData();
             // this won't generate a preflight span
             const propagateTraceHeaderCorsUrls = [url];
-            prepareData(done, window.location.origin + '/xml-http-request.js', {
+            prepareData(window.location.origin + '/xml-http-request.js', {
               propagateTraceHeaderCorsUrls,
             });
+            successfulGetRequest(window.location.origin, done);
           });
 
           it('should set trace headers', () => {
@@ -684,12 +691,13 @@ describe('xhr', () => {
             ' propagateTraceHeaderCorsUrls',
           () => {
             beforeEach(done => {
+              const ghUrl =
+                'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/master/package.json';
               clearData();
-              prepareData(
-                done,
-                'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/master/package.json',
-                { propagateTraceHeaderCorsUrls: /raw\.githubusercontent\.com/ }
-              );
+              prepareData(ghUrl, {
+                propagateTraceHeaderCorsUrls: /raw\.githubusercontent\.com/,
+              });
+              successfulGetRequest(ghUrl, done);
             });
             it('should set trace headers', () => {
               // span at exportSpy.args[0][0][0] is the preflight span
@@ -712,6 +720,7 @@ describe('xhr', () => {
             });
           }
         );
+
         describe(
           'AND origin does NOT match window.location And does NOT match' +
             ' with propagateTraceHeaderCorsUrls',
@@ -719,15 +728,16 @@ describe('xhr', () => {
             let spyDebug: sinon.SinonSpy;
             beforeEach(done => {
               clearData();
+              const ghUrl =
+                'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/master/package.json';
               const diagLogger = new api.DiagConsoleLogger();
               spyDebug = sinon.spy();
               diagLogger.debug = spyDebug;
               api.diag.setLogger(diagLogger, api.DiagLogLevel.ALL);
-              prepareData(
-                done,
-                'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/master/package.json'
-              );
+              prepareData(ghUrl);
+              successfulGetRequest(ghUrl, done);
             });
+
             it('should NOT set trace headers', () => {
               assert.strictEqual(
                 requests[0].requestHeaders[X_B3_TRACE_ID],
@@ -759,10 +769,11 @@ describe('xhr', () => {
           beforeEach(done => {
             clearData();
             const propagateTraceHeaderCorsUrls = url;
-            prepareData(done, url, {
+            prepareData(url, {
               propagateTraceHeaderCorsUrls,
               ignoreUrls: [propagateTraceHeaderCorsUrls],
             });
+            successfulGetRequest(url, done);
           });
 
           it('should NOT create any span', () => {
@@ -774,10 +785,11 @@ describe('xhr', () => {
           beforeEach(done => {
             clearData();
             const propagateTraceHeaderCorsUrls = url;
-            prepareData(done, url, {
+            prepareData(url, {
               propagateTraceHeaderCorsUrls,
               clearTimingResources: true,
             });
+            successfulGetRequest(url, done);
           });
 
           it('should clear the resources', () => {
@@ -793,57 +805,18 @@ describe('xhr', () => {
           const secondUrl = 'http://localhost:8099/get';
 
           beforeEach(done => {
-            requests = [];
-            const reusableReq = new XMLHttpRequest();
-            api.context.with(
-              api.trace.setSpan(api.context.active(), rootSpan),
-              () => {
-                void getData(
-                  reusableReq,
-                  firstUrl,
-                  () => {
-                    fakeNow = 100;
-                  },
-                  testAsync
-                ).then(() => {
-                  fakeNow = 0;
-                  timer.tick(1000);
-                });
-              }
-            );
-
-            api.context.with(
-              api.trace.setSpan(api.context.active(), rootSpan),
-              () => {
-                void getData(
-                  reusableReq,
-                  secondUrl,
-                  () => {
-                    fakeNow = 100;
-                  },
-                  testAsync
-                ).then(() => {
-                  fakeNow = 0;
-                  timer.tick(1000);
-                  done();
-                });
-
-                assert.strictEqual(
-                  requests.length,
-                  1,
-                  'first request not called'
-                );
-
-                requests[0].respond(
-                  200,
-                  { 'Content-Type': 'application/json' },
-                  '{"foo":"bar"}'
-                );
-              }
+            clearData();
+            prepareData(firstUrl);
+            // Must create xhr after prepareData call because it craetes the instrumentation
+            const xhr = new XMLHttpRequest();
+            successfulGetRequest(
+              firstUrl,
+              () => successfulGetRequest(secondUrl, done, xhr),
+              xhr
             );
           });
 
-          it.only('should clear previous span information', () => {
+          it('should clear previous span information', () => {
             const span: tracing.ReadableSpan = exportSpy.args[2][0][0];
             const attributes = span.attributes;
             const keys = Object.keys(attributes);
@@ -860,16 +833,18 @@ describe('xhr', () => {
           beforeEach(done => {
             clearData();
             const propagateTraceHeaderCorsUrls = [url];
-            prepareData(done, url, {
+            prepareData(url, {
               propagateTraceHeaderCorsUrls,
               applyCustomAttributesOnSpan: function (
                 span: api.Span,
                 xhr: XMLHttpRequest
               ) {
+                console.log('applyCustomAttributesOnSpan');
                 const res = JSON.parse(xhr.response);
                 span.setAttribute('xhr-custom-attribute', res.foo);
               },
             });
+            successfulGetRequest(url, done);
           });
 
           it('span should have custom attribute', () => {
@@ -883,7 +858,8 @@ describe('xhr', () => {
           beforeEach(done => {
             clearData();
             const propagateTraceHeaderCorsUrls = [window.location.origin];
-            prepareData(done, '/get', { propagateTraceHeaderCorsUrls });
+            prepareData('/get', { propagateTraceHeaderCorsUrls });
+            successfulGetRequest('/get', done);
           });
 
           it('should create correct span with events', () => {
@@ -939,9 +915,8 @@ describe('xhr', () => {
         describe('when network events are ignored', () => {
           beforeEach(done => {
             clearData();
-            prepareData(done, url, {
-              ignoreNetworkEvents: true,
-            });
+            prepareData(url, { ignoreNetworkEvents: true });
+            successfulGetRequest(url, done);
           });
           it('should NOT add network events', () => {
             const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
@@ -1049,10 +1024,6 @@ describe('xhr', () => {
           clearData();
           prepareData();
         });
-
-        // afterEach(() => {
-        //   clearData();
-        // });
 
         function timedOutRequest(done: any) {
           api.context.with(
@@ -1703,13 +1674,6 @@ describe('xhr', () => {
       });
 
       describe('when POST request is successful', () => {
-        let webTracerWithZone: api.Tracer;
-        let webTracerProviderWithZone: WebTracerProvider;
-        let dummySpanExporter: DummySpanExporter;
-        let exportSpy: any;
-        let clearResourceTimingsSpy: any;
-        let rootSpan: api.Span;
-        let spyEntries: any;
         const url = 'http://localhost:8090/xml-http-request.js';
         const secureUrl = 'https://localhost:8090/xml-http-request.js';
         let fakeNow = 0;
@@ -2209,57 +2173,65 @@ describe('xhr', () => {
           const secondUrl = 'http://localhost:8099/get';
 
           beforeEach(done => {
-            requests = [];
-            const reusableReq = new XMLHttpRequest();
-            api.context.with(
-              api.trace.setSpan(api.context.active(), rootSpan),
-              () => {
-                void postData(
-                  reusableReq,
-                  firstUrl,
-                  '{"embedded":"data"}',
-                  () => {
-                    fakeNow = 100;
-                  },
-                  testAsync
-                ).then(() => {
-                  fakeNow = 0;
-                  timer.tick(1000);
-                });
-              }
-            );
-
-            api.context.with(
-              api.trace.setSpan(api.context.active(), rootSpan),
-              () => {
-                void postData(
-                  reusableReq,
-                  secondUrl,
-                  '{"embedded":"data"}',
-                  () => {
-                    fakeNow = 100;
-                  },
-                  testAsync
-                ).then(() => {
-                  fakeNow = 0;
-                  timer.tick(1000);
-                  done();
-                });
-
-                assert.strictEqual(
-                  requests.length,
-                  1,
-                  'first request not called'
-                );
-
-                requests[0].respond(
-                  200,
-                  { 'Content-Type': 'application/json' },
-                  '{"foo":"bar"}'
-                );
-              }
-            );
+            clearData();
+            const propagateTraceHeaderCorsUrls = [firstUrl, secondUrl];
+            prepareData(done, firstUrl, {
+              propagateTraceHeaderCorsUrls,
+            });
           });
+
+          // beforeEach(done => {
+          //   requests = [];
+          //   const reusableReq = new XMLHttpRequest();
+          //   api.context.with(
+          //     api.trace.setSpan(api.context.active(), rootSpan),
+          //     () => {
+          //       void postData(
+          //         reusableReq,
+          //         firstUrl,
+          //         '{"embedded":"data"}',
+          //         () => {
+          //           fakeNow = 100;
+          //         },
+          //         testAsync
+          //       ).then(() => {
+          //         fakeNow = 0;
+          //         timer.tick(1000);
+          //       });
+          //     }
+          //   );
+
+          //   api.context.with(
+          //     api.trace.setSpan(api.context.active(), rootSpan),
+          //     () => {
+          //       void postData(
+          //         reusableReq,
+          //         secondUrl,
+          //         '{"embedded":"data"}',
+          //         () => {
+          //           fakeNow = 100;
+          //         },
+          //         testAsync
+          //       ).then(() => {
+          //         fakeNow = 0;
+          //         timer.tick(1000);
+          //         done();
+          //       });
+
+          //       assert.strictEqual(
+          //         requests.length,
+          //         1,
+          //         'first request not called'
+          //       );
+
+          //       requests[0].respond(
+          //         200,
+          //         { 'Content-Type': 'application/json' },
+          //         '{"foo":"bar"}'
+          //       );
+          //     }
+          //   );
+          // });
 
           it('should clear previous span information', () => {
             const span: tracing.ReadableSpan = exportSpy.args[2][0][0];

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -775,10 +775,11 @@ describe('xhr', () => {
         describe('when relative url is ignored via domain regex', () => {
           beforeEach(done => {
             clearData();
-            prepareData(done, '/xml-http-request.js', {
+            prepareData('/xml-http-request.js', {
               propagateTraceHeaderCorsUrls: [/.*/],
               ignoreUrls: [/.*localhost.*/],
             });
+            successfulGetRequest('/xml-http-request.js', done);
           });
 
           it('should NOT create any span', () => {

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -253,18 +253,58 @@ describe('xhr', () => {
   });
 
   describe('enable', () => {
-    it('should patch to wrap XML HTTP Requests when enabled', () => {
-      const xhttp = new XMLHttpRequest();
-      assert.ok(!isWrapped(xhttp.send), 'should not be wrapped');
-      // NOTE: constructor already calls `enable()`
-      // @ts-expect-error -- constructor already enables, no need to use the var
-      const xhrInstrumentation = new XMLHttpRequestInstrumentation();
-      const xhttp2 = new XMLHttpRequest();
-      assert.ok(isWrapped(xhttp2.send), 'should be wrapped');
-      // @ts-expect-error -- property added by instrumentation.wrap(...)
-      XMLHttpRequest.prototype.send.__unwrap();
-      // @ts-expect-error -- property added by instrumentation.wrap(...)
-      XMLHttpRequest.prototype.open.__unwrap();
+    let xhrInstrumentation: XMLHttpRequestInstrumentation;
+
+    describe('when XMLHttpRequest prototype methods can not be wrapped', () => {
+      // Simulate the production failure mode (third-party scripts locking
+      // `XMLHttpRequest.prototype.open` and `XMLHttpRequest.prototype.send`
+      // via `Object.defineProperty` with `writable: false,
+      // configurable: false`).
+      const wrapError = new TypeError(
+        "Cannot assign to read only property 'open' of object '[object XMLHttpRequest]'"
+      );
+
+      beforeEach(() => {
+        // Construct with `enabled: false` so the stub is in place before
+        // `enable()` runs — `_wrap` is an instance-level field inherited
+        // from `InstrumentationBase`, not a prototype method.
+        xhrInstrumentation = new XMLHttpRequestInstrumentation({
+          enabled: false,
+        });
+        // @ts-expect-error access internal property for testing
+        sinon.stub(xhrInstrumentation, '_wrap').throws(wrapError);
+      });
+
+      it('should not throw when _wrap fails', () => {
+        assert.doesNotThrow(() => xhrInstrumentation!.enable());
+      });
+
+      it('should leave open/send unwrapped when _wrap fails', () => {
+        xhrInstrumentation!.enable();
+        assert.ok(!isWrapped(globalThis.XMLHttpRequest.prototype.open));
+        assert.ok(!isWrapped(globalThis.XMLHttpRequest.prototype.send));
+      });
+
+      it('should allow enable() to be retried after _wrap fails', () => {
+        xhrInstrumentation!.enable();
+        assert.doesNotThrow(() => xhrInstrumentation!.enable());
+      });
+    });
+
+    describe('when XMLHttpRequest prototype methods can be wrapped', () => {
+      it('should patch to wrap XML HTTP Requests when enabled', () => {
+        const xhttp = new XMLHttpRequest();
+        assert.ok(!isWrapped(xhttp.send), 'should not be wrapped');
+        // NOTE: constructor already calls `enable()`
+        xhrInstrumentation = new XMLHttpRequestInstrumentation();
+        const xhttp2 = new XMLHttpRequest();
+        assert.ok(isWrapped(xhttp2.open), 'open method should be wrapped');
+        assert.ok(isWrapped(xhttp2.send), 'send method should be wrapped');
+        // @ts-expect-error -- property added by instrumentation.wrap(...)
+        XMLHttpRequest.prototype.send.__unwrap();
+        // @ts-expect-error -- property added by instrumentation.wrap(...)
+        XMLHttpRequest.prototype.open.__unwrap();
+      });
     });
   });
 

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -236,10 +236,10 @@ describe('xhr', () => {
   const asyncTests = [
     { async: true, semconvStabilityOptIn: undefined },
     { async: true, semconvStabilityOptIn: 'http' },
-    { async: true, semconvStabilityOptIn: 'http/dup' },
-    { async: false, semconvStabilityOptIn: undefined },
-    { async: false, semconvStabilityOptIn: 'http' },
-    { async: false, semconvStabilityOptIn: 'http/dup' },
+    // { async: true, semconvStabilityOptIn: 'http/dup' },
+    // { async: false, semconvStabilityOptIn: undefined },
+    // { async: false, semconvStabilityOptIn: 'http' },
+    // { async: false, semconvStabilityOptIn: 'http/dup' },
   ];
 
   let timer: sinon.SinonFakeTimers;
@@ -256,7 +256,7 @@ describe('xhr', () => {
     const testAsync = test.async;
     describe(`when async='${testAsync}', semconvStabilityOptIn=${test.semconvStabilityOptIn}`, () => {
       let requests: any[] = [];
-      let clearData: any;
+      // let clearData: any;
       let contextManager: ZoneContextManager;
 
       beforeEach(() => {
@@ -291,7 +291,7 @@ describe('xhr', () => {
         let fakeNow = 0;
         let xmlHttpRequestInstrumentation: XMLHttpRequestInstrumentation;
 
-        clearData = () => {
+        const clearData = () => {
           sinon.restore();
           timer = sinon.useFakeTimers();
           requests = [];
@@ -306,6 +306,16 @@ describe('xhr', () => {
           fakeXhr.onCreate = function (xhr: any) {
             requests.push(xhr);
           };
+          // @ts-expect-error -- custom property
+          if (typeof XMLHttpRequest.prototype.send.__unwrap === 'function') {
+            // @ts-expect-error -- custom property
+            XMLHttpRequest.prototype.send.__unwrap();
+          }
+          // @ts-expect-error -- custom property
+          if (typeof XMLHttpRequest.prototype.open.__unwrap === 'function') {
+            // @ts-expect-error -- custom property
+            XMLHttpRequest.prototype.open.__unwrap();
+          }
 
           sinon.stub(performance, 'timeOrigin').value(0);
           sinon.stub(performance, 'now').callsFake(() => fakeNow);
@@ -379,213 +389,212 @@ describe('xhr', () => {
           );
         };
 
-        beforeEach(function (done) {
-          const propagateTraceHeaderCorsUrls = [window.location.origin];
-          prepareData(done, url, {
-            propagateTraceHeaderCorsUrls,
-            measureRequestSize: true,
+        describe('AND the spans are exported', () => {
+          beforeEach(function (done) {
+            const propagateTraceHeaderCorsUrls = [window.location.origin];
+            prepareData(done, url, {
+              propagateTraceHeaderCorsUrls,
+              measureRequestSize: true,
+            });
+          });
+
+          afterEach(() => {
+            clearData();
+          });
+
+          it('should patch to wrap XML HTTP Requests when enabled', () => {
+            const xhttp = new XMLHttpRequest();
+            assert.ok(isWrapped(xhttp.send));
+            xmlHttpRequestInstrumentation.enable();
+            assert.ok(isWrapped(xhttp.send));
+          });
+
+          it('should create a span with correct root span', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            assert.strictEqual(
+              span.parentSpanContext?.spanId,
+              rootSpan.spanContext().spanId,
+              'parent span is not root span'
+            );
+          });
+
+          it('span should have correct name', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            assert.strictEqual(span.name, 'GET', 'span has wrong name');
+          });
+
+          it('span should have correct kind', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            assert.strictEqual(
+              span.kind,
+              api.SpanKind.CLIENT,
+              'span has wrong kind'
+            );
+          });
+
+          it('span should have correct attributes', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const attributes = span.attributes;
+            let expectedNumAttrs = 0;
+            const semconvStability = semconvStabilityFromStr(
+              'http',
+              test.semconvStabilityOptIn
+            );
+
+            if (semconvStability & SemconvStability.OLD) {
+              expectedNumAttrs += 8;
+
+              assert.strictEqual(
+                attributes[ATTR_HTTP_METHOD],
+                'GET',
+                `attributes ${ATTR_HTTP_METHOD} is wrong`
+              );
+              assert.strictEqual(
+                attributes[ATTR_HTTP_URL],
+                url,
+                `attributes ${ATTR_HTTP_URL} is wrong`
+              );
+              const requestContentLength = attributes[
+                ATTR_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED
+              ] as number;
+              assert.strictEqual(
+                requestContentLength,
+                undefined,
+                `attributes ${ATTR_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED} is defined`
+              );
+              const responseContentLength = attributes[
+                ATTR_HTTP_RESPONSE_CONTENT_LENGTH
+              ] as number;
+              assert.strictEqual(
+                responseContentLength,
+                60,
+                `attributes ${ATTR_HTTP_RESPONSE_CONTENT_LENGTH} <= 0`
+              );
+              assert.strictEqual(
+                attributes[ATTR_HTTP_STATUS_CODE],
+                200,
+                `attributes ${ATTR_HTTP_STATUS_CODE} is wrong`
+              );
+              assert.strictEqual(
+                attributes[AttributeNames.HTTP_STATUS_TEXT],
+                'OK',
+                `attributes ${AttributeNames.HTTP_STATUS_TEXT} is wrong`
+              );
+              assert.strictEqual(
+                attributes[ATTR_HTTP_HOST],
+                parseUrl(url).host,
+                `attributes ${ATTR_HTTP_HOST} is wrong`
+              );
+
+              const httpScheme = attributes[ATTR_HTTP_SCHEME];
+              assert.ok(
+                httpScheme === 'http' || httpScheme === 'https',
+                `attributes ${ATTR_HTTP_SCHEME} is wrong`
+              );
+              assert.notStrictEqual(
+                attributes[ATTR_HTTP_USER_AGENT],
+                '',
+                `attributes ${ATTR_HTTP_USER_AGENT} is not defined`
+              );
+            }
+
+            if (semconvStability & SemconvStability.STABLE) {
+              expectedNumAttrs += 5;
+
+              assert.strictEqual(attributes[ATTR_HTTP_REQUEST_METHOD], 'GET');
+              assert.strictEqual(attributes[ATTR_URL_FULL], url);
+              assert.strictEqual(
+                attributes[ATTR_HTTP_RESPONSE_STATUS_CODE],
+                200
+              );
+              assert.strictEqual(
+                attributes[ATTR_SERVER_ADDRESS],
+                parseUrl(url).hostname
+              );
+              assert.strictEqual(
+                attributes[ATTR_SERVER_PORT],
+                Number(parseUrl(url).port)
+              );
+            }
+
+            assert.strictEqual(
+              Object.keys(attributes).length,
+              expectedNumAttrs,
+              'number of attributes is wrong'
+            );
+          });
+
+          it('span should have correct events', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const events = span.events;
+            testForCorrectEvents(events, [
+              EventNames.METHOD_OPEN,
+              EventNames.METHOD_SEND,
+              PTN.FETCH_START,
+              PTN.DOMAIN_LOOKUP_START,
+              PTN.DOMAIN_LOOKUP_END,
+              PTN.CONNECT_START,
+              PTN.CONNECT_END,
+              PTN.REQUEST_START,
+              PTN.RESPONSE_START,
+              PTN.RESPONSE_END,
+              EventNames.EVENT_LOAD,
+            ]);
+            assert.strictEqual(events.length, 11, 'number of events is wrong');
+          });
+
+          it('should create a span for preflight request', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+            const parentSpan: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            assert.strictEqual(
+              span.parentSpanContext?.spanId,
+              parentSpan.spanContext().spanId,
+              'parent span is not root span'
+            );
+          });
+
+          it('preflight request span should have correct name', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+            assert.strictEqual(
+              span.name,
+              'CORS Preflight',
+              'preflight request span has wrong name'
+            );
+          });
+
+          it('preflight request span should have correct kind', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+            assert.strictEqual(
+              span.kind,
+              api.SpanKind.INTERNAL,
+              'span has wrong kind'
+            );
+          });
+
+          it('preflight request span should have correct events', () => {
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
+            const events = span.events;
+            assert.strictEqual(events.length, 8, 'number of events is wrong');
+            testForCorrectEvents(events, [
+              PTN.FETCH_START,
+              PTN.DOMAIN_LOOKUP_START,
+              PTN.DOMAIN_LOOKUP_END,
+              PTN.CONNECT_START,
+              PTN.CONNECT_END,
+              PTN.REQUEST_START,
+              PTN.RESPONSE_START,
+              PTN.RESPONSE_END,
+            ]);
+          });
+
+          it('should NOT clear the resources', () => {
+            assert.ok(
+              clearResourceTimingsSpy.notCalled,
+              'resources have been cleared'
+            );
           });
         });
 
-        afterEach(() => {
-          clearData();
-        });
-
-        it('should patch to wrap XML HTTP Requests when enabled', () => {
-          const xhttp = new XMLHttpRequest();
-          assert.ok(isWrapped(xhttp.send));
-          xmlHttpRequestInstrumentation.enable();
-          assert.ok(isWrapped(xhttp.send));
-        });
-
-        it('should unpatch to unwrap XML HTTP Requests when disabled', () => {
-          const xhttp = new XMLHttpRequest();
-          assert.ok(isWrapped(xhttp.send));
-          xmlHttpRequestInstrumentation.disable();
-          assert.ok(!isWrapped(xhttp.send));
-        });
-
-        it('should create a span with correct root span', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
-          assert.strictEqual(
-            span.parentSpanContext?.spanId,
-            rootSpan.spanContext().spanId,
-            'parent span is not root span'
-          );
-        });
-
-        it('span should have correct name', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
-          assert.strictEqual(span.name, 'GET', 'span has wrong name');
-        });
-
-        it('span should have correct kind', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
-          assert.strictEqual(
-            span.kind,
-            api.SpanKind.CLIENT,
-            'span has wrong kind'
-          );
-        });
-
-        it('span should have correct attributes', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
-          const attributes = span.attributes;
-          let expectedNumAttrs = 0;
-          const semconvStability = semconvStabilityFromStr(
-            'http',
-            test.semconvStabilityOptIn
-          );
-
-          if (semconvStability & SemconvStability.OLD) {
-            expectedNumAttrs += 8;
-
-            assert.strictEqual(
-              attributes[ATTR_HTTP_METHOD],
-              'GET',
-              `attributes ${ATTR_HTTP_METHOD} is wrong`
-            );
-            assert.strictEqual(
-              attributes[ATTR_HTTP_URL],
-              url,
-              `attributes ${ATTR_HTTP_URL} is wrong`
-            );
-            const requestContentLength = attributes[
-              ATTR_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED
-            ] as number;
-            assert.strictEqual(
-              requestContentLength,
-              undefined,
-              `attributes ${ATTR_HTTP_REQUEST_CONTENT_LENGTH_UNCOMPRESSED} is defined`
-            );
-            const responseContentLength = attributes[
-              ATTR_HTTP_RESPONSE_CONTENT_LENGTH
-            ] as number;
-            assert.strictEqual(
-              responseContentLength,
-              60,
-              `attributes ${ATTR_HTTP_RESPONSE_CONTENT_LENGTH} <= 0`
-            );
-            assert.strictEqual(
-              attributes[ATTR_HTTP_STATUS_CODE],
-              200,
-              `attributes ${ATTR_HTTP_STATUS_CODE} is wrong`
-            );
-            assert.strictEqual(
-              attributes[AttributeNames.HTTP_STATUS_TEXT],
-              'OK',
-              `attributes ${AttributeNames.HTTP_STATUS_TEXT} is wrong`
-            );
-            assert.strictEqual(
-              attributes[ATTR_HTTP_HOST],
-              parseUrl(url).host,
-              `attributes ${ATTR_HTTP_HOST} is wrong`
-            );
-
-            const httpScheme = attributes[ATTR_HTTP_SCHEME];
-            assert.ok(
-              httpScheme === 'http' || httpScheme === 'https',
-              `attributes ${ATTR_HTTP_SCHEME} is wrong`
-            );
-            assert.notStrictEqual(
-              attributes[ATTR_HTTP_USER_AGENT],
-              '',
-              `attributes ${ATTR_HTTP_USER_AGENT} is not defined`
-            );
-          }
-
-          if (semconvStability & SemconvStability.STABLE) {
-            expectedNumAttrs += 5;
-
-            assert.strictEqual(attributes[ATTR_HTTP_REQUEST_METHOD], 'GET');
-            assert.strictEqual(attributes[ATTR_URL_FULL], url);
-            assert.strictEqual(attributes[ATTR_HTTP_RESPONSE_STATUS_CODE], 200);
-            assert.strictEqual(
-              attributes[ATTR_SERVER_ADDRESS],
-              parseUrl(url).hostname
-            );
-            assert.strictEqual(
-              attributes[ATTR_SERVER_PORT],
-              Number(parseUrl(url).port)
-            );
-          }
-
-          assert.strictEqual(
-            Object.keys(attributes).length,
-            expectedNumAttrs,
-            'number of attributes is wrong'
-          );
-        });
-
-        it('span should have correct events', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
-          const events = span.events;
-          testForCorrectEvents(events, [
-            EventNames.METHOD_OPEN,
-            EventNames.METHOD_SEND,
-            PTN.FETCH_START,
-            PTN.DOMAIN_LOOKUP_START,
-            PTN.DOMAIN_LOOKUP_END,
-            PTN.CONNECT_START,
-            PTN.CONNECT_END,
-            PTN.REQUEST_START,
-            PTN.RESPONSE_START,
-            PTN.RESPONSE_END,
-            EventNames.EVENT_LOAD,
-          ]);
-          assert.strictEqual(events.length, 11, 'number of events is wrong');
-        });
-
-        it('should create a span for preflight request', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-          const parentSpan: tracing.ReadableSpan = exportSpy.args[1][0][0];
-          assert.strictEqual(
-            span.parentSpanContext?.spanId,
-            parentSpan.spanContext().spanId,
-            'parent span is not root span'
-          );
-        });
-
-        it('preflight request span should have correct name', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-          assert.strictEqual(
-            span.name,
-            'CORS Preflight',
-            'preflight request span has wrong name'
-          );
-        });
-
-        it('preflight request span should have correct kind', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-          assert.strictEqual(
-            span.kind,
-            api.SpanKind.INTERNAL,
-            'span has wrong kind'
-          );
-        });
-
-        it('preflight request span should have correct events', () => {
-          const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-          const events = span.events;
-          assert.strictEqual(events.length, 8, 'number of events is wrong');
-          testForCorrectEvents(events, [
-            PTN.FETCH_START,
-            PTN.DOMAIN_LOOKUP_START,
-            PTN.DOMAIN_LOOKUP_END,
-            PTN.CONNECT_START,
-            PTN.CONNECT_END,
-            PTN.REQUEST_START,
-            PTN.RESPONSE_START,
-            PTN.RESPONSE_END,
-          ]);
-        });
-
-        it('should NOT clear the resources', () => {
-          assert.ok(
-            clearResourceTimingsSpy.notCalled,
-            'resources have been cleared'
-          );
-        });
         describe('When making https requests', () => {
           beforeEach(done => {
             clearData();
@@ -646,6 +655,12 @@ describe('xhr', () => {
 
           it('should set trace headers', () => {
             const span: api.Span = exportSpy.args[0][0][0];
+            console.log(
+              span.spanContext().traceId,
+              '===',
+              requests[0].requestHeaders[X_B3_TRACE_ID]
+            );
+
             assert.strictEqual(
               requests[0].requestHeaders[X_B3_TRACE_ID],
               span.spanContext().traceId,
@@ -828,7 +843,7 @@ describe('xhr', () => {
             );
           });
 
-          it('should clear previous span information', () => {
+          it.only('should clear previous span information', () => {
             const span: tracing.ReadableSpan = exportSpy.args[2][0][0];
             const attributes = span.attributes;
             const keys = Object.keys(attributes);
@@ -967,6 +982,12 @@ describe('xhr', () => {
           'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/master/package.json';
         let fakeNow = 0;
 
+        const clearData = () => {
+          sinon.restore();
+          timer = sinon.useFakeTimers();
+          requests = [];
+        };
+
         const prepareData = function (
           config: XMLHttpRequestInstrumentationConfig = {}
         ) {
@@ -974,6 +995,16 @@ describe('xhr', () => {
           fakeXhr.onCreate = function (xhr: any) {
             requests.push(xhr);
           };
+          // @ts-expect-error -- custom property
+          if (typeof XMLHttpRequest.prototype.send.__unwrap === 'function') {
+            // @ts-expect-error -- custom property
+            XMLHttpRequest.prototype.send.__unwrap();
+          }
+          // @ts-expect-error -- custom property
+          if (typeof XMLHttpRequest.prototype.open.__unwrap === 'function') {
+            // @ts-expect-error -- custom property
+            XMLHttpRequest.prototype.open.__unwrap();
+          }
 
           sinon.stub(performance, 'timeOrigin').value(0);
           sinon.stub(performance, 'now').callsFake(() => fakeNow);
@@ -1015,12 +1046,13 @@ describe('xhr', () => {
         };
 
         beforeEach(() => {
+          clearData();
           prepareData();
         });
 
-        afterEach(() => {
-          clearData();
-        });
+        // afterEach(() => {
+        //   clearData();
+        // });
 
         function timedOutRequest(done: any) {
           api.context.with(
@@ -1683,7 +1715,7 @@ describe('xhr', () => {
         let fakeNow = 0;
         let xmlHttpRequestInstrumentation: XMLHttpRequestInstrumentation;
 
-        clearData = () => {
+        const clearData = () => {
           sinon.restore();
           timer = sinon.useFakeTimers();
           requests = [];
@@ -1698,6 +1730,16 @@ describe('xhr', () => {
           fakeXhr.onCreate = function (xhr: any) {
             requests.push(xhr);
           };
+          // @ts-expect-error -- custom property
+          if (typeof XMLHttpRequest.prototype.send.__unwrap === 'function') {
+            // @ts-expect-error -- custom property
+            XMLHttpRequest.prototype.send.__unwrap();
+          }
+          // @ts-expect-error -- custom property
+          if (typeof XMLHttpRequest.prototype.open.__unwrap === 'function') {
+            // @ts-expect-error -- custom property
+            XMLHttpRequest.prototype.open.__unwrap();
+          }
 
           sinon.stub(performance, 'timeOrigin').value(0);
           sinon.stub(performance, 'now').callsFake(() => fakeNow);
@@ -1789,13 +1831,6 @@ describe('xhr', () => {
           assert.ok(isWrapped(xhttp.send));
           xmlHttpRequestInstrumentation.enable();
           assert.ok(isWrapped(xhttp.send));
-        });
-
-        it('should unpatch to unwrap XML HTTP Requests when disabled', () => {
-          const xhttp = new XMLHttpRequest();
-          assert.ok(isWrapped(xhttp.send));
-          xmlHttpRequestInstrumentation.disable();
-          assert.ok(!isWrapped(xhttp.send));
         });
 
         it('should create a span with correct root span', () => {
@@ -2331,6 +2366,12 @@ describe('xhr', () => {
           'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/master/package.json';
         let fakeNow = 0;
 
+        const clearData = () => {
+          sinon.restore();
+          timer = sinon.useFakeTimers();
+          requests = [];
+        };
+
         const prepareData = function (
           config: XMLHttpRequestInstrumentationConfig = {}
         ) {
@@ -2338,6 +2379,16 @@ describe('xhr', () => {
           fakeXhr.onCreate = function (xhr: any) {
             requests.push(xhr);
           };
+          // @ts-expect-error -- custom property
+          if (typeof XMLHttpRequest.prototype.send.__unwrap === 'function') {
+            // @ts-expect-error -- custom property
+            XMLHttpRequest.prototype.send.__unwrap();
+          }
+          // @ts-expect-error -- custom property
+          if (typeof XMLHttpRequest.prototype.open.__unwrap === 'function') {
+            // @ts-expect-error -- custom property
+            XMLHttpRequest.prototype.open.__unwrap();
+          }
 
           sinon.stub(performance, 'timeOrigin').value(0);
           sinon.stub(performance, 'now').callsFake(() => fakeNow);

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -445,7 +445,20 @@ describe('xhr', () => {
           );
         }
 
-        describe('AND the spans are exported', () => {
+        describe('AND instrumentation is disabled', () => {
+          beforeEach(function (done) {
+            clearData();
+            prepareData(url);
+            xmlHttpRequestInstrumentation!.disable();
+            successfulGetRequest(url, done);
+          });
+
+          it('should not export spans', () => {
+            assert.equal(exportSpy.args.length, 0, 'no spans are exported');
+          });
+        });
+
+        describe('when making http requests', () => {
           beforeEach(function (done) {
             const propagateTraceHeaderCorsUrls = [window.location.origin];
             clearData();
@@ -642,7 +655,7 @@ describe('xhr', () => {
           });
         });
 
-        describe('When making https requests', () => {
+        describe('when making https requests', () => {
           beforeEach(done => {
             clearData();
             // this won't generate a preflight span
@@ -881,7 +894,7 @@ describe('xhr', () => {
           });
         });
 
-        describe('and applyCustomAttributesOnSpan hook is configured', () => {
+        describe('AND applyCustomAttributesOnSpan hook is configured', () => {
           beforeEach(done => {
             clearData();
             const propagateTraceHeaderCorsUrls = [url];
@@ -1690,7 +1703,20 @@ describe('xhr', () => {
           );
         }
 
-        describe('When making http requests', () => {
+        describe('AND instrumentation is disabled', () => {
+          beforeEach(function (done) {
+            clearData();
+            prepareData(url);
+            xmlHttpRequestInstrumentation!.disable();
+            successfulPostRequest(url, done);
+          });
+
+          it('should not export spans', () => {
+            assert.equal(exportSpy.args.length, 0, 'no spans are exported');
+          });
+        });
+
+        describe('when making http requests', () => {
           beforeEach(done => {
             clearData();
             const propagateTraceHeaderCorsUrls = [window.location.origin];


### PR DESCRIPTION
## Which problem is this PR solving?

removes the unpatch logic of XHR api in `@opentelemetry/instrumentation-xml-http-request` to avoid breaking other instrumentations that might patch the same API.

Refs: https://github.com/open-telemetry/opentelemetry-browser/issues/204

## Short description of the changes

- XHR instrumentation patched only once the API
- added `_isEnabled` flag to create Spans only when it has to
- 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran unit tests

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been added
