### PR TITLE
fix(sbom): add archive:false to skip double-zipping in upload-artifac…

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: SBOM.zip
+          archive: false
           path: ./sbom.zip
 
   add-release-artifact:
@@ -65,7 +65,8 @@ jobs:
       - name: Download artifact from generate-sboms
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: SBOM.zip
+          name: sbom.zip
+          skip-decompress: true
       - name: Upload release asset
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
         env:


### PR DESCRIPTION
…t v7
## Which problem is this PR solving?

This PR updates the SBOM workflow to use non-zipped artifacts when passing the generated `sbom.zip` file between jobs.

`actions/upload-artifact@v7` supports `archive: false`, which avoids wrapping an already-zipped file in another artifact zip. `actions/download-artifact@v8` can then download that non-zipped artifact by the uploaded file name.

Fixes # (issue)

## Short description of the changes

- Set `archive: false` for the SBOM artifact upload.
- Remove the explicit artifact `name`, since non-zipped artifacts are addressed by file name.
- Update the download step to download `sbom.zip` directly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Verified the workflow syntax for `.github/workflows/sbom.yml`.
- [x] Confirmed the uploaded artifact name matches the download step name: `sbom.zip`.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated