### PR TITLE
fix(otlp-transformer): pin protobufjs to 8.0.1

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -20,6 +20,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * fix(instrumentation-xhr): resolve relative URLs before matching `ignoreUrls` [#6551](https://github.com/open-telemetry/opentelemetry-js/pull/6551) @Maximiliano-Zeballos
 * fix(sdk-node): fix setting of ViewOption#name from ConfigurationModel [#6620](https://github.com/open-telemetry/opentelemetry-js/pull/6620) @trentm
 * fix(web-common): add limit for timeout [#6601](https://github.com/open-telemetry/opentelemetry-js/pull/6601) @maryliag
+* fix(otlp-transformer): pin protobufjs@8.0.1 as protobufjs@8.0.3 is broken for browser use [#6646](https://github.com/open-telemetry/opentelemetry-js/pull/6646)
 
 ### :books: Documentation
 

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -91,7 +91,7 @@
     "@opentelemetry/sdk-logs": "0.215.0",
     "@opentelemetry/sdk-metrics": "2.7.0",
     "@opentelemetry/sdk-trace-base": "2.7.0",
-    "protobufjs": "^8.0.1"
+    "protobufjs": "8.0.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/otlp-transformer",
   "sideEffects": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1093,7 +1093,7 @@
         "@opentelemetry/sdk-logs": "0.215.0",
         "@opentelemetry/sdk-metrics": "2.7.0",
         "@opentelemetry/sdk-trace-base": "2.7.0",
-        "protobufjs": "^8.0.1"
+        "protobufjs": "8.0.1"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.9.1",


### PR DESCRIPTION
## Which problem is this PR solving?

Something is wrong with `protobufjs@8.0.3` - when people install the `@opentelemtry/otlp-transformer` package today, they'll get this version and it's broken for bundlers (see bundler-tests on #6644)

This PR pins the version to `8.0.1` which is the last known good one.

Either merging this PR or both #6625 and #6629 fixes the issue, but this PR here should be quicker to get over the finish line.