### PR TITLE
test(webpack-4): include import-in-the-middle in transpilation

### DIFF
--- a/bundler-tests/browser/webpack-4/webpack.config.mjs
+++ b/bundler-tests/browser/webpack-4/webpack.config.mjs
@@ -25,7 +25,7 @@ export default {
       {
         test: /\.(?:js|mjs|cjs)$/,
         // Include OpenTelemetry ES2022 packages for transpilation
-        exclude: /node_modules\/(?!@opentelemetry)/,
+        exclude: /node_modules\/(?!@opentelemetry|import-in-the-middle)/,
         use: {
           loader: 'babel-loader',
           options: {

--- a/bundler-tests/node/webpack-4/webpack.config.mjs
+++ b/bundler-tests/node/webpack-4/webpack.config.mjs
@@ -23,7 +23,7 @@ export default {
     rules: [
       {
         test: /\.(?:js|mjs|cjs)$/,
-        exclude: /node_modules\/(?!@opentelemetry)/,
+        exclude: /node_modules\/(?!@opentelemetry|import-in-the-middle)/,
         use: {
           loader: 'babel-loader',
           options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13840,9 +13840,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz",
-      "integrity": "sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.15.0",


### PR DESCRIPTION
## Which problem is this PR solving?

`import-in-the-middle@3.0.1` is now using nullish coalescing here: https://github.com/nodejs/import-in-the-middle/blob/f67383cbf48ade6ca9642c9f892e696ad885ed30/index.js#L34

We need to transpile these away so that webpack 4 can work with it - we already do this with the OTel packages so this is nothing new, but it's likely going to be annoying to webpack 4 users since import-in-the-middle is not used in the browser.

Unblocks #6559 