### PR TITLE
chore(configuration): add a convenience parse-config.mjs script for development

### DIFF
--- a/experimental/packages/configuration/scripts/parse-config.mjs
+++ b/experimental/packages/configuration/scripts/parse-config.mjs
@@ -7,6 +7,9 @@
 /**
  * Parse declaractive config files and print its JS object representation.
  * This is a convenience script for development of this package.
+ *
+ * Usage:
+ *    ./scripts/parse-config.mjs CONFIG_FILE
  */
 
 /* eslint-disable no-console */

--- a/experimental/packages/configuration/scripts/parse-config.mjs
+++ b/experimental/packages/configuration/scripts/parse-config.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Parse declaractive config files and print its JS object representation.
+ * This is a convenience script for development of this package.
+ */
+
+/* eslint-disable no-console */
+
+import { createConfigFactory } from '@opentelemetry/configuration';
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+
+diag.setLogger(new DiagConsoleLogger(), { logLevel: DiagLogLevel.INFO });
+
+const configFile = process.argv[2];
+if (!configFile) {
+  console.error('parse-config: error: missing CONFIG_FILE argument');
+  console.error('usage: ./scripts/parse-config.mjs CONFIG_FILE');
+  process.exit(1);
+}
+
+process.env.OTEL_CONFIG_FILE = configFile;
+const fac = createConfigFactory();
+const config = fac.getConfigModel();
+console.dir(config, { depth: 50 });


### PR DESCRIPTION
usage: ./scripts/parse-config.mjs CONFIG_FILE

---

I've found this handy for seeing what the JS config parser yields for various YAML config files quickly.
E.g.:

```
% cat test/fixtures/samplers.yaml
file_format: "1.0-rc.3"
tracer_provider:
  processors:
    - simple:
        exporter:
          console:
  sampler:
    parent_based:
      root:
        trace_id_ratio_based:
          ratio: 0.5
      remote_parent_not_sampled:
        probability/development:
          ratio: 0.1

% ./scripts/parse-config.mjs test/fixtures/samplers.yaml
{
  disabled: false,
  log_level: 60,
  resource: {},
  attribute_limits: { attribute_count_limit: 128 },
  tracer_provider: {
    processors: [
      { simple: { exporter: { console: {} } } }
    ],
    limits: {
      attribute_count_limit: 128,
      event_count_limit: 128,
      link_count_limit: 128,
      event_attribute_count_limit: 128,
      link_attribute_count_limit: 128
    },
    sampler: {
      parent_based: {
        root: { trace_id_ratio_based: { ratio: 0.5 } },
        remote_parent_not_sampled: { 'probability/development': { ratio: 0.1 } }
      }
    }
  }
}
```
