### PR TITLE
fix(otlp-transformer): do not attempt to skip groups

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(otlp-transformer): do not attempt to skip groups [#6704](https://github.com/open-telemetry/opentelemetry-js/pull/6704) @pichlermarc
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/experimental/packages/otlp-transformer/src/common/protobuf/protobuf-reader.ts
+++ b/experimental/packages/otlp-transformer/src/common/protobuf/protobuf-reader.ts
@@ -81,7 +81,11 @@ export class ProtobufReader {
   /**
    * Skip an unknown field.
    * Handles wire types 0 (varint), 1 (64-bit), 2 (length-delimited),
-   * 3 (start-group), 4 (end-group), and 5 (32-bit).
+   * and 5 (32-bit).
+   *
+   * Wire types 3 and 4 (start-group / end-group) are deprecated in proto3
+   * and are not used by any OpenTelemetry proto definition. Encountering
+   * them is treated as an error.
    */
   skip(wireType: number): void {
     switch (wireType) {
@@ -93,26 +97,6 @@ export class ProtobufReader {
         break;
       case 2: // length-delimited
         this.readBytes();
-        break;
-      case 3: // start group (deprecated)
-        // We should never encounter this, but let's handle it gracefully in case we do:
-        // Read nested tags until matching end-group (wire type 4) is found.
-        // Groups can be nested, so continue until the end-group for this
-        // start-group is encountered.
-        while (!this.isAtEnd()) {
-          const { wireType: nestedWireType } = this.readTag();
-          if (nestedWireType === 4) {
-            // matched end-group for this start-group
-            break;
-          }
-          // recursive skip also handles nested groups
-          this.skip(nestedWireType);
-        }
-        break;
-      case 4: // end group
-        // End-group should be handled by the start-group logic above.
-        // When encountered directly in skip, treat it as a no-op (it signals
-        // termination of the enclosing group).
         break;
       case 5: // 32-bit fixed
         this.pos += 4;

--- a/experimental/packages/otlp-transformer/test/protobuf/protobuf-reader.test.ts
+++ b/experimental/packages/otlp-transformer/test/protobuf/protobuf-reader.test.ts
@@ -278,28 +278,26 @@ describe('ProtobufReader', function () {
       assert.strictEqual(reader.readVarint(), 0x2a);
     });
 
-    it('wire type 3 and 4: group is handled and does not throw', function () {
-      // Construct a deprecated start-group for field 1 containing an inner
-      // varint field 2 with value 3, then the matching end-group for field 1.
+    it('wire type 3 (start-group): throws because groups are not supported', function () {
       // start-group key for field 1: (1 << 3) | 3 = 0x0B
-      // field 2 varint key: (2 << 3) | 0 = 0x10
-      // varint value 3: 0x03
-      // end-group key for field 1: (1 << 3) | 4 = 0x0C
-      // Append a sentinel byte after the group so we can assert the reader
-      // stopped at the correct position and didn't consume the sentinel.
-      const bytes = new Uint8Array([0x0b, 0x10, 0x03, 0x0c, 0x2a]);
+      const bytes = new Uint8Array([0x0b, 0x10, 0x03, 0x0c]);
       const reader = new ProtobufReader(bytes);
 
-      // Read the start-group tag, ensure it is field 1 wire type 3
       const { fieldNumber, wireType } = reader.readTag();
       assert.strictEqual(fieldNumber, 1);
       assert.strictEqual(wireType, 3);
 
-      // Skip the group and verify we've advanced past the end-group but not
-      // the sentinel (sentinel should remain to be read by caller).
-      reader.skip(wireType);
-      assert.strictEqual(reader.pos, bytes.length - 1);
-      assert.strictEqual(reader.readVarint(), 0x2a);
+      assert.throws(() => reader.skip(wireType), /Unknown wire type 3/);
+    });
+
+    it('wire type 4 (end-group): throws because groups are not supported', function () {
+      // end-group key for field 1: (1 << 3) | 4 = 0x0C
+      const reader = new ProtobufReader(new Uint8Array([0x0c]));
+
+      const { wireType } = reader.readTag();
+      assert.strictEqual(wireType, 4);
+
+      assert.throws(() => reader.skip(wireType), /Unknown wire type 4/);
     });
 
     it('unknown tag (invalid wire type): skip throws and does not consume subsequent bytes', function () {


### PR DESCRIPTION
## Which problem is this PR solving?

While looking into the recent security advisories for `protobufjs`, I think that we also should not recurse into groups, mainly because we don't need them in OTLP. Doing it only adds attack surface and the OTLP response is only cosmetic. They're also deprecated and will therefore not show up in OTLP responses.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests
