### PR TITLE
refactor(sdk-node): model built-in exporter resolution on top of PluginComponentProvider spec

### DIFF
--- a/experimental/packages/configuration/src/index.ts
+++ b/experimental/packages/configuration/src/index.ts
@@ -18,5 +18,11 @@ export type {
   HttpTls as HttpTlsConfigModel,
   GrpcTls as GrpcTlsConfigModel,
   SeverityNumber as SeverityNumberConfigModel,
+  OtlpHttpExporter as OtlpHttpExporterConfigModel,
+  OtlpGrpcExporter as OtlpGrpcExporterConfigModel,
+  OtlpHttpMetricExporter as OtlpHttpMetricExporterConfigModel,
+  OtlpGrpcMetricExporter as OtlpGrpcMetricExporterConfigModel,
+  ConsoleExporter as ConsoleExporterConfigModel,
+  ConsoleMetricExporter as ConsoleMetricExporterConfigModel,
 } from './generated/types';
 export { createConfigFactory } from './ConfigFactory';

--- a/experimental/packages/opentelemetry-sdk-node/src/builtin-providers.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/builtin-providers.ts
@@ -44,9 +44,8 @@ import type {
   ConsoleExporterConfigModel,
   ConsoleMetricExporterConfigModel,
   NameStringValuePairConfigModel,
+  GrpcTlsConfigModel,
 } from '@opentelemetry/configuration';
