### PR TITLE
fix(api-logs)!: minimize noop logger exports

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -8,6 +8,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :boom: Breaking Changes
 
+* fix(api-logs): Removed `NOOP_LOGGER` and `NoopLogger` exports from `@opentelemetry/api-logs`. Use `createNoopLogger(): Logger` instead. [#6713](https://github.com/open-telemetry/opentelemetry-js/pull/6713) @dyladan
+
 ### :rocket: Features
 
 ### :bug: Bug Fixes

--- a/experimental/packages/api-logs/src/NoopLogger.ts
+++ b/experimental/packages/api-logs/src/NoopLogger.ts
@@ -14,3 +14,10 @@ export class NoopLogger implements Logger {
 }
 
 export const NOOP_LOGGER = new NoopLogger();
+
+/**
+ * Create a no-op Logger
+ */
+export function createNoopLogger(): Logger {
+  return NOOP_LOGGER;
+}

--- a/experimental/packages/api-logs/src/index.ts
+++ b/experimental/packages/api-logs/src/index.ts
@@ -9,7 +9,7 @@ export { SeverityNumber } from './types/LogRecord';
 export type { LogAttributes, LogBody, LogRecord } from './types/LogRecord';
 export type { LoggerOptions } from './types/LoggerOptions';
 export type { AnyValue, AnyValueMap } from './types/AnyValue';
-export { NOOP_LOGGER, NoopLogger } from './NoopLogger';
+export { createNoopLogger } from './NoopLogger';
 
 import { LogsAPI } from './api/logs';
 export const logs = LogsAPI.getInstance();

--- a/experimental/packages/api-logs/test/noop-implementations/noop-logger-provider.test.ts
+++ b/experimental/packages/api-logs/test/noop-implementations/noop-logger-provider.test.ts
@@ -4,21 +4,18 @@
  */
 
 import * as assert from 'assert';
-import { NoopLogger } from '../../src/NoopLogger';
 import { NoopLoggerProvider } from '../../src/NoopLoggerProvider';
 
 describe('NoopLoggerProvider', () => {
   const loggerProvider = new NoopLoggerProvider();
 
   it('should not crash', () => {
-    assert.ok(loggerProvider.getLogger('logger-name') instanceof NoopLogger);
-    assert.ok(
-      loggerProvider.getLogger('logger-name', 'v1') instanceof NoopLogger
-    );
+    assert.ok(loggerProvider.getLogger('logger-name'));
+    assert.ok(loggerProvider.getLogger('logger-name', 'v1'));
     assert.ok(
       loggerProvider.getLogger('logger-name', 'v1', {
         schemaUrl: 'https://opentelemetry.io/schemas/1.7.0',
-      }) instanceof NoopLogger
+      })
     );
   });
 
@@ -31,7 +28,7 @@ describe('NoopLoggerProvider', () => {
           enabled: true,
         },
       });
-      assert.ok(logger instanceof NoopLogger);
+      assert.ok(logger);
     });
 
     it('should accept scopeAttributes with LogAttribute value types', () => {
@@ -46,7 +43,7 @@ describe('NoopLoggerProvider', () => {
           nullVal: null,
         },
       });
-      assert.ok(logger instanceof NoopLogger);
+      assert.ok(logger);
     });
   });
 });

--- a/experimental/packages/api-logs/test/noop-implementations/noop-logger.test.ts
+++ b/experimental/packages/api-logs/test/noop-implementations/noop-logger.test.ts
@@ -5,15 +5,9 @@
 
 import * as assert from 'assert';
 import { SeverityNumber } from '../../src';
-import { NoopLogger } from '../../src/NoopLogger';
 import { NoopLoggerProvider } from '../../src/NoopLoggerProvider';
 
 describe('NoopLogger', () => {
-  it('constructor should not crash', () => {
-    const logger = new NoopLoggerProvider().getLogger('test-noop');
-    assert.ok(logger instanceof NoopLogger);
-  });
-
   it('calling emit should not crash', () => {
     const logger = new NoopLoggerProvider().getLogger('test-noop');
     logger.emit({

--- a/experimental/packages/sdk-logs/src/LoggerProvider.ts
+++ b/experimental/packages/sdk-logs/src/LoggerProvider.ts
@@ -8,7 +8,7 @@ import type {
   LoggerOptions as ILoggerOptions,
   Logger as ILogger,
 } from '@opentelemetry/api-logs';
-import { NOOP_LOGGER } from '@opentelemetry/api-logs';
+import { createNoopLogger } from '@opentelemetry/api-logs';
 import { defaultResource } from '@opentelemetry/resources';
 import { BindOnceFuture } from '@opentelemetry/core';
 
@@ -60,7 +60,7 @@ export class LoggerProvider implements ILoggerProvider {
   ): ILogger {
     if (this._shutdownOnce.isCalled) {
       diag.warn('A shutdown LoggerProvider cannot provide a Logger');
-      return NOOP_LOGGER;
+      return createNoopLogger();
     }
 
     if (!name) {

--- a/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
@@ -2,7 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { logs, NoopLogger } from '@opentelemetry/api-logs';
+import { logs } from '@opentelemetry/api-logs';
 import { diag } from '@opentelemetry/api';
 import {
   defaultResource,
@@ -275,12 +275,14 @@ describe('LoggerProvider', () => {
       sinon.assert.calledOnce(shutdownStub);
     });
 
-    it('get a noop logger on shutdown', () => {
+    it('get a noop logger after shutdown', () => {
       const provider = new LoggerProvider();
+      let logger = provider.getLogger('default', '1.0.0');
+      assert.ok(logger instanceof Logger);
       provider.shutdown();
-      const logger = provider.getLogger('default', '1.0.0');
-      // returned tracer should be no-op, not instance of Logger (from SDK)
-      assert.ok(logger instanceof NoopLogger);
+      logger = provider.getLogger('default', '1.0.0');
+      // returned logger should be no-op, not instance of Logger (from SDK)
+      assert.ok(!(logger instanceof Logger));
     });
 
     it('should not force flush on shutdown', () => {


### PR DESCRIPTION
## Summary

- Replaces the exported `NOOP_LOGGER` constant and `NoopLogger` class with a single `createNoopLogger(): Logger` function, following the same pattern as the metrics API's `createNoopMeter()`
- The return type is narrowed to `Logger` to guarantee only the minimum required interface
- Updates `sdk-logs` `LoggerProvider` to use `createNoopLogger()` instead of `NOOP_LOGGER`
- Updates tests that relied on `instanceof NoopLogger` to use behavioral checks instead

## Test plan

- [x] `api-logs` tests pass
- [x] `sdk-logs` tests pass

Fixes #6681

🤖 Generated with [Claude Code](https://claude.com/claude-code)