### PR TITLE
fix(otlp-exporter-base): remove brackets from IPv6 hostname in HTTP transport

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -15,6 +15,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(otlp-exporter-base): remove brackets from IPv6 hostname in HTTP transport [#5768](https://github.com/open-telemetry/opentelemetry-js/issues/5768) @raphaeltorquat0
 * fix(instrumentation-xml-http-request): avoid unwrapping `XMLHttpRequest` API when disabling [#6611](https://github.com/open-telemetry/opentelemetry-js/pull/6611) @david-luna
 * fix(instrumentation-fetch): tolerate non-writable `globalThis.fetch` and fix premature `_isEnabled` / `_isFetchPatched` flips in `enable()` @brunorodmoreira
 * fix(instrumentation-xhr): resolve relative URLs before matching `ignoreUrls` [#6551](https://github.com/open-telemetry/opentelemetry-js/pull/6551) @Maximiliano-Zeballos

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -15,7 +15,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
-* fix(otlp-exporter-base): remove brackets from IPv6 hostname in HTTP transport [#5768](https://github.com/open-telemetry/opentelemetry-js/issues/5768) @raphaeltorquat0
+* fix(otlp-exporter-base): fix IPv6 address handling by passing URL object to http.request [#5768](https://github.com/open-telemetry/opentelemetry-js/issues/5768) @raphaeltorquat0
 * fix(instrumentation-xml-http-request): avoid unwrapping `XMLHttpRequest` API when disabling [#6611](https://github.com/open-telemetry/opentelemetry-js/pull/6611) @david-luna
 * fix(instrumentation-fetch): tolerate non-writable `globalThis.fetch` and fix premature `_isEnabled` / `_isFetchPatched` flips in `enable()` @brunorodmoreira
 * fix(instrumentation-xhr): resolve relative URLs before matching `ignoreUrls` [#6551](https://github.com/open-telemetry/opentelemetry-js/pull/6551) @Maximiliano-Zeballos

--- a/experimental/packages/otlp-exporter-base/src/transport/http-transport-utils.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/http-transport-utils.ts
@@ -53,8 +53,15 @@ export function sendWithHttp(
       headers['User-Agent'] = DEFAULT_USER_AGENT;
     }
 
+    // Remove brackets from IPv6 addresses as they're only needed in URL format
+    // but http.RequestOptions.hostname expects the raw address
+    const hostname =
+      parsedUrl.hostname.startsWith('[') && parsedUrl.hostname.endsWith(']')
+        ? parsedUrl.hostname.slice(1, -1)
+        : parsedUrl.hostname;
+
     const options: http.RequestOptions | https.RequestOptions = {
-      hostname: parsedUrl.hostname,
+      hostname,
       port: parsedUrl.port,
       path: parsedUrl.pathname,
       method: 'POST',

--- a/experimental/packages/otlp-exporter-base/src/transport/http-transport-utils.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/http-transport-utils.ts
@@ -53,23 +53,13 @@ export function sendWithHttp(
       headers['User-Agent'] = DEFAULT_USER_AGENT;
     }
 
-    // Remove brackets from IPv6 addresses as they're only needed in URL format
-    // but http.RequestOptions.hostname expects the raw address
-    const hostname =
-      parsedUrl.hostname.startsWith('[') && parsedUrl.hostname.endsWith(']')
-        ? parsedUrl.hostname.slice(1, -1)
-        : parsedUrl.hostname;
-
     const options: http.RequestOptions | https.RequestOptions = {
-      hostname,
-      port: parsedUrl.port,
-      path: parsedUrl.pathname,
       method: 'POST',
       headers,
       agent,
     };
 
-    const req = request(options, (res: http.IncomingMessage) => {
+    const req = request(parsedUrl, options, (res: http.IncomingMessage) => {
       const responseData: Buffer[] = [];
       let responseSize = 0;
       res.on('data', (chunk: Buffer) => {

--- a/experimental/packages/otlp-exporter-base/test/node/http-exporter-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/node/http-exporter-transport.test.ts
@@ -106,6 +106,47 @@ describe('HttpExporterTransport', function () {
       );
     });
 
+    it('returns success when sending to IPv6 localhost address', async function () {
+      // arrange
+      const expectedResponseData = Buffer.from([4, 5, 6]);
+      server = http.createServer((_, res) => {
+        res.statusCode = 200;
+        res.write(expectedResponseData);
+        res.end();
+      });
+
+      // Listen on IPv6 localhost - skip test if IPv6 is not available
+      try {
+        await new Promise<void>((resolve, reject) => {
+          server!.listen(0, '::1', () => resolve());
+          server!.once('error', reject);
+        });
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code === 'EADDRNOTAVAIL') {
+          this.skip();
+        }
+        throw err;
+      }
+      const port = (server!.address() as any).port;
+
+      const transport = createHttpExporterTransport({
+        url: `http://[::1]:${port}`,
+        headers: async () => ({}),
+        compression: 'none',
+        agentFactory: () => new http.Agent(),
+      });
+
+      // act
+      const result = await transport.send(sampleRequestData, 1000);
+
+      // assert
+      assert.strictEqual(result.status, 'success');
+      assert.deepEqual(
+        (result as ExportResponseSuccess).data,
+        expectedResponseData
+      );
+    });
+
     it('returns retryable on retryable status', async function () {
       //arrange
       server = http.createServer((_, res) => {

--- a/experimental/packages/otlp-exporter-base/test/node/http-transport-utils.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/node/http-transport-utils.test.ts
@@ -26,17 +26,21 @@ describe('compressAndSend', function () {
 });
 
 describe('sendWithHttp', function () {
+  let sentUserAgent: string;
+  let sentHostname: string;
+
   const requestFn: typeof http.request = (
     opts: any,
     cb: any
   ): http.ClientRequest => {
     sentUserAgent = opts.headers['User-Agent'];
+    sentHostname = opts.hostname;
     return http.request(opts, cb).destroy();
   };
-  let sentUserAgent: string;
 
   beforeEach(function () {
     sentUserAgent = '';
+    sentHostname = '';
   });
 
   it('sends a request setting the default user-agent header', async function () {
@@ -71,5 +75,61 @@ describe('sendWithHttp', function () {
       sentUserAgent,
       `Transport-User-Agent/1.2.3 OTel-OTLP-Exporter-JavaScript/${VERSION}`
     );
+  });
+
+  it('removes brackets from IPv6 hostname', async function () {
+    await sendWithHttp(
+      requestFn,
+      'http://[::1]:4318/v1/traces',
+      {},
+      'none',
+      undefined,
+      new http.Agent(),
+      Buffer.from([1, 2, 3]),
+      100
+    );
+    assert.strictEqual(sentHostname, '::1');
+  });
+
+  it('handles IPv6 loopback address', async function () {
+    await sendWithHttp(
+      requestFn,
+      'http://[fe80::1]:4318/v1/traces',
+      {},
+      'none',
+      undefined,
+      new http.Agent(),
+      Buffer.from([1, 2, 3]),
+      100
+    );
+    assert.strictEqual(sentHostname, 'fe80::1');
+  });
+
+  it('preserves IPv4 hostname unchanged', async function () {
+    await sendWithHttp(
+      requestFn,
+      'http://192.168.1.1:4318/v1/traces',
+      {},
+      'none',
+      undefined,
+      new http.Agent(),
+      Buffer.from([1, 2, 3]),
+      100
+    );
+    assert.strictEqual(sentHostname, '192.168.1.1');
+  });
+
+  it('preserves regular hostname unchanged', async function () {
+    await sendWithHttp(
+      requestFn,
+      'http://example.com:4318/v1/traces',
+      {},
+      'none',
+      undefined,
+      new http.Agent(),
+      Buffer.from([1, 2, 3]),
+      100
+    );
+    assert.strictEqual(sentHostname, 'example.com');
   });
 });

--- a/experimental/packages/otlp-exporter-base/test/node/http-transport-utils.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/node/http-transport-utils.test.ts
@@ -27,7 +27,6 @@ describe('compressAndSend', function () {
 
 describe('sendWithHttp', function () {
   let sentUserAgent: string;
-  let sentUrl: URL;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const requestFn: any = (
@@ -35,7 +34,6 @@ describe('sendWithHttp', function () {
     opts: http.RequestOptions,
     cb?: (res: http.IncomingMessage) => void
   ): http.ClientRequest => {
-    sentUrl = url;
     sentUserAgent = (opts.headers as Record<string, string>)['User-Agent'];
     return http.request(url, opts, cb).destroy();
   };
@@ -76,67 +74,5 @@ describe('sendWithHttp', function () {
       sentUserAgent,
       `Transport-User-Agent/1.2.3 OTel-OTLP-Exporter-JavaScript/${VERSION}`
     );
-  });
-
-  it('passes URL object directly for IPv6 addresses', async function () {
-    await sendWithHttp(
-      requestFn,
-      'http://[::1]:4318/v1/traces',
-      {},
-      'none',
-      undefined,
-      new http.Agent(),
-      Buffer.from([1, 2, 3]),
-      100
-    );
-    assert.ok(sentUrl instanceof URL);
-    assert.strictEqual(sentUrl.hostname, '[::1]');
-    assert.strictEqual(sentUrl.port, '4318');
-    assert.strictEqual(sentUrl.pathname, '/v1/traces');
-  });
-
-  it('passes URL object directly for IPv6 link-local addresses', async function () {
-    await sendWithHttp(
-      requestFn,
-      'http://[fe80::1]:4318/v1/traces',
-      {},
-      'none',
-      undefined,
-      new http.Agent(),
-      Buffer.from([1, 2, 3]),
-      100
-    );
-    assert.ok(sentUrl instanceof URL);
-    assert.strictEqual(sentUrl.hostname, '[fe80::1]');
-  });
-
-  it('passes URL object directly for IPv4 addresses', async function () {
-    await sendWithHttp(
-      requestFn,
-      'http://192.168.1.1:4318/v1/traces',
-      {},
-      'none',
-      undefined,
-      new http.Agent(),
-      Buffer.from([1, 2, 3]),
-      100
-    );
-    assert.ok(sentUrl instanceof URL);
-    assert.strictEqual(sentUrl.hostname, '192.168.1.1');
-  });
-
-  it('passes URL object directly for regular hostnames', async function () {
-    await sendWithHttp(
-      requestFn,
-      'http://example.com:4318/v1/traces',
-      {},
-      'none',
-      undefined,
-      new http.Agent(),
-      Buffer.from([1, 2, 3]),
-      100
-    );
-    assert.ok(sentUrl instanceof URL);
-    assert.strictEqual(sentUrl.hostname, 'example.com');
   });
 });

--- a/experimental/packages/otlp-exporter-base/test/node/http-transport-utils.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/node/http-transport-utils.test.ts
@@ -27,20 +27,21 @@ describe('compressAndSend', function () {
 
 describe('sendWithHttp', function () {
   let sentUserAgent: string;
-  let sentHostname: string;
+  let sentUrl: URL;
 
-  const requestFn: typeof http.request = (
-    opts: any,
-    cb: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const requestFn: any = (
+    url: URL,
+    opts: http.RequestOptions,
+    cb?: (res: http.IncomingMessage) => void
   ): http.ClientRequest => {
-    sentUserAgent = opts.headers['User-Agent'];
-    sentHostname = opts.hostname;
-    return http.request(opts, cb).destroy();
+    sentUrl = url;
+    sentUserAgent = (opts.headers as Record<string, string>)['User-Agent'];
+    return http.request(url, opts, cb).destroy();
   };
 
   beforeEach(function () {
     sentUserAgent = '';
-    sentHostname = '';
   });
 
   it('sends a request setting the default user-agent header', async function () {
@@ -77,7 +78,7 @@ describe('sendWithHttp', function () {
     );
   });
 
-  it('removes brackets from IPv6 hostname', async function () {
+  it('passes URL object directly for IPv6 addresses', async function () {
     await sendWithHttp(
       requestFn,
       'http://[::1]:4318/v1/traces',
@@ -88,10 +89,13 @@ describe('sendWithHttp', function () {
       Buffer.from([1, 2, 3]),
       100
     );
-    assert.strictEqual(sentHostname, '::1');
+    assert.ok(sentUrl instanceof URL);
+    assert.strictEqual(sentUrl.hostname, '[::1]');
+    assert.strictEqual(sentUrl.port, '4318');
+    assert.strictEqual(sentUrl.pathname, '/v1/traces');
   });
 
-  it('handles IPv6 loopback address', async function () {
+  it('passes URL object directly for IPv6 link-local addresses', async function () {
     await sendWithHttp(
       requestFn,
       'http://[fe80::1]:4318/v1/traces',
@@ -102,10 +106,11 @@ describe('sendWithHttp', function () {
       Buffer.from([1, 2, 3]),
       100
     );
-    assert.strictEqual(sentHostname, 'fe80::1');
+    assert.ok(sentUrl instanceof URL);
+    assert.strictEqual(sentUrl.hostname, '[fe80::1]');
   });
 
-  it('preserves IPv4 hostname unchanged', async function () {
+  it('passes URL object directly for IPv4 addresses', async function () {
     await sendWithHttp(
       requestFn,
       'http://192.168.1.1:4318/v1/traces',
@@ -116,10 +121,11 @@ describe('sendWithHttp', function () {
       Buffer.from([1, 2, 3]),
       100
     );
-    assert.strictEqual(sentHostname, '192.168.1.1');
+    assert.ok(sentUrl instanceof URL);
+    assert.strictEqual(sentUrl.hostname, '192.168.1.1');
   });
 
-  it('preserves regular hostname unchanged', async function () {
+  it('passes URL object directly for regular hostnames', async function () {
     await sendWithHttp(
       requestFn,
       'http://example.com:4318/v1/traces',
@@ -130,6 +136,7 @@ describe('sendWithHttp', function () {
       Buffer.from([1, 2, 3]),
       100
     );
-    assert.strictEqual(sentHostname, 'example.com');
+    assert.ok(sentUrl instanceof URL);
+    assert.strictEqual(sentUrl.hostname, 'example.com');
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

When using IPv6 addresses in `OTEL_EXPORTER_OTLP_ENDPOINT` (e.g., `http://[::1]:4318`), the HTTP exporter fails with a DNS resolution error. This happens because `URL.hostname` includes the brackets for IPv6 addresses (e.g., `[::1]`), but `http.RequestOptions.hostname` expects the raw address without brackets.

Fixes #5768

## Short description of the changes

- Remove brackets from IPv6 hostnames before passing to `http.request`
- Add unit tests for IPv6 address handling
- Add CHANGELOG entry

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- Added 4 new unit tests:
  - `removes brackets from IPv6 hostname` - verifies `[::1]` becomes `::1`
  - `handles IPv6 loopback address` - verifies `[fe80::1]` becomes `fe80::1`
  - `preserves IPv4 hostname unchanged` - verifies `192.168.1.1` stays unchanged
  - `preserves regular hostname unchanged` - verifies `example.com` stays unchanged

All existing tests continue to pass.