### PR TITLE
chore(configuration): cosmetic changes to generated types.ts

### DIFF
--- a/experimental/packages/configuration/src/generated/types.ts
+++ b/experimental/packages/configuration/src/generated/types.ts
@@ -8,6 +8,7 @@
 // Run `npm run generate:config` from the configuration package to regenerate
 //
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type */
+
 /**
  * Configure the log level of the internal logger used by the SDK.
  * Values include:
@@ -36,7 +37,6 @@
  * * warn3: warn3, severity number 15.
  * * warn4: warn4, severity number 16.
  * If omitted, INFO is used.
- *
  */
 export type SeverityNumber =
   | 'trace'
@@ -63,6 +63,7 @@ export type SeverityNumber =
   | 'fatal2'
   | 'fatal3'
   | 'fatal4';
+
 /**
  * Configure the encoding used for messages.
  * Implementations may not support json.
@@ -70,9 +71,9 @@ export type SeverityNumber =
  * * json: Protobuf JSON encoding.
  * * protobuf: Protobuf binary encoding.
  * If omitted, protobuf is used.
- *
  */
 export type OtlpHttpEncoding = 'protobuf' | 'json';
+
 /**
  * Configure temporality preference.
  * Values include:
@@ -80,23 +81,23 @@ export type OtlpHttpEncoding = 'protobuf' | 'json';
  * * delta: Use delta aggregation for all instrument types except up down counter and asynchronous up down counter.
  * * low_memory: Use delta aggregation temporality for counter and histogram instrument types. Use cumulative aggregation temporality for all other instrument types.
  * If omitted, cumulative is used.
- *
  */
 export type ExporterTemporalityPreference =
   | 'cumulative'
   | 'delta'
   | 'low_memory';
+
 /**
  * Configure default histogram aggregation.
  * Values include:
  * * base2_exponential_bucket_histogram: Use base2 exponential histogram as the default aggregation for histogram instruments.
  * * explicit_bucket_histogram: Use explicit bucket histogram as the default aggregation for histogram instruments.
  * If omitted, explicit_bucket_histogram is used.
- *
  */
 export type ExporterDefaultHistogramAggregation =
   | 'explicit_bucket_histogram'
   | 'base2_exponential_bucket_histogram';
+
 /**
  * Configure how metric names are translated to Prometheus metric names.
  * Values include:
@@ -105,13 +106,13 @@ export type ExporterDefaultHistogramAggregation =
  * * underscore_escaping_with_suffixes: Special character escaping is enabled. Type and unit suffixes are enabled.
  * * underscore_escaping_without_suffixes/development: Special character escaping is enabled. Type and unit suffixes are disabled. This represents classic Prometheus metric name compatibility.
  * If omitted, underscore_escaping_with_suffixes is used.
- *
  */
 export type ExperimentalPrometheusTranslationStrategy =
   | 'underscore_escaping_with_suffixes'
   | 'underscore_escaping_without_suffixes/development'
   | 'no_utf8_escaping_with_suffixes/development'
   | 'no_translation/development';
+
 /**
  * Configure instrument type selection criteria.
  * Values include:
@@ -123,7 +124,6 @@ export type ExperimentalPrometheusTranslationStrategy =
  * * observable_up_down_counter: Asynchronous up down counter instruments.
  * * up_down_counter: Synchronous up down counter instruments.
  * If omitted, all instrument types match.
- *
  */
 export type InstrumentType =
   | 'counter'
@@ -133,6 +133,7 @@ export type InstrumentType =
   | 'observable_gauge'
   | 'observable_up_down_counter'
   | 'up_down_counter';
+
 /**
  * Configure the exemplar filter.
  * Values include:
@@ -140,16 +141,18 @@ export type InstrumentType =
  * * always_on: ExemplarFilter which makes all measurements eligible for being an Exemplar.
  * * trace_based: ExemplarFilter which makes measurements recorded in the context of a sampled parent span eligible for being an Exemplar.
  * If omitted, trace_based is used.
- *
  */
 export type ExemplarFilter = 'always_on' | 'always_off' | 'trace_based';
+
 export type SpanKind =
   | 'internal'
   | 'server'
   | 'client'
   | 'producer'
   | 'consumer';
+
 export type ExperimentalSpanParent = 'none' | 'remote' | 'local';
+
 /**
  * The attribute type.
  * Values include:
@@ -162,7 +165,6 @@ export type ExperimentalSpanParent = 'none' | 'remote' | 'local';
  * * string: String attribute value.
  * * string_array: String array attribute value.
  * If omitted, string is used.
- *
  */
 export type AttributeType =
   | 'string'
@@ -173,6 +175,7 @@ export type AttributeType =
   | 'bool_array'
   | 'int_array'
   | 'double_array';
