### PR TITLE
docs(otlp-exporter-base): add typedoc entry points so public API is indexed and linked

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -24,6 +24,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :books: Documentation
 
+* docs(otlp-exporter-base): index the package's public API in generated docs so types like `OTLPExporterNodeConfigBase` resolve and link from consumer exporter pages [#6725](https://github.com/open-telemetry/opentelemetry-js/issues/6725) @devareddy05
+
 ### :house: Internal
 
 * refactor(configuration): remove redundant env var parsing in EnvironmentConfigFactory [#6710](https://github.com/open-telemetry/opentelemetry-js/pull/6710) @MikeGoldsmith

--- a/experimental/packages/otlp-exporter-base/typedoc.json
+++ b/experimental/packages/otlp-exporter-base/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPoints": [
+    "src/index.ts",
+    "src/index-node-http.ts",
+    "src/index-browser-http.ts"
+  ]
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #6725.

On the published API docs (e.g. https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_exporter-metrics-otlp-http.OTLPMetricExporter.html), `OTLPExporterNodeConfigBase` appears as **plain text** in the constructor signature instead of a link to its interface page.

**Root cause:** `@opentelemetry/otlp-exporter-base`'s `package.json` `exports` field uses the conditional-object form (`{esnext, module, types, default}`) with three sub-paths (`.`, `./node-http`, `./browser-http`). Typedoc's auto-discovery from `package.json` exports handles the flat-string form (e.g. `shim-opencensus`) but not the conditional-object form, so during `npm run docs` it emits:

```
[warning] No entry points were provided or discovered from package.json exports, this is likely a misconfiguration
[info]    Converting project at ./experimental/packages/otlp-exporter-base
```

The package's public API (including `OTLPExporterNodeConfigBase`, `OTLPExporterConfigBase`, the export delegates, etc.) was never indexed, so every consumer page that referenced these types fell back to rendering them as plain text rather than a link.

## Short description of the changes

* Add `experimental/packages/otlp-exporter-base/typedoc.json` listing the three entry points that match the package's `exports` sub-paths. Same pattern as `api/typedoc.json`.
* CHANGELOG entry under **Documentation**.

```json
{
  "entryPoints": [
    "src/index.ts",
    "src/index-node-http.ts",
    "src/index-browser-http.ts"
  ]
}
```

## Type of change

- [x] This change requires a documentation update *(generated API docs only — no source/behavior change)*

## How Has This Been Tested?

Ran `rm -rf docs && npm run docs` against `main` and against this branch:

* **Before:** `[warning] No entry points were provided or discovered from package.json exports, this is likely a misconfiguration`. `docs/modules/_opentelemetry_otlp-exporter-base.html` rendered only the README. `OTLPExporterNodeConfigBase` appeared as plain text on consumer pages — `grep` for `href=".*OTLPExporterNodeConfigBase.*"` returned 0 hits.
* **After:** misconfiguration warning is gone. New interface page generated at `docs/interfaces/_opentelemetry_otlp-exporter-base.index.OTLPExporterNodeConfigBase.html`. Three sub-module pages now exist (`.index.html`, `.index-node-http.html`, `.index-browser-http.html`) — same shape as `shim-opencensus`. Six consumer exporter doc pages now contain a working `<a href="...">` link to the interface (verified via `grep`):
  * `_opentelemetry_exporter-trace-otlp-http.OTLPTraceExporter.html`
  * `_opentelemetry_exporter-trace-otlp-proto.OTLPTraceExporter.html`
  * `_opentelemetry_exporter-logs-otlp-http.OTLPLogExporter.html`
  * `_opentelemetry_exporter-logs-otlp-proto.OTLPLogExporter.html`
  * `_opentelemetry_exporter-metrics-otlp-http.OTLPMetricExporter.html` *(the page in the issue)*
  * `_opentelemetry_exporter-metrics-otlp-proto.OTLPMetricExporter.html`

Also ran in `experimental/packages/otlp-exporter-base`:

* `npm run compile` — clean.
* `npm run lint` — clean (only the pre-existing `path` shadow warning).
* `npm test` — same baseline as `main`.

## Out of scope

After this fix, one previously-hidden typedoc warning surfaces because the file is now indexed: `Failed to resolve link to "createOtlpFetchExportDelegate"` from the `@deprecated` JSDoc on `createOtlpSendBeaconExportDelegate` in `index-browser-http.ts`. That's a pre-existing JSDoc-link issue; left for a follow-up so this PR stays single-focus.

## Checklist

- [x] Followed the style guidelines of this project
- [x] Documentation has been updated *(typedoc config + CHANGELOG)*
- [x] DCO sign-off