### PR TITLE
docs(instrumentation-http): document request hook signatures

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-http/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-http/README.md
@@ -72,15 +72,15 @@ Options                                 | Type                                  
 
 #### Hook function signatures
 
-Hook type                                | Parameters                                                 | Return value
----------------------------------------- | ---------------------------------------------------------- | ------------
-`IgnoreIncomingRequestFunction`          | `request: IncomingMessage`                                 | `true` skips tracing the incoming request; `false` traces it
-`IgnoreOutgoingRequestFunction`          | `request: RequestOptions`                                  | `true` skips tracing the outgoing request; `false` traces it
-`HttpRequestCustomAttributeFunction`     | `span: Span`, `request: ClientRequest \| IncomingMessage`   | `void`
-`HttpResponseCustomAttributeFunction`    | `span: Span`, `response: IncomingMessage \| ServerResponse` | `void`
-`StartIncomingSpanCustomAttributeFunction` | `request: IncomingMessage`                               | `Attributes` to add before the incoming request span starts
-`StartOutgoingSpanCustomAttributeFunction` | `request: RequestOptions`                                | `Attributes` to add before the outgoing request span starts
-`HttpCustomAttributeFunction`            | `span: Span`, `request: ClientRequest \| IncomingMessage`, `response: IncomingMessage \| ServerResponse` | `void`
+Hook type                                  | Parameters                                                                                                   | Return value
+------------------------------------------ | ------------------------------------------------------------------------------------------------------------ | ------------
+`IgnoreIncomingRequestFunction`            | `request: IncomingMessage`                                                                                   | `true` skips tracing the incoming request; `false` traces it
+`IgnoreOutgoingRequestFunction`            | `request: RequestOptions`                                                                                    | `true` skips tracing the outgoing request; `false` traces it
+`HttpRequestCustomAttributeFunction`       | `span: Span`, `request: ClientRequest` or `IncomingMessage`                                                  | `void`
+`HttpResponseCustomAttributeFunction`      | `span: Span`, `response: IncomingMessage` or `ServerResponse`                                                | `void`
+`StartIncomingSpanCustomAttributeFunction` | `request: IncomingMessage`                                                                                   | `Attributes` to add before the incoming request span starts
+`StartOutgoingSpanCustomAttributeFunction` | `request: RequestOptions`                                                                                    | `Attributes` to add before the outgoing request span starts
+`HttpCustomAttributeFunction`              | `span: Span`, `request: ClientRequest` or `IncomingMessage`, `response: IncomingMessage` or `ServerResponse` | `void`
 
 ## Semantic Conventions
 

--- a/experimental/packages/opentelemetry-instrumentation-http/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-http/README.md
@@ -61,14 +61,26 @@ Options                                 | Type                                  
 `responseHook`                          | `HttpResponseCustomAttributeFunction`      | Function for adding custom attributes before response is handled
 `startIncomingSpanHook`                 | `StartIncomingSpanCustomAttributeFunction` | Function for adding custom attributes before a span is started in incomingRequest
 `startOutgoingSpanHook`                 | `StartOutgoingSpanCustomAttributeFunction` | Function for adding custom attributes before a span is started in outgoingRequest
-`ignoreIncomingRequestHook`             | `IgnoreIncomingRequestFunction`            | HTTP instrumentation will not trace all incoming requests that matched with custom function.
-`ignoreOutgoingRequestHook`             | `IgnoreOutgoingRequestFunction`            | HTTP instrumentation will not trace all outgoing requests that matched with custom function.
+`ignoreIncomingRequestHook`             | `IgnoreIncomingRequestFunction`            | Function for filtering incoming requests. HTTP instrumentation will not trace incoming requests for which the function returns `true`.
+`ignoreOutgoingRequestHook`             | `IgnoreOutgoingRequestFunction`            | Function for filtering outgoing requests. HTTP instrumentation will not trace outgoing requests for which the function returns `true`.
 `disableOutgoingRequestInstrumentation` | `boolean`                                  | Set to true to avoid instrumenting outgoing requests at all. This can be helpful when another instrumentation handles outgoing requests.
 `disableIncomingRequestInstrumentation` | `boolean`                                  | Set to true to avoid instrumenting incoming requests at all. This can be helpful when another instrumentation handles incoming requests.
 `serverName`                            | `string`                                   | The primary server name of the matched virtual host.
 `requireParentforOutgoingSpans`         | Boolean                                    | Require that is a parent span to create new span for outgoing requests.
 `requireParentforIncomingSpans`         | Boolean                                    | Require that is a parent span to create new span for incoming requests.
 `headersToSpanAttributes`               | `object`                                   | Specify which HTTP headers should be captured as span attributes. This is an object of the form `{client: {requestHeaders: [...], responseHeaders: [...]}, server: {requestHeaders: [...], responseHeaders: [...]}}`, where each `[...]` is an array of HTTP header names (case-insensitive) to capture. Client (outgoing requests, incoming responses) and server (incoming requests, outgoing responses) headers will be converted to span attributes in the form of `http.{request,response}.header.$header_name`, e.g. `http.response.header.content_length`. By default hyphens in header names are converted to underscore. However, if stable semantic conventions are selected (see next section), then, hyphens in header names are not changed, e.g. `http.response.header.content-length`.
