### PR TITLE
fix(sdk-node): warn and ignore zero exporter timeout in declarative config

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-node): warn and ignore zero exporter timeout in declarative config [#6711](https://github.com/open-telemetry/opentelemetry-js/pull/6711) @MikeGoldsmith
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -693,6 +693,23 @@ export function getHeadersFromConfiguration(
   return result;
 }
 
+/**
+ * Validate an exporter timeout value. The spec says 0 means "no limit
+ * (infinity)" but the JS exporters don't support that yet (see #6617).
+ * Warn and return undefined so the exporter falls back to its default.
+ */
+function validateExporterTimeout(
+  timeout: number | undefined
+): number | undefined {
+  if (timeout === 0) {
+    diag.warn(
+      'Exporter timeout of 0 (infinite) is not supported. Using default timeout.'
+    );
+    return undefined;
+  }
+  return timeout;
+}
+
 export function getHttpAgentOptionsFromTls(
   tls: HttpTlsConfigModel | undefined
 ): { ca?: Buffer; cert?: Buffer; key?: Buffer } | undefined {
@@ -737,7 +754,7 @@ export function getSpanExporter(
             : CompressionAlgorithm.NONE,
         url: exporter.otlp_http.endpoint,
         headers: getHeadersFromConfiguration(exporter.otlp_http.headers),
-        timeoutMillis: exporter.otlp_http.timeout,
+        timeoutMillis: validateExporterTimeout(exporter.otlp_http.timeout),
         httpAgentOptions: getHttpAgentOptionsFromTls(exporter.otlp_http.tls),
       });
     } else {
@@ -748,7 +765,7 @@ export function getSpanExporter(
             : CompressionAlgorithm.NONE,
         url: exporter.otlp_http.endpoint,
         headers: getHeadersFromConfiguration(exporter.otlp_http.headers),
-        timeoutMillis: exporter.otlp_http.timeout,
+        timeoutMillis: validateExporterTimeout(exporter.otlp_http.timeout),
         httpAgentOptions: getHttpAgentOptionsFromTls(exporter.otlp_http.tls),
       });
     }
@@ -759,7 +776,7 @@ export function getSpanExporter(
           ? CompressionAlgorithm.GZIP
           : CompressionAlgorithm.NONE,
       url: exporter.otlp_grpc.endpoint,
-      timeoutMillis: exporter.otlp_grpc.timeout,
+      timeoutMillis: validateExporterTimeout(exporter.otlp_grpc.timeout),
       // TODO (6614): add support for credentials
       // TODO (6615): add metadata (headers) support
     });

--- a/experimental/packages/opentelemetry-sdk-node/test/start.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/start.test.ts
@@ -55,7 +55,11 @@ import {
   ATTR_SERVICE_INSTANCE_ID,
 } from '../src/semconv';
 import { ATTR_OS_TYPE } from '@opentelemetry/resources/src/semconv';
-import { getLogRecordExporter, setupContextManager } from '../src/utils';
+import {
+  getLogRecordExporter,
+  getSpanExporter,
+  setupContextManager,
+} from '../src/utils';
 import { NOOP_SDK } from '../src/start';
 import {
   ConsoleMetricExporter,
@@ -960,6 +964,19 @@ describe('startNodeSDK', function () {
     it('should return undefined for invalid log record exporter model', async () => {
       const exporter: LogRecordExporterConfigModel = {};
       assert.equal(getLogRecordExporter(exporter), undefined);
+    });
+
+    it('should warn when exporter timeout is 0', async () => {
+      const warnSpy = Sinon.spy(diag, 'warn');
+      const exporter = getSpanExporter({
+        otlp_http: { timeout: 0 },
+      });
+      assert.ok(exporter !== undefined);
+      assert.ok(
+        warnSpy.args.some(args =>
+          String(args[0]).includes('timeout of 0 (infinite) is not supported')
+        )
+      );
     });
 
     it('null context manager', async () => {


### PR DESCRIPTION
## Which problem is this PR solving?

The declarative config schema says a `timeout` of `0` means "no limit (infinity)" for OTLP exporters. However, the JS exporters don't support infinite timeout yet (#6617). Currently, `timeout: 0` is passed through silently and may cause unexpected behavior.

## Short description of the changes

Add `validateExporterTimeout()` helper in sdk-node's `utils.ts` that checks for zero timeout values when creating exporters from declarative config. When `timeout: 0` is configured:
- Emits a `diag.warn` explaining that infinite timeout is not supported
- Returns `undefined` so the exporter falls back to its default timeout (10000ms)

Applied to all OTLP trace exporter creation paths (HTTP json, HTTP protobuf, gRPC).

Note: the metric and log exporter paths don't currently pass `timeout` through — that's being addressed in #6707 and #6708. Once those merge, this validation should be applied there too.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

189 sdk-node tests pass. Full lint passes.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated

Closes #6618