### PR TITLE
feat(opentelemetry-exporter-prometheus): add translation strategy support

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 * feat(otlp-transformer): replace protobufjs trace serialization with custom implementation [#6625](https://github.com/open-telemetry/opentelemetry-js/pull/6625) @pichlermarc
 * feat(configuration): auto-generate TypeScript types from OTel declarative config JSON schema (stable v1.0.0) using `json-schema-to-typescript` and `ajv` [#6533](https://github.com/open-telemetry/opentelemetry-js/pull/6533) @MikeGoldsmith
+* feat(opentelemetry-exporter-prometheus): add translation strategy support [#6653](https://github.com/open-telemetry/opentelemetry-js/pull/6653) @cjihrig
 
 ### :bug: Bug Fixes
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -13,6 +13,8 @@ import {
 import type { IncomingMessage, Server, ServerResponse } from 'http';
 import { createServer } from 'http';
 import type { ExporterConfig } from './export/types';
+import { TranslationStrategy } from './export/types';
+import type { TranslationStrategyOptions } from './PrometheusSerializer';
 import { PrometheusSerializer } from './PrometheusSerializer';
 /** Node.js v8.x compat */
 import { URL } from 'url';
@@ -24,6 +26,7 @@ export class PrometheusExporter extends MetricReader {
     endpoint: '/metrics',
     prefix: '',
     appendTimestamp: false,
+    translationStrategy: TranslationStrategy.UnderscoreEscapingWithSuffixes,
     withResourceConstantLabels: undefined,
     withoutScopeInfo: false,
     withoutTargetInfo: false,
@@ -36,6 +39,7 @@ export class PrometheusExporter extends MetricReader {
   private readonly _server: Server;
   private readonly _prefix?: string;
   private readonly _appendTimestamp: boolean;
+  private readonly _translationStrategy: TranslationStrategyOptions;
   private _serializer: PrometheusSerializer;
   private _startServerPromise: Promise<void> | undefined;
 
@@ -84,6 +88,22 @@ export class PrometheusExporter extends MetricReader {
     const _withoutTargetInfo =
       config.withoutTargetInfo ||
       PrometheusExporter.DEFAULT_OPTIONS.withoutTargetInfo;
+    const _translationStrategy =
+      config.translationStrategy ||
+      PrometheusExporter.DEFAULT_OPTIONS.translationStrategy;
+
+    this._translationStrategy = {
+      escape:
+        _translationStrategy ===
+          TranslationStrategy.UnderscoreEscapingWithSuffixes ||
+        _translationStrategy ===
+          TranslationStrategy.UnderscoreEscapingWithoutSuffixes,
+      suffixes:
+        _translationStrategy ===
+          TranslationStrategy.UnderscoreEscapingWithSuffixes ||
+        _translationStrategy === TranslationStrategy.NoUTF8EscapingWithSuffixes,
+    };
+
     // unref to prevent prometheus exporter from holding the process open on exit
     this._server = createServer(this._requestHandler).unref();
     this._serializer = new PrometheusSerializer(
@@ -220,7 +240,12 @@ export class PrometheusExporter extends MetricReader {
             ...errors
           );
         }
-        response.end(this._serializer.serialize(resourceMetrics));
+        // Translation strategy options are passed to the serlialize() method
+        // because in the future, these options may also be influenced by the
+        // content negotiation process of the incoming request.
+        response.end(
+          this._serializer.serialize(resourceMetrics, this._translationStrategy)
+        );
       },
       err => {
         response.end(`# failed to export metrics: ${err}`);

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -24,6 +24,19 @@ import {
 // This is currently listed as experimental.
 const ATTR_OTEL_SCOPE_SCHEMA_URL = 'otel.scope.schema_url';
 
+const invalidCharacterRegex = /[^a-z0-9_]/gi;
+const multipleUnderscoreRegex = /_{2,}/g;
+
+// These should be sanitized, even if escaping is disabled.
+const ATTR_OTEL_SCOPE_NAME_LABEL =
+  sanitizePrometheusMetricName(ATTR_OTEL_SCOPE_NAME);
+const ATTR_OTEL_SCOPE_VERSION_LABEL = sanitizePrometheusMetricName(
+  ATTR_OTEL_SCOPE_VERSION
+);
+const ATTR_OTEL_SCOPE_SCHEMA_URL_LABEL = sanitizePrometheusMetricName(
+  ATTR_OTEL_SCOPE_SCHEMA_URL
+);
+
 type PrometheusDataTypeLiteral =
   | 'counter'
   | 'gauge'
@@ -33,6 +46,14 @@ type PrometheusDataTypeLiteral =
 
 function escapeString(str: string) {
   return str.replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
+}
+
+function escapeQuotes(str: string) {
+  return str.replace(/"/g, '\\"');
+}
+
+function quoteName(str: string) {
+  return `"${escapeQuotes(str)}"`;
 }
 
 /**
@@ -45,11 +66,8 @@ function escapeAttributeValue(str: AttributeValue = '') {
   if (typeof str !== 'string') {
     str = JSON.stringify(str);
   }
-  return escapeString(str).replace(/"/g, '\\"');
+  return escapeQuotes(escapeString(str));
 }
-
-const invalidCharacterRegex = /[^a-z0-9_]/gi;
-const multipleUnderscoreRegex = /_{2,}/g;
 
 /**
  * Ensures metric names are valid Prometheus metric names by removing
@@ -101,6 +119,11 @@ function enforcePrometheusNamingConvention(
   return name;
 }
 
+function hasNonLegacyCharacters(name: string): boolean {
+  // Use search() instead of test() since this regex has the 'g' flag.
+  return name.search(invalidCharacterRegex) !== -1;
+}
+
 function valueString(value: number) {
   if (value === Infinity) {
     return '+Inf';
@@ -132,14 +155,19 @@ function stringify(
   metricName: string,
   attributes: Attributes,
   value: number,
-  timestamp?: number,
-  additionalAttributes?: Attributes
+  timestamp: number | undefined,
+  additionalAttributes: Attributes | undefined,
+  translationStrategy: TranslationStrategyOptions
 ) {
   let hasAttribute = false;
   let attributesStr = '';
 
   for (const [key, val] of Object.entries(attributes)) {
-    const sanitizedAttributeName = sanitizePrometheusMetricName(key);
+    const sanitizedAttributeName = translationStrategy.escape
+      ? sanitizePrometheusMetricName(key)
+      : hasNonLegacyCharacters(key)
+        ? quoteName(key)
+        : key;
     hasAttribute = true;
     attributesStr += `${
       attributesStr.length > 0 ? ',' : ''
@@ -147,7 +175,11 @@ function stringify(
   }
   if (additionalAttributes) {
     for (const [key, val] of Object.entries(additionalAttributes)) {
-      const sanitizedAttributeName = sanitizePrometheusMetricName(key);
+      const sanitizedAttributeName = translationStrategy.escape
+        ? sanitizePrometheusMetricName(key)
+        : hasNonLegacyCharacters(key)
+          ? quoteName(key)
+          : key;
       hasAttribute = true;
       attributesStr += `${
         attributesStr.length > 0 ? ',' : ''
@@ -155,7 +187,13 @@ function stringify(
     }
   }
 
-  if (hasAttribute) {
+  if (hasNonLegacyCharacters(metricName)) {
+    if (hasAttribute) {
+      metricName = `{${quoteName(metricName)} ${attributesStr}}`;
+    } else {
+      metricName = `{${quoteName(metricName)}}`;
+    }
+  } else if (hasAttribute) {
     metricName += `{${attributesStr}}`;
   }
 
@@ -165,6 +203,11 @@ function stringify(
 }
 
 const NO_REGISTERED_METRICS = '# no registered metrics';
+
+export interface TranslationStrategyOptions {
+  escape: boolean;
+  suffixes: boolean;
+}
 
 export class PrometheusSerializer {
   private _prefix: string | undefined;
@@ -190,7 +233,10 @@ export class PrometheusSerializer {
     this._withoutTargetInfo = !!withoutTargetInfo;
   }
 
-  serialize(resourceMetrics: ResourceMetrics): string {
+  serialize(
+    resourceMetrics: ResourceMetrics,
+    translationStrategy: TranslationStrategyOptions
+  ): string {
     let str = '';
 
     this._additionalAttributes = this._filterResourceConstantLabels(
@@ -199,14 +245,17 @@ export class PrometheusSerializer {
     );
 
     for (const scopeMetrics of resourceMetrics.scopeMetrics) {
-      str += this._serializeScopeMetrics(scopeMetrics);
+      str += this._serializeScopeMetrics(scopeMetrics, translationStrategy);
     }
 
     if (str === '') {
       str += NO_REGISTERED_METRICS;
     }
 
-    return this._serializeResource(resourceMetrics.resource) + str;
+    return (
+      this._serializeResource(resourceMetrics.resource, translationStrategy) +
+      str
+    );
   }
 
   private _filterResourceConstantLabels(
@@ -225,48 +274,69 @@ export class PrometheusSerializer {
     return;
   }
 
-  private _serializeScopeMetrics(scopeMetrics: ScopeMetrics) {
+  private _serializeScopeMetrics(
+    scopeMetrics: ScopeMetrics,
+    translationStrategy: TranslationStrategyOptions
+  ) {
     let str = '';
     for (const metric of scopeMetrics.metrics) {
-      str += this._serializeMetricData(metric, scopeMetrics.scope) + '\n';
+      str +=
+        this._serializeMetricData(
+          metric,
+          scopeMetrics.scope,
+          translationStrategy
+        ) + '\n';
     }
     return str;
   }
 
   private _serializeMetricData(
     metricData: MetricData,
-    scope: InstrumentationScope
+    scope: InstrumentationScope,
+    translationStrategy: TranslationStrategyOptions
   ) {
-    let name = sanitizePrometheusMetricName(
-      escapeString(metricData.descriptor.name)
-    );
+    let name = escapeString(metricData.descriptor.name);
+    let handleNonLegacyChars = false;
+
     if (this._prefix) {
       name = `${this._prefix}${name}`;
     }
+
+    if (translationStrategy.escape) {
+      name = sanitizePrometheusMetricName(name);
+    } else {
+      handleNonLegacyChars = hasNonLegacyCharacters(name);
+    }
+
+    if (translationStrategy.suffixes) {
+      name = enforcePrometheusNamingConvention(name, metricData);
+    }
+
     const dataPointType = metricData.dataPointType;
 
-    name = enforcePrometheusNamingConvention(name, metricData);
-
-    const help = `# HELP ${name} ${escapeString(
+    const outputName = handleNonLegacyChars ? quoteName(name) : name;
+    const help = `# HELP ${outputName} ${escapeString(
       metricData.descriptor.description || 'description missing'
     )}`;
     const unit = metricData.descriptor.unit
-      ? `\n# UNIT ${name} ${escapeString(metricData.descriptor.unit)}`
+      ? `\n# UNIT ${outputName} ${escapeString(metricData.descriptor.unit)}`
       : '';
-    const type = `# TYPE ${name} ${toPrometheusType(metricData)}`;
+    const type = `# TYPE ${outputName} ${toPrometheusType(metricData)}`;
     let additionalAttributes: Attributes | undefined;
 
     if (this._withoutScopeInfo) {
       additionalAttributes = this._additionalAttributes;
     } else {
-      const scopeInfo: Attributes = { [ATTR_OTEL_SCOPE_NAME]: scope.name };
+      const scopeInfo: Attributes = {
+        [ATTR_OTEL_SCOPE_NAME_LABEL]: scope.name,
+      };
 
       if (scope.schemaUrl) {
-        scopeInfo[ATTR_OTEL_SCOPE_SCHEMA_URL] = scope.schemaUrl;
+        scopeInfo[ATTR_OTEL_SCOPE_SCHEMA_URL_LABEL] = scope.schemaUrl;
       }
 
       if (scope.version) {
-        scopeInfo[ATTR_OTEL_SCOPE_VERSION] = scope.version;
+        scopeInfo[ATTR_OTEL_SCOPE_VERSION_LABEL] = scope.version;
       }
 
       additionalAttributes = Object.assign(
@@ -285,7 +355,8 @@ export class PrometheusSerializer {
               name,
               metricData,
               it,
-              additionalAttributes
+              additionalAttributes,
+              translationStrategy
             )
           )
           .join('');
@@ -298,7 +369,8 @@ export class PrometheusSerializer {
               name,
               metricData,
               it,
-              additionalAttributes
+              additionalAttributes,
+              translationStrategy
             )
           )
           .join('');
@@ -318,7 +390,8 @@ export class PrometheusSerializer {
     name: string,
     data: MetricData,
     dataPoint: DataPoint<number>,
-    additionalAttributes: Attributes | undefined
+    additionalAttributes: Attributes | undefined,
+    translationStrategy: TranslationStrategyOptions
   ): string {
     let results = '';
 
@@ -329,7 +402,8 @@ export class PrometheusSerializer {
       attributes,
       value,
       this._appendTimestamp ? timestamp : undefined,
-      additionalAttributes
+      additionalAttributes,
+      translationStrategy
     );
     return results;
   }
@@ -338,7 +412,8 @@ export class PrometheusSerializer {
     name: string,
     data: MetricData,
     dataPoint: DataPoint<Histogram>,
-    additionalAttributes: Attributes | undefined
+    additionalAttributes: Attributes | undefined,
+    translationStrategy: TranslationStrategyOptions
   ): string {
     let results = '';
 
@@ -354,7 +429,8 @@ export class PrometheusSerializer {
           attributes,
           value,
           this._appendTimestamp ? timestamp : undefined,
-          additionalAttributes
+          additionalAttributes,
+          translationStrategy
         );
     }
 
@@ -386,14 +462,18 @@ export class PrometheusSerializer {
             upperBound === undefined || upperBound === Infinity
               ? '+Inf'
               : String(upperBound),
-        })
+        }),
+        translationStrategy
       );
     }
 
     return results;
   }
 
-  protected _serializeResource(resource: Resource): string {
+  protected _serializeResource(
+    resource: Resource,
+    translationStrategy: TranslationStrategyOptions
+  ): string {
     if (this._withoutTargetInfo === true) {
       return '';
     }
@@ -402,7 +482,14 @@ export class PrometheusSerializer {
     const help = `# HELP ${name} Target metadata`;
     const type = `# TYPE ${name} gauge`;
 
-    const results = stringify(name, resource.attributes, 1).trim();
+    const results = stringify(
+      name,
+      resource.attributes,
+      1,
+      undefined,
+      undefined,
+      translationStrategy
+    ).trim();
     return `${help}\n${type}\n${results}\n`;
   }
 }

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/export/types.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/export/types.ts
@@ -57,6 +57,14 @@ export interface ExporterConfig {
   metricProducers?: MetricProducer[];
 
   /**
+   * This option controls the translation of metric names from OpenTelemetry Naming
+   * Conventions to Prometheus Naming conventions.
+   * @default TranslationStrategy.UnderscoreEscapingWithSuffixes
+   * @experimental
+   */
+  translationStrategy?: (typeof TranslationStrategy)[keyof typeof TranslationStrategy];
+
+  /**
    * Regex pattern for defining which resource attributes will be applied
    * as constant labels to the metrics.
    * e.g. 'telemetry_.+' for all attributes starting with 'telemetry'.
@@ -76,3 +84,26 @@ export interface ExporterConfig {
    */
   withoutTargetInfo?: boolean;
 }
+
+export const TranslationStrategy = {
+  /**
+   * This fully escapes metric names for classic Prometheus metric name compatibility,
+   * and includes appending type and unit suffixes. This is the default strategy.
+   */
+  UnderscoreEscapingWithSuffixes: 'UnderscoreEscapingWithSuffixes',
+  /**
+   * Metric names will continue to escape special characters to _, but suffixes
+   * won’t be attached.
+   */
+  UnderscoreEscapingWithoutSuffixes: 'UnderscoreEscapingWithoutSuffixes',
+  /**
+   * Disables changing special characters to _. Special suffixes like units and
+   * _total for counters will be attached.
+   */
+  NoUTF8EscapingWithSuffixes: 'NoUTF8EscapingWithSuffixes',
+  /**
+   * This strategy bypasses all metric and label name translation, passing them
+   * through unaltered.
+   */
+  NoTranslation: 'NoTranslation',
+} as const;

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/index.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/index.ts
@@ -5,4 +5,5 @@
 
 export { PrometheusExporter } from './PrometheusExporter';
 export { PrometheusSerializer } from './PrometheusSerializer';
+export { TranslationStrategy } from './export/types';
 export type { ExporterConfig } from './export/types';

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@opentelemetry/sdk-metrics';
 import * as sinon from 'sinon';
 import { PrometheusSerializer } from '../src';
+import type { TranslationStrategyOptions } from '../src/PrometheusSerializer';
 import {
   mockedHrTimeMs,
   mockHrTime,
@@ -25,17 +26,27 @@ import {
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import { AggregationType } from '@opentelemetry/sdk-metrics';
 
+const defaultTranslationStrategy: TranslationStrategyOptions = {
+  escape: true,
+  suffixes: true,
+};
+
 const attributes = {
   foo1: 'bar1',
   foo2: 'bar2',
 };
 
 const resourceAttributes = `service_name="${serviceName}",telemetry_sdk_language="${sdkLanguage}",telemetry_sdk_name="${sdkName}",telemetry_sdk_version="${sdkVersion}"`;
+const resourceAttributesUnescaped = `"service.name"="${serviceName}","telemetry.sdk.language"="${sdkLanguage}","telemetry.sdk.name"="${sdkName}","telemetry.sdk.version"="${sdkVersion}"`;
 
 const serializedDefaultResource =
   '# HELP target_info Target metadata\n' +
   '# TYPE target_info gauge\n' +
   `target_info{${resourceAttributes}} 1\n`;
+const serializedDefaultResourceUnescaped =
+  '# HELP target_info Target metadata\n' +
+  '# TYPE target_info gauge\n' +
+  `target_info{${resourceAttributesUnescaped}} 1\n`;
 
 class TestMetricReader extends MetricReader {
   constructor() {
@@ -103,7 +114,8 @@ describe('PrometheusSerializer', () => {
           metric.descriptor.name,
           metric,
           pointData[0],
-          serializer['_additionalAttributes']
+          serializer['_additionalAttributes'],
+          defaultTranslationStrategy
         );
         return result;
       }
@@ -163,7 +175,8 @@ describe('PrometheusSerializer', () => {
           metric.descriptor.name,
           metric,
           pointData[0],
-          serializer['_additionalAttributes']
+          serializer['_additionalAttributes'],
+          defaultTranslationStrategy
         );
         return result;
       }
@@ -243,7 +256,10 @@ describe('PrometheusSerializer', () => {
           '_filterResourceConstantLabels'
         ](resourceAttributes, serializer['_withResourceConstantLabels']);
 
-        const result = serializer['_serializeScopeMetrics'](scopeMetrics);
+        const result = serializer['_serializeScopeMetrics'](
+          scopeMetrics,
+          defaultTranslationStrategy
+        );
         return result;
       }
 
@@ -314,7 +330,10 @@ describe('PrometheusSerializer', () => {
           '_filterResourceConstantLabels'
         ](resourceAttributes, serializer['_withResourceConstantLabels']);
 
-        return serializer['_serializeScopeMetrics'](scopeMetrics);
+        return serializer['_serializeScopeMetrics'](
+          scopeMetrics,
+          defaultTranslationStrategy
+        );
       }
 
       it('should serialize metric record', async () => {
@@ -387,7 +406,10 @@ describe('PrometheusSerializer', () => {
           '_filterResourceConstantLabels'
         ](resourceAttributes, serializer['_withResourceConstantLabels']);
 
-        return serializer['_serializeScopeMetrics'](scopeMetrics);
+        return serializer['_serializeScopeMetrics'](
+          scopeMetrics,
+          defaultTranslationStrategy
+        );
       }
 
       it('should serialize metric record', async () => {
@@ -463,7 +485,10 @@ describe('PrometheusSerializer', () => {
           '_filterResourceConstantLabels'
         ](resourceAttributes, serializer['_withResourceConstantLabels']);
 
-        const result = serializer['_serializeScopeMetrics'](scopeMetrics);
+        const result = serializer['_serializeScopeMetrics'](
+          scopeMetrics,
+          defaultTranslationStrategy
+        );
         return result;
       }
 
@@ -547,7 +572,10 @@ describe('PrometheusSerializer', () => {
           '_filterResourceConstantLabels'
         ](resourceAttributes, serializer['_withResourceConstantLabels']);
 
-        const result = serializer['_serializeScopeMetrics'](scopeMetrics);
+        const result = serializer['_serializeScopeMetrics'](
+          scopeMetrics,
+          defaultTranslationStrategy
+        );
         assert.strictEqual(
           result,
           '# HELP test foobar\n' +
@@ -571,7 +599,11 @@ describe('PrometheusSerializer', () => {
     async function getCounterResult(
       name: string,
       serializer: PrometheusSerializer,
-      options: Partial<{ unit: string; exportAll: boolean }> = {}
+      options: Partial<{
+        unit: string;
+        exportAll: boolean;
+        translationStrategy: TranslationStrategyOptions;
+      }> = {}
     ) {
       const reader = new TestMetricReader();
       const meterProvider = new MeterProvider({
@@ -585,7 +617,11 @@ describe('PrometheusSerializer', () => {
       });
       const meter = meterProvider.getMeter('test');
 
-      const { unit, exportAll = false } = options;
+      const {
+        unit,
+        exportAll = false,
+        translationStrategy = defaultTranslationStrategy,
+      } = options;
       const counter = meter.createCounter(name, { unit: unit });
       counter.add(1);
 
@@ -603,14 +639,18 @@ describe('PrometheusSerializer', () => {
       ](resourceAttributes, serializer['_withResourceConstantLabels']);
 
       if (exportAll) {
-        const result = serializer.serialize(resourceMetrics);
+        const result = serializer.serialize(
+          resourceMetrics,
+          translationStrategy
+        );
         return result;
       } else {
         const result = serializer['_serializeSingularDataPoint'](
           metric.descriptor.name,
           metric,
           pointData[0],
-          serializer['_additionalAttributes']
+          serializer['_additionalAttributes'],
+          translationStrategy
         );
         return result;
       }
@@ -670,6 +710,70 @@ describe('PrometheusSerializer', () => {
 
       assert.strictEqual(result, 'test_total 1\n');
     });
+
+    it('should not append _total to counters when suffixes are disabled', async () => {
+      const serializer = new PrometheusSerializer();
+      const result = await getCounterResult('test', serializer, {
+        exportAll: true,
+        translationStrategy: { escape: true, suffixes: false },
+      });
+
+      assert.strictEqual(
+        result,
+        serializedDefaultResource +
+          '# HELP test description missing\n' +
+          '# TYPE test counter\n' +
+          'test{otel_scope_name="test"} 1\n'
+      );
+    });
+
+    it('should not sanitize names when escaping is disabled', async () => {
+      const serializer = new PrometheusSerializer();
+      const result = await getCounterResult('test.dotted', serializer, {
+        exportAll: true,
+        translationStrategy: { escape: false, suffixes: true },
+      });
+
+      assert.strictEqual(
+        result,
+        serializedDefaultResourceUnescaped +
+          '# HELP "test.dotted_total" description missing\n' +
+          '# TYPE "test.dotted_total" counter\n' +
+          '{"test.dotted_total" otel_scope_name="test"} 1\n'
+      );
+    });
+
+    it('escapes quotes within quoted names', async () => {
+      const serializer = new PrometheusSerializer();
+      const result = await getCounterResult('test"quoted"', serializer, {
+        exportAll: true,
+        translationStrategy: { escape: false, suffixes: true },
+      });
+
+      assert.strictEqual(
+        result,
+        serializedDefaultResourceUnescaped +
+          '# HELP "test\\"quoted\\"_total" description missing\n' +
+          '# TYPE "test\\"quoted\\"_total" counter\n' +
+          '{"test\\"quoted\\"_total" otel_scope_name="test"} 1\n'
+      );
+    });
+
+    it('does not quote names if escaping is disabled but name is legacy compatible', async () => {
+      const serializer = new PrometheusSerializer();
+      const result = await getCounterResult('test', serializer, {
+        exportAll: true,
+        translationStrategy: { escape: false, suffixes: true },
+      });
+
+      assert.strictEqual(
+        result,
+        serializedDefaultResourceUnescaped +
+          '# HELP test_total description missing\n' +
+          '# TYPE test_total counter\n' +
+          'test_total{otel_scope_name="test"} 1\n'
+      );
+    });
   });
 
   describe('serialize non-normalized values', () => {
@@ -710,7 +814,8 @@ describe('PrometheusSerializer', () => {
         metric.descriptor.name,
         metric,
         pointData[0],
-        serializer['_additionalAttributes']
+        serializer['_additionalAttributes'],
+        defaultTranslationStrategy
       );
       return result;
     }
@@ -820,7 +925,8 @@ describe('PrometheusSerializer', () => {
           datacenter: 'sdc',
           region: 'europe',
           owner: 'frontend',
-        })
+        }),
+        defaultTranslationStrategy
       );
 
       assert.strictEqual(
@@ -845,7 +951,8 @@ describe('PrometheusSerializer', () => {
           datacenter: 'sdc',
           region: 'europe',
           owner: 'frontend',
-        })
+        }),
+        defaultTranslationStrategy
       );
 
       assert.strictEqual(result.includes('target_info'), false);
@@ -866,7 +973,8 @@ describe('PrometheusSerializer', () => {
           datacenter: 'sdc',
           region: 'europe',
           owner: 'frontend',
-        })
+        }),
+        defaultTranslationStrategy
       );
 
       assert.strictEqual(result.includes('otel_scope_name'), false);


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The Prometheus exporter does not currently support [Translation Strategy](https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/prometheus/#translation-strategy).

Related to #6605

## Short description of the changes

This PR adds support for Translation Strategy in a way that can also work with [Content Negotiation](https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/prometheus/#interaction-with-translation-strategy) in the future if necessary.

I am opening as a draft because I need to add more tests for the non-default behavior. There is also the issue of adding unit suffixes. I have [another branch](https://github.com/cjihrig/opentelemetry-js/commits/prom-units/) that implements unit suffixes, but turning them on by default (which is the spec behavior) would be a breaking change, so that will need to be figured out too.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Existing and new tests

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
