### PR TITLE
Update publish-instrumentation workflow with OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-instrumentation.yml
+++ b/.github/workflows/publish-instrumentation.yml
@@ -1,0 +1,27 @@
+name: Publish instrumentation
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to run the workflow against
+        required: true
+        default: coralogix-autoinstrumentation
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - run: |
+          npm install
+          npm publish --access public
+        working-directory: ./experimental/packages/opentelemetry-instrumentation
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish-instrumentation.yml
+++ b/.github/workflows/publish-instrumentation.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
+      - name: Generate API version file
+        run: npm run version
+        working-directory: ./api
       - run: |
           npm install
           sed -i 's/"name": "@opentelemetry\/instrumentation"/"name": "@coralogix\/instrumentation"/' package.json

--- a/.github/workflows/publish-instrumentation.yml
+++ b/.github/workflows/publish-instrumentation.yml
@@ -1,10 +1,13 @@
 name: Publish instrumentation
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: Branch to run the workflow against
+      ref:
+        description: Branch, tag, or SHA to publish from
         required: true
         default: coralogix-autoinstrumentation
 
@@ -14,13 +17,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.ref }}
       - uses: actions/setup-node@v3
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
       - run: |
           npm install
+          sed -i 's/"name": "@opentelemetry\/instrumentation"/"name": "@coralogix\/instrumentation"/' package.json
           npm publish --access public
         working-directory: ./experimental/packages/opentelemetry-instrumentation
         env:

--- a/.github/workflows/publish-instrumentation.yml
+++ b/.github/workflows/publish-instrumentation.yml
@@ -20,13 +20,11 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           registry-url: https://registry.npmjs.org/
-      - name: Generate API version file
-        run: npm run version
-        working-directory: ./api
       - run: |
-          npm install
+          npm install --workspaces=false
+          npm run compile
           sed -i 's/"name": "@opentelemetry\/instrumentation"/"name": "@coralogix\/instrumentation"/' package.json
           npm publish --access public
         working-directory: ./experimental/packages/opentelemetry-instrumentation

--- a/.github/workflows/publish-instrumentation.yml
+++ b/.github/workflows/publish-instrumentation.yml
@@ -24,9 +24,11 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: |
           npm install --workspaces=false --include=dev
-          ./node_modules/.bin/tsc -p tsconfig.json
+          printf '%s\n' '{' '  "extends": "./tsconfig.json",' '  "include": ["src/**/*.ts"]' '}' > tsconfig.publish.cjs.json
+          ./node_modules/.bin/tsc -p tsconfig.publish.cjs.json
           ./node_modules/.bin/tsc -p tsconfig.esm.json
           ./node_modules/.bin/tsc -p tsconfig.esnext.json
+          rm -f tsconfig.publish.cjs.json
           npm pkg set name=@coralogix/instrumentation
           npm publish --ignore-scripts --access public
         working-directory: ./experimental/packages/opentelemetry-instrumentation

--- a/.github/workflows/publish-instrumentation.yml
+++ b/.github/workflows/publish-instrumentation.yml
@@ -14,14 +14,16 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
+          node-version: 24
       - run: |
           npm install --workspaces=false --include=dev
           printf '%s\n' '{' '  "extends": "./tsconfig.json",' '  "include": ["src/**/*.ts"]' '}' > tsconfig.publish.cjs.json
@@ -32,5 +34,3 @@ jobs:
           npm pkg set name=@coralogix/instrumentation
           npm publish --ignore-scripts --access public
         working-directory: ./experimental/packages/opentelemetry-instrumentation
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish-instrumentation.yml
+++ b/.github/workflows/publish-instrumentation.yml
@@ -24,9 +24,11 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: |
           npm install --workspaces=false
-          npm run compile
-          sed -i 's/"name": "@opentelemetry\/instrumentation"/"name": "@coralogix\/instrumentation"/' package.json
-          npm publish --access public
+          npx tsc -p tsconfig.json
+          npx tsc -p tsconfig.esm.json
+          npx tsc -p tsconfig.esnext.json
+          npm pkg set name=@coralogix/instrumentation
+          npm publish --ignore-scripts --access public
         working-directory: ./experimental/packages/opentelemetry-instrumentation
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish-instrumentation.yml
+++ b/.github/workflows/publish-instrumentation.yml
@@ -23,10 +23,10 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: |
-          npm install --workspaces=false
-          npx tsc -p tsconfig.json
-          npx tsc -p tsconfig.esm.json
-          npx tsc -p tsconfig.esnext.json
+          npm install --workspaces=false --include=dev
+          ./node_modules/.bin/tsc -p tsconfig.json
+          ./node_modules/.bin/tsc -p tsconfig.esm.json
+          ./node_modules/.bin/tsc -p tsconfig.esnext.json
           npm pkg set name=@coralogix/instrumentation
           npm publish --ignore-scripts --access public
         working-directory: ./experimental/packages/opentelemetry-instrumentation


### PR DESCRIPTION
## Summary
- Switch `@coralogix/instrumentation` from `NPM_TOKEN` to OIDC trusted publishing
- Add per-job `id-token: write` permission scoped to the publish job (workflow-level stays at `contents: read`)
- Drop the `registry-url` from `actions/setup-node` and `NODE_AUTH_TOKEN` env — both are vestigial under OIDC; the `registry-url` would otherwise write an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}` and short-circuit the OIDC token exchange
- Bump Node 20 → 24 (npm trusted publishing requires npm ≥ 11.5.1, which is bundled with Node ≥ 22.14; matches the rest of the org's repos on Node 24)
- Update actions: `actions/checkout` v3 → v6, `actions/setup-node` v3 → v6

## Prerequisites before merging
- [ ] Configure trusted publisher on npmjs.com for **`@coralogix/instrumentation`** — workflow filename: `publish-instrumentation.yml`, repo: `coralogix/opentelemetry-js`

## Notes
- Trigger remains `workflow_dispatch` only — no behavior change to when/how publishes are initiated, only how they authenticate
- This workflow has no `workflow_call` invocation, so the protofetch-style permissions-inheritance issue does not apply here
- `--ignore-scripts --access public` flags on `npm publish` are preserved