### PR TITLE
refactor(sdk-logs): use `Logger#enabled()` logic in `Logger#emit()`

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,6 +16,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
+* refactor(sdk-logs): use `Logger.enabled()` within `Logger.emit()` implementation [#6680](https://github.com/open-telemetry/opentelemetry-js/pull/6680) @david-luna
+
 ## 0.217.0
 
 ### :rocket: Features

--- a/experimental/packages/sdk-logs/src/Logger.ts
+++ b/experimental/packages/sdk-logs/src/Logger.ts
@@ -38,40 +38,45 @@ export class Logger implements logsAPI.Logger {
   }
 
   public emit(logRecord: logsAPI.LogRecord): void {
-    const loggerConfig = this._loggerConfig;
+    // const loggerConfig = this._loggerConfig;
+
+    // const currentContext = logRecord.context || context.active();
+
+    // // Apply minimum severity filtering
+    // const recordSeverity =
+    //   logRecord.severityNumber ?? SeverityNumber.UNSPECIFIED;
+
+    // // 1. Minimum severity: If the log record's SeverityNumber is specified
+    // //    (i.e. not 0) and is less than the configured minimum_severity,
+    // //    the log record MUST be dropped.
+    // if (
+    //   recordSeverity !== SeverityNumber.UNSPECIFIED &&
+    //   recordSeverity < loggerConfig.minimumSeverity
+    // ) {
+    //   // Log record is dropped due to minimum severity filter
+    //   return;
+    // }
+
+    // // 2. Trace-based: If trace_based is true, and if the log record has a
+    // //    SpanId and the TraceFlags SAMPLED flag is unset, the log record MUST be dropped.
+    // if (loggerConfig.traceBased) {
+    //   const spanContext = trace.getSpanContext(currentContext);
+    //   if (spanContext && isSpanContextValid(spanContext)) {
+    //     // Check if the trace is unsampled (SAMPLED flag is unset)
+    //     const isSampled =
+    //       (spanContext.traceFlags & TraceFlags.SAMPLED) === TraceFlags.SAMPLED;
+    //     if (!isSampled) {
+    //       // Log record is dropped due to trace-based filter
+    //       return;
+    //     }
+    //   }
+    //   // If there's no valid span context, the log record is not associated with a trace
+    //   // and therefore bypasses trace-based filtering (as per spec)
+    // }
 
     const currentContext = logRecord.context || context.active();
-
-    // Apply minimum severity filtering
-    const recordSeverity =
-      logRecord.severityNumber ?? SeverityNumber.UNSPECIFIED;
-
-    // 1. Minimum severity: If the log record's SeverityNumber is specified
-    //    (i.e. not 0) and is less than the configured minimum_severity,
-    //    the log record MUST be dropped.
-    if (
-      recordSeverity !== SeverityNumber.UNSPECIFIED &&
-      recordSeverity < loggerConfig.minimumSeverity
-    ) {
-      // Log record is dropped due to minimum severity filter
+    if (!this.enabled(logRecord)) {
       return;
-    }
-
-    // 2. Trace-based: If trace_based is true, and if the log record has a
-    //    SpanId and the TraceFlags SAMPLED flag is unset, the log record MUST be dropped.
-    if (loggerConfig.traceBased) {
-      const spanContext = trace.getSpanContext(currentContext);
-      if (spanContext && isSpanContextValid(spanContext)) {
-        // Check if the trace is unsampled (SAMPLED flag is unset)
-        const isSampled =
-          (spanContext.traceFlags & TraceFlags.SAMPLED) === TraceFlags.SAMPLED;
-        if (!isSampled) {
-          // Log record is dropped due to trace-based filter
-          return;
-        }
-      }
-      // If there's no valid span context, the log record is not associated with a trace
-      // and therefore bypasses trace-based filtering (as per spec)
     }
 
     /**

--- a/experimental/packages/sdk-logs/src/Logger.ts
+++ b/experimental/packages/sdk-logs/src/Logger.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type * as logsAPI from '@opentelemetry/api-logs';
+import type { Logger as ILogger, LogRecord } from '@opentelemetry/api-logs';
 import { SeverityNumber } from '@opentelemetry/api-logs';
 import type { InstrumentationScope } from '@opentelemetry/core';
 import type { Context } from '@opentelemetry/api';
@@ -18,7 +18,7 @@ import { LogRecordImpl } from './LogRecordImpl';
 import type { LoggerProviderSharedState } from './internal/LoggerProviderSharedState';
 import type { LoggerConfig } from './types';
 
-export class Logger implements logsAPI.Logger {
+export class Logger implements ILogger {
   public readonly instrumentationScope: InstrumentationScope;
   private _sharedState: LoggerProviderSharedState;
   private readonly _loggerConfig: Required<LoggerConfig>;
@@ -37,43 +37,7 @@ export class Logger implements logsAPI.Logger {
     );
   }
 
-  public emit(logRecord: logsAPI.LogRecord): void {
-    // const loggerConfig = this._loggerConfig;
-
-    // const currentContext = logRecord.context || context.active();
-
-    // // Apply minimum severity filtering
-    // const recordSeverity =
-    //   logRecord.severityNumber ?? SeverityNumber.UNSPECIFIED;
-
-    // // 1. Minimum severity: If the log record's SeverityNumber is specified
-    // //    (i.e. not 0) and is less than the configured minimum_severity,
-    // //    the log record MUST be dropped.
-    // if (
-    //   recordSeverity !== SeverityNumber.UNSPECIFIED &&
-    //   recordSeverity < loggerConfig.minimumSeverity
-    // ) {
-    //   // Log record is dropped due to minimum severity filter
-    //   return;
-    // }
-
-    // // 2. Trace-based: If trace_based is true, and if the log record has a
-    // //    SpanId and the TraceFlags SAMPLED flag is unset, the log record MUST be dropped.
-    // if (loggerConfig.traceBased) {
-    //   const spanContext = trace.getSpanContext(currentContext);
-    //   if (spanContext && isSpanContextValid(spanContext)) {
-    //     // Check if the trace is unsampled (SAMPLED flag is unset)
-    //     const isSampled =
-    //       (spanContext.traceFlags & TraceFlags.SAMPLED) === TraceFlags.SAMPLED;
-    //     if (!isSampled) {
-    //       // Log record is dropped due to trace-based filter
-    //       return;
-    //     }
-    //   }
-    //   // If there's no valid span context, the log record is not associated with a trace
-    //   // and therefore bypasses trace-based filtering (as per spec)
-    // }
-
+  public emit(logRecord: LogRecord): void {
     const currentContext = logRecord.context || context.active();
     if (!this.enabled(logRecord)) {
       return;

--- a/experimental/packages/sdk-logs/src/export/NoopLogRecordProcessor.ts
+++ b/experimental/packages/sdk-logs/src/export/NoopLogRecordProcessor.ts
@@ -6,7 +6,7 @@
 import type { InstrumentationScope } from '@opentelemetry/core';
 import type { Context } from '@opentelemetry/api';
 import type { LogRecordProcessor } from '../LogRecordProcessor';
-import type { ReadableLogRecord } from './ReadableLogRecord';
+import type { SdkLogRecord } from '../export/SdkLogRecord';
 import type { SeverityNumber } from '@opentelemetry/api-logs';
 
 export class NoopLogRecordProcessor implements LogRecordProcessor {
@@ -14,7 +14,7 @@ export class NoopLogRecordProcessor implements LogRecordProcessor {
     return Promise.resolve();
   }
 
-  public onEmit(_logRecord: ReadableLogRecord, _context: Context): void {}
+  public onEmit(_logRecord: SdkLogRecord, _context: Context): void {}
 
   public shutdown(): Promise<void> {
     return Promise.resolve();

--- a/experimental/packages/sdk-logs/src/export/SimpleLogRecordProcessor.ts
+++ b/experimental/packages/sdk-logs/src/export/SimpleLogRecordProcessor.ts
@@ -13,6 +13,7 @@ import {
 import type { LogRecordExporter } from './LogRecordExporter';
 import type { LogRecordProcessor } from '../LogRecordProcessor';
 import type { SdkLogRecord } from './SdkLogRecord';
+import type { Context } from '@opentelemetry/api';
 
 /**
  * An implementation of the {@link LogRecordProcessor} interface that exports
@@ -34,7 +35,7 @@ export class SimpleLogRecordProcessor implements LogRecordProcessor {
     this._unresolvedExports = new Set<Promise<void>>();
   }
 
-  public onEmit(logRecord: SdkLogRecord): void {
+  public onEmit(logRecord: SdkLogRecord, _context?: Context): void {
     if (this._shutdownOnce.isCalled) {
       return;
     }

--- a/experimental/packages/sdk-logs/test/common/Logger.test.ts
+++ b/experimental/packages/sdk-logs/test/common/Logger.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import type { LoggerPattern } from '../../src';
 import { LoggerProvider, createLoggerConfigurator } from '../../src';
 import { NoopLogRecordProcessor } from '../../src/export/NoopLogRecordProcessor';
 import { LogRecordImpl } from '../../src/LogRecordImpl';
@@ -16,34 +17,34 @@ import { InMemoryLogRecordExporter } from '../../src/export/InMemoryLogRecordExp
 import { SimpleLogRecordProcessor } from '../../src/export/SimpleLogRecordProcessor';
 import { LoggerProviderSharedState } from '../../src/internal/LoggerProviderSharedState';
 
-const setup = () => {
-  const logProcessor = new NoopLogRecordProcessor();
-  const loggerProvider = new LoggerProvider({ processors: [logProcessor] });
+function setupLoggerProvider(
+  processor: 'noop' | 'simple',
+  patterns?: LoggerPattern[]
+) {
+  const isNoop = processor === 'noop';
+  const logExporter = new InMemoryLogRecordExporter();
+  const logProcessor = isNoop
+    ? new NoopLogRecordProcessor()
+    : new SimpleLogRecordProcessor(logExporter);
+  const loggerProvider = new LoggerProvider({
+    processors: [logProcessor],
+    loggerConfigurator: patterns && createLoggerConfigurator(patterns),
+  });
   const logger = loggerProvider.getLogger('test name', 'test version', {
     schemaUrl: 'test schema url',
   }) as Logger;
-  return { logger, logProcessor };
-};
+  return { logger, loggerProvider, logProcessor, logExporter };
+}
 
 describe('Logger', () => {
   describe('constructor', () => {
     it('should create an instance', () => {
-      const { logger } = setup();
+      const { logger } = setupLoggerProvider('simple');
       assert.ok(logger instanceof Logger);
     });
 
     it('should cache the logger config at construction time', () => {
-      const logProcessor = new NoopLogRecordProcessor();
-      const loggerProvider = new LoggerProvider({
-        processors: [logProcessor],
-        loggerConfigurator: createLoggerConfigurator([
-          {
-            pattern: 'test-logger',
-            config: { minimumSeverity: SeverityNumber.WARN },
-          },
-        ]),
-      });
-
+      const { loggerProvider } = setupLoggerProvider('simple');
       const getLoggerConfigSpy = sinon.spy(
         LoggerProviderSharedState.prototype,
         'getLoggerConfig'
@@ -78,8 +79,17 @@ describe('Logger', () => {
   });
 
   describe('emit', () => {
+    it('should not emit a logRecord instance if no processors are active', () => {
+      const { logger, logProcessor } = setupLoggerProvider('noop');
+      const callSpy = sinon.spy(logProcessor, 'onEmit');
+      logger.emit({
+        body: 'test log body',
+      });
+      assert.ok(callSpy.called === false);
+    });
+
     it('should emit a logRecord instance', () => {
-      const { logger, logProcessor } = setup();
+      const { logger, logProcessor } = setupLoggerProvider('simple');
       const callSpy = sinon.spy(logProcessor, 'onEmit');
       logger.emit({
         body: 'test log body',
@@ -88,7 +98,8 @@ describe('Logger', () => {
     });
 
     it('should make log record instance readonly after emit it', () => {
-      const { logger } = setup();
+      // const { logger } = setup();
+      const { logger } = setupLoggerProvider('simple');
       const makeOnlySpy = sinon.spy(LogRecordImpl.prototype, '_makeReadonly');
       logger.emit({
         body: 'test log body',
@@ -97,7 +108,7 @@ describe('Logger', () => {
     });
 
     it('should emit with current Context', () => {
-      const { logger, logProcessor } = setup();
+      const { logger, logProcessor } = setupLoggerProvider('simple');
       const callSpy = sinon.spy(logProcessor, 'onEmit');
       logger.emit({
         body: 'test log body',
@@ -106,7 +117,7 @@ describe('Logger', () => {
     });
 
     it('should emit with Context specified in LogRecord', () => {
-      const { logger, logProcessor } = setup();
+      const { logger, logProcessor } = setupLoggerProvider('simple');
       const spanContext = {
         traceId: 'd4cda95b652f4a1592b449d5929fda1b',
         spanId: '6e0c63257de34c92',
@@ -124,16 +135,12 @@ describe('Logger', () => {
 
     describe('minimum severity filtering', () => {
       it('should emit log records with severity above minimum', () => {
-        const exporter = new InMemoryLogRecordExporter();
-        const loggerProvider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(exporter)],
-          loggerConfigurator: createLoggerConfigurator([
-            {
-              pattern: 'test-logger',
-              config: { minimumSeverity: SeverityNumber.INFO },
-            },
-          ]),
-        });
+        const { loggerProvider, logExporter } = setupLoggerProvider('simple', [
+          {
+            pattern: 'test-logger',
+            config: { minimumSeverity: SeverityNumber.INFO },
+          },
+        ]);
         const logger = loggerProvider.getLogger('test-logger') as Logger;
 
         logger.emit({
@@ -146,22 +153,18 @@ describe('Logger', () => {
           severityNumber: SeverityNumber.WARN,
         });
 
-        const logRecords = exporter.getFinishedLogRecords();
+        const logRecords = logExporter.getFinishedLogRecords();
         assert.strictEqual(logRecords.length, 2);
       });
 
       it('should drop log records with severity below minimum', () => {
-        const exporter = new InMemoryLogRecordExporter();
-        const loggerProvider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(exporter)],
-          loggerConfigurator: createLoggerConfigurator([
-            {
-              pattern: 'test-logger',
-              config: { minimumSeverity: SeverityNumber.WARN },
-            },
-          ]),
-        });
-        const logger = loggerProvider.getLogger('test-logger') as Logger;
+        const { loggerProvider, logExporter } = setupLoggerProvider('simple', [
+          {
+            pattern: 'test-logger',
+            config: { minimumSeverity: SeverityNumber.WARN },
+          },
+        ]);
+        const logger = loggerProvider.getLogger('test-logger');
 
         logger.emit({
           body: 'debug message',
@@ -173,43 +176,35 @@ describe('Logger', () => {
           severityNumber: SeverityNumber.INFO,
         });
 
-        const logRecords = exporter.getFinishedLogRecords();
+        const logRecords = logExporter.getFinishedLogRecords();
         assert.strictEqual(logRecords.length, 0);
       });
 
       it('should emit log records with severity equal to minimum', () => {
-        const exporter = new InMemoryLogRecordExporter();
-        const loggerProvider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(exporter)],
-          loggerConfigurator: createLoggerConfigurator([
-            {
-              pattern: 'test-logger',
-              config: { minimumSeverity: SeverityNumber.WARN },
-            },
-          ]),
-        });
-        const logger = loggerProvider.getLogger('test-logger') as Logger;
+        const { loggerProvider, logExporter } = setupLoggerProvider('simple', [
+          {
+            pattern: 'test-logger',
+            config: { minimumSeverity: SeverityNumber.WARN },
+          },
+        ]);
+        const logger = loggerProvider.getLogger('test-logger');
 
         logger.emit({
           body: 'warn message',
           severityNumber: SeverityNumber.WARN,
         });
 
-        const logRecords = exporter.getFinishedLogRecords();
+        const logRecords = logExporter.getFinishedLogRecords();
         assert.strictEqual(logRecords.length, 1);
       });
 
       it('should emit log records with unspecified severity (0) regardless of minimum', () => {
-        const exporter = new InMemoryLogRecordExporter();
-        const loggerProvider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(exporter)],
-          loggerConfigurator: createLoggerConfigurator([
-            {
-              pattern: 'test-logger',
-              config: { minimumSeverity: SeverityNumber.ERROR },
-            },
-          ]),
-        });
+        const { loggerProvider, logExporter } = setupLoggerProvider('simple', [
+          {
+            pattern: 'test-logger',
+            config: { minimumSeverity: SeverityNumber.ERROR },
+          },
+        ]);
         const logger = loggerProvider.getLogger('test-logger') as Logger;
 
         logger.emit({
@@ -222,18 +217,13 @@ describe('Logger', () => {
           // severityNumber not specified at all
         });
 
-        const logRecords = exporter.getFinishedLogRecords();
+        const logRecords = logExporter.getFinishedLogRecords();
         assert.strictEqual(logRecords.length, 2);
       });
 
       it('should use default minimum severity of 0 when not configured', () => {
-        const exporter = new InMemoryLogRecordExporter();
-        const loggerProvider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(exporter)],
-        });
-        const logger = loggerProvider.getLogger(
-          'unconfigured-logger'
-        ) as Logger;
+        const { loggerProvider, logExporter } = setupLoggerProvider('simple');
+        const logger = loggerProvider.getLogger('unconfigured-logger');
 
         logger.emit({
           body: 'debug message',
@@ -245,31 +235,23 @@ describe('Logger', () => {
           severityNumber: SeverityNumber.TRACE,
         });
 
-        const logRecords = exporter.getFinishedLogRecords();
+        const logRecords = logExporter.getFinishedLogRecords();
         assert.strictEqual(logRecords.length, 2);
       });
 
       it('should only filter logs for configured logger, not other loggers', () => {
-        const exporter = new InMemoryLogRecordExporter();
-        const loggerProvider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(exporter)],
-          loggerConfigurator: createLoggerConfigurator([
-            {
-              pattern: 'filtered-logger',
-              config: { minimumSeverity: SeverityNumber.ERROR },
-            },
-            {
-              pattern: '*',
-              config: { minimumSeverity: SeverityNumber.UNSPECIFIED },
-            },
-          ]),
-        });
-        const filteredLogger = loggerProvider.getLogger(
-          'filtered-logger'
-        ) as Logger;
-        const unfilteredLogger = loggerProvider.getLogger(
-          'unfiltered-logger'
-        ) as Logger;
+        const { loggerProvider, logExporter } = setupLoggerProvider('simple', [
+          {
+            pattern: 'filtered-logger',
+            config: { minimumSeverity: SeverityNumber.ERROR },
+          },
+          {
+            pattern: '*',
+            config: { minimumSeverity: SeverityNumber.UNSPECIFIED },
+          },
+        ]);
+        const filteredLogger = loggerProvider.getLogger('filtered-logger');
+        const unfilteredLogger = loggerProvider.getLogger('unfiltered-logger');
 
         // Should be dropped (below minimum)
         filteredLogger.emit({
@@ -283,7 +265,7 @@ describe('Logger', () => {
           severityNumber: SeverityNumber.DEBUG,
         });
 
-        const logRecords = exporter.getFinishedLogRecords();
+        const logRecords = logExporter.getFinishedLogRecords();
         assert.strictEqual(logRecords.length, 1);
         assert.strictEqual(logRecords[0].body, 'unfiltered debug');
       });
@@ -291,16 +273,12 @@ describe('Logger', () => {
 
     describe('trace-based filtering', () => {
       it('should emit log records associated with sampled traces', () => {
-        const exporter = new InMemoryLogRecordExporter();
-        const loggerProvider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(exporter)],
-          loggerConfigurator: createLoggerConfigurator([
-            {
-              pattern: 'test-logger',
-              config: { traceBased: true },
-            },
-          ]),
-        });
+        const { loggerProvider, logExporter } = setupLoggerProvider('simple', [
+          {
+            pattern: 'test-logger',
+            config: { traceBased: true },
+          },
+        ]);
         const logger = loggerProvider.getLogger('test-logger') as Logger;
 
         const spanContext = {
@@ -315,21 +293,17 @@ describe('Logger', () => {
           context: activeContext,
         });
 
-        const logRecords = exporter.getFinishedLogRecords();
+        const logRecords = logExporter.getFinishedLogRecords();
         assert.strictEqual(logRecords.length, 1);
       });
 
       it('should drop log records associated with unsampled traces', () => {
-        const exporter = new InMemoryLogRecordExporter();
-        const loggerProvider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(exporter)],
-          loggerConfigurator: createLoggerConfigurator([
-            {
-              pattern: 'test-logger',
-              config: { traceBased: true },
-            },
-          ]),
-        });
+        const { loggerProvider, logExporter } = setupLoggerProvider('simple', [
+          {
+            pattern: 'test-logger',
+            config: { traceBased: true },
+          },
+        ]);
         const logger = loggerProvider.getLogger('test-logger') as Logger;
 
         const spanContext = {
@@ -344,21 +318,17 @@ describe('Logger', () => {
           context: activeContext,
         });
 
-        const logRecords = exporter.getFinishedLogRecords();
+        const logRecords = logExporter.getFinishedLogRecords();
         assert.strictEqual(logRecords.length, 0);
       });
 
       it('should emit log records without trace context when trace-based filtering is enabled', () => {
-        const exporter = new InMemoryLogRecordExporter();
-        const loggerProvider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(exporter)],
-          loggerConfigurator: createLoggerConfigurator([
-            {
-              pattern: 'test-logger',
-              config: { traceBased: true },
-            },
-          ]),
-        });
+        const { loggerProvider, logExporter } = setupLoggerProvider('simple', [
+          {
+            pattern: 'test-logger',
+            config: { traceBased: true },
+          },
+        ]);
         const logger = loggerProvider.getLogger('test-logger') as Logger;
 
         logger.emit({
@@ -366,15 +336,12 @@ describe('Logger', () => {
           context: ROOT_CONTEXT,
         });
 
-        const logRecords = exporter.getFinishedLogRecords();
+        const logRecords = logExporter.getFinishedLogRecords();
         assert.strictEqual(logRecords.length, 1);
       });
 
       it('should not filter when trace-based filtering is disabled (default)', () => {
-        const exporter = new InMemoryLogRecordExporter();
-        const loggerProvider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(exporter)],
-        });
+        const { loggerProvider, logExporter } = setupLoggerProvider('simple');
         const logger = loggerProvider.getLogger('test-logger') as Logger;
 
         const spanContext = {
@@ -389,24 +356,20 @@ describe('Logger', () => {
           context: activeContext,
         });
 
-        const logRecords = exporter.getFinishedLogRecords();
+        const logRecords = logExporter.getFinishedLogRecords();
         assert.strictEqual(logRecords.length, 1);
       });
 
       it('should combine trace-based and minimum severity filtering', () => {
-        const exporter = new InMemoryLogRecordExporter();
-        const loggerProvider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(exporter)],
-          loggerConfigurator: createLoggerConfigurator([
-            {
-              pattern: 'test-logger',
-              config: {
-                traceBased: true,
-                minimumSeverity: SeverityNumber.WARN,
-              },
+        const { loggerProvider, logExporter } = setupLoggerProvider('simple', [
+          {
+            pattern: 'test-logger',
+            config: {
+              traceBased: true,
+              minimumSeverity: SeverityNumber.WARN,
             },
-          ]),
-        });
+          },
+        ]);
         const logger = loggerProvider.getLogger('test-logger') as Logger;
 
         const sampledSpanContext = {
@@ -457,7 +420,7 @@ describe('Logger', () => {
           context: unsampledContext,
         });
 
-        const logRecords = exporter.getFinishedLogRecords();
+        const logRecords = logExporter.getFinishedLogRecords();
         assert.strictEqual(logRecords.length, 1);
         assert.strictEqual(logRecords[0].body, 'sampled warn');
       });
@@ -466,7 +429,7 @@ describe('Logger', () => {
 
   describe('enabled', () => {
     describe('with default configuration and disabled log processors', () => {
-      const { logger } = setup();
+      const { logger } = setupLoggerProvider('noop');
 
       it('should return "false" when called with no options', () => {
         assert.ok(!logger.enabled());
@@ -488,11 +451,7 @@ describe('Logger', () => {
     });
 
     describe('with default configuration and enabled log processors', () => {
-      const exporter = new InMemoryLogRecordExporter();
-      const loggerProvider = new LoggerProvider({
-        processors: [new SimpleLogRecordProcessor(exporter)],
-      });
-      const logger = loggerProvider.getLogger('test-logger');
+      const { logger } = setupLoggerProvider('simple');
 
       it('should return "true" when called with no options', () => {
         assert.ok(logger.enabled());
@@ -514,23 +473,20 @@ describe('Logger', () => {
     });
 
     describe('with custom configuration and disabled log processors', () => {
-      const loggerProvider = new LoggerProvider({
-        processors: [new NoopLogRecordProcessor()],
-        loggerConfigurator: createLoggerConfigurator([
-          {
-            pattern: 'disabled-logger',
-            config: { disabled: true },
-          },
-          {
-            pattern: 'warn-logger',
-            config: { minimumSeverity: SeverityNumber.WARN },
-          },
-          {
-            pattern: 'trace-logger',
-            config: { traceBased: true },
-          },
-        ]),
-      });
+      const { loggerProvider } = setupLoggerProvider('noop', [
+        {
+          pattern: 'disabled-logger',
+          config: { disabled: true },
+        },
+        {
+          pattern: 'warn-logger',
+          config: { minimumSeverity: SeverityNumber.WARN },
+        },
+        {
+          pattern: 'trace-logger',
+          config: { traceBased: true },
+        },
+      ]);
 
       it('should return "false" no matter the combinations', () => {
         const disabledLogger = loggerProvider.getLogger('disabled-logger');
@@ -560,24 +516,20 @@ describe('Logger', () => {
     });
 
     describe('with custom configuration and enabled log processors', () => {
-      const exporter = new InMemoryLogRecordExporter();
-      const loggerProvider = new LoggerProvider({
-        processors: [new SimpleLogRecordProcessor(exporter)],
-        loggerConfigurator: createLoggerConfigurator([
-          {
-            pattern: 'disabled-logger',
-            config: { disabled: true },
-          },
-          {
-            pattern: 'warn-logger',
-            config: { minimumSeverity: SeverityNumber.WARN },
-          },
-          {
-            pattern: 'trace-logger',
-            config: { traceBased: true },
-          },
-        ]),
-      });
+      const { loggerProvider } = setupLoggerProvider('simple', [
+        {
+          pattern: 'disabled-logger',
+          config: { disabled: true },
+        },
+        {
+          pattern: 'warn-logger',
+          config: { minimumSeverity: SeverityNumber.WARN },
+        },
+        {
+          pattern: 'trace-logger',
+          config: { traceBased: true },
+        },
+      ]);
 
       it('should return "false" if the logger is configured to be disabled', () => {
         const logger = loggerProvider.getLogger('disabled-logger');

--- a/experimental/packages/sdk-logs/test/common/Logger.test.ts
+++ b/experimental/packages/sdk-logs/test/common/Logger.test.ts
@@ -98,7 +98,6 @@ describe('Logger', () => {
     });
 
     it('should make log record instance readonly after emit it', () => {
-      // const { logger } = setup();
       const { logger } = setupLoggerProvider('simple');
       const makeOnlySpy = sinon.spy(LogRecordImpl.prototype, '_makeReadonly');
       logger.emit({

--- a/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
@@ -12,7 +12,11 @@ import { MeterProvider } from '@opentelemetry/sdk-metrics';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 
-import { LoggerProvider } from '../../src';
+import {
+  InMemoryLogRecordExporter,
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+} from '../../src';
 import { NoopLogRecordProcessor } from '../../src/export/NoopLogRecordProcessor';
 import { DEFAULT_LOGGER_NAME } from './../../src/LoggerProvider';
 import { MultiLogRecordProcessor } from '../../src/MultiLogRecordProcessor';
@@ -313,7 +317,10 @@ describe('LoggerProvider', () => {
         readers: [metricReader],
       });
 
-      const logRecordProcessor = new NoopLogRecordProcessor();
+      const logRecordExporter = new InMemoryLogRecordExporter();
+      const logRecordProcessor = new SimpleLogRecordProcessor(
+        logRecordExporter
+      );
       const provider = new LoggerProvider({
         processors: [logRecordProcessor],
         meterProvider,


### PR DESCRIPTION
## Which problem is this PR solving?

Reuse `Logger#enabled()` logic for `Logger#emit()` since they have mostly the same logic. There is a small change in the internal logic that does not affect the outcome. With this change the active processor `onEmit` method is not called if all the processors are not active.

Closes #6678

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [X] refactor (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Unit tests

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been added/updated