### PR TITLE
feat(configuration): show all config validation errors, if there are multiple

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -10,6 +10,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :rocket: Features
 
+* feat(configuration): show all config validation errors, if there are multiple [#6683](https://github.com/open-telemetry/opentelemetry-js/pull/6683) @trentm
+
 ### :bug: Bug Fixes
 
 ### :books: Documentation

--- a/experimental/packages/configuration/src/FileConfigFactory.ts
+++ b/experimental/packages/configuration/src/FileConfigFactory.ts
@@ -52,11 +52,23 @@ export function parseConfigFile(): ConfigurationModel {
 
   const valid = validateConfig(processed);
   if (!valid) {
-    const firstError = validateConfig.errors?.[0];
-    const detail = firstError
-      ? `${firstError.instancePath} ${firstError.message}`
-      : 'unknown error';
-    throw new Error(`Invalid OpenTelemetry config file: ${detail.trim()}`);
+    let detail: string;
+    if (!validateConfig.errors) {
+      detail = 'unknown error';
+    } else if (validateConfig.errors.length === 1) {
+      const err = validateConfig.errors[0];
+      detail = `${err.instancePath} ${err.message}`;
+    } else {
+      const sep = '\n  ';
+      detail =
+        sep +
+        validateConfig.errors
+          .map(e => `${e.instancePath} ${e.message}`)
+          .join(sep);
+    }
+    throw new Error(
+      `Invalid OpenTelemetry config file: ${configFile}: ${detail}`
+    );
   }
 
   const data = processed as unknown as ConfigurationModel;

--- a/experimental/packages/configuration/test/ConfigFactory.test.ts
+++ b/experimental/packages/configuration/test/ConfigFactory.test.ts
@@ -2274,6 +2274,14 @@ describe('ConfigFactory', function () {
       assert.throws(() => createConfigFactory(), /Unsupported file_format/);
     });
 
+    it('should show multiple validation errors for invalid config', function () {
+      process.env.OTEL_CONFIG_FILE =
+        'test/fixtures/invalid-multiple-errors.yaml';
+      assert.throws(() => createConfigFactory(),
+        /Invalid OpenTelemetry config file: .*?:.*must be string.*must be number/s
+      );
+    });
+
     it('should initialize config with default values with empty string for config file', function () {
       process.env.OTEL_CONFIG_FILE = '';
       const configFactory = createConfigFactory();
@@ -2502,15 +2510,9 @@ describe('ConfigFactory', function () {
 
     it('should throw for empty processors (minItems)', function () {
       process.env.OTEL_CONFIG_FILE = 'test/fixtures/invalid-providers.yaml';
-      try {
-        createConfigFactory();
-      } catch (err) {
-        assert.ok(err);
-        assert.strictEqual(
-          err.message,
-          'Invalid OpenTelemetry config file: /logger_provider/processors must be array'
-        );
-      }
+      assert.throws(() => createConfigFactory(),
+        /Invalid OpenTelemetry config file: .*?: \/logger_provider\/processors must be array/
+      );
     });
 
     it('check resources priority', function () {

--- a/experimental/packages/configuration/test/ConfigFactory.test.ts
+++ b/experimental/packages/configuration/test/ConfigFactory.test.ts
@@ -2277,7 +2277,8 @@ describe('ConfigFactory', function () {
     it('should show multiple validation errors for invalid config', function () {
       process.env.OTEL_CONFIG_FILE =
         'test/fixtures/invalid-multiple-errors.yaml';
-      assert.throws(() => createConfigFactory(),
+      assert.throws(
+        () => createConfigFactory(),
         /Invalid OpenTelemetry config file: .*?:.*must be string.*must be number/s
       );
     });
@@ -2510,7 +2511,8 @@ describe('ConfigFactory', function () {
 
     it('should throw for empty processors (minItems)', function () {
       process.env.OTEL_CONFIG_FILE = 'test/fixtures/invalid-providers.yaml';
-      assert.throws(() => createConfigFactory(),
+      assert.throws(
+        () => createConfigFactory(),
         /Invalid OpenTelemetry config file: .*?: \/logger_provider\/processors must be array/
       );
     });

--- a/experimental/packages/configuration/test/fixtures/invalid-multiple-errors.yaml
+++ b/experimental/packages/configuration/test/fixtures/invalid-multiple-errors.yaml
@@ -1,0 +1,8 @@
+file_format: "1.0"
+resource:
+  attributes:
+    - name: my.null
+      # This results in multiple ajv validation errors, one for each
+      # element of the 'oneOf' for supported attribute value types.
+      # (At least if/until extended/complex attributes are supported.)
+      value: {}


### PR DESCRIPTION
Given this "foo.yml" with an invalid resource attribute value:

```yaml
file_format: "1.0"
resource:
  attributes:
    - name: my.null
      value: {}
```

Before:

```
% ./scripts/parse-config.mjs foo.yml
/Users/trentm/semconv/opentelemetry-js3/experimental/packages/configuration/build/src/FileConfigFactory.js:46
        throw new Error(`Invalid OpenTelemetry config file: ${detail.trim()}`);
              ^

Error: Invalid OpenTelemetry config file: /resource/attributes/0/value must be string
    at parseConfigFile (/Users/trentm/semconv/opentelemetry-js3/experimental/packages/configuration/build/src/FileConfigFactory.js:46:15)
    at new FileConfigFactory (/Users/trentm/semconv/opentelemetry-js3/experimental/packages/configuration/build/src/FileConfigFactory.js:18:24)
    at createConfigFactory (/Users/trentm/semconv/opentelemetry-js3/experimental/packages/configuration/build/src/ConfigFactory.js:14:16)
    at file:///Users/trentm/semconv/opentelemetry-js3/experimental/packages/configuration/scripts/parse-config.mjs:30:13
```

After:

```
% ./scripts/parse-config.mjs foo.yml
/Users/trentm/semconv/opentelemetry-js3/experimental/packages/configuration/build/src/FileConfigFactory.js:62
        throw new Error(`Invalid OpenTelemetry config file: ${configFile}: ${detail}`);
              ^

Error: Invalid OpenTelemetry config file: foo.yml:
  /resource/attributes/0/value must be string
  /resource/attributes/0/value must be number
  /resource/attributes/0/value must be boolean
  /resource/attributes/0/value must be null
  /resource/attributes/0/value must be array
  /resource/attributes/0/value must be array
  /resource/attributes/0/value must be array
  /resource/attributes/0/value must match exactly one schema in oneOf
    at parseConfigFile (/Users/trentm/semconv/opentelemetry-js3/experimental/packages/configuration/build/src/FileConfigFactory.js:62:15)
    at new FileConfigFactory (/Users/trentm/semconv/opentelemetry-js3/experimental/packages/configuration/build/src/FileConfigFactory.js:18:24)
    at createConfigFactory (/Users/trentm/semconv/opentelemetry-js3/experimental/packages/configuration/build/src/ConfigFactory.js:14:16)
    at file:///Users/trentm/semconv/opentelemetry-js3/experimental/packages/configuration/scripts/parse-config.mjs:30:13
```

I've also added the config file path to the error message.