### PR TITLE
Revert "chore: allow browser maintainers to approve changelog edits"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,7 +34,3 @@ experimental/packages/web-common/ @open-telemetry/browser-maintainers @open-tele
 packages/opentelemetry-context-zone/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
 packages/opentelemetry-context-zone-peer-dep/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
 packages/opentelemetry-sdk-trace-web/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
-
-# Also SDK/instrumentation changelogs are co-owned:
-CHANGELOG.md  @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
-experimental/CHANGELOG.md  @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-js#6622

Browser Maintainers now *could* approve changelog files, but are getting tagged on **all** changes and that just adds to the noise. 