### PR TITLE
feat(sdk-node): allow startNodeSDK() without an arg

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -11,6 +11,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :rocket: Features
 
 * feat(configuration): show all config validation errors, if there are multiple [#6683](https://github.com/open-telemetry/opentelemetry-js/pull/6683) @trentm
+* feat(sdk-node): allow startNodeSDK() without an arg [#6688](https://github.com/open-telemetry/opentelemetry-js/pull/6688) @trentm
 
 ### :bug: Bug Fixes
 

--- a/experimental/packages/opentelemetry-sdk-node/src/start.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/start.ts
@@ -55,7 +55,7 @@ export const NOOP_SDK = {
  * @experimental Function to start the OpenTelemetry Node SDK
  * @param sdkOptions
  */
-export function startNodeSDK(sdkOptions: SDKOptions): {
+export function startNodeSDK(sdkOptions?: SDKOptions): {
   shutdown: () => Promise<void>;
 } {
   let config: ConfigurationModel;
@@ -119,7 +119,7 @@ export function startNodeSDK(sdkOptions: SDKOptions): {
  */
 function create(
   config: ConfigurationModel,
-  sdkOptions: SDKOptions
+  sdkOptions?: SDKOptions
 ): SDKComponents {
   const defaultContextManager = new AsyncLocalStorageContextManager();
   defaultContextManager.enable();
@@ -181,13 +181,13 @@ function create(
 
 export function setupResource(
   config: ConfigurationModel,
-  sdkOptions: SDKOptions
+  sdkOptions?: SDKOptions
 ): Resource {
   let resource: Resource =
     getResourceFromConfiguration(config) ?? defaultResource();
   let resourceDetectors: ResourceDetector[] = [];
 
-  if (sdkOptions.resourceDetectors != null) {
+  if (sdkOptions?.resourceDetectors != null) {
     resourceDetectors = sdkOptions.resourceDetectors;
   } else if (config.resource?.['detection/development']?.detectors) {
     resourceDetectors = getResourceDetectorsFromConfiguration(config);

--- a/experimental/packages/opentelemetry-sdk-node/test/start.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/start.test.ts
@@ -111,7 +111,7 @@ describe('startNodeSDK', function () {
   describe('Basic Registration', function () {
     it('should return NOOP_SDK when disabled is true', async () => {
       process.env.OTEL_SDK_DISABLED = 'true';
-      const sdk = startNodeSDK({});
+      const sdk = startNodeSDK();
 
       assert.strictEqual(sdk, NOOP_SDK);
 
@@ -123,7 +123,7 @@ describe('startNodeSDK', function () {
       process.env.OTEL_TRACES_EXPORTER = 'none';
       process.env.OTEL_LOGS_EXPORTER = 'none';
       process.env.OTEL_METRICS_EXPORTER = 'none';
-      const sdk = startNodeSDK({});
+      const sdk = startNodeSDK();
 
       // These are minimal OTel functionality and always registered.
       assertDefaultContextManagerRegistered();
@@ -146,7 +146,7 @@ describe('startNodeSDK', function () {
       process.env.OTEL_LOG_LEVEL = 'ERROR';
 
       const spy = Sinon.spy(diag, 'setLogger');
-      const sdk = startNodeSDK({});
+      const sdk = startNodeSDK();
 
       assert.strictEqual(spy.callCount, 1);
       assert.ok(spy.args[0][0] instanceof DiagConsoleLogger);
@@ -161,7 +161,7 @@ describe('startNodeSDK', function () {
       delete process.env.OTEL_LOG_LEVEL;
 
       const spy = Sinon.spy(diag, 'setLogger');
-      const sdk = startNodeSDK({});
+      const sdk = startNodeSDK();
 
       assert.strictEqual(spy.callCount, 1);
       assert.ok(spy.args[0][0] instanceof DiagConsoleLogger);


### PR DESCRIPTION
Currently it requires `startNodeSDK({})` if passing no options (they are all optional), else it crashes.