### PR TITLE
refactor(opentelemetry-exporter-prometheus): do not call `enforcePrometheusNamingConvention()` multiple times per metric

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -25,7 +25,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
-* refactor(opentelemetry-exporter-prometheus): do not call enforcePrometheusNamingConvention() multiple times per metric [#xxxx](https://github.com/open-telemetry/opentelemetry-js/pull/xxxx) @cjihrig
+* refactor(opentelemetry-exporter-prometheus): do not call enforcePrometheusNamingConvention() multiple times per metric [#6636](https://github.com/open-telemetry/opentelemetry-js/pull/6636) @cjihrig
 
 ## 0.215.0
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -25,6 +25,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
+* refactor(opentelemetry-exporter-prometheus): do not call enforcePrometheusNamingConvention() multiple times per metric [#xxxx](https://github.com/open-telemetry/opentelemetry-js/pull/xxxx) @cjihrig
+
 ## 0.215.0
 
 ### :boom: Breaking Changes

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -322,7 +322,6 @@ export class PrometheusSerializer {
   ): string {
     let results = '';
 
-    name = enforcePrometheusNamingConvention(name, data);
     const { value, attributes } = dataPoint;
     const timestamp = hrTimeToMilliseconds(dataPoint.endTime);
     results += stringify(
@@ -343,7 +342,6 @@ export class PrometheusSerializer {
   ): string {
     let results = '';
 
-    name = enforcePrometheusNamingConvention(name, data);
     const attributes = dataPoint.attributes;
     const histogram = dataPoint.value;
     const timestamp = hrTimeToMilliseconds(dataPoint.endTime);

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -652,8 +652,16 @@ describe('PrometheusSerializer', () => {
     it('should rename metric of type counter when name misses _total suffix', async () => {
       const serializer = new PrometheusSerializer();
 
-      const result = await getCounterResult('test', serializer);
-      assert.strictEqual(result, 'test_total 1\n');
+      const result = await getCounterResult('test', serializer, {
+        exportAll: true,
+      });
+      assert.strictEqual(
+        result,
+        serializedDefaultResource +
+          '# HELP test_total description missing\n' +
+          '# TYPE test_total counter\n' +
+          'test_total{otel_scope_name="test"} 1\n'
+      );
     });
 
     it('should not rename metric of type counter when name contains _total suffix', async () => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

In the `PrometheusSerializer` class, the `_serializeMetricData()` method ensures that the metric name follows Prometheus naming conventions by calling `enforcePrometheusNamingConvention(name, metricData)`. Later, `_serializeMetricData()` passes `name` and `metricData` to `_serializeSingularDataPoint()` and `_serializeHistogramDataPoint()`, which also call `enforcePrometheusNamingConvention()` with the same arguments. `_serializeSingularDataPoint()` and `_serializeHistogramDataPoint()` are private methods that are only called by `_serializeMetricData()` (and test code that reached into internals). So, these extra calls are currently unnecessary.

Fixes # N/A

## Short description of the changes

This PR removes the extra calls to `enforcePrometheusNamingConvention()` in `_serializeSingularDataPoint()` and `_serializeHistogramDataPoint()` and updates the only relevant test to not call `_serializeSingularDataPoint()`.

## Type of change

Internal refactor.

## How Has This Been Tested?

- [x] Existing unit tests

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
