### PR TITLE
chore(renovate): add minimumReleaseAge to config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -51,5 +51,6 @@
   "assignees": ["@dyladan", "@legendecas", "@pichlermarc", "@trentm"],
   "labels": ["dependencies"],
   "ignorePaths": ["**/bundler-tests/**"],
-  "postUpdateOptions": ["npmDedupe"]
+  "postUpdateOptions": ["npmDedupe"],
+  "minimumReleaseAge": "1 week"
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Configures `minimumReleaseAge` for renovate

Fixes #6696 

