### PR TITLE
feat(exporter-prometheus): add config option for default aggregation

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -14,6 +14,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :rocket: Features
 
+* feat(exporter-prometheus): support configuring the default aggregation [#6761](https://github.com/open-telemetry/opentelemetry-js/pull/6761) @ArthurSens
+
 ### :bug: Bug Fixes
 
 * fix(sdk-node): pass all config properties to log record exporters in declarative config [#6708](https://github.com/open-telemetry/opentelemetry-js/pull/6708) @MikeGoldsmith

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -10,12 +10,19 @@ import {
   AggregationType,
   MetricReader,
 } from '@opentelemetry/sdk-metrics';
+import type { AggregationSelector } from '@opentelemetry/sdk-metrics';
 import type { IncomingMessage, Server, ServerResponse } from 'http';
 import { createServer } from 'http';
 import type { ExporterConfig } from './export/types';
 import { PrometheusSerializer } from './PrometheusSerializer';
 /** Node.js v8.x compat */
 import { URL } from 'url';
+
+const DEFAULT_AGGREGATION_SELECTOR: AggregationSelector = _instrumentType => {
+  return {
+    type: AggregationType.DEFAULT,
+  };
+};
 
 export class PrometheusExporter extends MetricReader {
   static readonly DEFAULT_OPTIONS = {
@@ -53,11 +60,8 @@ export class PrometheusExporter extends MetricReader {
     callback: (error: Error | void) => void = () => {}
   ) {
     super({
-      aggregationSelector: _instrumentType => {
-        return {
-          type: AggregationType.DEFAULT,
-        };
-      },
+      aggregationSelector:
+        config.defaultAggregation ?? DEFAULT_AGGREGATION_SELECTOR,
       aggregationTemporalitySelector: _instrumentType =>
         AggregationTemporality.CUMULATIVE,
       metricProducers: config.metricProducers,

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/export/types.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/export/types.ts
@@ -3,12 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { MetricProducer } from '@opentelemetry/sdk-metrics';
+import type {
+  AggregationSelector,
+  MetricProducer,
+} from '@opentelemetry/sdk-metrics';
 
 /**
  * Configuration interface for prometheus exporter
  */
 export interface ExporterConfig {
+  /**
+   * Default aggregation to use as a function of instrument kind.
+   * @default AggregationType.DEFAULT
+   */
+  defaultAggregation?: AggregationSelector;
+
   /**
    * App prefix for metrics, if needed
    *

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -4,7 +4,12 @@
  */
 
 import type { Counter, Meter, ObservableResult } from '@opentelemetry/api';
-import { MeterProvider } from '@opentelemetry/sdk-metrics';
+import {
+  AggregationType,
+  InstrumentType,
+  MeterProvider,
+} from '@opentelemetry/sdk-metrics';
+import type { AggregationOption } from '@opentelemetry/sdk-metrics';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as http from 'http';
@@ -78,6 +83,35 @@ describe('PrometheusExporter', () => {
     it('should not start the server if preventServerStart is passed as an option', () => {
       const exporter = new PrometheusExporter({ preventServerStart: true });
       assert.ok(exporter['_server'].listening === false);
+    });
+
+    it('should use default aggregation when no defaultAggregation is configured', () => {
+      const exporter = new PrometheusExporter({ preventServerStart: true });
+
+      assert.deepStrictEqual(
+        exporter.selectAggregation(InstrumentType.COUNTER),
+        {
+          type: AggregationType.DEFAULT,
+        }
+      );
+    });
+
+    it('should use configured defaultAggregation', () => {
+      const aggregation: AggregationOption = {
+        type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,
+        options: {
+          boundaries: [0, 100, 100000],
+        },
+      };
+      const exporter = new PrometheusExporter({
+        defaultAggregation: _instrumentType => aggregation,
+        preventServerStart: true,
+      });
+
+      assert.strictEqual(
+        exporter.selectAggregation(InstrumentType.HISTOGRAM),
+        aggregation
+      );
     });
   });
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Adds support for configuring the Prometheus exporter's MetricReader default aggregation as a function of instrument kind.
This implements the behavior described in the Prometheus exporter spec section being stabilized in open-telemetry/opentelemetry-specification#5113


Fixes # (issue)

## Short description of the changes


- Adds a `defaultAggregation` option to `PrometheusExporter` config.
- Passes the configured aggregation selector through to the underlying `MetricReader`.
- Keeps the existing default behavior by using SDK default aggregation when no option is configured.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] `npm run compile --workspace=@opentelemetry/exporter-prometheus`
- [x] `npm run lint --workspace=@opentelemetry/exporter-prometheus -- --quiet`
- [x] `npm test -- --grep "defaultAggregation|default aggregation|configured defaultAggregation"`

## Checklist:

- [ ] Followed the style guidelines of this project
- [ ] Unit tests have been added
- [ ] Documentation has been updated

---

Disclaimer: This PR was assisted by LLMs