### PR TITLE
fix(configuration): improve how 'additionalProperties' in JSON schema is translated to TS types

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -15,6 +15,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :bug: Bug Fixes
 
 * fix(configuration): do not validate `OTEL_CONFIG_FILE` value before using it for file config [#6643](https://github.com/open-telemetry/opentelemetry-js/pull/6643) @trentm
+* fix(configuration): improve how 'additionalProperties' in JSON schema is translated to TS types [#6650](https://github.com/open-telemetry/opentelemetry-js/pull/6650) @trentm
 
 ### :books: Documentation
 

--- a/experimental/packages/configuration/.eslintignore
+++ b/experimental/packages/configuration/.eslintignore
@@ -1,1 +1,2 @@
 build
+test/fixtures/types

--- a/experimental/packages/configuration/src/generated/types.ts
+++ b/experimental/packages/configuration/src/generated/types.ts
@@ -1246,7 +1246,7 @@ export interface LoggerProvider {
 export interface LogRecordProcessor {
   batch?: BatchLogRecordProcessor;
   simple?: SimpleLogRecordProcessor;
-  [k: string]: unknown;
+  [k: string]: object | undefined;
 }
 /**
  * Configure a batch log record processor.
@@ -1292,7 +1292,7 @@ export interface LogRecordExporter {
   otlp_grpc?: OtlpGrpcExporter;
   'otlp_file/development'?: ExperimentalOtlpFileExporter;
   console?: ConsoleExporter;
-  [k: string]: unknown;
+  [k: string]: object | undefined;
 }
 export interface NameStringValuePair {
   /**
@@ -1524,11 +1524,11 @@ export interface PushMetricExporter {
   otlp_grpc?: OtlpGrpcMetricExporter;
   'otlp_file/development'?: ExperimentalOtlpFileMetricExporter;
   console?: ConsoleMetricExporter;
-  [k: string]: unknown;
+  [k: string]: object | undefined;
 }
 export interface MetricProducer {
   opencensus?: OpenCensusMetricProducer;
-  [k: string]: unknown;
+  [k: string]: object | undefined;
 }
 /**
  * Configure cardinality limits.
@@ -1610,7 +1610,7 @@ export interface PullMetricReader {
  */
 export interface PullMetricExporter {
   'prometheus/development'?: ExperimentalPrometheusMetricExporter;
-  [k: string]: unknown;
+  [k: string]: object | undefined;
 }
 /**
  * Configure Prometheus Exporter to add resource attributes as metrics attributes, where the resource attribute keys match the patterns.
@@ -1822,7 +1822,7 @@ export interface TextMapPropagator {
   baggage?: BaggagePropagator;
   b3?: B3Propagator;
   b3multi?: B3MultiPropagator;
-  [k: string]: unknown;
+  [k: string]: object | undefined;
 }
 /**
  * Configure tracer provider.
@@ -1845,7 +1845,7 @@ export interface TracerProvider {
 export interface SpanProcessor {
   batch?: BatchSpanProcessor;
   simple?: SimpleSpanProcessor;
-  [k: string]: unknown;
+  [k: string]: object | undefined;
 }
 /**
  * Configure a batch span processor.
@@ -1891,7 +1891,7 @@ export interface SpanExporter {
   otlp_grpc?: OtlpGrpcExporter;
   'otlp_file/development'?: ExperimentalOtlpFileExporter;
   console?: ConsoleExporter;
-  [k: string]: unknown;
+  [k: string]: object | undefined;
 }
 /**
  * Configure a simple span processor.
@@ -1963,7 +1963,7 @@ export interface Sampler {
   parent_based?: ParentBasedSampler;
   'probability/development'?: ExperimentalProbabilitySampler;
   trace_id_ratio_based?: TraceIdRatioBasedSampler;
-  [k: string]: unknown;
+  [k: string]: object | undefined;
 }
 /**
  * Configure sampler to be composite.
@@ -1976,7 +1976,7 @@ export interface ExperimentalComposableSampler {
   parent_threshold?: ExperimentalComposableParentThresholdSampler;
   probability?: ExperimentalComposableProbabilitySampler;
   rule_based?: ExperimentalComposableRuleBasedSampler;
-  [k: string]: unknown;
+  [k: string]: object | undefined;
 }
 /**
  * Configure sampler to be parent_threshold.
@@ -2209,7 +2209,7 @@ export interface ExperimentalResourceDetector {
   host?: ExperimentalHostResourceDetector;
   process?: ExperimentalProcessResourceDetector;
   service?: ExperimentalServiceResourceDetector;
-  [k: string]: unknown;
+  [k: string]: object | undefined;
 }
 /**
  * Configure instrumentation.
@@ -2479,7 +2479,7 @@ export interface ExperimentalUrlSanitization {
  *
  */
 export interface ExperimentalLanguageSpecificInstrumentation {
-  [k: string]: unknown;
+  [k: string]: object;
 }
 /**
  * Configure .NET language-specific instrumentation libraries.
@@ -2488,7 +2488,7 @@ export interface ExperimentalLanguageSpecificInstrumentation {
  *
  */
 export interface Distribution {
-  [k: string]: unknown;
+  [k: string]: object;
 }
 
 export const InstrumentType = {

--- a/experimental/packages/configuration/test/fixtures/types/fail-span-processor-non-object.ts
+++ b/experimental/packages/configuration/test/fixtures/types/fail-span-processor-non-object.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ConfigurationModel } from '@opentelemetry/configuration';
+const config: ConfigurationModel = {
+  tracer_provider: {
+    processors: [{ my_custom_processor: 42 }],
+  },
+};

--- a/experimental/packages/configuration/test/fixtures/types/pass-custom-span-processor.ts
+++ b/experimental/packages/configuration/test/fixtures/types/pass-custom-span-processor.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ConfigurationModel } from '@opentelemetry/configuration';
+const config: ConfigurationModel = {
+  tracer_provider: {
+    processors: [{ my_custom_processor: {} }],
+  },
+};

--- a/experimental/packages/configuration/test/fixtures/types/tsconfig-fail.json
+++ b/experimental/packages/configuration/test/fixtures/types/tsconfig-fail.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "lib": ["es2022"],
+    "module": "node16",
+    "target": "es2022",
+
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node16"
+  },
+  "include": [
+    "fail-*.ts"
+  ]
+}
+

