### PR TITLE
chore: add explicit "types" to tsconfig files

### DIFF
--- a/packages/opentelemetry-sdk-trace-web/tsconfig.esm.json
+++ b/packages/opentelemetry-sdk-trace-web/tsconfig.esm.json
@@ -6,6 +6,7 @@
       "dom",
       "dom.iterable"
     ],
+    "types": ["node", "mocha", "webpack-env", "jquery"],
     "outDir": "build/esm",
     "rootDir": "src",
     "tsBuildInfoFile": "build/esm/tsconfig.esm.tsbuildinfo"

--- a/packages/opentelemetry-sdk-trace-web/tsconfig.esnext.json
+++ b/packages/opentelemetry-sdk-trace-web/tsconfig.esnext.json
@@ -6,6 +6,7 @@
       "dom",
       "dom.iterable"
     ],
+    "types": ["node", "mocha", "webpack-env", "jquery"],
     "outDir": "build/esnext",
     "rootDir": "src",
     "tsBuildInfoFile": "build/esnext/tsconfig.esnext.tsbuildinfo"

--- a/packages/opentelemetry-sdk-trace-web/tsconfig.json
+++ b/packages/opentelemetry-sdk-trace-web/tsconfig.json
@@ -6,6 +6,7 @@
       "dom",
       "dom.iterable"
     ],
+    "types": ["node", "mocha", "webpack-env", "jquery"],
     "outDir": "build",
     "rootDir": "."
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,6 +24,9 @@
     "strict": true,
     "strictNullChecks": true,
     "target": "es2022",
+    // The types used by most workspaces. A workspace that requires more can
+    // add its own.
+    "types": ["node", "mocha", "webpack-env"],
     "useUnknownInCatchVariables": false,
     "lib": [
       "es2022"


### PR DESCRIPTION
We use typescript v5 for compilation. However, sometimes external
tooling like an IDE will, by default, use the latest TS version for
editor support (like "squigglies" for lint/problems). This is the
case for VS Code and TS v6.

TS v6 changed the "types" tsconfig setting to default to `[]`.
  https://devblogs.microsoft.com/typescript/announcing-typescript-6-0/#types-now-defaults-to-[]
It previously defaulted to "enumerate everything in node_modules/@types".

As (mild) preparation for eventually migrating to TS v6 and
to be nice to developers whose IDE or other tool defaults to using TS
v6, let's explicitly list our "types".

I don't believe there is a downside to this, other than needing
to add "types" entries as usage changes.
