### PR TITLE
fix(configuration): add missing config fallback defaults for file/env consistency

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,7 +12,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
-* fix(configuration): add missing config fallback defaults for consistency between file and env config [#6713](https://github.com/open-telemetry/opentelemetry-js/pull/6713) @MikeGoldsmith
+* fix(configuration): add missing config fallback defaults for consistency between file and env config [#6717](https://github.com/open-telemetry/opentelemetry-js/pull/6717) @MikeGoldsmith
 * fix(sdk-node): pass gRPC credentials and headers to span exporter in declarative config [#6705](https://github.com/open-telemetry/opentelemetry-js/pull/6705) @MikeGoldsmith
 * fix(otlp-transformer): do not attempt to skip groups [#6704](https://github.com/open-telemetry/opentelemetry-js/pull/6704) @pichlermarc
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(configuration): add missing config fallback defaults for consistency between file and env config [#6713](https://github.com/open-telemetry/opentelemetry-js/pull/6713) @MikeGoldsmith
 * fix(sdk-node): pass gRPC credentials and headers to span exporter in declarative config [#6705](https://github.com/open-telemetry/opentelemetry-js/pull/6705) @MikeGoldsmith
 * fix(otlp-transformer): do not attempt to skip groups [#6704](https://github.com/open-telemetry/opentelemetry-js/pull/6704) @pichlermarc
 

--- a/experimental/packages/configuration/src/FileConfigFactory.ts
+++ b/experimental/packages/configuration/src/FileConfigFactory.ts
@@ -186,20 +186,26 @@ function mergeCompositeList(data: ConfigurationModel): void {
  * are not encoded in the JSON schema.
  */
 function applyBatchProcessorDefaults(data: ConfigurationModel): void {
-  const applyDefaults = (
-    batch: BatchSpanProcessor | BatchLogRecordProcessor
-  ) => {
+  const applySpanDefaults = (batch: BatchSpanProcessor) => {
     if (batch.schedule_delay == null) batch.schedule_delay = 5000;
     if (batch.export_timeout == null) batch.export_timeout = 30000;
     if (batch.max_queue_size == null) batch.max_queue_size = 2048;
     if (batch.max_export_batch_size == null) batch.max_export_batch_size = 512;
   };
 
+  // BLRP has a different schedule_delay default (1000) than BSP (5000)
+  const applyLogDefaults = (batch: BatchLogRecordProcessor) => {
+    if (batch.schedule_delay == null) batch.schedule_delay = 1000;
+    if (batch.export_timeout == null) batch.export_timeout = 30000;
+    if (batch.max_queue_size == null) batch.max_queue_size = 2048;
+    if (batch.max_export_batch_size == null) batch.max_export_batch_size = 512;
+  };
+
   for (const processor of data.tracer_provider?.processors ?? []) {
-    if (processor.batch) applyDefaults(processor.batch);
+    if (processor.batch) applySpanDefaults(processor.batch);
   }
   for (const processor of data.logger_provider?.processors ?? []) {
-    if (processor.batch) applyDefaults(processor.batch);
+    if (processor.batch) applyLogDefaults(processor.batch);
   }
 }
 
@@ -234,6 +240,31 @@ function applyConfigDefaults(data: ConfigurationModel): void {
     data.attribute_limits = { attribute_count_limit: 128 };
   } else if (data.attribute_limits.attribute_count_limit == null) {
     data.attribute_limits.attribute_count_limit = 128;
+  }
+
+  // Tracer provider limits
+  const tpLimits = data.tracer_provider?.limits;
+  if (tpLimits) {
+    if (tpLimits.attribute_count_limit == null)
+      tpLimits.attribute_count_limit = 128;
+    if (tpLimits.event_count_limit == null) tpLimits.event_count_limit = 128;
+    if (tpLimits.link_count_limit == null) tpLimits.link_count_limit = 128;
+    if (tpLimits.event_attribute_count_limit == null)
+      tpLimits.event_attribute_count_limit = 128;
+    if (tpLimits.link_attribute_count_limit == null)
+      tpLimits.link_attribute_count_limit = 128;
+  }
+
+  // Logger provider limits
+  const lpLimits = data.logger_provider?.limits;
+  if (lpLimits) {
+    if (lpLimits.attribute_count_limit == null)
+      lpLimits.attribute_count_limit = 128;
+  }
+
+  // Meter provider exemplar filter
+  if (data.meter_provider && data.meter_provider.exemplar_filter == null) {
+    data.meter_provider.exemplar_filter = 'trace_based';
   }
 }
 

--- a/experimental/packages/configuration/src/utils.ts
+++ b/experimental/packages/configuration/src/utils.ts
@@ -58,6 +58,7 @@ export function getGrpcTlsConfig(
 export function initializeDefaultConfiguration(): ConfigurationModel {
   return {
     disabled: false,
+    log_level: 'info',
     resource: {},
     attribute_limits: {
       attribute_count_limit: 128,

--- a/experimental/packages/configuration/test/ConfigFactory.test.ts
+++ b/experimental/packages/configuration/test/ConfigFactory.test.ts
@@ -2627,6 +2627,40 @@ describe('ConfigFactory', function () {
           composite: [{ tracecontext: {} }],
           composite_list: 'tracecontext',
         },
+        tracer_provider: {
+          processors: [
+            {
+              simple: {
+                exporter: {
+                  console: {},
+                },
+              },
+            },
+          ],
+          limits: {
+            attribute_value_length_limit: 4096,
+            attribute_count_limit: 128,
+            event_count_limit: 128,
+            link_count_limit: 128,
+            event_attribute_count_limit: 128,
+            link_attribute_count_limit: 128,
+          },
+        },
+        meter_provider: {
+          readers: [
+            {
+              periodic: {
+                interval: 60000,
+                timeout: 30000,
+                exporter: {
+                  console: {},
+                },
+                cardinality_limits: { default: 2000 },
+              },
+            },
+          ],
+          exemplar_filter: 'trace_based',
+        },
         logger_provider: {
           processors: [
             {
@@ -2637,6 +2671,10 @@ describe('ConfigFactory', function () {
               },
             },
           ],
+          limits: {
+            attribute_value_length_limit: 4096,
+            attribute_count_limit: 128,
+          },
           'logger_configurator/development': {
             loggers: [
               {

--- a/experimental/packages/configuration/test/ConfigFactory.test.ts
+++ b/experimental/packages/configuration/test/ConfigFactory.test.ts
@@ -18,6 +18,7 @@ import { parseConfigFile } from '../src/FileConfigFactory';
 
 const defaultConfig: ConfigurationModel = {
   disabled: false,
+  log_level: 'info',
   resource: {},
   attribute_limits: {
     attribute_count_limit: 128,
@@ -552,7 +553,7 @@ const configFromKitchenSinkFile = {
       },
       {
         batch: {
-          schedule_delay: 5000,
+          schedule_delay: 1000,
           export_timeout: 30000,
           max_queue_size: 2048,
           max_export_batch_size: 512,
@@ -575,7 +576,7 @@ const configFromKitchenSinkFile = {
       },
       {
         batch: {
-          schedule_delay: 5000,
+          schedule_delay: 1000,
           export_timeout: 30000,
           max_queue_size: 2048,
           max_export_batch_size: 512,
@@ -588,7 +589,7 @@ const configFromKitchenSinkFile = {
       },
       {
         batch: {
-          schedule_delay: 5000,
+          schedule_delay: 1000,
           export_timeout: 30000,
           max_queue_size: 2048,
           max_export_batch_size: 512,

--- a/experimental/packages/configuration/test/fixtures/test-for-coverage.yaml
+++ b/experimental/packages/configuration/test/fixtures/test-for-coverage.yaml
@@ -3,11 +3,25 @@ resource:
   attributes_list:
 propagator:
   composite_list: tracecontext
+tracer_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  limits:
+    attribute_value_length_limit: 4096
+meter_provider:
+  readers:
+    - periodic:
+        exporter:
+          console:
 logger_provider:
   processors:
     - simple:
           exporter:
             console:
+  limits:
+    attribute_value_length_limit: 4096
   logger_configurator/development:
     loggers:
       - name: io.opentelemetry.contrib.*


### PR DESCRIPTION
## Which problem is this PR solving?

Several spec-defined default values were missing or inconsistent between `FileConfigFactory` (YAML config) and `EnvironmentConfigFactory` (env vars), causing different behavior depending on config source.

Key issues:
- **BLRP `schedule_delay`** defaulted to 5000ms (BSP value) instead of the spec-defined 1000ms for batch log record processors
- **`log_level`** defaulted to `'info'` in file config but was unset in env config
- **Tracer provider limits** (event_count_limit, link_count_limit, etc.) were initialized in env config but not applied as defaults in file config
- **Meter provider `exemplar_filter`** defaulted to `'trace_based'` in env config but not in file config

## Short description of the changes

**`FileConfigFactory.ts`**:
- Split `applyBatchProcessorDefaults` into separate span (5000ms) and log (1000ms) schedule_delay defaults
- Add tracer provider limits defaults: `event_count_limit`, `link_count_limit`, `event_attribute_count_limit`, `link_attribute_count_limit` (all 128)
- Add logger provider `attribute_count_limit` default (128)
- Add meter provider `exemplar_filter` default (`'trace_based'`)

**`utils.ts`**:
- Add `log_level: 'info'` to `initializeDefaultConfiguration()` so env-based config matches file-based config

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

82 configuration package tests pass. 189 sdk-node tests pass. Full repo compiles cleanly.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated

Closes #5945