### PR TITLE
chore: allow browser maintainers to approve changelog edits

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,3 +34,7 @@ experimental/packages/web-common/ @open-telemetry/browser-maintainers @open-tele
 packages/opentelemetry-context-zone/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
 packages/opentelemetry-context-zone-peer-dep/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
 packages/opentelemetry-sdk-trace-web/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
+
+# Also SDK/instrumentation changelogs are co-owned:
+CHANGELOG.md  @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
+experimental/CHANGELOG.md  @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers


### PR DESCRIPTION
PRs that modify the co-owned packages still need changelog entries - this PR allows Browser Maintainers to also approve these changelog edits, so they can merge independently of JS SIG Approvals.

Still excludes API and semconv changelogs.