-
-type GrpcTlsConfigModel = OtlpGrpcExporterConfigModel['tls'];
 
 /**
  * Validate an exporter timeout value. The spec says 0 means "no limit
@@ -108,29 +107,25 @@ class OtlpHttpSpanExporterProvider
   readonly name = 'otlp_http';
 
   createComponent(properties: OtlpHttpExporterConfigModel): SpanExporter {
+    const cfg = properties ?? {};
     const compressionAlg =
-      properties.compression === 'gzip'
+      cfg.compression === 'gzip'
         ? CompressionAlgorithm.GZIP
         : CompressionAlgorithm.NONE;
-    const headers = getHeadersFromConfiguration(properties.headers);
-    const httpAgentOptions = getHttpAgentOptionsFromTls(properties.tls);
-
-    if (properties.encoding === 'json') {
-      return new OTLPHttpTraceExporter({
-        compression: compressionAlg,
-        url: properties.endpoint,
-        headers,
-        timeoutMillis: validateExporterTimeout(properties.timeout),
-        httpAgentOptions,
-      });
-    }
-    return new OTLPProtoTraceExporter({
+    const headers = getHeadersFromConfiguration(cfg.headers);
+    const httpAgentOptions = getHttpAgentOptionsFromTls(cfg.tls);
+    const commonOpts = {
       compression: compressionAlg,
-      url: properties.endpoint,
+      url: cfg.endpoint ?? undefined,
       headers,
-      timeoutMillis: validateExporterTimeout(properties.timeout),
+      timeoutMillis: validateExporterTimeout(cfg.timeout),
       httpAgentOptions,
-    });
+    };
+
+    if (cfg.encoding === 'json') {
+      return new OTLPHttpTraceExporter(commonOpts);
+    }
+    return new OTLPProtoTraceExporter(commonOpts);
   }
 }
 
@@ -140,15 +135,16 @@ class OtlpGrpcSpanExporterProvider
   readonly name = 'otlp_grpc';
 
   createComponent(properties: OtlpGrpcExporterConfigModel): SpanExporter {
+    const cfg = properties ?? {};
     return new OTLPGrpcTraceExporter({
       compression:
-        properties.compression === 'gzip'
+        cfg.compression === 'gzip'
           ? CompressionAlgorithm.GZIP
           : CompressionAlgorithm.NONE,
-      url: properties.endpoint,
-      timeoutMillis: validateExporterTimeout(properties.timeout),
-      credentials: getGrpcCredentialsFromTls(properties.tls),
-      metadata: getGrpcMetadataFromHeaders(properties.headers),
+      url: cfg.endpoint ?? undefined,
+      timeoutMillis: validateExporterTimeout(cfg.timeout),
+      credentials: getGrpcCredentialsFromTls(cfg.tls ?? undefined),
+      metadata: getGrpcMetadataFromHeaders(cfg.headers),
     });
   }
 }
@@ -161,27 +157,28 @@ class OtlpHttpLogRecordExporterProvider
   readonly name = 'otlp_http';
 
   createComponent(properties: OtlpHttpExporterConfigModel): LogRecordExporter {
+    const cfg = properties ?? {};
     const compressionAlg =
-      properties.compression === 'gzip'
+      cfg.compression === 'gzip'
         ? CompressionAlgorithm.GZIP
         : CompressionAlgorithm.NONE;
     const commonOpts = {
       compression: compressionAlg,
-      url: properties.endpoint,
-      headers: getHeadersFromConfiguration(properties.headers),
-      timeoutMillis: validateExporterTimeout(properties.timeout),
-      httpAgentOptions: getHttpAgentOptionsFromTls(properties.tls),
+      url: cfg.endpoint ?? undefined,
+      headers: getHeadersFromConfiguration(cfg.headers),
+      timeoutMillis: validateExporterTimeout(cfg.timeout),
+      httpAgentOptions: getHttpAgentOptionsFromTls(cfg.tls),
     };
 
-    if (properties.encoding === 'json') {
+    if (cfg.encoding === 'json') {
       return new OTLPHttpLogExporter(commonOpts);
     }
-    if (properties.encoding === 'protobuf') {
+    if (cfg.encoding === 'protobuf') {
       return new OTLPProtoLogExporter(commonOpts);
     }
-    if (properties.encoding != null) {
+    if (cfg.encoding != null) {
       diag.warn(
-        `Unsupported OTLP logs encoding: ${properties.encoding}. Using http/protobuf.`
+        `Unsupported OTLP logs encoding: ${cfg.encoding}. Using http/protobuf.`
       );
     }
     return new OTLPProtoLogExporter(commonOpts);
@@ -194,15 +191,16 @@ class OtlpGrpcLogRecordExporterProvider
   readonly name = 'otlp_grpc';
 
   createComponent(properties: OtlpGrpcExporterConfigModel): LogRecordExporter {
+    const cfg = properties ?? {};
     return new OTLPGrpcLogExporter({
       compression:
-        properties.compression === 'gzip'
+        cfg.compression === 'gzip'
           ? CompressionAlgorithm.GZIP
           : CompressionAlgorithm.NONE,
-      url: properties.endpoint,
-      timeoutMillis: validateExporterTimeout(properties.timeout),
-      credentials: getGrpcCredentialsFromTls(properties.tls),
-      metadata: getGrpcMetadataFromHeaders(properties.headers),
+      url: cfg.endpoint ?? undefined,
+      timeoutMillis: validateExporterTimeout(cfg.timeout),
+      credentials: getGrpcCredentialsFromTls(cfg.tls ?? undefined),
+      metadata: getGrpcMetadataFromHeaders(cfg.headers),
     });
   }
 }
@@ -218,27 +216,28 @@ class OtlpHttpPushMetricExporterProvider
   createComponent(
     properties: OtlpHttpMetricExporterConfigModel
   ): PushMetricExporter {
+    const cfg = properties ?? {};
     const compressionAlg =
-      properties.compression === 'gzip'
+      cfg.compression === 'gzip'
         ? CompressionAlgorithm.GZIP
         : CompressionAlgorithm.NONE;
     const commonOpts = {
       compression: compressionAlg,
-      url: properties.endpoint,
-      headers: getHeadersFromConfiguration(properties.headers),
-      timeoutMillis: validateExporterTimeout(properties.timeout),
-      httpAgentOptions: getHttpAgentOptionsFromTls(properties.tls),
+      url: cfg.endpoint ?? undefined,
+      headers: getHeadersFromConfiguration(cfg.headers),
+      timeoutMillis: validateExporterTimeout(cfg.timeout),
+      httpAgentOptions: getHttpAgentOptionsFromTls(cfg.tls),
     };
 
-    if (properties.encoding === 'json') {
+    if (cfg.encoding === 'json') {
       return new OTLPHttpMetricExporter(commonOpts);
     }
-    if (properties.encoding === 'protobuf') {
+    if (cfg.encoding === 'protobuf') {
       return new OTLPProtoMetricExporter(commonOpts);
     }
-    if (properties.encoding != null) {
+    if (cfg.encoding != null) {
       diag.warn(
-        `Unsupported OTLP metrics encoding: ${properties.encoding}. Using http/protobuf.`
+        `Unsupported OTLP metrics encoding: ${cfg.encoding}. Using http/protobuf.`
       );
     }
     return new OTLPProtoMetricExporter(commonOpts);
@@ -254,15 +253,16 @@ class OtlpGrpcPushMetricExporterProvider
   createComponent(
     properties: OtlpGrpcMetricExporterConfigModel
   ): PushMetricExporter {
+    const cfg = properties ?? {};
     return new OTLPGrpcMetricExporter({
       compression:
-        properties.compression === 'gzip'
+        cfg.compression === 'gzip'
           ? CompressionAlgorithm.GZIP
           : CompressionAlgorithm.NONE,
-      url: properties.endpoint,
-      timeoutMillis: validateExporterTimeout(properties.timeout),
-      credentials: getGrpcCredentialsFromTls(properties.tls),
-      metadata: getGrpcMetadataFromHeaders(properties.headers),
+      url: cfg.endpoint ?? undefined,
+      timeoutMillis: validateExporterTimeout(cfg.timeout),
+      credentials: getGrpcCredentialsFromTls(cfg.tls ?? undefined),
+      metadata: getGrpcMetadataFromHeaders(cfg.headers),
     });
   }
 }

--- a/experimental/packages/opentelemetry-sdk-node/src/builtin-providers.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/builtin-providers.ts
@@ -1,0 +1,333 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { diag } from '@opentelemetry/api';
+import { OTLPTraceExporter as OTLPProtoTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
+import { OTLPTraceExporter as OTLPHttpTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { OTLPTraceExporter as OTLPGrpcTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
+import { OTLPLogExporter as OTLPHttpLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
+import { OTLPLogExporter as OTLPGrpcLogExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
+import { OTLPLogExporter as OTLPProtoLogExporter } from '@opentelemetry/exporter-logs-otlp-proto';
+import { OTLPMetricExporter as OTLPGrpcMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
+import { OTLPMetricExporter as OTLPHttpMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+import { OTLPMetricExporter as OTLPProtoMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto';
+import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base';
+import {
+  createEmptyMetadata,
+  createInsecureCredentials,
+  createSslCredentials,
+} from '@opentelemetry/otlp-grpc-exporter-base';
+import type { SpanExporter } from '@opentelemetry/sdk-trace-base';
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+import type { LogRecordExporter } from '@opentelemetry/sdk-logs';
+import { ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
+import type { PushMetricExporter } from '@opentelemetry/sdk-metrics';
+import { ConsoleMetricExporter as SdkConsoleMetricExporter } from '@opentelemetry/sdk-metrics';
+import type {
+  SpanExporterComponentProvider,
+  LogRecordExporterComponentProvider,
+  PushMetricExporterComponentProvider,
+  ComponentProviderMap,
+} from './component-provider';
+import {
+  getHeadersFromConfiguration,
+  getHttpAgentOptionsFromTls,
+  readFileOrWarn,
+} from './utils';
+import type {
+  OtlpHttpExporterConfigModel,
+  OtlpGrpcExporterConfigModel,
+  OtlpHttpMetricExporterConfigModel,
+  OtlpGrpcMetricExporterConfigModel,
+  ConsoleExporterConfigModel,
+  ConsoleMetricExporterConfigModel,
+  NameStringValuePairConfigModel,
+} from '@opentelemetry/configuration';
+
+type GrpcTlsConfigModel = OtlpGrpcExporterConfigModel['tls'];
+
+/**
+ * Validate an exporter timeout value. The spec says 0 means "no limit
+ * (infinity)" but the JS exporters don't support that yet (see #6617).
+ * Warn and return undefined so the exporter falls back to its default.
+ */
+function validateExporterTimeout(
+  timeout: number | null | undefined
+): number | undefined {
+  if (timeout === null) {
+    return undefined;
+  } else if (timeout === 0) {
+    diag.warn(
+      'Exporter timeout of 0 (infinite) is not supported. Using default timeout.'
+    );
+    return undefined;
+  }
+  return timeout;
+}
+
+function getGrpcCredentialsFromTls(tls?: GrpcTlsConfigModel) {
+  if (tls?.insecure) {
+    return createInsecureCredentials();
+  }
+  const rootCert = readFileOrWarn(tls?.ca_file, 'TLS CA');
+  const privateKey = readFileOrWarn(tls?.key_file, 'TLS key');
+  const certChain = readFileOrWarn(tls?.cert_file, 'TLS cert');
+  if (rootCert || privateKey || certChain) {
+    try {
+      return createSslCredentials(rootCert, privateKey, certChain);
+    } catch (e) {
+      diag.warn(`Failed to create gRPC SSL credentials: ${e}`);
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function getGrpcMetadataFromHeaders(
+  headers: NameStringValuePairConfigModel[] | undefined
+) {
+  if (!headers || headers.length === 0) {
+    return undefined;
+  }
+  const metadata = createEmptyMetadata();
+  for (const header of headers) {
+    if (header.value !== null) {
+      metadata.set(header.name, header.value);
+    }
+  }
+  return metadata;
+}
+
+// --- Span Exporter Providers ---
+
+class OtlpHttpSpanExporterProvider
+  implements SpanExporterComponentProvider<OtlpHttpExporterConfigModel>
+{
+  readonly name = 'otlp_http';
+
+  createComponent(properties: OtlpHttpExporterConfigModel): SpanExporter {
+    const compressionAlg =
+      properties.compression === 'gzip'
+        ? CompressionAlgorithm.GZIP
+        : CompressionAlgorithm.NONE;
+    const headers = getHeadersFromConfiguration(properties.headers);
+    const httpAgentOptions = getHttpAgentOptionsFromTls(properties.tls);
+
+    if (properties.encoding === 'json') {
+      return new OTLPHttpTraceExporter({
+        compression: compressionAlg,
+        url: properties.endpoint,
+        headers,
+        timeoutMillis: validateExporterTimeout(properties.timeout),
+        httpAgentOptions,
+      });
+    }
+    return new OTLPProtoTraceExporter({
+      compression: compressionAlg,
+      url: properties.endpoint,
+      headers,
+      timeoutMillis: validateExporterTimeout(properties.timeout),
+      httpAgentOptions,
+    });
+  }
+}
+
+class OtlpGrpcSpanExporterProvider
+  implements SpanExporterComponentProvider<OtlpGrpcExporterConfigModel>
+{
+  readonly name = 'otlp_grpc';
+
+  createComponent(properties: OtlpGrpcExporterConfigModel): SpanExporter {
+    return new OTLPGrpcTraceExporter({
+      compression:
+        properties.compression === 'gzip'
+          ? CompressionAlgorithm.GZIP
+          : CompressionAlgorithm.NONE,
+      url: properties.endpoint,
+      timeoutMillis: validateExporterTimeout(properties.timeout),
+      credentials: getGrpcCredentialsFromTls(properties.tls),
+      metadata: getGrpcMetadataFromHeaders(properties.headers),
+    });
+  }
+}
+
+// --- LogRecord Exporter Providers ---
+
+class OtlpHttpLogRecordExporterProvider
+  implements LogRecordExporterComponentProvider<OtlpHttpExporterConfigModel>
+{
+  readonly name = 'otlp_http';
+
+  createComponent(properties: OtlpHttpExporterConfigModel): LogRecordExporter {
+    const compressionAlg =
+      properties.compression === 'gzip'
+        ? CompressionAlgorithm.GZIP
+        : CompressionAlgorithm.NONE;
+    const commonOpts = {
+      compression: compressionAlg,
+      url: properties.endpoint,
+      headers: getHeadersFromConfiguration(properties.headers),
+      timeoutMillis: validateExporterTimeout(properties.timeout),
+      httpAgentOptions: getHttpAgentOptionsFromTls(properties.tls),
+    };
+
+    if (properties.encoding === 'json') {
+      return new OTLPHttpLogExporter(commonOpts);
+    }
+    if (properties.encoding === 'protobuf') {
+      return new OTLPProtoLogExporter(commonOpts);
+    }
+    if (properties.encoding != null) {
+      diag.warn(
+        `Unsupported OTLP logs encoding: ${properties.encoding}. Using http/protobuf.`
+      );
+    }
+    return new OTLPProtoLogExporter(commonOpts);
+  }
+}
+
+class OtlpGrpcLogRecordExporterProvider
+  implements LogRecordExporterComponentProvider<OtlpGrpcExporterConfigModel>
+{
+  readonly name = 'otlp_grpc';
+
+  createComponent(properties: OtlpGrpcExporterConfigModel): LogRecordExporter {
+    return new OTLPGrpcLogExporter({
+      compression:
+        properties.compression === 'gzip'
+          ? CompressionAlgorithm.GZIP
+          : CompressionAlgorithm.NONE,
+      url: properties.endpoint,
+      timeoutMillis: validateExporterTimeout(properties.timeout),
+      credentials: getGrpcCredentialsFromTls(properties.tls),
+      metadata: getGrpcMetadataFromHeaders(properties.headers),
+    });
+  }
+}
+
+// --- PushMetricExporter Providers ---
+
+class OtlpHttpPushMetricExporterProvider
+  implements
+    PushMetricExporterComponentProvider<OtlpHttpMetricExporterConfigModel>
+{
+  readonly name = 'otlp_http';
+
+  createComponent(
+    properties: OtlpHttpMetricExporterConfigModel
+  ): PushMetricExporter {
+    const compressionAlg =
+      properties.compression === 'gzip'
+        ? CompressionAlgorithm.GZIP
+        : CompressionAlgorithm.NONE;
+    const commonOpts = {
+      compression: compressionAlg,
+      url: properties.endpoint,
+      headers: getHeadersFromConfiguration(properties.headers),
+      timeoutMillis: validateExporterTimeout(properties.timeout),
+      httpAgentOptions: getHttpAgentOptionsFromTls(properties.tls),
+    };
+
+    if (properties.encoding === 'json') {
+      return new OTLPHttpMetricExporter(commonOpts);
+    }
+    if (properties.encoding === 'protobuf') {
+      return new OTLPProtoMetricExporter(commonOpts);
+    }
+    if (properties.encoding != null) {
+      diag.warn(
+        `Unsupported OTLP metrics encoding: ${properties.encoding}. Using http/protobuf.`
+      );
+    }
+    return new OTLPProtoMetricExporter(commonOpts);
+  }
+}
+
+class OtlpGrpcPushMetricExporterProvider
+  implements
+    PushMetricExporterComponentProvider<OtlpGrpcMetricExporterConfigModel>
+{
+  readonly name = 'otlp_grpc';
+
+  createComponent(
+    properties: OtlpGrpcMetricExporterConfigModel
+  ): PushMetricExporter {
+    return new OTLPGrpcMetricExporter({
+      compression:
+        properties.compression === 'gzip'
+          ? CompressionAlgorithm.GZIP
+          : CompressionAlgorithm.NONE,
+      url: properties.endpoint,
+      timeoutMillis: validateExporterTimeout(properties.timeout),
+      credentials: getGrpcCredentialsFromTls(properties.tls),
+      metadata: getGrpcMetadataFromHeaders(properties.headers),
+    });
+  }
+}
+
+// --- Console Exporter Providers ---
+
+class ConsoleSpanExporterProvider
+  implements SpanExporterComponentProvider<ConsoleExporterConfigModel>
+{
+  readonly name = 'console';
+
+  createComponent(_properties: ConsoleExporterConfigModel): SpanExporter {
+    return new ConsoleSpanExporter();
+  }
+}
+
+class ConsoleLogRecordExporterProvider
+  implements LogRecordExporterComponentProvider<ConsoleExporterConfigModel>
+{
+  readonly name = 'console';
+
+  createComponent(_properties: ConsoleExporterConfigModel): LogRecordExporter {
+    return new ConsoleLogRecordExporter();
+  }
+}
+
+class ConsolePushMetricExporterProvider
+  implements
+    PushMetricExporterComponentProvider<ConsoleMetricExporterConfigModel>
+{
+  readonly name = 'console';
+
+  createComponent(
+    _properties: ConsoleMetricExporterConfigModel
+  ): PushMetricExporter {
+    return new SdkConsoleMetricExporter();
+  }
+}
+
+/**
+ * Register all built-in component providers with the given registry.
+ *
+ * This may be exported in the future as the "core" distribution of components.
+ * "contrib" could be a different set composed on top of this, third-party providers could easily extend this too.
+ *
+ * In the future, we could also provide a mechanism for dynamic loading - this may especially
+ * be useful for the OTel Operator, where people could load third-party instrumentations
+ * via component providers and then configure them via declarative config.
+ */
+export function getBuiltinComponentProviders(): ComponentProviderMap {
+  return {
+    logRecordExporters: [
+      new OtlpHttpLogRecordExporterProvider(),
+      new OtlpGrpcLogRecordExporterProvider(),
+      new ConsoleLogRecordExporterProvider(),
+    ],
+    spanExporters: [
+      new OtlpHttpSpanExporterProvider(),
+      new OtlpGrpcSpanExporterProvider(),
+      new ConsoleSpanExporterProvider(),
+    ],
+    pushMetricExporters: [
+      new OtlpHttpPushMetricExporterProvider(),
+      new OtlpGrpcPushMetricExporterProvider(),
+      new ConsolePushMetricExporterProvider(),
+    ],
+  };
+}

--- a/experimental/packages/opentelemetry-sdk-node/src/component-provider.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/component-provider.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SpanExporter } from '@opentelemetry/sdk-trace-base';
+import type { LogRecordExporter } from '@opentelemetry/sdk-logs';
+import type { PushMetricExporter } from '@opentelemetry/sdk-metrics';
+
+/**
+ * Schemaless configuration properties passed to a component provider.
+ */
+export type ConfigProperties = Record<string, unknown>;
+
+/**
+ * A provider responsible for creating a {@link SpanExporter} from configuration.
+ *
+ * @typeParam TConfig - The configuration properties type. Built-in providers
+ *   use typed config model interfaces for full type safety. Custom providers
+ *   default to the schemaless {@link ConfigProperties}.
+ */
+export interface SpanExporterComponentProvider<TConfig = ConfigProperties> {
+  /** Configuration key that this provider handles (e.g. `'otlp_http'`). */
+  readonly name: string;
+  /** Create the exporter from the given configuration properties. */
+  createComponent(properties: TConfig): SpanExporter;
+}
+
+/**
+ * A provider responsible for creating a {@link LogRecordExporter} from configuration.
+ *
+ * @typeParam TConfig - The configuration properties type. Built-in providers
+ *   use typed config model interfaces for full type safety. Custom providers
+ *   default to the schemaless {@link ConfigProperties}.
+ */
+export interface LogRecordExporterComponentProvider<
+  TConfig = ConfigProperties,
+> {
+  /** Configuration key that this provider handles (e.g. `'otlp_http'`). */
+  readonly name: string;
+  /** Create the exporter from the given configuration properties. */
+  createComponent(properties: TConfig): LogRecordExporter;
+}
+
+/**
+ * A provider responsible for creating a {@link PushMetricExporter} from configuration.
+ *
+ * @typeParam TConfig - The configuration properties type. Built-in providers
+ *   use typed config model interfaces for full type safety. Custom providers
+ *   default to the schemaless {@link ConfigProperties}.
+ */
+export interface PushMetricExporterComponentProvider<
+  TConfig = ConfigProperties,
+> {
+  /** Configuration key that this provider handles (e.g. `'otlp_http'`). */
+  readonly name: string;
+  /** Create the exporter from the given configuration properties. */
+  createComponent(properties: TConfig): PushMetricExporter;
+}
+
+/**
+ * A map of component providers by kind, used to initialize a {@link ComponentProviderRegistry}.
+ */
+export interface ComponentProviderMap {
+  spanExporters?: SpanExporterComponentProvider[];
+  logRecordExporters?: LogRecordExporterComponentProvider[];
+  pushMetricExporters?: PushMetricExporterComponentProvider[];
+}
+
+/**
+ * Registry for component providers, keyed by name, with separate typed maps
+ * per component kind. Providers are registered once at construction time.
+ *
+ * @internal implementation detail, not intended for public consumption.
+ */
+export class ComponentProviderRegistry {
+  private readonly _spanExporters: ReadonlyMap<
+    string,
+    SpanExporterComponentProvider
+  >;
+  private readonly _logRecordExporters: ReadonlyMap<
+    string,
+    LogRecordExporterComponentProvider
+  >;
+  private readonly _pushMetricExporters: ReadonlyMap<
+    string,
+    PushMetricExporterComponentProvider
+  >;
+
+  constructor(providers: ComponentProviderMap) {
+    this._spanExporters = buildProviderMap(
+      providers.spanExporters ?? [],
+      'SpanExporterComponentProvider'
+    );
+    this._logRecordExporters = buildProviderMap(
+      providers.logRecordExporters ?? [],
+      'LogRecordExporterComponentProvider'
+    );
+    this._pushMetricExporters = buildProviderMap(
+      providers.pushMetricExporters ?? [],
+      'PushMetricExporterComponentProvider'
+    );
+  }
+
+  /** Get a registered {@link SpanExporterComponentProvider} by name. */
+  getSpanExporterProvider(
+    name: string
+  ): SpanExporterComponentProvider | undefined {
+    return this._spanExporters.get(name);
+  }
+
+  /** Get a registered {@link LogRecordExporterComponentProvider} by name. */
+  getLogRecordExporterProvider(
+    name: string
+  ): LogRecordExporterComponentProvider | undefined {
+    return this._logRecordExporters.get(name);
+  }
+
+  /** Get a registered {@link PushMetricExporterComponentProvider} by name. */
+  getPushMetricExporterProvider(
+    name: string
+  ): PushMetricExporterComponentProvider | undefined {
+    return this._pushMetricExporters.get(name);
+  }
+}
+
+function buildProviderMap<T extends { name: string }>(
+  providers: T[],
+  kind: string
+): ReadonlyMap<string, T> {
+  const map = new Map<string, T>();
+  for (const provider of providers) {
+    if (map.has(provider.name)) {
+      throw new Error(`${kind} already registered for name="${provider.name}"`);
+    }
+    map.set(provider.name, provider);
+  }
+  return map;
+}

--- a/experimental/packages/opentelemetry-sdk-node/src/index.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/index.ts
@@ -24,3 +24,8 @@ export type { LoggerProviderConfig, MeterProviderConfig } from './sdk';
 export type { NodeSDKConfiguration } from './types';
 export { startNodeSDK } from './start';
 export { buildSamplerFromConfig } from './utils';
+export type {
+  SpanExporterComponentProvider,
+  LogRecordExporterComponentProvider,
+  PushMetricExporterComponentProvider,
+} from './component-provider';

--- a/experimental/packages/opentelemetry-sdk-node/src/start.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/start.ts
@@ -17,14 +17,14 @@ import {
 } from '@opentelemetry/api';
 import {
   getInstanceID,
-  getLogRecordProcessorsFromConfiguration,
-  getMeterReadersFromConfiguration,
+  resolveLogRecordProcessorsFromConfiguration,
+  resolveMeterReadersFromConfiguration,
   getMeterViewsFromConfiguration,
   getPropagatorFromConfiguration,
   getResourceDetectorsFromConfiguration,
   getResourceFromConfiguration,
   getSpanLimitsFromConfiguration,
-  getSpanProcessorsFromConfiguration,
+  resolveSpanProcessorsFromConfiguration,
 } from './utils';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import type { SDKComponents, SDKOptions } from './types';
@@ -45,6 +45,9 @@ import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-ho
 import { ATTR_SERVICE_INSTANCE_ID } from './semconv';
 import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import { diagLogLevelFromSeverityNumberConfig } from './diag';
+import type { ComponentProviderMap } from './component-provider';
+import { ComponentProviderRegistry } from './component-provider';
+import { getBuiltinComponentProviders } from './builtin-providers';
 
 // Exported for testing.
 export const NOOP_SDK = {
@@ -83,7 +86,13 @@ export function startNodeSDK(sdkOptions?: SDKOptions): {
     instrumentations: sdkOptions?.instrumentations?.flat() ?? [],
   });
 
-  const components = create(config, sdkOptions);
+  const components = create(config, {
+    ...sdkOptions,
+    // note: it is intentional that users cannot provide these yet so that we can move quickly without breaking users,
+    // we may want to start modeling everything (resource detectors, instrumentations, etc.) as component providers in the future
+    // instead of the sdkOptions provided to this function. If we do that, then these can be removed from the SDKOptions type.
+    componentProviders: getBuiltinComponentProviders(),
+  });
   context.setGlobalContextManager(components.contextManager);
   if (components.loggerProvider) {
     logs.setGlobalLoggerProvider(components.loggerProvider);
@@ -119,25 +128,31 @@ export function startNodeSDK(sdkOptions?: SDKOptions): {
  */
 function create(
   config: ConfigurationModel,
-  sdkOptions?: SDKOptions
+  options?: SDKOptions & {
+    componentProviders: ComponentProviderMap;
+  }
 ): SDKComponents {
+  const registry = new ComponentProviderRegistry(options?.componentProviders ?? {});
+
   const defaultContextManager = new AsyncLocalStorageContextManager();
   defaultContextManager.enable();
   const components: SDKComponents = {
     contextManager: defaultContextManager,
   };
-  const resource = setupResource(config, sdkOptions);
+  const resource = setupResource(config, options);
 
   const propagator =
-    sdkOptions?.textMapPropagator === null
+    options?.textMapPropagator === null
       ? null
-      : (sdkOptions?.textMapPropagator ??
-        getPropagatorFromConfiguration(config));
+      : (options?.textMapPropagator ?? getPropagatorFromConfiguration(config));
   if (propagator) {
     components.propagator = propagator;
   }
 
-  const logProcessors = getLogRecordProcessorsFromConfiguration(config);
+  const logProcessors = resolveLogRecordProcessorsFromConfiguration(
+    config,
+    registry
+  );
   if (logProcessors) {
     const loggerProvider = new LoggerProvider({
       resource: resource,
@@ -146,7 +161,7 @@ function create(
     components.loggerProvider = loggerProvider;
   }
 
-  const meterReaders = getMeterReadersFromConfiguration(config);
+  const meterReaders = resolveMeterReadersFromConfiguration(config, registry);
   if (meterReaders) {
     const meterViews = getMeterViewsFromConfiguration(config);
     const meterProvider = new MeterProvider({
@@ -157,7 +172,10 @@ function create(
     components.meterProvider = meterProvider;
   }
 
-  const spanProcessors = getSpanProcessorsFromConfiguration(config);
+  const spanProcessors = resolveSpanProcessorsFromConfiguration(
+    config,
+    registry
+  );
   if (spanProcessors) {
     const spanLimits = getSpanLimitsFromConfiguration(config);
     // TODO (6506): support sampler configuration from config

--- a/experimental/packages/opentelemetry-sdk-node/src/types.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/types.ts
@@ -45,6 +45,7 @@ export interface NodeSDKConfiguration {
   spanLimits: SpanLimits;
   idGenerator: IdGenerator;
 }
+
 /**
  * @experimental Options for new experimental SDK setup
  */

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -48,27 +48,19 @@ import {
 import { B3InjectEncoding, B3Propagator } from '@opentelemetry/propagator-b3';
 import { JaegerPropagator } from '@opentelemetry/propagator-jaeger';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
-import { OTLPLogExporter as OTLPHttpLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
-import { OTLPLogExporter as OTLPGrpcLogExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
-import { OTLPLogExporter as OTLPProtoLogExporter } from '@opentelemetry/exporter-logs-otlp-proto';
-import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base';
-import {
-  createEmptyMetadata,
-  createInsecureCredentials,
-  createSslCredentials,
-} from '@opentelemetry/otlp-grpc-exporter-base';
 import type {
   ConfigurationModel,
   LogRecordExporterConfigModel,
   InstrumentTypeConfigModel,
   AggregationConfigModel,
   PeriodicMetricReaderConfigModel,
+  PushMetricExporterConfigModel,
   SpanExporterConfigModel,
   SamplerConfigModel,
   NameStringValuePairConfigModel,
   HttpTlsConfigModel,
-  GrpcTlsConfigModel,
 } from '@opentelemetry/configuration';
+import type { ComponentProviderRegistry } from './component-provider';
 import type {
   AggregationOption,
   IAttributesProcessor,
@@ -78,7 +70,6 @@ import type {
 } from '@opentelemetry/sdk-metrics';
 import {
   AggregationType,
-  ConsoleMetricExporter,
   createAllowListAttributesProcessor,
   createDenyListAttributesProcessor,
   InstrumentType,
@@ -95,7 +86,6 @@ import type {
 } from '@opentelemetry/sdk-logs';
 import {
   BatchLogRecordProcessor,
-  ConsoleLogRecordExporter,
   SimpleLogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
 import * as fs from 'fs';
@@ -519,57 +509,6 @@ export function getOtlpMetricExporterFromEnv(): PushMetricExporter {
   return new OTLPProtoMetricExporter();
 }
 
-export function getPeriodicMetricReaderFromConfiguration(
-  periodic: PeriodicMetricReaderConfigModel
-): IMetricReader | undefined {
-  if (periodic.exporter) {
-    let exporter;
-    if (periodic.exporter.otlp_http !== undefined) {
-      const encoding = periodic.exporter.otlp_http?.encoding ?? 'protobuf';
-      if (encoding === 'json') {
-        exporter = new OTLPHttpMetricExporter({
-          compression:
-            periodic.exporter.otlp_http?.compression === 'gzip'
-              ? CompressionAlgorithm.GZIP
-              : CompressionAlgorithm.NONE,
-        });
-      } else if (encoding === 'protobuf') {
-        exporter = new OTLPProtoMetricExporter({
-          compression:
-            periodic.exporter.otlp_http?.compression === 'gzip'
-              ? CompressionAlgorithm.GZIP
-              : CompressionAlgorithm.NONE,
-        });
-      } else {
-        diag.warn(`Unsupported OTLP metrics encoding: ${encoding}.`);
-      }
-    }
-    if (periodic.exporter.otlp_grpc !== undefined) {
-      exporter = new OTLPGrpcMetricExporter({
-        compression:
-          periodic.exporter.otlp_grpc?.compression === 'gzip'
-            ? CompressionAlgorithm.GZIP
-            : CompressionAlgorithm.NONE,
-      });
-    }
-
-    if (exporter) {
-      // TODO(6425): add cardinality_limits
-      return new PeriodicExportingMetricReader({
-        exportIntervalMillis: periodic.interval ?? 60_000,
-        exportTimeoutMillis: periodic.timeout ?? 30_000,
-        exporter,
-      });
-    }
-    if (periodic.exporter.console !== undefined) {
-      return new PeriodicExportingMetricReader({
-        exporter: new ConsoleMetricExporter(),
-      });
-    }
-  }
-  diag.warn(`Unsupported Metric Exporter.`);
-  return undefined;
-}
 
 /**
  * Get LoggerProviderConfig from environment variables.
@@ -615,82 +554,6 @@ export function getBatchLogRecordProcessorFromEnv(
   );
 }
 
-export function getLogRecordExporter(
-  exporter: LogRecordExporterConfigModel
-): LogRecordExporter | undefined {
-  if (exporter.otlp_http !== undefined) {
-    const cfg = exporter.otlp_http;
-    const commonOpts = {
-      compression:
-        cfg?.compression === 'gzip'
-          ? CompressionAlgorithm.GZIP
-          : CompressionAlgorithm.NONE,
-      url: cfg?.endpoint ?? undefined,
-      headers: getHeadersFromConfiguration(cfg?.headers),
-      timeoutMillis: validateExporterTimeout(cfg?.timeout),
-      httpAgentOptions: getHttpAgentOptionsFromTls(cfg?.tls),
-    };
-    const encoding = cfg?.encoding ?? 'protobuf';
-    if (encoding === 'json') {
-      return new OTLPHttpLogExporter(commonOpts);
-    }
-    if (encoding === 'protobuf') {
-      return new OTLPProtoLogExporter(commonOpts);
-    }
-    diag.warn(
-      `Unsupported OTLP logs encoding: ${encoding}. Using http/protobuf.`
-    );
-    return new OTLPProtoLogExporter(commonOpts);
-  } else if (exporter.otlp_grpc !== undefined) {
-    const cfg = exporter.otlp_grpc;
-    return new OTLPGrpcLogExporter({
-      compression:
-        cfg?.compression === 'gzip'
-          ? CompressionAlgorithm.GZIP
-          : CompressionAlgorithm.NONE,
-      url: cfg?.endpoint ?? undefined,
-      timeoutMillis: validateExporterTimeout(cfg?.timeout),
-      credentials: getGrpcCredentialsFromTls(cfg?.tls),
-      metadata: getGrpcMetadataFromHeaders(cfg?.headers),
-    });
-  } else if (exporter.console !== undefined) {
-    return new ConsoleLogRecordExporter();
-  }
-  diag.warn(`Unsupported Exporter value. No Log Record Exporter registered`);
-  return undefined;
-}
-
-export function getLogRecordProcessorsFromConfiguration(
-  config: ConfigurationModel
-): LogRecordProcessor[] | undefined {
-  const logRecordProcessors: LogRecordProcessor[] = [];
-  config.logger_provider?.processors?.forEach(processor => {
-    if (processor.batch) {
-      const exporter = getLogRecordExporter(processor.batch.exporter);
-      if (exporter) {
-        logRecordProcessors.push(
-          new BatchLogRecordProcessor(exporter, {
-            maxQueueSize: processor.batch.max_queue_size ?? undefined,
-            maxExportBatchSize:
-              processor.batch.max_export_batch_size ?? undefined,
-            scheduledDelayMillis: processor.batch.schedule_delay ?? undefined,
-            exportTimeoutMillis: processor.batch.export_timeout ?? undefined,
-          })
-        );
-      }
-    }
-    if (processor.simple) {
-      const exporter = getLogRecordExporter(processor.simple.exporter);
-      if (exporter) {
-        logRecordProcessors.push(new SimpleLogRecordProcessor(exporter));
-      }
-    }
-  });
-  if (logRecordProcessors.length > 0) {
-    return logRecordProcessors;
-  }
-  return undefined;
-}
 
 export function getHeadersFromConfiguration(
   headers: NameStringValuePairConfigModel[] | undefined
@@ -707,24 +570,6 @@ export function getHeadersFromConfiguration(
   return result;
 }
 
-/**
- * Validate an exporter timeout value. The spec says 0 means "no limit
- * (infinity)" but the JS exporters don't support that yet (see #6617).
- * Warn and return undefined so the exporter falls back to its default.
- */
-function validateExporterTimeout(
-  timeout: number | null | undefined
-): number | undefined {
-  if (timeout === null) {
-    return undefined;
-  } else if (timeout === 0) {
-    diag.warn(
-      'Exporter timeout of 0 (infinite) is not supported. Using default timeout.'
-    );
-    return undefined;
-  }
-  return timeout;
-}
 
 export function getHttpAgentOptionsFromTls(
   tls: HttpTlsConfigModel | undefined
@@ -739,40 +584,7 @@ export function getHttpAgentOptionsFromTls(
   return undefined;
 }
 
-function getGrpcCredentialsFromTls(tls?: GrpcTlsConfigModel) {
-  if (tls?.insecure) {
-    return createInsecureCredentials();
-  }
-  const rootCert = readFileOrWarn(tls?.ca_file, 'TLS CA');
-  const privateKey = readFileOrWarn(tls?.key_file, 'TLS key');
-  const certChain = readFileOrWarn(tls?.cert_file, 'TLS cert');
-  if (rootCert || privateKey || certChain) {
-    try {
-      return createSslCredentials(rootCert, privateKey, certChain);
-    } catch (e) {
-      diag.warn(`Failed to create gRPC SSL credentials: ${e}`);
-      return undefined;
-    }
-  }
-  return undefined;
-}
-
-function getGrpcMetadataFromHeaders(
-  headers: NameStringValuePairConfigModel[] | undefined
-) {
-  if (!headers || headers.length === 0) {
-    return undefined;
-  }
-  const metadata = createEmptyMetadata();
-  for (const header of headers) {
-    if (header.value !== null) {
-      metadata.set(header.name, header.value);
-    }
-  }
-  return metadata;
-}
-
-function readFileOrWarn(
+export function readFileOrWarn(
   filePath: string | null | undefined,
   label: string
 ): Buffer | undefined {
@@ -785,83 +597,6 @@ function readFileOrWarn(
   }
 }
 
-export function getSpanExporter(
-  exporter: SpanExporterConfigModel
-): SpanExporter | undefined {
-  if (exporter.otlp_http !== undefined) {
-    const encoding = exporter.otlp_http?.encoding ?? 'protobuf';
-    if (encoding === 'json') {
-      return new OTLPHttpTraceExporter({
-        compression:
-          exporter.otlp_http?.compression === 'gzip'
-            ? CompressionAlgorithm.GZIP
-            : CompressionAlgorithm.NONE,
-        url: exporter.otlp_http?.endpoint ?? undefined,
-        headers: getHeadersFromConfiguration(exporter.otlp_http?.headers),
-        timeoutMillis: validateExporterTimeout(exporter.otlp_http?.timeout),
-        httpAgentOptions: getHttpAgentOptionsFromTls(exporter.otlp_http?.tls),
-      });
-    } else {
-      return new OTLPProtoTraceExporter({
-        compression:
-          exporter.otlp_http?.compression === 'gzip'
-            ? CompressionAlgorithm.GZIP
-            : CompressionAlgorithm.NONE,
-        url: exporter.otlp_http?.endpoint ?? undefined,
-        headers: getHeadersFromConfiguration(exporter.otlp_http?.headers),
-        timeoutMillis: validateExporterTimeout(exporter.otlp_http?.timeout),
-        httpAgentOptions: getHttpAgentOptionsFromTls(exporter.otlp_http?.tls),
-      });
-    }
-  } else if (exporter.otlp_grpc !== undefined) {
-    return new OTLPGrpcTraceExporter({
-      compression:
-        exporter.otlp_grpc?.compression === 'gzip'
-          ? CompressionAlgorithm.GZIP
-          : CompressionAlgorithm.NONE,
-      url: exporter.otlp_grpc?.endpoint ?? undefined,
-      timeoutMillis: validateExporterTimeout(exporter.otlp_grpc?.timeout),
-      credentials: getGrpcCredentialsFromTls(exporter.otlp_grpc?.tls),
-      metadata: getGrpcMetadataFromHeaders(exporter.otlp_grpc?.headers),
-    });
-  } else if (exporter.console !== undefined) {
-    return new ConsoleSpanExporter();
-  }
-  diag.warn(`Unsupported Exporter value. No Span Exporter registered`);
-  return undefined;
-}
-
-export function getSpanProcessorsFromConfiguration(
-  config: ConfigurationModel
-): SpanProcessor[] | undefined {
-  const spanProcessors: SpanProcessor[] = [];
-  config.tracer_provider?.processors?.forEach(processor => {
-    if (processor.batch) {
-      const exporter = getSpanExporter(processor.batch.exporter);
-      if (exporter) {
-        spanProcessors.push(
-          new BatchSpanProcessor(exporter, {
-            maxQueueSize: processor.batch.max_queue_size ?? undefined,
-            maxExportBatchSize:
-              processor.batch.max_export_batch_size ?? undefined,
-            scheduledDelayMillis: processor.batch.schedule_delay ?? undefined,
-            exportTimeoutMillis: processor.batch.export_timeout ?? undefined,
-          })
-        );
-      }
-    }
-    if (processor.simple) {
-      const exporter = getSpanExporter(processor.simple.exporter);
-      if (exporter) {
-        spanProcessors.push(new SimpleSpanProcessor(exporter));
-      }
-    }
-  });
-  if (spanProcessors.length > 0) {
-    return spanProcessors;
-  }
-  return undefined;
-}
 
 export function getSpanLimitsFromConfiguration(
   config: ConfigurationModel
@@ -883,26 +618,6 @@ export function getSpanLimitsFromConfiguration(
     }
 
     return spanLimits;
-  }
-  return undefined;
-}
-
-export function getMeterReadersFromConfiguration(
-  config: ConfigurationModel
-): IMetricReader[] | undefined {
-  const metricReaders: IMetricReader[] = [];
-  config.meter_provider?.readers?.forEach(reader => {
-    if (reader.periodic) {
-      const periodicReader = getPeriodicMetricReaderFromConfiguration(
-        reader.periodic
-      );
-      if (periodicReader) {
-        metricReaders.push(periodicReader);
-      }
-    }
-  });
-  if (metricReaders.length > 0) {
-    return metricReaders;
   }
   return undefined;
 }
@@ -1119,4 +834,205 @@ export function buildSamplerFromConfig(
   }
   diag.error('Unknown sampler config, defaulting to ParentBased(AlwaysOn).');
   return new ParentBasedSampler({ root: new AlwaysOnSampler() });
+}
+
+// --- Registry-aware exporter resolution ---
+
+/**
+ * Resolve a {@link SpanExporter} from a config model using the component provider registry.
+ */
+export function resolveSpanExporter(
+  exporter: SpanExporterConfigModel,
+  registry: ComponentProviderRegistry
+): SpanExporter | undefined {
+  for (const [name, properties] of Object.entries(exporter)) {
+    if (properties === undefined) {
+      continue;
+    }
+
+    const provider = registry.getSpanExporterProvider(name);
+    if (provider) {
+      return provider.createComponent(
+        (properties as Record<string, unknown>) ?? {}
+      );
+    }
+
+    diag.warn(
+      `No SpanExporterComponentProvider registered for name "${name}". Skipping.`
+    );
+  }
+  diag.warn('Unsupported Exporter value. No Span Exporter registered');
+  return undefined;
+}
+
+/**
+ * Resolve a {@link LogRecordExporter} from a config model using the component provider registry.
+ */
+export function resolveLogRecordExporter(
+  exporter: LogRecordExporterConfigModel,
+  registry: ComponentProviderRegistry
+): LogRecordExporter | undefined {
+  for (const [name, properties] of Object.entries(exporter)) {
+    if (properties === undefined) {
+      continue;
+    }
+
+    const provider = registry.getLogRecordExporterProvider(name);
+    if (provider) {
+      return provider.createComponent(
+        (properties as Record<string, unknown>) ?? {}
+      );
+    }
+
+    diag.warn(
+      `No LogRecordExporterComponentProvider registered for name "${name}". Skipping.`
+    );
+  }
+  diag.warn('Unsupported Exporter value. No Log Record Exporter registered');
+  return undefined;
+}
+
+/**
+ * Resolve a {@link PushMetricExporter} from a config model using the component provider registry.
+ */
+export function resolvePushMetricExporter(
+  exporter: PushMetricExporterConfigModel,
+  registry: ComponentProviderRegistry
+): PushMetricExporter | undefined {
+  for (const [name, properties] of Object.entries(exporter)) {
+    if (properties === undefined) {
+      continue;
+    }
+
+    const provider = registry.getPushMetricExporterProvider(name);
+    if (provider) {
+      return provider.createComponent(
+        (properties as Record<string, unknown>) ?? {}
+      );
+    }
+
+    diag.warn(
+      `No PushMetricExporterComponentProvider registered for name "${name}". Skipping.`
+    );
+  }
+  diag.warn('Unsupported Metric Exporter.');
+  return undefined;
+}
+
+/**
+ * Registry-aware version of {@link getSpanProcessorsFromConfiguration}.
+ */
+export function resolveSpanProcessorsFromConfiguration(
+  config: ConfigurationModel,
+  registry: ComponentProviderRegistry
+): SpanProcessor[] | undefined {
+  const spanProcessors: SpanProcessor[] = [];
+  config.tracer_provider?.processors?.forEach(processor => {
+    if (processor.batch) {
+      const exporter = resolveSpanExporter(processor.batch.exporter, registry);
+      if (exporter) {
+        spanProcessors.push(
+          new BatchSpanProcessor(exporter, {
+            maxQueueSize: processor.batch.max_queue_size,
+            maxExportBatchSize: processor.batch.max_export_batch_size,
+            scheduledDelayMillis: processor.batch.schedule_delay,
+            exportTimeoutMillis: processor.batch.export_timeout,
+          })
+        );
+      }
+    }
+    if (processor.simple) {
+      const exporter = resolveSpanExporter(processor.simple.exporter, registry);
+      if (exporter) {
+        spanProcessors.push(new SimpleSpanProcessor(exporter));
+      }
+    }
+  });
+  if (spanProcessors.length > 0) {
+    return spanProcessors;
+  }
+  return undefined;
+}
+
+/**
+ * Registry-aware version of {@link getLogRecordProcessorsFromConfiguration}.
+ */
+export function resolveLogRecordProcessorsFromConfiguration(
+  config: ConfigurationModel,
+  registry: ComponentProviderRegistry
+): LogRecordProcessor[] | undefined {
+  const logRecordProcessors: LogRecordProcessor[] = [];
+  config.logger_provider?.processors?.forEach(processor => {
+    if (processor.batch) {
+      const exporter = resolveLogRecordExporter(
+        processor.batch.exporter,
+        registry
+      );
+      if (exporter) {
+        logRecordProcessors.push(
+          new BatchLogRecordProcessor(exporter, {
+            maxQueueSize: processor.batch.max_queue_size,
+            maxExportBatchSize: processor.batch.max_export_batch_size,
+            scheduledDelayMillis: processor.batch.schedule_delay,
+            exportTimeoutMillis: processor.batch.export_timeout,
+          })
+        );
+      }
+    }
+    if (processor.simple) {
+      const exporter = resolveLogRecordExporter(
+        processor.simple.exporter,
+        registry
+      );
+      if (exporter) {
+        logRecordProcessors.push(new SimpleLogRecordProcessor(exporter));
+      }
+    }
+  });
+  if (logRecordProcessors.length > 0) {
+    return logRecordProcessors;
+  }
+  return undefined;
+}
+
+/**
+ * Registry-aware version of {@link getMeterReadersFromConfiguration}.
+ */
+export function resolveMeterReadersFromConfiguration(
+  config: ConfigurationModel,
+  registry: ComponentProviderRegistry
+): IMetricReader[] | undefined {
+  const metricReaders: IMetricReader[] = [];
+  config.meter_provider?.readers?.forEach(reader => {
+    if (reader.periodic) {
+      const metricReader = resolvePeriodicMetricReaderFromConfiguration(
+        reader.periodic,
+        registry
+      );
+      if (metricReader) {
+        metricReaders.push(metricReader);
+      }
+    }
+  });
+  if (metricReaders.length > 0) {
+    return metricReaders;
+  }
+  return undefined;
+}
+
+function resolvePeriodicMetricReaderFromConfiguration(
+  periodic: PeriodicMetricReaderConfigModel,
+  registry: ComponentProviderRegistry
+): IMetricReader | undefined {
+  if (periodic.exporter) {
+    const exporter = resolvePushMetricExporter(periodic.exporter, registry);
+    if (exporter) {
+      return new PeriodicExportingMetricReader({
+        exportIntervalMillis: periodic.interval ?? 60_000,
+        exportTimeoutMillis: periodic.timeout ?? 30_000,
+        exporter,
+      });
+    }
+  }
+  return undefined;
 }

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -933,10 +933,10 @@ export function resolveSpanProcessorsFromConfiguration(
       if (exporter) {
         spanProcessors.push(
           new BatchSpanProcessor(exporter, {
-            maxQueueSize: processor.batch.max_queue_size,
-            maxExportBatchSize: processor.batch.max_export_batch_size,
-            scheduledDelayMillis: processor.batch.schedule_delay,
-            exportTimeoutMillis: processor.batch.export_timeout,
+            maxQueueSize: processor.batch.max_queue_size ?? undefined,
+            maxExportBatchSize: processor.batch.max_export_batch_size ?? undefined,
+            scheduledDelayMillis: processor.batch.schedule_delay ?? undefined,
+            exportTimeoutMillis: processor.batch.export_timeout ?? undefined,
           })
         );
       }
@@ -971,10 +971,10 @@ export function resolveLogRecordProcessorsFromConfiguration(
       if (exporter) {
         logRecordProcessors.push(
           new BatchLogRecordProcessor(exporter, {
-            maxQueueSize: processor.batch.max_queue_size,
-            maxExportBatchSize: processor.batch.max_export_batch_size,
-            scheduledDelayMillis: processor.batch.schedule_delay,
-            exportTimeoutMillis: processor.batch.export_timeout,
+            maxQueueSize: processor.batch.max_queue_size ?? undefined,
+            maxExportBatchSize: processor.batch.max_export_batch_size ?? undefined,
+            scheduledDelayMillis: processor.batch.schedule_delay ?? undefined,
+            exportTimeoutMillis: processor.batch.export_timeout ?? undefined,
           })
         );
       }

--- a/experimental/packages/opentelemetry-sdk-node/test/component-provider.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/component-provider.test.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { diag } from '@opentelemetry/api';
+import {
+  ComponentProviderRegistry,
+  type SpanExporterComponentProvider,
+  type LogRecordExporterComponentProvider,
+  type ConfigProperties,
+} from '../src/component-provider';
+import { getBuiltinComponentProviders } from '../src/builtin-providers';
+import {
+  resolveSpanExporter,
+  resolveLogRecordExporter,
+  resolvePushMetricExporter,
+} from '../src/utils';
+import type { SpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import type { LogRecordExporter } from '@opentelemetry/sdk-logs';
+import type { ExportResult } from '@opentelemetry/core';
+
+/** Minimal no-op SpanExporter for test purposes. */
+const noopSpanExporter: SpanExporter = {
+  export(
+    _spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void
+  ) {
+    resultCallback({ code: 0 });
+  },
+  shutdown() {
+    return Promise.resolve();
+  },
+};
+
+/** Minimal no-op LogRecordExporter for test purposes. */
+const noopLogExporter: LogRecordExporter = {
+  export(_logs: any[], resultCallback: (result: ExportResult) => void) {
+    resultCallback({ code: 0 });
+  },
+  shutdown() {
+    return Promise.resolve();
+  },
+  forceFlush() {
+    return Promise.resolve();
+  },
+};
+
+describe('ComponentProviderRegistry', function () {
+  it('should retrieve a SpanExporter provider registered via constructor', function () {
+    const provider: SpanExporterComponentProvider = {
+      name: 'test-exporter',
+      createComponent: (_props: ConfigProperties) => noopSpanExporter,
+    };
+    const registry = new ComponentProviderRegistry({
+      spanExporters: [provider],
+    });
+    assert.strictEqual(
+      registry.getSpanExporterProvider('test-exporter'),
+      provider
+    );
+  });
+
+  it('should return undefined for unregistered SpanExporter provider', function () {
+    const registry = new ComponentProviderRegistry({});
+    assert.strictEqual(
+      registry.getSpanExporterProvider('nonexistent'),
+      undefined
+    );
+  });
+
+  it('should throw on duplicate SpanExporter names', function () {
+    const provider: SpanExporterComponentProvider = {
+      name: 'dup',
+      createComponent: () => noopSpanExporter,
+    };
+    assert.throws(
+      () =>
+        new ComponentProviderRegistry({ spanExporters: [provider, provider] }),
+      /SpanExporterComponentProvider already registered for name="dup"/
+    );
+  });
+
+  it('should allow the same name for different component kinds', function () {
+    const spanProvider: SpanExporterComponentProvider = {
+      name: 'otlp_http',
+      createComponent: () => noopSpanExporter,
+    };
+    const logProvider: LogRecordExporterComponentProvider = {
+      name: 'otlp_http',
+      createComponent: () => noopLogExporter,
+    };
+    const registry = new ComponentProviderRegistry({
+      spanExporters: [spanProvider],
+      logRecordExporters: [logProvider],
+    });
+    assert.strictEqual(
+      registry.getSpanExporterProvider('otlp_http'),
+      spanProvider
+    );
+    assert.strictEqual(
+      registry.getLogRecordExporterProvider('otlp_http'),
+      logProvider
+    );
+  });
+});
+
+describe('getBuiltinComponentProviders', function () {
+  it('should return all 9 built-in providers', function () {
+    const registry = new ComponentProviderRegistry(
+      getBuiltinComponentProviders()
+    );
+
+    assert.ok(registry.getSpanExporterProvider('otlp_http'));
+    assert.ok(registry.getSpanExporterProvider('otlp_grpc'));
+    assert.ok(registry.getSpanExporterProvider('console'));
+    assert.ok(registry.getLogRecordExporterProvider('otlp_http'));
+    assert.ok(registry.getLogRecordExporterProvider('otlp_grpc'));
+    assert.ok(registry.getLogRecordExporterProvider('console'));
+    assert.ok(registry.getPushMetricExporterProvider('otlp_http'));
+    assert.ok(registry.getPushMetricExporterProvider('otlp_grpc'));
+    assert.ok(registry.getPushMetricExporterProvider('console'));
+  });
+});
+
+describe('resolveSpanExporter', function () {
+  let registry: ComponentProviderRegistry;
+
+  beforeEach(function () {
+    registry = new ComponentProviderRegistry(getBuiltinComponentProviders());
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('should resolve console exporter via registry', function () {
+    const exporter = resolveSpanExporter({ console: {} }, registry);
+    assert.ok(exporter);
+    assert.strictEqual(exporter.constructor.name, 'ConsoleSpanExporter');
+  });
+
+  it('should resolve otlp_http via registry', function () {
+    const exporter = resolveSpanExporter(
+      { otlp_http: { encoding: 'protobuf' } },
+      registry
+    );
+    assert.ok(exporter);
+  });
+
+  it('should resolve otlp_grpc via registry', function () {
+    const exporter = resolveSpanExporter({ otlp_grpc: {} }, registry);
+    assert.ok(exporter);
+  });
+
+  it('should warn for unknown exporter without registered provider', function () {
+    const warnStub = sinon.stub(diag, 'warn');
+    const result = resolveSpanExporter(
+      { 'unknown-exporter': { foo: 'bar' } },
+      registry
+    );
+    assert.strictEqual(result, undefined);
+    assert.ok(
+      warnStub.calledWith(
+        sinon.match(/No SpanExporterComponentProvider registered/)
+      )
+    );
+  });
+});
+
+describe('resolveLogRecordExporter', function () {
+  let registry: ComponentProviderRegistry;
+
+  beforeEach(function () {
+    registry = new ComponentProviderRegistry(getBuiltinComponentProviders());
+  });
+
+  it('should resolve console exporter', function () {
+    const exporter = resolveLogRecordExporter({ console: {} }, registry);
+    assert.ok(exporter);
+    assert.strictEqual(exporter.constructor.name, 'ConsoleLogRecordExporter');
+  });
+
+  it('should resolve otlp_http via registry', function () {
+    const exporter = resolveLogRecordExporter(
+      { otlp_http: { encoding: 'protobuf' } },
+      registry
+    );
+    assert.ok(exporter);
+  });
+});
+
+describe('resolvePushMetricExporter', function () {
+  let registry: ComponentProviderRegistry;
+
+  beforeEach(function () {
+    registry = new ComponentProviderRegistry(getBuiltinComponentProviders());
+  });
+
+  it('should resolve console exporter', function () {
+    const exporter = resolvePushMetricExporter({ console: {} }, registry);
+    assert.ok(exporter);
+    assert.strictEqual(exporter.constructor.name, 'ConsoleMetricExporter');
+  });
+
+  it('should resolve otlp_http via registry', function () {
+    const exporter = resolvePushMetricExporter(
+      { otlp_http: { encoding: 'protobuf' } },
+      registry
+    );
+    assert.ok(exporter);
+  });
+});

--- a/experimental/packages/opentelemetry-sdk-node/test/start.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/start.test.ts
@@ -56,10 +56,11 @@ import {
 } from '../src/semconv';
 import { ATTR_OS_TYPE } from '@opentelemetry/resources/src/semconv';
 import {
-  getLogRecordExporter,
-  getSpanExporter,
+  resolveSpanExporter,
+  resolveLogRecordExporter,
   setupContextManager,
 } from '../src/utils';
+import { ComponentProviderRegistry } from '../src/component-provider';
 import { NOOP_SDK } from '../src/start';
 import {
   ConsoleMetricExporter,
@@ -76,6 +77,7 @@ import {
   ConsoleSpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-node';
+import { getBuiltinComponentProviders } from '../src/builtin-providers';
 
 describe('startNodeSDK', function () {
   let setGlobalLoggerProviderSpy: Sinon.SinonSpy;
@@ -350,11 +352,16 @@ describe('startNodeSDK', function () {
     const sdk = startNodeSDK({});
 
     // otlp_file/development exporters are not supported yet
-    const unsupportedWarnings = stubLoggerWarn.args.filter(
+    const unsupportedProviderWarnings = stubLoggerWarn.args.filter(
       args =>
-        args[0] === 'Unsupported Exporter value. No Span Exporter registered'
+        args[0] ===
+        'No SpanExporterComponentProvider registered for name "otlp_file/development". Skipping.'
     );
-    assert.strictEqual(unsupportedWarnings.length, 2);
+    assert.strictEqual(unsupportedProviderWarnings.length, 2);
+    const unsupportedExporterWarnings = stubLoggerWarn.args.filter(
+      args => args[0] === 'Unsupported Exporter value. No Span Exporter registered'
+    );
+    assert.strictEqual(unsupportedExporterWarnings.length, 2);
 
     assert.strictEqual(setGlobalTracerProviderSpy.callCount, 1);
     assert.ok(
@@ -959,15 +966,20 @@ describe('startNodeSDK', function () {
 
   describe('tests to increase code coverage', function () {
     it('should return undefined for invalid log record exporter model', async () => {
+      const registry = new ComponentProviderRegistry(
+        getBuiltinComponentProviders()
+      );
       const exporter: LogRecordExporterConfigModel = {};
-      assert.equal(getLogRecordExporter(exporter), undefined);
+      assert.equal(resolveLogRecordExporter(exporter, registry), undefined);
     });
 
     it('should warn when exporter timeout is 0', async () => {
       const warnSpy = Sinon.spy(diag, 'warn');
-      const exporter = getSpanExporter({
-        otlp_http: { timeout: 0 },
-      });
+      const registry = new ComponentProviderRegistry(getBuiltinComponentProviders());
+      const exporter = resolveSpanExporter(
+        { otlp_http: { timeout: 0 } },
+        registry
+      );
       assert.ok(exporter !== undefined);
       assert.ok(
         warnSpy.args.some(args =>

--- a/experimental/packages/opentelemetry-sdk-node/test/utils.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/utils.test.ts
@@ -9,7 +9,6 @@ import {
   getPropagatorFromConfiguration,
   getLoggerProviderConfigFromEnv,
   getBatchLogRecordProcessorConfigFromEnv,
-  getPeriodicMetricReaderFromConfiguration,
   getInstrumentType,
   getAggregationType,
   getResourceDetectorsFromConfiguration,
@@ -17,6 +16,7 @@ import {
   getMeterViewsFromConfiguration,
   getSpanLimitsFromConfiguration,
   getHttpAgentOptionsFromTls,
+  resolvePushMetricExporter,
 } from '../src/utils';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
@@ -423,13 +423,17 @@ describe('getBatchLogRecordProcessorConfigFromEnv', function () {
   });
 
   it('should return warning message for invalid compression type for meter provider', function () {
+    const { ComponentProviderRegistry } = require('../src/component-provider');
+    const { getBuiltinComponentProviders } = require('../src/builtin-providers');
+    const registry = new ComponentProviderRegistry(getBuiltinComponentProviders());
     const warnStub = sinon.stub(diag, 'warn');
-    getPeriodicMetricReaderFromConfiguration({
-      exporter: { otlp_http: { encoding: 'invalid' } },
-    } as any);
+    resolvePushMetricExporter(
+      { otlp_http: { encoding: 'invalid' } } as any,
+      registry
+    );
     sinon.assert.calledWithExactly(
       warnStub,
-      'Unsupported OTLP metrics encoding: invalid.'
+      'Unsupported OTLP metrics encoding: invalid. Using http/protobuf.'
     );
   });
 

--- a/experimental/packages/opentelemetry-sdk-node/test/utils.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/utils.test.ts
@@ -36,6 +36,8 @@ import {
 import type { LoggerProviderOptions } from '@opentelemetry/sdk-logs';
 import { AggregationType, InstrumentType } from '@opentelemetry/sdk-metrics';
 import type { SpanLimits } from '@opentelemetry/sdk-trace-node';
+import { getBuiltinComponentProviders } from '../src/builtin-providers';
+import { ComponentProviderRegistry } from '../src/component-provider';
 
 describe('getPropagatorFromEnv', function () {
   afterEach(() => {
@@ -423,9 +425,9 @@ describe('getBatchLogRecordProcessorConfigFromEnv', function () {
   });
 
   it('should return warning message for invalid compression type for meter provider', function () {
-    const { ComponentProviderRegistry } = require('../src/component-provider');
-    const { getBuiltinComponentProviders } = require('../src/builtin-providers');
-    const registry = new ComponentProviderRegistry(getBuiltinComponentProviders());
+    const registry = new ComponentProviderRegistry(
+      getBuiltinComponentProviders()
+    );
     const warnStub = sinon.stub(diag, 'warn');
     resolvePushMetricExporter(
       { otlp_http: { encoding: 'invalid' } } as any,


### PR DESCRIPTION
## Which problem is this PR solving?

This is an example of how we could go about modeling the resolution of plugin components (exporters in this example, but could be other things like samplers, instrumentations, resource detectors) by applying the [`PluginComponentProvider`](https://github.com/open-telemetry/opentelemetry-specification/blob/5b27616de656fc124253240743761b91fd2ff442/specification/configuration/sdk.md?plain=1#L116-L178) specification.

This PR is intentionally structured as an internal refactor so that if we go ahead and apply it we can still keep moving quickly without having third-parties (or the contrib repo) take on any dependencies on the new interface. It currently only focuses on exporters, but could be expanded later to include other types as well

The `type` field mentioned by the spec is modeled here by concrete types for each `ComponentProvider`, as well as through the `ComponentProviderMap`, so that we don't need to specifically add it. I've experimented with different ways trying to bend TypeScript to my will, but this was the most elegant solution I could find.

The `ComponentProviderMap` is passed to `create()`. This gives us the option to add a different loading mechanism in the future, like a dynamic loader for components. Usage could look something like this:

```ts
create(config, mergeComponentProviderMap(
    getBuiltInComponentProviders(),
    dynamicallyLoadComponentProviders() // possible future implementation of a dynamic component loader
  )
);

// note: mergeComponentProviderMap() is not implemented in this prototype, 
// but it's trivial to implement once we decide to make `create()` public
``` 

This also leaves the option open for folks that would like to bundle their own declarative-config supporting distro. In contrib for instance, we could do:

```ts
create(config, mergeComponentProviderMap(
    getBuiltInComponentProviders(),
    getContribComponentProviders() // selected components available from contrib
  )
);
```

**Disclosure of AI use:** I used Claude Sonnet 4.6 to do most of the refactor based on a few interfaces I proposed - this PR is the outcome that I found most appealing in the end.

Towards #5825 

## How Has This Been Tested?

- [x] Unit tests

