### PR TITLE
fix(browser-detector): set `user_agent.original` resource attribute always

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -21,6 +21,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * fix(sdk-node): pass gRPC credentials and headers to span exporter in declarative config [#6705](https://github.com/open-telemetry/opentelemetry-js/pull/6705) @MikeGoldsmith
 * fix(otlp-transformer): do not attempt to skip groups [#6704](https://github.com/open-telemetry/opentelemetry-js/pull/6704) @pichlermarc
 * fix(browser-detector): use the right semantic convention for user agent resource attribute [#6729](https://github.com/open-telemetry/opentelemetry-js/pull/6729) @david-luna
+* fix(browser-detector): user agent resource attribute always [#6754](https://github.com/open-telemetry/opentelemetry-js/pull/6754) @david-luna
 
 ### :books: Documentation
 

--- a/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
+++ b/experimental/packages/opentelemetry-browser-detector/src/BrowserDetector.ts
@@ -71,9 +71,8 @@ function getBrowserAttributes(): Attributes {
       b => `${b.brand} ${b.version}`
     );
     browserAttribs[ATTR_BROWSER_MOBILE] = userAgentData.mobile;
-  } else {
-    browserAttribs[ATTR_USER_AGENT_ORIGINAL] = navigator.userAgent;
   }
+  browserAttribs[ATTR_USER_AGENT_ORIGINAL] = navigator.userAgent;
   browserAttribs[ATTR_BROWSER_LANGUAGE] = navigator.language;
   return browserAttribs;
 }

--- a/experimental/packages/opentelemetry-browser-detector/test/BrowserDetector.test.ts
+++ b/experimental/packages/opentelemetry-browser-detector/test/BrowserDetector.test.ts
@@ -46,6 +46,7 @@ describeBrowser('browserDetector()', () => {
       brands: ['Chromium 106', 'Google Chrome 106', 'Not;A=Brand 99'],
       mobile: false,
       language: 'en-US',
+      user_agent: 'dddd',
     });
   });
 


### PR DESCRIPTION
## Which problem is this PR solving?

As a result of the discussion in the Browser SIG it is decided that the user agent should be set in the resource. This PR
aligns with the changes proposed in semantic conventions in https://github.com/open-telemetry/semantic-conventions/pull/3738 

## Short description of the changes

- set the `user_agent.original` resource attribute always

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit tests

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been updated