+
 export interface ConfigurationModel {
   /**
    * The file format version.
@@ -180,13 +183,11 @@ export interface ConfigurationModel {
    * See https://github.com/open-telemetry/opentelemetry-configuration/blob/main/VERSIONING.md for more details.
    * The yaml format is documented at https://github.com/open-telemetry/opentelemetry-configuration/tree/main/schema
    * Property is required and must be non-null.
-   *
    */
   file_format?: string;
   /**
    * Configure if the SDK is disabled or not.
    * If omitted or null, false is used.
-   *
    */
   disabled?: boolean;
   log_level?: SeverityNumber;
@@ -200,37 +201,34 @@ export interface ConfigurationModel {
   distribution?: Distribution;
   [k: string]: any;
 }
+
 /**
  * Configure general attribute limits. See also tracer_provider.limits, logger_provider.limits.
  * If omitted, default values as described in AttributeLimits are used.
- *
  */
 export interface AttributeLimits {
   /**
    * Configure max attribute value size.
    * Value must be non-negative.
    * If omitted or null, there is no limit.
-   *
    */
   attribute_value_length_limit?: number;
   /**
    * Configure max attribute count.
    * Value must be non-negative.
    * If omitted or null, 128 is used.
-   *
    */
   attribute_count_limit?: number;
 }
+
 /**
  * Configure logger provider.
  * If omitted, a noop logger provider is used.
- *
  */
 export interface LoggerProvider {
   /**
    * Configure log record processors.
    * Property is required and must be non-null.
-   *
    *
    * @minItems 1
    */
@@ -238,49 +236,46 @@ export interface LoggerProvider {
   limits?: LogRecordLimits;
   'logger_configurator/development'?: ExperimentalLoggerConfigurator;
 }
+
 export interface LogRecordProcessor {
   batch?: BatchLogRecordProcessor;
   simple?: SimpleLogRecordProcessor;
   [k: string]: object | undefined;
 }
+
 /**
  * Configure a batch log record processor.
  * If omitted, ignore.
- *
  */
 export interface BatchLogRecordProcessor {
   /**
    * Configure delay interval (in milliseconds) between two consecutive exports.
    * Value must be non-negative.
    * If omitted or null, 1000 is used.
-   *
    */
   schedule_delay?: number;
   /**
    * Configure maximum allowed time (in milliseconds) to export data.
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 30000 is used.
-   *
    */
   export_timeout?: number;
   /**
    * Configure maximum queue size. Value must be positive.
    * If omitted or null, 2048 is used.
-   *
    */
   max_queue_size?: number;
   /**
    * Configure maximum batch size. Value must be positive.
    * If omitted or null, 512 is used.
-   *
    */
   max_export_batch_size?: number;
   exporter: LogRecordExporter;
 }
+
 /**
  * Configure exporter.
  * Property is required and must be non-null.
- *
  */
 export interface LogRecordExporter {
   otlp_http?: OtlpHttpExporter;
@@ -289,16 +284,15 @@ export interface LogRecordExporter {
   console?: ConsoleExporter;
   [k: string]: object | undefined;
 }
+
 /**
  * Configure exporter to be OTLP with HTTP transport.
  * If omitted, ignore.
- *
  */
 export interface OtlpHttpExporter {
   /**
    * Configure endpoint, including the signal specific path.
    * If omitted or null, the http://localhost:4318/v1/{signal} (where signal is 'traces', 'logs', or 'metrics') is used.
-   *
    */
   endpoint?: string;
   tls?: HttpTls;
@@ -307,7 +301,6 @@ export interface OtlpHttpExporter {
    * If an entry's .value is null, the entry is ignored.
    * If omitted, no headers are added.
    *
-   *
    * @minItems 1
    */
   headers?: NameStringValuePair[];
@@ -315,77 +308,69 @@ export interface OtlpHttpExporter {
    * Configure headers. Entries have lower priority than entries from .headers.
    * The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
    * If omitted or null, no headers are added.
-   *
    */
   headers_list?: string;
   /**
    * Configure compression.
    * Known values include: gzip, none. Implementations may support other compression algorithms.
    * If omitted or null, none is used.
-   *
    */
   compression?: string;
   /**
    * Configure max time (in milliseconds) to wait for each export.
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 10000 is used.
-   *
    */
   timeout?: number;
   encoding?: OtlpHttpEncoding;
 }
+
 /**
  * Configure TLS settings for the exporter.
  * If omitted, system default TLS settings are used.
- *
  */
 export interface HttpTls {
   /**
    * Configure certificate used to verify a server's TLS credentials.
    * Absolute path to certificate file in PEM format.
    * If omitted or null, system default certificate verification is used for secure connections.
-   *
    */
   ca_file?: string;
   /**
    * Configure mTLS private client key.
    * Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
    * If omitted or null, mTLS is not used.
-   *
    */
   key_file?: string;
   /**
    * Configure mTLS client certificate.
    * Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
    * If omitted or null, mTLS is not used.
-   *
    */
   cert_file?: string;
 }
+
 export interface NameStringValuePair {
   /**
    * The name of the pair.
    * Property is required and must be non-null.
-   *
    */
   name: string;
   /**
    * The value of the pair.
    * Property must be present, but if null the behavior is dependent on usage context.
-   *
    */
   value: string;
 }
+
 /**
  * Configure exporter to be OTLP with gRPC transport.
  * If omitted, ignore.
- *
  */
 export interface OtlpGrpcExporter {
   /**
    * Configure endpoint.
    * If omitted or null, http://localhost:4317 is used.
-   *
    */
   endpoint?: string;
   tls?: GrpcTls;
@@ -394,7 +379,6 @@ export interface OtlpGrpcExporter {
    * If an entry's .value is null, the entry is ignored.
    * If omitted, no headers are added.
    *
-   *
    * @minItems 1
    */
   headers?: NameStringValuePair[];
@@ -402,112 +386,102 @@ export interface OtlpGrpcExporter {
    * Configure headers. Entries have lower priority than entries from .headers.
    * The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
    * If omitted or null, no headers are added.
-   *
    */
   headers_list?: string;
   /**
    * Configure compression.
    * Known values include: gzip, none. Implementations may support other compression algorithms.
    * If omitted or null, none is used.
-   *
    */
   compression?: string;
   /**
    * Configure max time (in milliseconds) to wait for each export.
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 10000 is used.
-   *
    */
   timeout?: number;
 }
+
 /**
  * Configure TLS settings for the exporter.
  * If omitted, system default TLS settings are used.
- *
  */
 export interface GrpcTls {
   /**
    * Configure certificate used to verify a server's TLS credentials.
    * Absolute path to certificate file in PEM format.
    * If omitted or null, system default certificate verification is used for secure connections.
-   *
    */
   ca_file?: string;
   /**
    * Configure mTLS private client key.
    * Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
    * If omitted or null, mTLS is not used.
-   *
    */
   key_file?: string;
   /**
    * Configure mTLS client certificate.
    * Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
    * If omitted or null, mTLS is not used.
-   *
    */
   cert_file?: string;
   /**
    * Configure client transport security for the exporter's connection.
    * Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
    * If omitted or null, false is used.
-   *
    */
   insecure?: boolean;
 }
+
 /**
  * Configure exporter to be OTLP with file transport.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalOtlpFileExporter {
   /**
    * Configure output stream.
    * Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
    * If omitted or null, stdout is used.
-   *
    */
   output_stream?: string;
 }
+
 /**
  * Configure exporter to be console.
  * If omitted, ignore.
- *
  */
 export interface ConsoleExporter {}
+
 /**
  * Configure a simple log record processor.
  * If omitted, ignore.
- *
  */
 export interface SimpleLogRecordProcessor {
   exporter: LogRecordExporter;
 }
+
 /**
  * Configure log record limits. See also attribute_limits.
  * If omitted, default values as described in LogRecordLimits are used.
- *
  */
 export interface LogRecordLimits {
   /**
    * Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit.
    * Value must be non-negative.
    * If omitted or null, there is no limit.
-   *
    */
   attribute_value_length_limit?: number;
   /**
    * Configure max attribute count. Overrides .attribute_limits.attribute_count_limit.
    * Value must be non-negative.
    * If omitted or null, 128 is used.
-   *
    */
   attribute_count_limit?: number;
 }
+
 /**
  * Configure loggers.
  * If omitted, all loggers use default values as described in ExperimentalLoggerConfig.
- *
  */
 export interface ExperimentalLoggerConfigurator {
   default_config?: ExperimentalLoggerConfig;
@@ -515,21 +489,19 @@ export interface ExperimentalLoggerConfigurator {
    * Configure loggers.
    * If omitted, all loggers use .default_config.
    *
-   *
    * @minItems 1
    */
   loggers?: ExperimentalLoggerMatcherAndConfig[];
 }
+
 /**
  * Configure the default logger config used there is no matching entry in .logger_configurator/development.loggers.
  * If omitted, unmatched .loggers use default values as described in ExperimentalLoggerConfig.
- *
  */
 export interface ExperimentalLoggerConfig {
   /**
    * Configure if the logger is enabled or not.
    * If omitted or null, true is used.
-   *
    */
   enabled?: boolean;
   minimum_severity?: SeverityNumber;
@@ -537,10 +509,10 @@ export interface ExperimentalLoggerConfig {
    * Configure trace based filtering.
    * If true, log records associated with unsampled trace contexts traces are not processed. If false, or if a log record is not associated with a trace context, trace based filtering is not applied.
    * If omitted or null, trace based filtering is not applied.
-   *
    */
   trace_based?: boolean;
 }
+
 export interface ExperimentalLoggerMatcherAndConfig {
   /**
    * Configure logger names to match, evaluated as follows:
@@ -548,21 +520,19 @@ export interface ExperimentalLoggerMatcherAndConfig {
    *  * If the logger name exactly matches.
    *  * If the logger name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * Property is required and must be non-null.
-   *
    */
   name: string;
   config: ExperimentalLoggerConfig;
 }
+
 /**
  * Configure meter provider.
  * If omitted, a noop meter provider is used.
- *
  */
 export interface MeterProvider {
   /**
    * Configure metric readers.
    * Property is required and must be non-null.
-   *
    *
    * @minItems 1
    */
@@ -572,35 +542,33 @@ export interface MeterProvider {
    * Each view has a selector which determines the instrument(s) it applies to, and a configuration for the resulting stream(s).
    * If omitted, no views are registered.
    *
-   *
    * @minItems 1
    */
   views?: View[];
   exemplar_filter?: ExemplarFilter;
   'meter_configurator/development'?: ExperimentalMeterConfigurator;
 }
+
 export interface MetricReader {
   periodic?: PeriodicMetricReader;
   pull?: PullMetricReader;
 }
+
 /**
  * Configure a periodic metric reader.
  * If omitted, ignore.
- *
  */
 export interface PeriodicMetricReader {
   /**
    * Configure delay interval (in milliseconds) between start of two consecutive exports.
    * Value must be non-negative.
    * If omitted or null, 60000 is used.
-   *
    */
   interval?: number;
   /**
    * Configure maximum allowed time (in milliseconds) to export data.
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 30000 is used.
-   *
    */
   timeout?: number;
   exporter: PushMetricExporter;
@@ -608,16 +576,15 @@ export interface PeriodicMetricReader {
    * Configure metric producers.
    * If omitted, no metric producers are added.
    *
-   *
    * @minItems 1
    */
   producers?: MetricProducer[];
   cardinality_limits?: CardinalityLimits;
 }
+
 /**
  * Configure exporter.
  * Property is required and must be non-null.
- *
  */
 export interface PushMetricExporter {
   otlp_http?: OtlpHttpMetricExporter;
@@ -626,16 +593,15 @@ export interface PushMetricExporter {
   console?: ConsoleMetricExporter;
   [k: string]: object | undefined;
 }
+
 /**
  * Configure exporter to be OTLP with HTTP transport.
  * If omitted, ignore.
- *
  */
 export interface OtlpHttpMetricExporter {
   /**
    * Configure endpoint.
    * If omitted or null, http://localhost:4318/v1/metrics is used.
-   *
    */
   endpoint?: string;
   tls?: HttpTls;
@@ -644,7 +610,6 @@ export interface OtlpHttpMetricExporter {
    * If an entry's .value is null, the entry is ignored.
    * If omitted, no headers are added.
    *
-   *
    * @minItems 1
    */
   headers?: NameStringValuePair[];
@@ -652,37 +617,33 @@ export interface OtlpHttpMetricExporter {
    * Configure headers. Entries have lower priority than entries from .headers.
    * The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
    * If omitted or null, no headers are added.
-   *
    */
   headers_list?: string;
   /**
    * Configure compression.
    * Known values include: gzip, none. Implementations may support other compression algorithms.
    * If omitted or null, none is used.
-   *
    */
   compression?: string;
   /**
    * Configure max time (in milliseconds) to wait for each export.
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 10000 is used.
-   *
    */
   timeout?: number;
   encoding?: OtlpHttpEncoding;
   temporality_preference?: ExporterTemporalityPreference;
   default_histogram_aggregation?: ExporterDefaultHistogramAggregation;
 }
+
 /**
  * Configure exporter to be OTLP with gRPC transport.
  * If omitted, ignore.
- *
  */
 export interface OtlpGrpcMetricExporter {
   /**
    * Configure endpoint.
    * If omitted or null, http://localhost:4317 is used.
-   *
    */
   endpoint?: string;
   tls?: GrpcTls;
@@ -691,7 +652,6 @@ export interface OtlpGrpcMetricExporter {
    * If an entry's .value is null, the entry is ignored.
    * If omitted, no headers are added.
    *
-   *
    * @minItems 1
    */
   headers?: NameStringValuePair[];
@@ -699,121 +659,110 @@ export interface OtlpGrpcMetricExporter {
    * Configure headers. Entries have lower priority than entries from .headers.
    * The value is a list of comma separated key-value pairs matching the format of OTEL_EXPORTER_OTLP_HEADERS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options for details.
    * If omitted or null, no headers are added.
-   *
    */
   headers_list?: string;
   /**
    * Configure compression.
    * Known values include: gzip, none. Implementations may support other compression algorithms.
    * If omitted or null, none is used.
-   *
    */
   compression?: string;
   /**
    * Configure max time (in milliseconds) to wait for each export.
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 10000 is used.
-   *
    */
   timeout?: number;
   temporality_preference?: ExporterTemporalityPreference;
   default_histogram_aggregation?: ExporterDefaultHistogramAggregation;
 }
+
 /**
  * Configure exporter to be OTLP with file transport.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalOtlpFileMetricExporter {
   /**
    * Configure output stream.
    * Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
    * If omitted or null, stdout is used.
-   *
    */
   output_stream?: string;
   temporality_preference?: ExporterTemporalityPreference;
   default_histogram_aggregation?: ExporterDefaultHistogramAggregation;
 }
+
 /**
  * Configure exporter to be console.
  * If omitted, ignore.
- *
  */
 export interface ConsoleMetricExporter {
   temporality_preference?: ExporterTemporalityPreference;
   default_histogram_aggregation?: ExporterDefaultHistogramAggregation;
 }
+
 export interface MetricProducer {
   opencensus?: OpenCensusMetricProducer;
   [k: string]: object | undefined;
 }
+
 /**
  * Configure metric producer to be opencensus.
  * If omitted, ignore.
- *
  */
 export interface OpenCensusMetricProducer {}
+
 /**
  * Configure cardinality limits.
  * If omitted, default values as described in CardinalityLimits are used.
- *
  */
 export interface CardinalityLimits {
   /**
    * Configure default cardinality limit for all instrument types.
    * Instrument-specific cardinality limits take priority.
    * If omitted or null, 2000 is used.
-   *
    */
   default?: number;
   /**
    * Configure default cardinality limit for counter instruments.
    * If omitted or null, the value from .default is used.
-   *
    */
   counter?: number;
   /**
    * Configure default cardinality limit for gauge instruments.
    * If omitted or null, the value from .default is used.
-   *
    */
   gauge?: number;
   /**
    * Configure default cardinality limit for histogram instruments.
    * If omitted or null, the value from .default is used.
-   *
    */
   histogram?: number;
   /**
    * Configure default cardinality limit for observable_counter instruments.
    * If omitted or null, the value from .default is used.
-   *
    */
   observable_counter?: number;
   /**
    * Configure default cardinality limit for observable_gauge instruments.
    * If omitted or null, the value from .default is used.
-   *
    */
   observable_gauge?: number;
   /**
    * Configure default cardinality limit for observable_up_down_counter instruments.
    * If omitted or null, the value from .default is used.
-   *
    */
   observable_up_down_counter?: number;
   /**
    * Configure default cardinality limit for up_down_counter instruments.
    * If omitted or null, the value from .default is used.
-   *
    */
   up_down_counter?: number;
 }
+
 /**
  * Configure a pull based metric reader.
  * If omitted, ignore.
- *
  */
 export interface PullMetricReader {
   exporter: PullMetricExporter;
@@ -821,58 +770,53 @@ export interface PullMetricReader {
    * Configure metric producers.
    * If omitted, no metric producers are added.
    *
-   *
    * @minItems 1
    */
   producers?: MetricProducer[];
   cardinality_limits?: CardinalityLimits;
 }
+
 /**
  * Configure exporter.
  * Property is required and must be non-null.
- *
  */
 export interface PullMetricExporter {
   'prometheus/development'?: ExperimentalPrometheusMetricExporter;
   [k: string]: object | undefined;
 }
+
 /**
  * Configure exporter to be prometheus.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalPrometheusMetricExporter {
   /**
    * Configure host.
    * If omitted or null, localhost is used.
-   *
    */
   host?: string;
   /**
    * Configure port.
    * If omitted or null, 9464 is used.
-   *
    */
   port?: number;
   /**
    * Configure Prometheus Exporter to produce metrics without scope labels.
    * If omitted or null, false is used.
-   *
    */
   without_scope_info?: boolean;
   /**
    * Configure Prometheus Exporter to produce metrics without a target info metric for the resource.
    * If omitted or null, false is used.
-   *
    */
   'without_target_info/development'?: boolean;
   with_resource_constant_labels?: IncludeExclude;
   translation_strategy?: ExperimentalPrometheusTranslationStrategy;
 }
+
 /**
  * Configure Prometheus Exporter to add resource attributes as metrics attributes, where the resource attribute keys match the patterns.
  * If omitted, no resource attributes are added.
- *
  */
 export interface IncludeExclude {
   /**
@@ -881,7 +825,6 @@ export interface IncludeExclude {
    *  * If the value exactly matches.
    *  * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * If omitted, all values are included.
-   *
    *
    * @minItems 1
    */
@@ -893,85 +836,77 @@ export interface IncludeExclude {
    *  * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * If omitted, .included attributes are included.
    *
-   *
    * @minItems 1
    */
   excluded?: string[];
 }
+
 export interface View {
   selector: ViewSelector;
   stream: ViewStream;
 }
+
 /**
  * Configure view selector.
  * Selection criteria is additive as described in https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-selection-criteria.
  * Property is required and must be non-null.
- *
  */
 export interface ViewSelector {
   /**
    * Configure instrument name selection criteria.
    * If omitted or null, all instrument names match.
-   *
    */
   instrument_name?: string;
   instrument_type?: InstrumentType;
   /**
    * Configure the instrument unit selection criteria.
    * If omitted or null, all instrument units match.
-   *
    */
   unit?: string;
   /**
    * Configure meter name selection criteria.
    * If omitted or null, all meter names match.
-   *
    */
   meter_name?: string;
   /**
    * Configure meter version selection criteria.
    * If omitted or null, all meter versions match.
-   *
    */
   meter_version?: string;
   /**
    * Configure meter schema url selection criteria.
    * If omitted or null, all meter schema URLs match.
-   *
    */
   meter_schema_url?: string;
 }
+
 /**
  * Configure view stream.
  * Property is required and must be non-null.
- *
  */
 export interface ViewStream {
   /**
    * Configure metric name of the resulting stream(s).
    * If omitted or null, the instrument's original name is used.
-   *
    */
   name?: string;
   /**
    * Configure metric description of the resulting stream(s).
    * If omitted or null, the instrument's origin description is used.
-   *
    */
   description?: string;
   aggregation?: Aggregation;
   /**
    * Configure the aggregation cardinality limit.
    * If omitted or null, the metric reader's default cardinality limit is used.
-   *
    */
   aggregation_cardinality_limit?: number;
   attribute_keys?: IncludeExclude;
 }
+
 /**
  * Configure aggregation of the resulting stream(s).
  * If omitted, default is used.
- *
  */
 export interface Aggregation {
   default?: DefaultAggregation;
@@ -981,28 +916,27 @@ export interface Aggregation {
   last_value?: LastValueAggregation;
   sum?: SumAggregation;
 }
+
 /**
  * Configures the stream to use the instrument kind to select an aggregation and advisory parameters to influence aggregation configuration parameters. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#default-aggregation for details.
  * If omitted, ignore.
- *
  */
 export interface DefaultAggregation {}
+
 /**
  * Configures the stream to ignore/drop all instrument measurements. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#drop-aggregation for details.
  * If omitted, ignore.
- *
  */
 export interface DropAggregation {}
+
 /**
  * Configures the stream to collect data for the histogram metric point using a set of explicit boundary values for histogram bucketing. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#explicit-bucket-histogram-aggregation for details
  * If omitted, ignore.
- *
  */
 export interface ExplicitBucketHistogramAggregation {
   /**
    * Configure bucket boundaries.
    * If omitted, [0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000] is used.
-   *
    *
    * @minItems 0
    */
@@ -1010,51 +944,47 @@ export interface ExplicitBucketHistogramAggregation {
   /**
    * Configure record min and max.
    * If omitted or null, true is used.
-   *
    */
   record_min_max?: boolean;
 }
+
 /**
  * Configures the stream to collect data for the exponential histogram metric point, which uses a base-2 exponential formula to determine bucket boundaries and an integer scale parameter to control resolution. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#base2-exponential-bucket-histogram-aggregation for details.
  * If omitted, ignore.
- *
  */
 export interface Base2ExponentialBucketHistogramAggregation {
   /**
    * Configure the max scale factor.
    * If omitted or null, 20 is used.
-   *
    */
   max_scale?: number;
   /**
    * Configure the maximum number of buckets in each of the positive and negative ranges, not counting the special zero bucket.
    * If omitted or null, 160 is used.
-   *
    */
   max_size?: number;
   /**
    * Configure whether or not to record min and max.
    * If omitted or null, true is used.
-   *
    */
   record_min_max?: boolean;
 }
+
 /**
  * Configures the stream to collect data using the last measurement. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#last-value-aggregation for details.
  * If omitted, ignore.
- *
  */
 export interface LastValueAggregation {}
+
 /**
  * Configures the stream to collect the arithmetic sum of measurement values. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#sum-aggregation for details.
  * If omitted, ignore.
- *
  */
 export interface SumAggregation {}
+
 /**
  * Configure meters.
  * If omitted, all meters use default values as described in ExperimentalMeterConfig.
- *
  */
 export interface ExperimentalMeterConfigurator {
   default_config?: ExperimentalMeterConfig;
@@ -1062,24 +992,23 @@ export interface ExperimentalMeterConfigurator {
    * Configure meters.
    * If omitted, all meters used .default_config.
    *
-   *
    * @minItems 1
    */
   meters?: ExperimentalMeterMatcherAndConfig[];
 }
+
 /**
  * Configure the default meter config used there is no matching entry in .meter_configurator/development.meters.
  * If omitted, unmatched .meters use default values as described in ExperimentalMeterConfig.
- *
  */
 export interface ExperimentalMeterConfig {
   /**
    * Configure if the meter is enabled or not.
    * If omitted, true is used.
-   *
    */
   enabled?: boolean;
 }
+
 export interface ExperimentalMeterMatcherAndConfig {
   /**
    * Configure meter names to match, evaluated as follows:
@@ -1087,22 +1016,20 @@ export interface ExperimentalMeterMatcherAndConfig {
    *  * If the meter name exactly matches.
    *  * If the meter name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * Property is required and must be non-null.
-   *
    */
   name: string;
   config: ExperimentalMeterConfig;
 }
+
 /**
  * Configure text map context propagators.
  * If omitted, a noop propagator is used.
- *
  */
 export interface Propagator {
   /**
    * Configure the propagators in the composite text map propagator. Entries from .composite_list are appended to the list here with duplicates filtered out.
    * Built-in propagator keys include: tracecontext, baggage, b3, b3multi. Known third party keys include: xray.
    * If omitted, and .composite_list is omitted or null, a noop propagator is used.
-   *
    *
    * @minItems 1
    */
@@ -1112,10 +1039,10 @@ export interface Propagator {
    * The value is a comma separated list of propagator identifiers matching the format of OTEL_PROPAGATORS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details.
    * Built-in propagator identifiers include: tracecontext, baggage, b3, b3multi. Known third party identifiers include: xray.
    * If omitted or null, and .composite is omitted or null, a noop propagator is used.
-   *
    */
   composite_list?: string;
 }
+
 export interface TextMapPropagator {
   tracecontext?: TraceContextPropagator;
   baggage?: BaggagePropagator;
@@ -1123,40 +1050,39 @@ export interface TextMapPropagator {
   b3multi?: B3MultiPropagator;
   [k: string]: object | undefined;
 }
+
 /**
  * Include the w3c trace context propagator.
  * If omitted, ignore.
- *
  */
 export interface TraceContextPropagator {}
+
 /**
  * Include the w3c baggage propagator.
  * If omitted, ignore.
- *
  */
 export interface BaggagePropagator {}
+
 /**
  * Include the zipkin b3 propagator.
  * If omitted, ignore.
- *
  */
 export interface B3Propagator {}
+
 /**
  * Include the zipkin b3 multi propagator.
  * If omitted, ignore.
- *
  */
 export interface B3MultiPropagator {}
+
 /**
  * Configure tracer provider.
  * If omitted, a noop tracer provider is used.
- *
  */
 export interface TracerProvider {
   /**
    * Configure span processors.
    * Property is required and must be non-null.
-   *
    *
    * @minItems 1
    */
@@ -1165,49 +1091,46 @@ export interface TracerProvider {
   sampler?: Sampler;
   'tracer_configurator/development'?: ExperimentalTracerConfigurator;
 }
+
 export interface SpanProcessor {
   batch?: BatchSpanProcessor;
   simple?: SimpleSpanProcessor;
   [k: string]: object | undefined;
 }
+
 /**
  * Configure a batch span processor.
  * If omitted, ignore.
- *
  */
 export interface BatchSpanProcessor {
   /**
    * Configure delay interval (in milliseconds) between two consecutive exports.
    * Value must be non-negative.
    * If omitted or null, 5000 is used.
-   *
    */
   schedule_delay?: number;
   /**
    * Configure maximum allowed time (in milliseconds) to export data.
    * Value must be non-negative. A value of 0 indicates no limit (infinity).
    * If omitted or null, 30000 is used.
-   *
    */
   export_timeout?: number;
   /**
    * Configure maximum queue size. Value must be positive.
    * If omitted or null, 2048 is used.
-   *
    */
   max_queue_size?: number;
   /**
    * Configure maximum batch size. Value must be positive.
    * If omitted or null, 512 is used.
-   *
    */
   max_export_batch_size?: number;
   exporter: SpanExporter;
 }
+
 /**
  * Configure exporter.
  * Property is required and must be non-null.
- *
  */
 export interface SpanExporter {
   otlp_http?: OtlpHttpExporter;
@@ -1216,67 +1139,61 @@ export interface SpanExporter {
   console?: ConsoleExporter;
   [k: string]: object | undefined;
 }
+
 /**
  * Configure a simple span processor.
  * If omitted, ignore.
- *
  */
 export interface SimpleSpanProcessor {
   exporter: SpanExporter;
 }
+
 /**
  * Configure span limits. See also attribute_limits.
  * If omitted, default values as described in SpanLimits are used.
- *
  */
 export interface SpanLimits {
   /**
    * Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit.
    * Value must be non-negative.
    * If omitted or null, there is no limit.
-   *
    */
   attribute_value_length_limit?: number;
   /**
    * Configure max attribute count. Overrides .attribute_limits.attribute_count_limit.
    * Value must be non-negative.
    * If omitted or null, 128 is used.
-   *
    */
   attribute_count_limit?: number;
   /**
    * Configure max span event count.
    * Value must be non-negative.
    * If omitted or null, 128 is used.
-   *
    */
   event_count_limit?: number;
   /**
    * Configure max span link count.
    * Value must be non-negative.
    * If omitted or null, 128 is used.
-   *
    */
   link_count_limit?: number;
   /**
    * Configure max attributes per span event.
    * Value must be non-negative.
    * If omitted or null, 128 is used.
-   *
    */
   event_attribute_count_limit?: number;
   /**
    * Configure max attributes per span link.
    * Value must be non-negative.
    * If omitted or null, 128 is used.
-   *
    */
   link_attribute_count_limit?: number;
 }
+
 /**
  * Configure the sampler.
  * If omitted, parent based sampler with a root of always_on is used.
- *
  */
 export interface Sampler {
   always_off?: AlwaysOffSampler;
@@ -1288,22 +1205,22 @@ export interface Sampler {
   trace_id_ratio_based?: TraceIdRatioBasedSampler;
   [k: string]: object | undefined;
 }
+
 /**
  * Configure sampler to be always_off.
  * If omitted, ignore.
- *
  */
 export interface AlwaysOffSampler {}
+
 /**
  * Configure sampler to be always_on.
  * If omitted, ignore.
- *
  */
 export interface AlwaysOnSampler {}
+
 /**
  * Configure sampler to be composite.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalComposableSampler {
   always_off?: ExperimentalComposableAlwaysOffSampler;
@@ -1313,43 +1230,42 @@ export interface ExperimentalComposableSampler {
   rule_based?: ExperimentalComposableRuleBasedSampler;
   [k: string]: object | undefined;
 }
+
 /**
  * Configure sampler to be always_off.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalComposableAlwaysOffSampler {}
+
 /**
  * Configure sampler to be always_on.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalComposableAlwaysOnSampler {}
+
 /**
  * Configure sampler to be parent_threshold.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalComposableParentThresholdSampler {
   root: ExperimentalComposableSampler;
 }
+
 /**
  * Configure sampler to be probability.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalComposableProbabilitySampler {
   /**
    * Configure ratio.
    * If omitted or null, 1.0 is used.
-   *
    */
   ratio?: number;
 }
+
 /**
  * Configure sampler to be rule_based.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalComposableRuleBasedSampler {
   /**
@@ -1359,15 +1275,14 @@ export interface ExperimentalComposableRuleBasedSampler {
    * If no rules match, the span is not sampled.
    * If omitted, no span is sampled.
    *
-   *
    * @minItems 1
    */
   rules?: ExperimentalComposableRuleBasedSamplerRule[];
 }
+
 /**
  * A rule for ExperimentalComposableRuleBasedSampler. A rule can have multiple match conditions - the sampler will be applied if all match.
  * If no conditions are specified, the rule matches all spans that reach it.
- *
  */
 export interface ExperimentalComposableRuleBasedSamplerRule {
   attribute_values?: ExperimentalComposableRuleBasedSamplerRuleAttributeValues;
@@ -1382,7 +1297,6 @@ export interface ExperimentalComposableRuleBasedSamplerRule {
    * * server: server, a server span.
    * If omitted, ignore.
    *
-   *
    * @minItems 1
    */
   span_kinds?: SpanKind[];
@@ -1394,47 +1308,43 @@ export interface ExperimentalComposableRuleBasedSamplerRule {
    * * remote: remote, a remote parent.
    * If omitted, ignore.
    *
-   *
    * @minItems 1
    */
   parent?: ExperimentalSpanParent[];
   sampler: ExperimentalComposableSampler;
 }
+
 /**
  * Values to match against a single attribute. Non-string attributes are matched using their string representation:
  * for example, a value of "404" would match the http.response.status_code 404. For array attributes, if any
  * item matches, it is considered a match.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalComposableRuleBasedSamplerRuleAttributeValues {
   /**
    * The attribute key to match against.
    * Property is required and must be non-null.
-   *
    */
   key: string;
   /**
    * The attribute values to match against. If the attribute's value matches any of these, it matches.
    * Property is required and must be non-null.
    *
-   *
    * @minItems 1
    */
   values: string[];
 }
+
 /**
  * Patterns to match against a single attribute. Non-string attributes are matched using their string representation:
  * for example, a pattern of "4*" would match any http.response.status_code in 400-499. For array attributes, if any
  * item matches, it is considered a match.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalComposableRuleBasedSamplerRuleAttributePatterns {
   /**
    * The attribute key to match against.
    * Property is required and must be non-null.
-   *
    */
   key: string;
   /**
@@ -1443,7 +1353,6 @@ export interface ExperimentalComposableRuleBasedSamplerRuleAttributePatterns {
    *  * If the value exactly matches.
    *  * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * If omitted, all values are included.
-   *
    *
    * @minItems 1
    */
@@ -1455,35 +1364,32 @@ export interface ExperimentalComposableRuleBasedSamplerRuleAttributePatterns {
    *  * If the value matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * If omitted, .included attributes are included.
    *
-   *
    * @minItems 1
    */
   excluded?: string[];
 }
+
 /**
  * Configure sampler to be jaeger_remote.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalJaegerRemoteSampler {
   /**
    * Configure the endpoint of the jaeger remote sampling service.
    * Property is required and must be non-null.
-   *
    */
   endpoint: string;
   /**
    * Configure the polling interval (in milliseconds) to fetch from the remote sampling service.
    * If omitted or null, 60000 is used.
-   *
    */
   interval?: number;
   initial_sampler: Sampler;
 }
+
 /**
  * Configure sampler to be parent_based.
  * If omitted, ignore.
- *
  */
 export interface ParentBasedSampler {
   root?: Sampler;
@@ -1492,36 +1398,34 @@ export interface ParentBasedSampler {
   local_parent_sampled?: Sampler;
   local_parent_not_sampled?: Sampler;
 }
+
 /**
  * Configure sampler to be probability.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalProbabilitySampler {
   /**
    * Configure ratio.
    * If omitted or null, 1.0 is used.
-   *
    */
   ratio?: number;
 }
+
 /**
  * Configure sampler to be trace_id_ratio_based.
  * If omitted, ignore.
- *
  */
 export interface TraceIdRatioBasedSampler {
   /**
    * Configure trace_id_ratio.
    * If omitted or null, 1.0 is used.
-   *
    */
   ratio?: number;
 }
+
 /**
  * Configure tracers.
  * If omitted, all tracers use default values as described in ExperimentalTracerConfig.
- *
  */
 export interface ExperimentalTracerConfigurator {
   default_config?: ExperimentalTracerConfig;
@@ -1529,24 +1433,23 @@ export interface ExperimentalTracerConfigurator {
    * Configure tracers.
    * If omitted, all tracers use .default_config.
    *
-   *
    * @minItems 1
    */
   tracers?: ExperimentalTracerMatcherAndConfig[];
 }
+
 /**
  * Configure the default tracer config used there is no matching entry in .tracer_configurator/development.tracers.
  * If omitted, unmatched .tracers use default values as described in ExperimentalTracerConfig.
- *
  */
 export interface ExperimentalTracerConfig {
   /**
    * Configure if the tracer is enabled or not.
    * If omitted, true is used.
-   *
    */
   enabled?: boolean;
 }
+
 export interface ExperimentalTracerMatcherAndConfig {
   /**
    * Configure tracer names to match, evaluated as follows:
@@ -1554,21 +1457,19 @@ export interface ExperimentalTracerMatcherAndConfig {
    *  * If the tracer name exactly matches.
    *  * If the tracer name matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
    * Property is required and must be non-null.
-   *
    */
   name: string;
   config: ExperimentalTracerConfig;
 }
+
 /**
  * Configure resource for all signals.
  * If omitted, the default resource is used.
- *
  */
 export interface Resource {
   /**
    * Configure resource attributes. Entries have higher priority than entries from .resource.attributes_list.
    * If omitted, no resource attributes are added.
-   *
    *
    * @minItems 1
    */
@@ -1577,37 +1478,34 @@ export interface Resource {
   /**
    * Configure resource schema URL.
    * If omitted or null, no schema URL is used.
-   *
    */
   schema_url?: string;
   /**
    * Configure resource attributes. Entries have lower priority than entries from .resource.attributes.
    * The value is a list of comma separated key-value pairs matching the format of OTEL_RESOURCE_ATTRIBUTES. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details.
    * If omitted or null, no resource attributes are added.
-   *
    */
   attributes_list?: string;
 }
+
 export interface AttributeNameValue {
   /**
    * The attribute name.
    * Property is required and must be non-null.
-   *
    */
   name: string;
   /**
    * The attribute value.
    * The type of value must match .type.
    * Property is required and must be non-null.
-   *
    */
   value: string | number | boolean | string[] | boolean[] | number[];
   type?: AttributeType;
 }
+
 /**
  * Configure resource detection.
  * If omitted, resource detection is disabled.
- *
  */
 export interface ExperimentalResourceDetection {
   attributes?: IncludeExclude;
@@ -1616,11 +1514,11 @@ export interface ExperimentalResourceDetection {
    * Resource detector names are dependent on the SDK language ecosystem. Please consult documentation for each respective language.
    * If omitted, no resource detectors are enabled.
    *
-   *
    * @minItems 1
    */
   detectors?: ExperimentalResourceDetector[];
 }
+
 export interface ExperimentalResourceDetector {
   container?: ExperimentalContainerResourceDetector;
   host?: ExperimentalHostResourceDetector;
@@ -1628,34 +1526,34 @@ export interface ExperimentalResourceDetector {
   service?: ExperimentalServiceResourceDetector;
   [k: string]: object | undefined;
 }
+
 /**
  * Enable the container resource detector, which populates container.* attributes.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalContainerResourceDetector {}
+
 /**
  * Enable the host resource detector, which populates host.* and os.* attributes.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalHostResourceDetector {}
+
 /**
  * Enable the process resource detector, which populates process.* attributes.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalProcessResourceDetector {}
+
 /**
  * Enable the service detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id.
  * If omitted, ignore.
- *
  */
 export interface ExperimentalServiceResourceDetector {}
+
 /**
  * Configure instrumentation.
  * If omitted, instrumentation defaults are used.
- *
  */
 export interface ExperimentalInstrumentation {
   general?: ExperimentalGeneralInstrumentation;
@@ -1671,11 +1569,11 @@ export interface ExperimentalInstrumentation {
   rust?: ExperimentalLanguageSpecificInstrumentation;
   swift?: ExperimentalLanguageSpecificInstrumentation;
 }
+
 /**
  * Configure general SemConv options that may apply to multiple languages and instrumentations.
  * Instrumenation may merge general config options with the language specific configuration at .instrumentation.<language>.
  * If omitted, default values as described in ExperimentalGeneralInstrumentation are used.
- *
  */
 export interface ExperimentalGeneralInstrumentation {
   http?: ExperimentalHttpInstrumentation;
@@ -1714,21 +1612,21 @@ export interface ExperimentalGeneralInstrumentation {
    * - RPC: https://opentelemetry.io/docs/specs/semconv/rpc/
    * - Messaging: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/
    * If omitted or null, no opt-in is configured and instrumentations continue emitting their default semantic convention version.
-   *
    */
   stability_opt_in_list?: string;
 }
+
 /**
  * Configure instrumentations following the http semantic conventions.
  * See http semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/
  * If omitted, defaults as described in ExperimentalHttpInstrumentation are used.
- *
  */
 export interface ExperimentalHttpInstrumentation {
   semconv?: ExperimentalSemconvConfig;
   client?: ExperimentalHttpClientInstrumentation;
   server?: ExperimentalHttpServerInstrumentation;
 }
+
 /**
  * Configure HTTP semantic convention version and migration behavior.
  *
@@ -1736,19 +1634,16 @@ export interface ExperimentalHttpInstrumentation {
  *
  * See HTTP migration: https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/
  * If omitted, uses the general stability_opt_in_list setting, or instrumentations continue emitting their default semantic convention version if not set.
- *
  */
 export interface ExperimentalSemconvConfig {
   /**
    * The target semantic convention version for this domain (e.g., 1).
    * If omitted or null, the latest stable version is used, or if no stable version is available and .experimental is true then the latest experimental version is used.
-   *
    */
   version?: number;
   /**
    * Use latest experimental semantic conventions (before stable is available or to enable experimental features on top of stable conventions).
    * If omitted or null, false is used.
-   *
    */
   experimental?: boolean;
   /**
@@ -1757,20 +1652,18 @@ export interface ExperimentalSemconvConfig {
    * For version=2 and above, the previous version is the prior stable major version (e.g., version=2, dual_emit=true emits both v2 and v1).
    * Enables dual-emit for phased migration between versions.
    * If omitted or null, false is used.
-   *
    */
   dual_emit?: boolean;
 }
+
 /**
  * Configure instrumentations following the http client semantic conventions.
  * If omitted, defaults as described in ExperimentalHttpClientInstrumentation are used.
- *
  */
 export interface ExperimentalHttpClientInstrumentation {
   /**
    * Configure headers to capture for outbound http requests.
    * If omitted, no outbound request headers are captured.
-   *
    *
    * @minItems 1
    */
@@ -1779,7 +1672,6 @@ export interface ExperimentalHttpClientInstrumentation {
    * Configure headers to capture for inbound http responses.
    * If omitted, no inbound response headers are captured.
    *
-   *
    * @minItems 1
    */
   response_captured_headers?: string[];
@@ -1789,21 +1681,19 @@ export interface ExperimentalHttpClientInstrumentation {
    * This is a full override of the default known methods, not a list of known methods in addition to the defaults.
    * If omitted, HTTP methods GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH are known.
    *
-   *
    * @minItems 0
    */
   known_methods?: string[];
 }
+
 /**
  * Configure instrumentations following the http server semantic conventions.
  * If omitted, defaults as described in ExperimentalHttpServerInstrumentation are used.
- *
  */
 export interface ExperimentalHttpServerInstrumentation {
   /**
    * Configure headers to capture for inbound http requests.
    * If omitted, no request headers are captured.
-   *
    *
    * @minItems 1
    */
@@ -1812,7 +1702,6 @@ export interface ExperimentalHttpServerInstrumentation {
    * Configure headers to capture for outbound http responses.
    * If omitted, no response headers are captures.
    *
-   *
    * @minItems 1
    */
   response_captured_headers?: string[];
@@ -1822,68 +1711,67 @@ export interface ExperimentalHttpServerInstrumentation {
    * This is a full override of the default known methods, not a list of known methods in addition to the defaults.
    * If omitted, HTTP methods GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH are known.
    *
-   *
    * @minItems 0
    */
   known_methods?: string[];
 }
+
 /**
  * Configure instrumentations following the code semantic conventions.
  * See code semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/code/
  * If omitted, defaults as described in ExperimentalCodeInstrumentation are used.
- *
  */
 export interface ExperimentalCodeInstrumentation {
   semconv?: ExperimentalSemconvConfig;
 }
+
 /**
  * Configure instrumentations following the database semantic conventions.
  * See database semantic conventions: https://opentelemetry.io/docs/specs/semconv/database/
  * If omitted, defaults as described in ExperimentalDbInstrumentation are used.
- *
  */
 export interface ExperimentalDbInstrumentation {
   semconv?: ExperimentalSemconvConfig;
 }
+
 /**
  * Configure instrumentations following the GenAI semantic conventions.
  * See GenAI semantic conventions: https://opentelemetry.io/docs/specs/semconv/gen-ai/
  * If omitted, defaults as described in ExperimentalGenAiInstrumentation are used.
- *
  */
 export interface ExperimentalGenAiInstrumentation {
   semconv?: ExperimentalSemconvConfig;
 }
+
 /**
  * Configure instrumentations following the messaging semantic conventions.
  * See messaging semantic conventions: https://opentelemetry.io/docs/specs/semconv/messaging/
  * If omitted, defaults as described in ExperimentalMessagingInstrumentation are used.
- *
  */
 export interface ExperimentalMessagingInstrumentation {
   semconv?: ExperimentalSemconvConfig;
 }
+
 /**
  * Configure instrumentations following the RPC semantic conventions.
  * See RPC semantic conventions: https://opentelemetry.io/docs/specs/semconv/rpc/
  * If omitted, defaults as described in ExperimentalRpcInstrumentation are used.
- *
  */
 export interface ExperimentalRpcInstrumentation {
   semconv?: ExperimentalSemconvConfig;
 }
+
 /**
  * Configure general sanitization options.
  * If omitted, defaults as described in ExperimentalSanitization are used.
- *
  */
 export interface ExperimentalSanitization {
   url?: ExperimentalUrlSanitization;
 }
+
 /**
  * Configure URL sanitization options.
  * If omitted, defaults as described in ExperimentalUrlSanitization are used.
- *
  */
 export interface ExperimentalUrlSanitization {
   /**
@@ -1893,26 +1781,25 @@ export interface ExperimentalUrlSanitization {
    * Set to an empty array to disable query parameter redaction.
    * If omitted, the default sensitive query parameter list as defined by the url semantic conventions (https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/url.md) is used.
    *
-   *
    * @minItems 0
    */
   sensitive_query_parameters?: string[];
 }
+
 /**
  * Configure C++ language-specific instrumentation libraries.
  * If omitted, instrumentation defaults are used.
- *
  */
 export interface ExperimentalLanguageSpecificInstrumentation {
   [k: string]: object;
 }
+
 /**
  * Defines configuration parameters specific to a particular OpenTelemetry distribution or vendor.
  * This section provides a standardized location for distribution-specific settings
  * that are not part of the OpenTelemetry configuration model.
  * It allows vendors to expose their own extensions and general configuration options.
  * If omitted, distribution defaults are used.
- *
  */
 export interface Distribution {
   [k: string]: object;

--- a/scripts/config/generate-config.js
+++ b/scripts/config/generate-config.js
@@ -178,6 +178,24 @@ for (const name of Object.keys(schema.$defs)) {
   schema.$defs[name].title = name;
 }
 
+// Trim newlines from the end of descriptions. This is to avoid an extra
+// blank line in TypeScript comments. This is purely cosmetic.
+function rtrimDescription(node) {
+  if (Array.isArray(node)) {
+    for (let item of node) {
+      rtrimDescription(item);
+    }
+  } else if (typeof node === 'object' && node !== null) {
+    if (typeof node.description === 'string') {
+      node.description = node.description.trimEnd();
+    }
+    for (const val of Object.values(node)) {
+      rtrimDescription(val);
+    }
+  }
+}
+rtrimDescription(schema)
+
 // Avoid unnecessary `| null` in TypeScript types.
 //
 // opentelemetry-configuration intentionally adds an optional "null" type to
@@ -286,6 +304,10 @@ compile(schema, 'OpenTelemetryConfiguration', {
     // See https://github.com/bcherny/json-schema-to-typescript/issues/193
     // `removeDuplicateTsDeclarations` removes those duplicates.
     ts = removeDuplicateTsDeclarations(ts);
+
+    // Cosmetic: add blank lines between exports.
+    ts = ts.replace(/\n\/\*\*/g, '\n\n/**')
+      .replace(/([^/])\nexport/g, '$1\n\nexport');
 
     fs.mkdirSync(path.dirname(TYPES_PATH), { recursive: true });
     fs.writeFileSync(TYPES_PATH, ts);


### PR DESCRIPTION
This trims trailing newlines in comments, and adds newlines between
exports for readability. No functional change.
