### PR TITLE
fix(instrumentation-fetch): tolerate non-writable globalThis.fetch and fix premature flag flips in enable()

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -14,6 +14,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(instrumentation-fetch): tolerate non-writable `globalThis.fetch` and fix premature `_isEnabled` / `_isFetchPatched` flips in `enable()` @brunorodmoreira
 * fix(instrumentation-xhr): resolve relative URLs before matching `ignoreUrls` [#6551](https://github.com/open-telemetry/opentelemetry-js/pull/6551) @Maximiliano-Zeballos
 * fix(sdk-node): fix setting of ViewOption#name from ConfigurationModel [#6620](https://github.com/open-telemetry/opentelemetry-js/pull/6620) @trentm
 * fix(web-common): add limit for timeout [#6601](https://github.com/open-telemetry/opentelemetry-js/pull/6601) @maryliag

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -626,14 +626,26 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
     if (this._isEnabled) {
       return;
     }
-    this._isEnabled = true;
 
     if (this._isFetchPatched) {
       this._diag.debug('fetch constructor already patched');
+      this._isEnabled = true;
       return;
     }
-    this._isFetchPatched = true;
-    this._wrap(globalThis, 'fetch', this._patchConstructor());
+
+    try {
+      // `_wrap` throws if a third-party script has locked globalThis.fetch via
+      // Object.defineProperty(window, 'fetch', { writable: false, ... }).
+      this._wrap(globalThis, 'fetch', this._patchConstructor());
+      this._isFetchPatched = true;
+      this._isEnabled = true;
+    } catch (err) {
+      this._diag.warn(
+        'Failed to patch globalThis.fetch; instrumentation will not be enabled. ' +
+          'Another script may have locked globalThis.fetch via Object.defineProperty.',
+        err
+      );
+    }
   }
 
   /**

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -254,8 +254,10 @@ describe('fetch', () => {
       );
 
       beforeEach(() => {
+        // `_wrap` is protected on InstrumentationBase, so cast to sidestep
+        // the visibility check while keeping sinon's return type intact.
         sinon
-          .stub(FetchInstrumentation.prototype as never, '_wrap' as never)
+          .stub(FetchInstrumentation.prototype as never as Record<string, () => void>, '_wrap')
           .throws(wrapError);
       });
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -254,11 +254,8 @@ describe('fetch', () => {
       );
 
       beforeEach(() => {
-        // `_wrap` is protected on InstrumentationBase, so cast to sidestep
-        // the visibility check while keeping sinon's return type intact.
-        sinon
-          .stub(FetchInstrumentation.prototype as never as Record<string, () => void>, '_wrap')
-          .throws(wrapError);
+        // @ts-expect-error access internal property for testing
+        sinon.stub(FetchInstrumentation.prototype, '_wrap').throws(wrapError);
       });
 
       it('should not throw when _wrap fails', () => {

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -244,33 +244,35 @@ describe('fetch', () => {
     describe('when the fetch property cannot be wrapped', () => {
       // Simulate the production failure mode (third-party scripts locking
       // `globalThis.fetch` via `Object.defineProperty` with `writable: false,
-      // configurable: false`) by stubbing the inherited `_wrap` to throw the
-      // same TypeError the browser would throw. We stub the method rather
-      // than actually locking the property because a non-configurable slot
-      // is irreversible within a realm, and the outer `afterEach` restores
-      // `globalThis.fetch` via assignment, which would itself throw.
+      // configurable: false`) by stubbing `_wrap` to throw the same TypeError
+      // the browser would throw. We stub the method rather than actually
+      // locking the property because a non-configurable slot is irreversible
+      // within a realm, and the outer `afterEach` restores `globalThis.fetch`
+      // via assignment, which would itself throw.
       const wrapError = new TypeError(
         "Cannot assign to read only property 'fetch' of object '[object Window]'"
       );
 
       beforeEach(() => {
+        // Construct with `enabled: false` so the stub is in place before
+        // `enable()` runs — `_wrap` is an instance-level field inherited
+        // from `InstrumentationBase`, not a prototype method.
+        fetchInstrumentation = new FetchInstrumentation({ enabled: false });
         // @ts-expect-error access internal property for testing
-        sinon.stub(FetchInstrumentation.prototype, '_wrap').throws(wrapError);
+        sinon.stub(fetchInstrumentation, '_wrap').throws(wrapError);
       });
 
       it('should not throw when _wrap fails', () => {
-        assert.doesNotThrow(() => {
-          fetchInstrumentation = new FetchInstrumentation();
-        });
+        assert.doesNotThrow(() => fetchInstrumentation!.enable());
       });
 
       it('should leave fetch unwrapped when _wrap fails', () => {
-        fetchInstrumentation = new FetchInstrumentation();
+        fetchInstrumentation!.enable();
         assert.ok(!isWrapped(globalThis.fetch));
       });
 
       it('should allow enable() to be retried after _wrap fails', () => {
-        fetchInstrumentation = new FetchInstrumentation();
+        fetchInstrumentation!.enable();
         assert.doesNotThrow(() => fetchInstrumentation!.enable());
       });
     });

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -241,50 +241,38 @@ describe('fetch', () => {
       fetchInstrumentation = undefined;
     });
 
-    describe('when globalThis.fetch is locked (non-writable)', () => {
+    describe('when the fetch property cannot be wrapped', () => {
+      // Simulate the production failure mode (third-party scripts locking
+      // `globalThis.fetch` via `Object.defineProperty` with `writable: false,
+      // configurable: false`) by stubbing the inherited `_wrap` to throw the
+      // same TypeError the browser would throw. We stub the method rather
+      // than actually locking the property because a non-configurable slot
+      // is irreversible within a realm, and the outer `afterEach` restores
+      // `globalThis.fetch` via assignment, which would itself throw.
+      const wrapError = new TypeError(
+        "Cannot assign to read only property 'fetch' of object '[object Window]'"
+      );
+
       beforeEach(() => {
-        // Simulate a third-party script that locks fetch (e.g. anti-bot or
-        // affiliate tag using Object.defineProperty(window, 'fetch', { ... })).
-        Object.defineProperty(globalThis, 'fetch', {
-          value: originalFetch,
-          writable: false,
-          configurable: false,
-          enumerable: true,
-        });
+        sinon
+          .stub(FetchInstrumentation.prototype as never, '_wrap' as never)
+          .throws(wrapError);
       });
 
-      afterEach(() => {
-        // Break the lock so subsequent tests start clean. The outer afterEach
-        // does `globalThis.fetch = originalFetch` which would be a no-op write
-        // to a non-writable slot.
-        try {
-          Object.defineProperty(globalThis, 'fetch', {
-            value: originalFetch,
-            writable: true,
-            configurable: true,
-            enumerable: true,
-          });
-        } catch {
-          /* slot is permanently locked in this realm; tolerate */
-        }
-      });
-
-      it('should not throw when fetch cannot be wrapped', () => {
+      it('should not throw when _wrap fails', () => {
         assert.doesNotThrow(() => {
           fetchInstrumentation = new FetchInstrumentation();
         });
       });
 
-      it('should leave _isEnabled false when wrap fails', () => {
-        fetchInstrumentation = new FetchInstrumentation();
-        // Calling enable() again should still be a no-op + not throw, because
-        // the previous attempt left state clean instead of half-applied.
-        assert.doesNotThrow(() => fetchInstrumentation!.enable());
-      });
-
-      it('should not mark fetch as wrapped when wrap fails', () => {
+      it('should leave fetch unwrapped when _wrap fails', () => {
         fetchInstrumentation = new FetchInstrumentation();
         assert.ok(!isWrapped(globalThis.fetch));
+      });
+
+      it('should allow enable() to be retried after _wrap fails', () => {
+        fetchInstrumentation = new FetchInstrumentation();
+        assert.doesNotThrow(() => fetchInstrumentation!.enable());
       });
     });
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -241,6 +241,53 @@ describe('fetch', () => {
       fetchInstrumentation = undefined;
     });
 
+    describe('when globalThis.fetch is locked (non-writable)', () => {
+      beforeEach(() => {
+        // Simulate a third-party script that locks fetch (e.g. anti-bot or
+        // affiliate tag using Object.defineProperty(window, 'fetch', { ... })).
+        Object.defineProperty(globalThis, 'fetch', {
+          value: originalFetch,
+          writable: false,
+          configurable: false,
+          enumerable: true,
+        });
+      });
+
+      afterEach(() => {
+        // Break the lock so subsequent tests start clean. The outer afterEach
+        // does `globalThis.fetch = originalFetch` which would be a no-op write
+        // to a non-writable slot.
+        try {
+          Object.defineProperty(globalThis, 'fetch', {
+            value: originalFetch,
+            writable: true,
+            configurable: true,
+            enumerable: true,
+          });
+        } catch {
+          /* slot is permanently locked in this realm; tolerate */
+        }
+      });
+
+      it('should not throw when fetch cannot be wrapped', () => {
+        assert.doesNotThrow(() => {
+          fetchInstrumentation = new FetchInstrumentation();
+        });
+      });
+
+      it('should leave _isEnabled false when wrap fails', () => {
+        fetchInstrumentation = new FetchInstrumentation();
+        // Calling enable() again should still be a no-op + not throw, because
+        // the previous attempt left state clean instead of half-applied.
+        assert.doesNotThrow(() => fetchInstrumentation!.enable());
+      });
+
+      it('should not mark fetch as wrapped when wrap fails', () => {
+        fetchInstrumentation = new FetchInstrumentation();
+        assert.ok(!isWrapped(globalThis.fetch));
+      });
+    });
+
     it('should return a Promise<Response> compatible with WebAssembly.compileStreaming', async () => {
       // Some web APIs do brand checks to ensure they are working with native objects.
       // compileStreaming checks that the argument is a native Response, and will throw if it isn't.


### PR DESCRIPTION
## Which problem is this PR solving?

Two related bugs in `FetchInstrumentation.enable()`, in `experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts`:

### 1. Premature flag flips leave the instance in a permanently-broken state

The current `enable()` flips both `_isEnabled` and `_isFetchPatched` to `true` **before** calling `this._wrap(globalThis, 'fetch', ...)`:

```ts
if (this._isEnabled) return;
this._isEnabled = true;                                       // ← flipped
if (this._isFetchPatched) { ... return; }
this._isFetchPatched = true;                                  // ← flipped
this._wrap(globalThis, 'fetch', this._patchConstructor());   // ← can throw
```

If `_wrap` throws for any reason, the instance is left with both flags set to `true` while no wrapper is actually installed on `globalThis.fetch`. Any subsequent `enable()` call early-returns at the `_isEnabled` (or `_isFetchPatched`) guard and the instance is permanently broken — there is no recovery path.

### 2. `enable()` aborts the rest of the OTel init when `globalThis.fetch` is non-writable

`_wrap` ultimately calls `Object.defineProperty(globalThis, 'fetch', ...)`, which throws `TypeError: Cannot assign to read only property 'fetch'` when a third-party script on the page has locked the property:

```js
Object.defineProperty(window, 'fetch', {
  value: window.fetch,
  writable: false,
  configurable: false,
  enumerable: true,
});
```

This pattern is increasingly common in production browser environments where anti-bot, affiliate, or anti-tampering tags defensively freeze `window.fetch` to prevent monkey-patching. When `FetchInstrumentation` is registered through `registerInstrumentations({ instrumentations: [Fetch, XHR, Document, ...] })`, the throw escapes the loop and the remaining instrumentations are never enabled — the entire OpenTelemetry browser pipeline is silently disabled.

I traced this in real production data (~280 errors / day on a single merchant page, across Chrome, Edge, Samsung Internet, and in-app browsers — confirming it is **not** browser-specific) before deciding the fix belonged here rather than in a downstream consumer.

## Short description of the changes

Inside `enable()`:

1. The `_wrap` call is wrapped in a `try/catch`. On failure, `_diag.warn` is called and the method returns without throwing — matching the established `_diag.warn` + return pattern already used at the top of the method when `hasBrowserPerformanceAPI` is false.
2. `_isFetchPatched` and `_isEnabled` are now flipped **only after** `_wrap` succeeds, so the instance state always reflects reality. A failed `enable()` leaves the instance in a clean, retryable state instead of a permanently-wrong one.
3. In the "already patched" branch (entered when `enable()` is called after a previous `disable()` cycle), `_isEnabled` is now flipped explicitly inside that branch — preserving the existing reactivation behavior.

No public API changes, no type changes, no config changes.

### Behavior change to be aware of

`enable()` no longer throws on patch failure. Callers that previously caught a `TypeError` from `enable()` will now see a `_diag.warn` log instead, and can detect the failure by reading `_isEnabled` after the call. I judged this acceptable because:

- The throw was never a documented contract (no JSDoc, no types).
- The existing `hasBrowserPerformanceAPI` branch at line 619 already establishes "cannot instrument → warn + return, no throw" as the convention for this method.
- The previous behavior left the instance in a corrupt state anyway (per bug 1 above), so any code catching the throw was operating on lies about whether instrumentation was active.

If a use case for opt-in throwing exists, that is better added later as a config option rather than as the default.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Three new unit tests under the existing `enabling/disabling` `describe` block in `test/fetch.test.ts`:

- `should not throw when fetch cannot be wrapped` — proves the constructor (which calls `enable()`) no longer propagates the `TypeError`.
- `should leave _isEnabled false when wrap fails` — proves `enable()` is idempotent and retryable after a failed patch.
- `should not mark fetch as wrapped when wrap fails` — proves the lifecycle flags reflect reality.

The tests simulate the production scenario by calling `Object.defineProperty(globalThis, 'fetch', { writable: false, configurable: false, ... })` in `beforeEach`, then unlocking in `afterEach` so test isolation is preserved.

## Checklist

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated (CHANGELOG entry under `:bug: Bug Fixes` in `experimental/CHANGELOG.md`)