### PR TITLE
fix(sdk-node): fix setting of ViewOption#name from ConfigurationModel

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-node): fix setting of ViewOption#name from ConfigurationModel [#6620](https://github.com/open-telemetry/opentelemetry-js/pull/6620) @trentm
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -787,7 +787,9 @@ export function getMeterViewsFromConfiguration(
       }
     }
     if (view.stream) {
-      viewOption.name = view.stream.name ?? view.selector?.instrument_name;
+      if (view.stream.name) {
+        viewOption.name = view.stream.name;
+      }
       viewOption.aggregationCardinalityLimit =
         view.stream.aggregation_cardinality_limit ?? 2_000;
       if (view.stream.description) {


### PR DESCRIPTION
The ViewOption.name is not meant to default to the *ViewOption*
instrument_name. Rather it is the Metrics SDK processing that will
use whatever the relevant matching instrument's name is.
That is done here:
https://github.com/trentm/opentelemetry-js/blob/49d3cc0b6d87fc06801deb612f045cbc3ee7a1b2/packages/sdk-metrics/src/InstrumentDescriptor.ts#L58
