### PR TITLE
fix(opentelemetry-exporter-prometheus)!: apply ratio suffix to gauges when necessary

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -11,7 +11,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * feat(sdk-logs)!: add required `forceFlush()` to `LogRecordExporter` interface [#6356](https://github.com/open-telemetry/opentelemetry-js/pull/6356) @pichlermarc
   * (user-facing): `LogRecordExporter` interface now requires a `forceFlush()` method to be implemented. Custom exporters will need to implement this method to continue working with the Logs SDK.
 * feat(api-logs, sdk-logs)!: add Logger#enabled() [#6371](https://github.com/open-telemetry/opentelemetry-js/pull/6371) @david-luna
-* fix(opentelemetry-exporter-prometheus)!: apply ratio suffix to gauges when necessary [#xxxx](https://github.com/open-telemetry/opentelemetry-js/pull/xxxx) @cjihrig
+* fix(opentelemetry-exporter-prometheus)!: apply ratio suffix to gauges when necessary [#6613](https://github.com/open-telemetry/opentelemetry-js/pull/6613) @cjihrig
 
 ### :rocket: Features
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -11,6 +11,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * feat(sdk-logs)!: add required `forceFlush()` to `LogRecordExporter` interface [#6356](https://github.com/open-telemetry/opentelemetry-js/pull/6356) @pichlermarc
   * (user-facing): `LogRecordExporter` interface now requires a `forceFlush()` method to be implemented. Custom exporters will need to implement this method to continue working with the Logs SDK.
 * feat(api-logs, sdk-logs)!: add Logger#enabled() [#6371](https://github.com/open-telemetry/opentelemetry-js/pull/6371) @david-luna
+* fix(opentelemetry-exporter-prometheus)!: apply ratio suffix to gauges when necessary [#xxxx](https://github.com/open-telemetry/opentelemetry-js/pull/xxxx) @cjihrig
 
 ### :rocket: Features
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -89,11 +89,19 @@ function enforcePrometheusNamingConvention(
   name: string,
   data: MetricData
 ): string {
+  if (
+    data.dataPointType === DataPointType.GAUGE &&
+    data.descriptor.unit === '1' &&
+    !name.endsWith('_ratio')
+  ) {
+    name += '_ratio';
+  }
+
   // Prometheus requires that metrics of the Counter kind have "_total" suffix
   if (
-    !name.endsWith('_total') &&
     data.dataPointType === DataPointType.SUM &&
-    data.isMonotonic
+    data.isMonotonic &&
+    !name.endsWith('_total')
   ) {
     name = name + '_total';
   }

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -662,6 +662,46 @@ describe('PrometheusSerializer', () => {
 
       assert.strictEqual(result, 'test_total 1\n');
     });
+
+    it('gauges should rename metric of type counter when name misses _total suffix', async () => {
+      const serializer = new PrometheusSerializer();
+      const reader = new TestMetricReader();
+      const meterProvider = new MeterProvider({
+        views: [
+          {
+            aggregation: {
+              type: AggregationType.LAST_VALUE,
+            },
+            instrumentName: '*',
+          },
+        ],
+        readers: [reader],
+      });
+      const meter = meterProvider.getMeter('test');
+      const gauge = meter.createUpDownCounter('test_gauge', {
+        description: 'foobar',
+        unit: '1',
+      });
+
+      gauge.add(1, { val: '1' });
+      const { resourceMetrics, errors } = await reader.collect();
+      assert.strictEqual(errors.length, 0);
+      assert.strictEqual(resourceMetrics.scopeMetrics.length, 1);
+      assert.strictEqual(resourceMetrics.scopeMetrics[0].metrics.length, 1);
+      const scopeMetrics = resourceMetrics.scopeMetrics[0];
+      const resourceAttributes = resourceMetrics.resource.attributes;
+      serializer['_additionalAttributes'] = serializer[
+        '_filterResourceConstantLabels'
+      ](resourceAttributes, serializer['_withResourceConstantLabels']);
+      const result = serializer['_serializeScopeMetrics'](scopeMetrics);
+      assert.strictEqual(
+        result,
+        '# HELP test_gauge_ratio foobar\n' +
+          '# UNIT test_gauge_ratio 1\n' +
+          '# TYPE test_gauge_ratio gauge\n' +
+          'test_gauge_ratio{val="1",otel_scope_name="test"} 1\n'
+      );
+    });
   });
 
   describe('serialize non-normalized values', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

When [converting OTLP metrics to Prometheus](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/), `_ratio` should be appended to gauges whose unit is `"1"`.

[Here](https://github.com/prometheus/otlptranslator/blob/ab718f015b85ef4213f23a52ccbeec2bd826ce78/metric_namer.go#L242-L249) is the corresponding code in the Golang library (it is a Prometheus library used by the OTLP library). Here is the OTLP Golang [unit test](https://github.com/open-telemetry/opentelemetry-go/blob/bec9f66b45ae1e679212285467572d132b627ff4/exporters/prometheus/exporter_test.go#L279-L296) and corresponding [test output snapshot](https://github.com/open-telemetry/opentelemetry-go/blob/bec9f66b45ae1e679212285467572d132b627ff4/exporters/prometheus/testdata/gauge.txt).

There are a fairly significant amount of other similar changes missing from the JavaScript library that I'd like to work on, but I wanted to start with a small change to see how it would be received. However, because they can change the names of the output metrics, they would be breaking changes.

Fixes # N/A but found when looking into https://github.com/open-telemetry/opentelemetry-js/issues/6605

## Short description of the changes

This commit appends the `_ratio` suffix to gauges as necessary.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] New and existing unit tests

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
