### PR TITLE
fix(browser-detector): fix name for user agent resource attribute

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -20,7 +20,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * fix(sdk-node): warn and ignore zero exporter timeout in declarative config [#6711](https://github.com/open-telemetry/opentelemetry-js/pull/6711) @MikeGoldsmith
 * fix(sdk-node): pass gRPC credentials and headers to span exporter in declarative config [#6705](https://github.com/open-telemetry/opentelemetry-js/pull/6705) @MikeGoldsmith
 * fix(otlp-transformer): do not attempt to skip groups [#6704](https://github.com/open-telemetry/opentelemetry-js/pull/6704) @pichlermarc
-* fix(browser-detector): use the right semantic convention for user agent resource attribute [#6729](https://github.com/open-telemetry/opentelemetry-js/pull/6729) @david-luna
+* fix(browser-detector): use the right semantic convention for user agent resource attribute and add missing document URL [#6729](https://github.com/open-telemetry/opentelemetry-js/pull/6729) @david-luna
 
 ### :books: Documentation
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -20,7 +20,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * fix(sdk-node): warn and ignore zero exporter timeout in declarative config [#6711](https://github.com/open-telemetry/opentelemetry-js/pull/6711) @MikeGoldsmith
 * fix(sdk-node): pass gRPC credentials and headers to span exporter in declarative config [#6705](https://github.com/open-telemetry/opentelemetry-js/pull/6705) @MikeGoldsmith
 * fix(otlp-transformer): do not attempt to skip groups [#6704](https://github.com/open-telemetry/opentelemetry-js/pull/6704) @pichlermarc
-* fix(browser-detector): use the right semantic convention for user agent resource attribute and add missing document URL [#6729](https://github.com/open-telemetry/opentelemetry-js/pull/6729) @david-luna
+* fix(browser-detector): use the right semantic convention for user agent resource attribute [#6729](https://github.com/open-telemetry/opentelemetry-js/pull/6729) @david-luna
 
 ### :books: Documentation
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -20,6 +20,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * fix(sdk-node): warn and ignore zero exporter timeout in declarative config [#6711](https://github.com/open-telemetry/opentelemetry-js/pull/6711) @MikeGoldsmith
 * fix(sdk-node): pass gRPC credentials and headers to span exporter in declarative config [#6705](https://github.com/open-telemetry/opentelemetry-js/pull/6705) @MikeGoldsmith
 * fix(otlp-transformer): do not attempt to skip groups [#6704](https://github.com/open-telemetry/opentelemetry-js/pull/6704) @pichlermarc
+* fix(browser-detector): use the right semantic convention for user agent resource attribute [#6729](https://github.com/open-telemetry/opentelemetry-js/pull/6729) @david-luna
 
 ### :books: Documentation
 

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -77,7 +77,8 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/resources": "2.7.1"
+    "@opentelemetry/resources": "2.7.1",
+    "@opentelemetry/semantic-conventions": "^1.29.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/browser-detector"
 }

--- a/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
+++ b/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
@@ -11,8 +11,14 @@ import type {
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 import { emptyResource } from '@opentelemetry/resources';
+import { ATTR_USER_AGENT_ORIGINAL } from '@opentelemetry/semantic-conventions';
 import type { UserAgentData } from './types';
-import { BROWSER_ATTRIBUTES } from './types';
+import {
+  ATTR_BROWSER_LANGUAGE,
+  ATTR_BROWSER_PLATFORM,
+  ATTR_BROWSER_BRANDS,
+  ATTR_BROWSER_MOBILE,
+} from './semconv';
 
 /**
  * BrowserDetector will be used to detect the resources related to browser.
@@ -40,8 +46,8 @@ class BrowserDetector implements ResourceDetector {
     _config?: ResourceDetectionConfig
   ): DetectedResource {
     if (
-      !browserResource[BROWSER_ATTRIBUTES.USER_AGENT] &&
-      !browserResource[BROWSER_ATTRIBUTES.PLATFORM]
+      !browserResource[ATTR_USER_AGENT_ORIGINAL] &&
+      !browserResource[ATTR_BROWSER_PLATFORM]
     ) {
       diag.debug(
         'BrowserDetector failed: Unable to find required browser resources. '
@@ -60,15 +66,14 @@ function getBrowserAttributes(): Attributes {
     navigator as Navigator & { userAgentData?: UserAgentData }
   ).userAgentData;
   if (userAgentData) {
-    browserAttribs[BROWSER_ATTRIBUTES.PLATFORM] = userAgentData.platform;
-    browserAttribs[BROWSER_ATTRIBUTES.BRANDS] = userAgentData.brands.map(
+    browserAttribs[ATTR_BROWSER_PLATFORM] = userAgentData.platform;
+    browserAttribs[ATTR_BROWSER_BRANDS] = userAgentData.brands.map(
       b => `${b.brand} ${b.version}`
     );
-    browserAttribs[BROWSER_ATTRIBUTES.MOBILE] = userAgentData.mobile;
-  } else {
-    browserAttribs[BROWSER_ATTRIBUTES.USER_AGENT] = navigator.userAgent;
+    browserAttribs[ATTR_BROWSER_MOBILE] = userAgentData.mobile;
   }
-  browserAttribs[BROWSER_ATTRIBUTES.LANGUAGE] = navigator.language;
+  browserAttribs[ATTR_USER_AGENT_ORIGINAL] = navigator.userAgent;
+  browserAttribs[ATTR_BROWSER_LANGUAGE] = navigator.language;
   return browserAttribs;
 }
 

--- a/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
+++ b/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
@@ -18,6 +18,7 @@ import {
   ATTR_BROWSER_PLATFORM,
   ATTR_BROWSER_BRANDS,
   ATTR_BROWSER_MOBILE,
+  ATTR_BROWSER_DOCUMENT_URL_FULL,
 } from './semconv';
 
 /**
@@ -74,6 +75,7 @@ function getBrowserAttributes(): Attributes {
   }
   browserAttribs[ATTR_USER_AGENT_ORIGINAL] = navigator.userAgent;
   browserAttribs[ATTR_BROWSER_LANGUAGE] = navigator.language;
+  browserAttribs[ATTR_BROWSER_DOCUMENT_URL_FULL] = location.href;
   return browserAttribs;
 }
 

--- a/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
+++ b/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
@@ -18,7 +18,6 @@ import {
   ATTR_BROWSER_PLATFORM,
   ATTR_BROWSER_BRANDS,
   ATTR_BROWSER_MOBILE,
-  ATTR_BROWSER_DOCUMENT_URL_FULL,
 } from './semconv';
 
 /**
@@ -72,10 +71,10 @@ function getBrowserAttributes(): Attributes {
       b => `${b.brand} ${b.version}`
     );
     browserAttribs[ATTR_BROWSER_MOBILE] = userAgentData.mobile;
+  } else {
+    browserAttribs[ATTR_USER_AGENT_ORIGINAL] = navigator.userAgent;
   }
-  browserAttribs[ATTR_USER_AGENT_ORIGINAL] = navigator.userAgent;
   browserAttribs[ATTR_BROWSER_LANGUAGE] = navigator.language;
-  browserAttribs[ATTR_BROWSER_DOCUMENT_URL_FULL] = location.href;
   return browserAttribs;
 }
 

--- a/experimental/packages/opentelemetry-browser-detector/src/semconv.ts
+++ b/experimental/packages/opentelemetry-browser-detector/src/semconv.ts
@@ -50,3 +50,13 @@ export const ATTR_BROWSER_MOBILE = 'browser.mobile' as const;
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_BROWSER_PLATFORM = 'browser.platform' as const;
+
+/**
+ * Absolute URL of the current browser document according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986)
+ *
+ * @example https://www.example.com/search?q=OpenTelemetry#SemConv
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_BROWSER_DOCUMENT_URL_FULL =
+  'browser.document.url.full' as const;

--- a/experimental/packages/opentelemetry-browser-detector/src/semconv.ts
+++ b/experimental/packages/opentelemetry-browser-detector/src/semconv.ts
@@ -50,13 +50,3 @@ export const ATTR_BROWSER_MOBILE = 'browser.mobile' as const;
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_BROWSER_PLATFORM = 'browser.platform' as const;
-
-/**
- * Absolute URL of the current browser document according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986)
- *
- * @example https://www.example.com/search?q=OpenTelemetry#SemConv
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_BROWSER_DOCUMENT_URL_FULL =
-  'browser.document.url.full' as const;

--- a/experimental/packages/opentelemetry-browser-detector/src/semconv.ts
+++ b/experimental/packages/opentelemetry-browser-detector/src/semconv.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Array of brand name and version separated by a space
+ *
+ * @example [" Not A;Brand 99", "Chromium 99", "Chrome 99"]
+ *
+ * @note This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.brands`).
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_BROWSER_BRANDS = 'browser.brands' as const;
+
+/**
+ * Preferred language of the user using the browser
+ *
+ * @example en
+ * @example en-US
+ * @example fr
+ * @example fr-FR
+ *
+ * @note This value is intended to be taken from the Navigator API `navigator.language`.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_BROWSER_LANGUAGE = 'browser.language' as const;
+
+/**
+ * A boolean that is true if the browser is running on a mobile device
+ *
+ * @note This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.mobile`). If unavailable, this attribute **SHOULD** be left unset.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_BROWSER_MOBILE = 'browser.mobile' as const;
+
+/**
+ * The platform on which the browser is running
+ *
+ * @example Windows
+ * @example macOS
+ * @example Android
+ *
+ * @note This value is intended to be taken from the [UA client hints API](https://wicg.github.io/ua-client-hints/#interface) (`navigator.userAgentData.platform`). If unavailable, the legacy `navigator.platform` API **SHOULD NOT** be used instead and this attribute **SHOULD** be left unset in order for the values to be consistent.
+ * The list of possible values is defined in the [W3C User-Agent Client Hints specification](https://wicg.github.io/ua-client-hints/#sec-ch-ua-platform). Note that some (but not all) of these values can overlap with values in the [`os.type` and `os.name` attributes](./os.md). However, for consistency, the values in the `browser.platform` attribute should capture the exact value that the user agent provides.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_BROWSER_PLATFORM = 'browser.platform' as const;

--- a/experimental/packages/opentelemetry-browser-detector/src/types.ts
+++ b/experimental/packages/opentelemetry-browser-detector/src/types.ts
@@ -2,16 +2,9 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 export type UserAgentData = {
   brands: { brand: string; version: string }[];
   platform: string;
   mobile: boolean;
-};
-
-export const BROWSER_ATTRIBUTES = {
-  PLATFORM: 'browser.platform', //TODO replace with SemanticConventions attribute when available
-  BRANDS: 'browser.brands',
-  MOBILE: 'browser.mobile',
-  LANGUAGE: 'browser.language',
-  USER_AGENT: 'browser.user_agent',
 };

--- a/experimental/packages/opentelemetry-browser-detector/test/util.ts
+++ b/experimental/packages/opentelemetry-browser-detector/test/util.ts
@@ -8,6 +8,7 @@ import type { DetectedResource } from '@opentelemetry/resources';
 import { ATTR_USER_AGENT_ORIGINAL } from '@opentelemetry/semantic-conventions';
 import {
   ATTR_BROWSER_BRANDS,
+  ATTR_BROWSER_DOCUMENT_URL_FULL,
   ATTR_BROWSER_LANGUAGE,
   ATTR_BROWSER_MOBILE,
   ATTR_BROWSER_PLATFORM,
@@ -73,6 +74,10 @@ export const assertResource = (
       validations.user_agent
     );
   }
+  assert.strictEqual(
+    resource.attributes?.[ATTR_BROWSER_DOCUMENT_URL_FULL],
+    location.href
+  );
 };
 
 /**

--- a/experimental/packages/opentelemetry-browser-detector/test/util.ts
+++ b/experimental/packages/opentelemetry-browser-detector/test/util.ts
@@ -4,8 +4,14 @@
  */
 import type { Suite } from 'mocha';
 import * as assert from 'assert';
-import { BROWSER_ATTRIBUTES } from '../src/types';
 import type { DetectedResource } from '@opentelemetry/resources';
+import { ATTR_USER_AGENT_ORIGINAL } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_BROWSER_BRANDS,
+  ATTR_BROWSER_LANGUAGE,
+  ATTR_BROWSER_MOBILE,
+  ATTR_BROWSER_PLATFORM,
+} from '../src/semconv';
 
 const isBrowser =
   typeof window !== 'undefined' && typeof document !== 'undefined';
@@ -38,32 +44,32 @@ export const assertResource = (
 ) => {
   if (validations.platform) {
     assert.strictEqual(
-      resource.attributes?.[BROWSER_ATTRIBUTES.PLATFORM],
+      resource.attributes?.[ATTR_BROWSER_PLATFORM],
       validations.platform
     );
   }
   if (validations.brands) {
-    assert.ok(Array.isArray(resource.attributes?.[BROWSER_ATTRIBUTES.BRANDS]));
+    assert.ok(Array.isArray(resource.attributes?.[ATTR_BROWSER_BRANDS]));
     assert.deepStrictEqual(
-      resource.attributes?.[BROWSER_ATTRIBUTES.BRANDS] as string[],
+      resource.attributes?.[ATTR_BROWSER_BRANDS] as string[],
       validations.brands
     );
   }
   if (validations.mobile) {
     assert.strictEqual(
-      resource.attributes?.[BROWSER_ATTRIBUTES.MOBILE],
+      resource.attributes?.[ATTR_BROWSER_MOBILE],
       validations.mobile
     );
   }
   if (validations.language) {
     assert.strictEqual(
-      resource.attributes?.[BROWSER_ATTRIBUTES.LANGUAGE],
+      resource.attributes?.[ATTR_BROWSER_LANGUAGE],
       validations.language
     );
   }
   if (validations.user_agent) {
     assert.strictEqual(
-      resource.attributes?.[BROWSER_ATTRIBUTES.USER_AGENT],
+      resource.attributes?.[ATTR_USER_AGENT_ORIGINAL],
       validations.user_agent
     );
   }

--- a/experimental/packages/opentelemetry-browser-detector/test/util.ts
+++ b/experimental/packages/opentelemetry-browser-detector/test/util.ts
@@ -8,7 +8,6 @@ import type { DetectedResource } from '@opentelemetry/resources';
 import { ATTR_USER_AGENT_ORIGINAL } from '@opentelemetry/semantic-conventions';
 import {
   ATTR_BROWSER_BRANDS,
-  ATTR_BROWSER_DOCUMENT_URL_FULL,
   ATTR_BROWSER_LANGUAGE,
   ATTR_BROWSER_MOBILE,
   ATTR_BROWSER_PLATFORM,
@@ -74,10 +73,6 @@ export const assertResource = (
       validations.user_agent
     );
   }
-  assert.strictEqual(
-    resource.attributes?.[ATTR_BROWSER_DOCUMENT_URL_FULL],
-    location.href
-  );
 };
 
 /**

--- a/experimental/packages/opentelemetry-browser-detector/tsconfig.esm.json
+++ b/experimental/packages/opentelemetry-browser-detector/tsconfig.esm.json
@@ -19,6 +19,9 @@
     },
     {
       "path": "../../../packages/opentelemetry-resources"
+    },
+    {
+      "path": "../../../semantic-conventions"
     }
   ]
 }

--- a/experimental/packages/opentelemetry-browser-detector/tsconfig.esnext.json
+++ b/experimental/packages/opentelemetry-browser-detector/tsconfig.esnext.json
@@ -19,6 +19,9 @@
     },
     {
       "path": "../../../packages/opentelemetry-resources"
+    },
+    {
+      "path": "../../../semantic-conventions"
     }
   ]
 }

--- a/experimental/packages/opentelemetry-browser-detector/tsconfig.json
+++ b/experimental/packages/opentelemetry-browser-detector/tsconfig.json
@@ -20,6 +20,9 @@
     },
     {
       "path": "../../../packages/opentelemetry-resources"
+    },
+    {
+      "path": "../../../semantic-conventions"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -613,7 +613,8 @@
       "version": "0.218.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/resources": "2.7.1"
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "devDependencies": {
         "@babel/core": "7.27.1",


### PR DESCRIPTION
## Which problem is this PR solving?

Browser detector is sending the wrong semantic convetion for user agent. This PR adds `@opentelemetry/semantic-conventions` dependency into browser detector package and also aligns with other packages in the way incubating semconv are implemented.

## Short description of the changes

- add semantic conventions package
- use `ATTR_USER_AGENT_ORIGINAL` attribute in resource detection
- add `semconv.ts` file with the incubating attributes and remove the current enum 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Unit tests

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been updated