### PR TITLE
refactor(sdk-logs): alias `LoggerProviderConfig` to `LoggerProviderOptions`

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,6 +16,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
+* refactor(sdk-logs): rename `LoggerProviderConfig` to `LoggerProviderOptions` [#6691](https://github.com/open-telemetry/opentelemetry-js/pull/6691) @david-luna
 * refactor(sdk-logs): use `Logger.enabled()` within `Logger.emit()` implementation [#6680](https://github.com/open-telemetry/opentelemetry-js/pull/6680) @david-luna
 
 ## 0.217.0

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,7 +16,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
-* refactor(sdk-logs): rename `LoggerProviderConfig` to `LoggerProviderOptions` [#6691](https://github.com/open-telemetry/opentelemetry-js/pull/6691) @david-luna
+* refactor(sdk-logs): alias `LoggerProviderConfig` to `LoggerProviderOptions` [#6691](https://github.com/open-telemetry/opentelemetry-js/pull/6691) @david-luna
 * refactor(sdk-logs): use `Logger.enabled()` within `Logger.emit()` implementation [#6680](https://github.com/open-telemetry/opentelemetry-js/pull/6680) @david-luna
 
 ## 0.217.0

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -84,7 +84,7 @@ import { OTLPMetricExporter as OTLPProtoMetricExporter } from '@opentelemetry/ex
 import type {
   BufferConfig,
   LogRecordExporter,
-  LoggerProviderConfig,
+  LoggerProviderOptions,
   LogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
 import {
@@ -564,7 +564,7 @@ export function getPeriodicMetricReaderFromConfiguration(
 /**
  * Get LoggerProviderConfig from environment variables.
  */
-export function getLoggerProviderConfigFromEnv(): LoggerProviderConfig {
+export function getLoggerProviderConfigFromEnv(): LoggerProviderOptions {
   return {
     logRecordLimits: {
       attributeCountLimit:

--- a/experimental/packages/opentelemetry-sdk-node/test/utils.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/utils.test.ts
@@ -33,7 +33,7 @@ import {
   processDetector,
   serviceInstanceIdDetector,
 } from '@opentelemetry/resources';
-import type { LoggerProviderConfig } from '@opentelemetry/sdk-logs';
+import type { LoggerProviderOptions } from '@opentelemetry/sdk-logs';
 import { AggregationType, InstrumentType } from '@opentelemetry/sdk-metrics';
 import type { SpanLimits } from '@opentelemetry/sdk-trace-node';
 
@@ -223,7 +223,7 @@ describe('getLoggerProviderConfigFromEnv', function () {
   it('should return empty config when no env variables are set', function () {
     const config = getLoggerProviderConfigFromEnv();
 
-    const expectedConfig: LoggerProviderConfig = {
+    const expectedConfig: LoggerProviderOptions = {
       logRecordLimits: {
         attributeValueLengthLimit: undefined,
         attributeCountLimit: undefined,
@@ -236,7 +236,7 @@ describe('getLoggerProviderConfigFromEnv', function () {
     process.env.OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT = '512';
     const config = getLoggerProviderConfigFromEnv();
 
-    const expectedConfig: LoggerProviderConfig = {
+    const expectedConfig: LoggerProviderOptions = {
       logRecordLimits: {
         attributeValueLengthLimit: 512,
         attributeCountLimit: undefined,
@@ -249,7 +249,7 @@ describe('getLoggerProviderConfigFromEnv', function () {
     process.env.OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT = '35';
     const config = getLoggerProviderConfigFromEnv();
 
-    const expectedConfig: LoggerProviderConfig = {
+    const expectedConfig: LoggerProviderOptions = {
       logRecordLimits: {
         attributeValueLengthLimit: undefined,
         attributeCountLimit: 35,
@@ -265,7 +265,7 @@ describe('getLoggerProviderConfigFromEnv', function () {
 
     const config = getLoggerProviderConfigFromEnv();
 
-    const expectedConfig: LoggerProviderConfig = {
+    const expectedConfig: LoggerProviderOptions = {
       logRecordLimits: {
         attributeValueLengthLimit: undefined,
         attributeCountLimit: undefined,
@@ -287,7 +287,7 @@ describe('getLoggerProviderConfigFromEnv', function () {
 
     const config = getLoggerProviderConfigFromEnv();
 
-    const expectedConfig: LoggerProviderConfig = {
+    const expectedConfig: LoggerProviderOptions = {
       logRecordLimits: {
         attributeValueLengthLimit: undefined,
         attributeCountLimit: undefined,

--- a/experimental/packages/sdk-logs/src/LoggerProvider.ts
+++ b/experimental/packages/sdk-logs/src/LoggerProvider.ts
@@ -3,12 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { diag } from '@opentelemetry/api';
-import type * as logsAPI from '@opentelemetry/api-logs';
+import type {
+  LoggerProvider as ILoggerProvider,
+  LoggerOptions as ILoggerOptions,
+  Logger as ILogger,
+} from '@opentelemetry/api-logs';
 import { NOOP_LOGGER } from '@opentelemetry/api-logs';
 import { defaultResource } from '@opentelemetry/resources';
 import { BindOnceFuture } from '@opentelemetry/core';
 
-import type { LoggerProviderConfig } from './types';
+import type { LoggerProviderOptions } from './types';
 import { Logger } from './Logger';
 import {
   DEFAULT_LOGGER_CONFIGURATOR,
@@ -17,11 +21,11 @@ import {
 
 export const DEFAULT_LOGGER_NAME = 'unknown';
 
-export class LoggerProvider implements logsAPI.LoggerProvider {
+export class LoggerProvider implements ILoggerProvider {
   private _shutdownOnce: BindOnceFuture<void>;
   private readonly _sharedState: LoggerProviderSharedState;
 
-  constructor(config: LoggerProviderConfig = {}) {
+  constructor(config: LoggerProviderOptions = {}) {
     const mergedConfig = {
       resource: config.resource ?? defaultResource(),
       forceFlushTimeoutMillis: config.forceFlushTimeoutMillis ?? 30000,
@@ -52,8 +56,8 @@ export class LoggerProvider implements logsAPI.LoggerProvider {
   public getLogger(
     name: string,
     version?: string,
-    options?: logsAPI.LoggerOptions
-  ): logsAPI.Logger {
+    options?: ILoggerOptions
+  ): ILogger {
     if (this._shutdownOnce.isCalled) {
       diag.warn('A shutdown LoggerProvider cannot provide a Logger');
       return NOOP_LOGGER;

--- a/experimental/packages/sdk-logs/src/index.ts
+++ b/experimental/packages/sdk-logs/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 export type {
-  LoggerProviderConfig,
+  LoggerProviderOptions,
   LoggerConfig,
   LoggerConfigurator,
   LogRecordLimits,

--- a/experimental/packages/sdk-logs/src/index.ts
+++ b/experimental/packages/sdk-logs/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 export type {
+  LoggerProviderConfig,
   LoggerProviderOptions,
   LoggerConfig,
   LoggerConfigurator,

--- a/experimental/packages/sdk-logs/src/types.ts
+++ b/experimental/packages/sdk-logs/src/types.ts
@@ -61,7 +61,7 @@ export type LoggerConfigurator = (
   loggerScope: InstrumentationScope
 ) => Required<LoggerConfig>;
 
-export interface LoggerProviderConfig {
+export interface LoggerProviderOptions {
   /** Resource associated with trace telemetry  */
   resource?: Resource;
 

--- a/experimental/packages/sdk-logs/src/types.ts
+++ b/experimental/packages/sdk-logs/src/types.ts
@@ -92,6 +92,11 @@ export interface LoggerProviderOptions {
   meterProvider?: MeterProvider;
 }
 
+/**
+ * @deprecated please use {@link LoggerProviderOptions}
+ */
+export type LoggerProviderConfig = LoggerProviderOptions;
+
 export interface LogRecordLimits {
   /** attributeValueLengthLimit is maximum allowed attribute value size */
   attributeValueLengthLimit?: number;


### PR DESCRIPTION
## Which problem is this PR solving?

The goal is to align all provider constructor types to match the pattern `*ProviderOptions`. This PR deprecates the current `LoggerProviderConfig` interface and exposes the new `LoggerProviderOptions`.

The deprecated interface will be removed in the next major. Updated `sdk-node` already to use the new interface.

Ref #6469

## Short description of the changes

## Type of change

Please delete options that are not relevant.

- [X] Refactor
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] compilation works for `sdk-logs` and its dependants
- [X] unit tests

## Checklist:

- [X] Followed the style guidelines of this project
