### PR TITLE
docs(trace): clarify that startActiveSpan requires manual span.end()

### DIFF
--- a/api/src/trace/tracer.ts
+++ b/api/src/trace/tracer.ts
@@ -35,6 +35,11 @@ export interface Tracer {
    * Additionally the new span gets set in context and this context is activated
    * for the duration of the function call.
    *
+   * **Important**: The callback function is responsible for calling `span.end()`
+   * to finish the span. Unlike some other OpenTelemetry implementations, the span
+   * is NOT automatically ended when the callback returns. If `span.end()` is not
+   * called, the span will never be exported and will be silently lost.
+   *
    * @param name The name of the span
    * @param [options] SpanOptions used for span creation
    * @param [context] Context to use to extract parent

--- a/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/Tracer.ts
@@ -164,6 +164,11 @@ export class Tracer implements api.Tracer {
    * Additionally the new span gets set in context and this context is activated
    * for the duration of the function call.
    *
+   * **Important**: The callback function is responsible for calling `span.end()`
+   * to finish the span. Unlike some other OpenTelemetry implementations, the span
+   * is NOT automatically ended when the callback returns. If `span.end()` is not
+   * called, the span will never be exported and will be silently lost.
+   *
    * @param name The name of the span
    * @param [options] SpanOptions used for span creation
    * @param [context] Context to use to extract parent


### PR DESCRIPTION
## Which problem is this PR solving?

The JSDoc for `startActiveSpan` does not make it clear that the callback function is responsible for calling `span.end()`. Users coming from other OpenTelemetry implementations (like Go) where spans are automatically ended may silently lose spans when using the JavaScript SDK.

This PR adds explicit documentation warning that:
1. The callback is responsible for calling `span.end()`
2. The span is NOT automatically ended when the callback returns
3. If `span.end()` is not called, the span will never be exported

Fixes #5905

## Short description of the changes

Added an "Important" note to the JSDoc for `startActiveSpan` in both:
- `api/src/trace/tracer.ts` (the interface)
- `packages/opentelemetry-sdk-trace-base/src/Tracer.ts` (the implementation)

The note explicitly states that `span.end()` must be called by the callback function, otherwise the span is silently lost.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Note: parts of this implementation were developed with AI assistance.

---

**CLA Status**: I have signed the [Contributor License Agreement](https://identity.linuxfoundation.org/projects/cncf) for this project.