### PR TITLE
fix(ci): restore persisting git creds for create-or-update-release-pr workflow, because they are needed in subsequent steps

### DIFF
--- a/.github/workflows/create-or-update-release-pr.yml
+++ b/.github/workflows/create-or-update-release-pr.yml
@@ -56,7 +56,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ steps.otelbot-token.outputs.token }}
-          persist-credentials: false
+          # Credentials are used in 'Create/Update Release PR' git commands below.
+          persist-credentials: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
Fixes: https://github.com/open-telemetry/opentelemetry-js/issues/6736

---

This also passes zizmor (which had been the original reason `persist-credentials: false` had been added (for https://docs.zizmor.sh/audits/#artipacked):

```
% zizmor .github/workflows/create-or-update-release-pr.yml
 INFO zizmor: 🌈 zizmor v1.25.2
 INFO audit: zizmor: 🌈 completed .github/workflows/create-or-update-release-pr.yml
No findings to report. Good job! (4 suppressed)
```

I'll need to merge this to actually *verify* that this fixes the workflow.