### PR TITLE
ci: zizmor: pin one uses-dep, ignore current pull_request_target usage, reduce perms in sbom.yml

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -57,7 +57,7 @@ jobs:
           find . -name .benchmark-results.txt -exec cat {} + > combined_benchmarks.txt
 
       - name: Store benchmark results
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1
         with:
           tool: 'benchmarkjs'
           output-file-path: combined_benchmarks.txt

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -3,7 +3,8 @@ on:
   release:
     types: [published]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   generate-sboms:
@@ -17,6 +18,12 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22.22.1" # pin to avoid bug in 22.22.2
+          # Disable caching in release workflows (https://docs.zizmor.sh/audits/#cache-poisoning).
+          # Zizmor didn't actually warn about this, but its general advice
+          # was to avoid caching in workflows that publish artifacts. While
+          # the published SBOM.zip does not include executable code, it is
+          # still a published artifact.
+          package-manager-cache: false
 
       - run: npm install -g npm@latest
 

--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -1,8 +1,12 @@
 name: Survey on Merged PR by Non-Member
 
 on:
+  # Using 'pull_request_target' for permission to `gh pr comment`.
+  # https://docs.zizmor.sh/audits/#dangerous-triggers
+  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [closed]
+    branches: [main]
 
 permissions:
   contents: read
@@ -28,19 +32,19 @@ jobs:
           USERNAME="${GITHUB_EVENT_PULL_REQUEST_USER_LOGIN}"
           USER_TYPE="${GITHUB_EVENT_PULL_REQUEST_USER_TYPE}"
           ORG="${{ github.repository_owner }}"
-          
+
           # Skip if user is a bot
           if [[ "$USER_TYPE" == "Bot" ]]; then
             echo "Skipping survey for bot user: $USERNAME"
             exit 0
           fi
-          
+
           # Skip if user is an org member
           if gh api "orgs/$ORG/members/$USERNAME" --silent; then
             echo "Skipping survey for org member: $USERNAME"
             exit 0
           fi
-          
+
           # Add survey comment for external contributor
           echo "Adding survey comment for external contributor: $USERNAME"
           gh pr comment ${PR_NUM} --repo ${{ github.repository }} --body "Thank you for your contribution @${USERNAME}! 🎉 We would like to hear from you about your experience contributing to OpenTelemetry by taking a few minutes to fill out this [survey](${SURVEY_URL})."


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3535
for my justitification on ignoring the 'pull_request_target' usage
in "survey-on-merged-pr.yml". The same workflow is in both repos.

On reducing sbom.yml read permissions. My best guess is that 'contents:
read' is all that is required, but I have not tested this.
https://docs.zizmor.sh/audits/#excessive-permissions
