### PR TITLE
ci: drop 'repositories:' unnecessary usage with actions/create-github-app-token

### DIFF
--- a/.github/workflows/create-or-update-release-pr.yml
+++ b/.github/workflows/create-or-update-release-pr.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           app-id: ${{ vars.OTELBOT_JS_APP_ID }}
           private-key: ${{ secrets.OTELBOT_JS_PRIVATE_KEY }}
-          repositories: ${{ github.repository }}
           # Scope to just the permissions required by the "Create/Update Release PR" step below.
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           app-id: ${{ vars.OTELBOT_APP_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
-          repositories: ${{ github.repository }}
           permission-pull-requests: write # for 'gh pr comment ...'
           permission-members: read # for 'gh api orgs/$ORG/members/$USERNAME'
 


### PR DESCRIPTION
Scoping to just the curr repo is the default as long as the
'owner:' field is empty. I misread the action config earlier.