--- a/experimental/packages/configuration/test/fixtures/types/tsconfig-pass.json
+++ b/experimental/packages/configuration/test/fixtures/types/tsconfig-pass.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "lib": ["es2022"],
+    "module": "node16",
+    "target": "es2022",
+
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node16"
+  },
+  "include": [
+    "pass-*.ts"
+  ]
+}
+

--- a/experimental/packages/configuration/test/types.test.ts
+++ b/experimental/packages/configuration/test/types.test.ts
@@ -24,7 +24,7 @@ describe('types', function () {
         encoding: 'utf8',
       }
     );
-    assert.strictEqual(p.status, 0);
+    assert.ifError(p.error);
   });
 
   it('should FAIL to tsc compile test/fixtures/types/fail-*.ts files', function () {
@@ -48,6 +48,8 @@ describe('types', function () {
     //     test/fixtures/types/fail-2.ts(12,20): error TS2322: Type 'number' is not assignable to type 'object'.
     //     test/fixtures/types/fail-span-processor-non-object.ts(9,20): error TS2322: Type 'number' is not assignable to type 'object'.
     const ERR_RE = /^test\/fixtures\/types\/([^(]*)\((\d+),\d+\): (.*?)$/;
+    console.log('XXX stdout: ', p.stdout);
+    console.log('XXX stderr: ', p.stderr);
     const actualErrs = p.stdout
       .trim()
       .split(/\n/g)
@@ -63,6 +65,6 @@ describe('types', function () {
       });
 
     assert.deepStrictEqual(actualErrs, expectedErrs);
-    assert.strictEqual(p.status, 2);
+    assert.ok(p.error);
   });
 });

--- a/experimental/packages/configuration/test/types.test.ts
+++ b/experimental/packages/configuration/test/types.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Test that usage of TypeScript *types* from the configuration package work
+ * as expected.
+ * This is done by using `tsc` to compile the `test/fixtures/types/*.ts` files.
+ * `pass-*.ts` should succeed, `fail-*.ts` should fail.
+ */
+
+import * as assert from 'assert';
+import { spawnSync } from 'child_process';
+
+describe('types', function () {
+  it('should tsc compile test/fixtures/types/pass-*.ts files successfully', function () {
+    const p = spawnSync(
+      'npx',
+      ['tsc', '-p', 'test/fixtures/types/tsconfig-pass.json'],
+      {
+        encoding: 'utf8',
+      }
+    );
+    assert.strictEqual(p.status, 0);
+  });
+
+  it('should FAIL to tsc compile test/fixtures/types/fail-*.ts files', function () {
+    const expectedErrs = [
+      {
+        file: 'fail-span-processor-non-object.ts',
+        line: 9,
+        msg: "error TS2322: Type 'number' is not assignable to type 'object'.",
+      },
+    ];
+
+    const p = spawnSync(
+      'npx',
+      ['tsc', '-p', 'test/fixtures/types/tsconfig-fail.json'],
+      {
+        encoding: 'utf8',
+      }
+    );
+
+    // Parse tsc error output to a structure to compare to `expectedErrs`. E.g.:
+    //     test/fixtures/types/fail-2.ts(12,20): error TS2322: Type 'number' is not assignable to type 'object'.
+    //     test/fixtures/types/fail-span-processor-non-object.ts(9,20): error TS2322: Type 'number' is not assignable to type 'object'.
+    const ERR_RE = /^test\/fixtures\/types\/([^(]*)\((\d+),\d+\): (.*?)$/;
+    const actualErrs = p.stdout
+      .trim()
+      .split(/\n/g)
+      .filter(line => line.trim().length > 0)
+      .map(line => {
+        const match = ERR_RE.exec(line);
+        if (!match) {
+          throw new Error(
+            `could not match 'tsc' output line: ${JSON.stringify(line)}`
+          );
+        }
+        return { file: match[1], line: Number(match[2]), msg: match[3] };
+      });
+
+    assert.deepStrictEqual(actualErrs, expectedErrs);
+    assert.strictEqual(p.status, 2);
+  });
+});

--- a/experimental/packages/configuration/test/types.test.ts
+++ b/experimental/packages/configuration/test/types.test.ts
@@ -14,6 +14,8 @@ import * as assert from 'assert';
 import { spawnSync } from 'child_process';
 
 describe('types', function () {
+  this.timeout(5000); // Running `tsc` in the tests below can be slow in CI.
+
   it('should tsc compile test/fixtures/types/pass-*.ts files successfully', function () {
     const p = spawnSync(
       'npx',

--- a/experimental/packages/configuration/test/types.test.ts
+++ b/experimental/packages/configuration/test/types.test.ts
@@ -22,8 +22,13 @@ describe('types', function () {
       ['tsc', '-p', 'test/fixtures/types/tsconfig-pass.json'],
       {
         encoding: 'utf8',
+        shell: true, // Use 'shell' so Windows can spawn `npx`.
       }
     );
+    console.log('XXX stdout: ', p.stdout);
+    console.log('XXX stderr: ', p.stderr);
+    console.log('XXX error: ', p.error);
+    console.log('XXX status: ', p.status);
     assert.ifError(p.error);
   });
 
@@ -41,6 +46,7 @@ describe('types', function () {
       ['tsc', '-p', 'test/fixtures/types/tsconfig-fail.json'],
       {
         encoding: 'utf8',
+        shell: true, // Use 'shell' so Windows can spawn `npx`.
       }
     );
 
@@ -50,6 +56,8 @@ describe('types', function () {
     const ERR_RE = /^test\/fixtures\/types\/([^(]*)\((\d+),\d+\): (.*?)$/;
     console.log('XXX stdout: ', p.stdout);
     console.log('XXX stderr: ', p.stderr);
+    console.log('XXX error: ', p.error);
+    console.log('XXX status: ', p.status);
     const actualErrs = p.stdout
       .trim()
       .split(/\n/g)

--- a/experimental/packages/configuration/test/types.test.ts
+++ b/experimental/packages/configuration/test/types.test.ts
@@ -25,11 +25,7 @@ describe('types', function () {
         shell: true, // Use 'shell' so Windows can spawn `npx`.
       }
     );
-    console.log('XXX stdout: ', p.stdout);
-    console.log('XXX stderr: ', p.stderr);
-    console.log('XXX error: ', p.error);
-    console.log('XXX status: ', p.status);
-    assert.ifError(p.error);
+    assert.strictEqual(p.status, 0);
   });
 
   it('should FAIL to tsc compile test/fixtures/types/fail-*.ts files', function () {
@@ -54,10 +50,6 @@ describe('types', function () {
     //     test/fixtures/types/fail-2.ts(12,20): error TS2322: Type 'number' is not assignable to type 'object'.
     //     test/fixtures/types/fail-span-processor-non-object.ts(9,20): error TS2322: Type 'number' is not assignable to type 'object'.
     const ERR_RE = /^test\/fixtures\/types\/([^(]*)\((\d+),\d+\): (.*?)$/;
-    console.log('XXX stdout: ', p.stdout);
-    console.log('XXX stderr: ', p.stderr);
-    console.log('XXX error: ', p.error);
-    console.log('XXX status: ', p.status);
     const actualErrs = p.stdout
       .trim()
       .split(/\n/g)
@@ -73,6 +65,6 @@ describe('types', function () {
       });
 
     assert.deepStrictEqual(actualErrs, expectedErrs);
-    assert.ok(p.error);
+    assert.ok(typeof p.status === 'number' && p.status !== 0);
   });
 });

--- a/experimental/packages/configuration/tsconfig.json
+++ b/experimental/packages/configuration/tsconfig.json
@@ -10,6 +10,9 @@
     "src/generated/*.js",
     "test/**/*.ts"
   ],
+  "exclude": [
+    "test/fixtures/**"
+  ],
   "references": [
     {
       "path": "../../../api"

--- a/scripts/config/generate-config.js
+++ b/scripts/config/generate-config.js
@@ -2,26 +2,16 @@
 
 /*
  * Copyright The OpenTelemetry Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /**
  * Generates TypeScript types from the OpenTelemetry configuration JSON schema
  * using json-schema-to-typescript.
  *
- * Usage: node generate-config.js
- * Run from the configuration package: npm run generate:config
+ * Usage:
+ *    cd experimental/packages/configuration
+ *    npm run generate:config
  */
 
 'use strict';
@@ -177,11 +167,32 @@ compile(schema, 'OpenTelemetryConfiguration', {
       }
     }
 
-    // Replace overly-narrow index signatures that conflict with typed properties.
-    // When additionalProperties is absent or true, json-schema-to-typescript emits
-    // [k: string]: {} | null which is too narrow to accommodate specific typed fields.
-    ts = ts.replace(/\[k: string\]: \{\} \| null;/g, '[k: string]: unknown;');
-    ts = ts.replace(/\[k: string\]: \{\};/g, '[k: string]: unknown;');
+    // Change the TypeScript representation for interfaces where
+    // "additionalProperties" is allowed.
+    //
+    // The configuration JSON schema uses the following for types that have
+    // well-known property keys (e.g. 'batch' or 'simple' for `SpanProcessor`),
+    // but also allow custom values.
+    //    "additionalProperties": {
+    //      "type": [ "object", "null" ],
+    //
+    // json-schema-to-typescript represents this with:
+    //    [k: string]: {} | null
+    //
+    // However, we want:
+    //    [k: string]: object | undefined
+    //
+    // - `object` instead of `{}`, because JSON schema "object" means a thing
+    //   with keys and values (https://json-schema.org/understanding-json-schema/reference/object)
+    //   and TypeScript "object" means non-Primitive values (https://stackoverflow.com/a/49465172)
+    //   which is closest. `{}` allows too much (e.g. 42 matches `{}`).
+    // - `undefined` rather than `null` because we want to express that the
+    //   property can be unspecified.
+    ts = ts.replace(/\[k: string\]: \{\} \| null;/g, '[k: string]: object | undefined;');
+    // Similarly for schema types with the following (e.g. `Distribution`):
+    //    "additionalProperties": {
+    //      "type": [ "object" ],
+    ts = ts.replace(/\[k: string\]: \{\};/g, '[k: string]: object;');
 
     // Strip `| null` from type unions. The JSON schema uses
     // "type": ["string", "null"] to express optional/nullable fields, which


### PR DESCRIPTION
tl;dr: Use this TypeScript:

    [k: string]: object | undefined

rather than this:

    [k: string]: {} | null

in the interface for a JSON schema property with:

    "additionalProperties": {
        "type": [ "object", "null" ],

It more accurately represents the type intention.
This change makes it so this TS fails type check:

    const config: ConfigurationModel = {
      tracer_provider: {
        processors: [
          { my_custom_processor: 42 }
          // `-- Type 'number' is not assignable to type 'object'. ts(2322)
        ],
      }
    };

but this passes, as intended by the JSON schema:

    const config: ConfigurationModel = {
      tracer_provider: {
        processors: [
          { my_custom_processor: {} }
        ],
      }
    };

This is because TypeScript `{}` is any non-null type, where as
`object` is more specific.
https://stackoverflow.com/a/49465172 explains the diffs.