+
+#### Hook function signatures
+
+Hook type                                | Parameters                                                 | Return value
+---------------------------------------- | ---------------------------------------------------------- | ------------
+`IgnoreIncomingRequestFunction`          | `request: IncomingMessage`                                 | `true` skips tracing the incoming request; `false` traces it
+`IgnoreOutgoingRequestFunction`          | `request: RequestOptions`                                  | `true` skips tracing the outgoing request; `false` traces it
+`HttpRequestCustomAttributeFunction`     | `span: Span`, `request: ClientRequest \| IncomingMessage`   | `void`
+`HttpResponseCustomAttributeFunction`    | `span: Span`, `response: IncomingMessage \| ServerResponse` | `void`
+`StartIncomingSpanCustomAttributeFunction` | `request: IncomingMessage`                               | `Attributes` to add before the incoming request span starts
+`StartOutgoingSpanCustomAttributeFunction` | `request: RequestOptions`                                | `Attributes` to add before the outgoing request span starts
+`HttpCustomAttributeFunction`            | `span: Span`, `request: ClientRequest \| IncomingMessage`, `response: IncomingMessage \| ServerResponse` | `void`
 
 ## Semantic Conventions
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
@@ -19,26 +19,48 @@ export interface HttpCustomAttributeFunction {
   ): void;
 }
 
+/**
+ * Called with each incoming request. Return `true` to skip creating a server
+ * span for that request.
+ */
 export interface IgnoreIncomingRequestFunction {
   (request: IncomingMessage): boolean;
 }
 
+/**
+ * Called with each outgoing request's parsed options. Return `true` to skip
+ * creating a client span for that request.
+ */
 export interface IgnoreOutgoingRequestFunction {
   (request: RequestOptions): boolean;
 }
 
+/**
+ * Called with the active span and request before the request is handled.
+ */
 export interface HttpRequestCustomAttributeFunction {
   (span: Span, request: ClientRequest | IncomingMessage): void;
 }
 
+/**
+ * Called with the active span and response before the response is handled.
+ */
 export interface HttpResponseCustomAttributeFunction {
   (span: Span, response: IncomingMessage | ServerResponse): void;
 }
 
+/**
+ * Called before an incoming request span is started. Returned attributes are
+ * added to the new server span.
+ */
 export interface StartIncomingSpanCustomAttributeFunction {
   (request: IncomingMessage): Attributes;
 }
 
+/**
+ * Called with an outgoing request's parsed options before the span is started.
+ * Returned attributes are added to the new client span.
+ */
 export interface StartOutgoingSpanCustomAttributeFunction {
   (request: RequestOptions): Attributes;
 }
@@ -47,9 +69,9 @@ export interface StartOutgoingSpanCustomAttributeFunction {
  * Options available for the HTTP instrumentation (see [documentation](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http#http-instrumentation-options))
  */
 export interface HttpInstrumentationConfig extends InstrumentationConfig {
-  /** Not trace all incoming requests that matched with custom function */
+  /** Do not trace incoming requests for which this function returns `true`. */
   ignoreIncomingRequestHook?: IgnoreIncomingRequestFunction;
-  /** Not trace all outgoing requests that matched with custom function */
+  /** Do not trace outgoing requests for which this function returns `true`. */
   ignoreOutgoingRequestHook?: IgnoreOutgoingRequestFunction;
   /** If set to true, incoming requests will not be instrumented at all. */
   disableIncomingRequestInstrumentation?: boolean;


### PR DESCRIPTION
## Which problem is this PR solving?

Adds clearer HTTP instrumentation hook documentation, including the parameters and return value for `ignoreOutgoingRequestHook`.

Fixes #5516

## Short description of the changes

- Adds TSDoc for the HTTP instrumentation hook function types.
- Expands the README option descriptions for the incoming and outgoing ignore hooks.
- Adds a README hook signature table covering the request/response/start/custom-attribute hooks.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `git diff --check`

This is a documentation/TSDoc-only change. I did not run the full npm install and test suite locally because it would be a large dependency install for a docs-only patch.

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [x] Documentation has been updated

This was implemented with Codex assistance, with the patch kept focused and manually reviewed before sending.
