### PR TITLE
fix(build): ensure 'update-ts-configs' script doesn't blow away 'exclude' entry recently added to configuration/tsconfig.json

### DIFF
--- a/experimental/packages/configuration/tsconfig.json
+++ b/experimental/packages/configuration/tsconfig.json
@@ -5,13 +5,13 @@
     "outDir": "build",
     "rootDir": "."
   },
+  "exclude": [
+    "test/fixtures/**"
+  ],
   "include": [
     "src/**/*.ts",
     "src/generated/*.js",
     "test/**/*.ts"
-  ],
-  "exclude": [
-    "test/fixtures/**"
   ],
   "references": [
     {

--- a/scripts/update-ts-configs.js
+++ b/scripts/update-ts-configs.js
@@ -27,6 +27,7 @@ const {
 const packageJsonDependencyFields = ['dependencies', 'peerDependencies', 'devDependencies'];
 const tsConfigMergeKeys = [
   'compilerOptions',
+  'exclude',
   'include',
   'files',
 ];


### PR DESCRIPTION
We have a postinstall step that updates tsconfig.json files in packages.
I think this is mainly to update the references section, which is
easy to forget to update.

Recently #6650 added an 'exclude' entry to configuration/tsconfig.json.
update-ts-configs.js would just remove that 'exclude' entry during postinstall.
The symptom was that a subsequent 'npm run compile' would error out with

    error TS5055: Cannot write file '.../experimental/packages/configuration/build/src/ConfigFactory.d.ts' because it would overwrite input file.
    ...
