### PR TITLE
ci: drop 'filter: tree:0' on actions/checkout, it is more work than the default

### DIFF
--- a/.github/workflows/zizmor-check.yml
+++ b/.github/workflows/zizmor-check.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          filter: 'tree:0'
           persist-credentials: false
 
       - name: Run zizmor


### PR DESCRIPTION
By default https://github.com/actions/checkout sets `fetch-depth: 1` which roughly translates to `git clone --depth=1 git@github.com:open-telemetry/opentelemetry-js-contrib.git`.
In my understanding that is a *faster and smaller*.

Just `--depth=1` (the default behaviour of actions/checkout):

```
% git clone --depth=1 git@github.com:open-telemetry/opentelemetry-js-contrib.git ojc-depth-1
Cloning into 'ojc-depth-1'...
remote: Enumerating objects: 1563, done.
remote: Counting objects: 100% (1563/1563), done.
remote: Compressing objects: 100% (1143/1143), done.
remote: Total 1563 (delta 448), reused 1221 (delta 365), pack-reused 0 (from 0)
Receiving objects: 100% (1563/1563), 9.45 MiB | 13.32 MiB/s, done.
Resolving deltas: 100% (448/448), done.
```

Just `--filter=tree:0`:

```
% git clone --filter=tree:0 git@github.com:open-telemetry/opentelemetry-js-contrib.git ojc-filtertree0
Cloning into 'ojc-filtertree0'...
remote: Enumerating objects: 2767, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 2767 (delta 0), reused 0 (delta 0), pack-reused 2763 (from 3)
Receiving objects: 100% (2767/2767), 1.82 MiB | 6.86 MiB/s, done.
Resolving deltas: 100% (6/6), done.
remote: Enumerating objects: 355, done.
remote: Counting objects: 100% (83/83), done.
remote: Compressing objects: 100% (83/83), done.
remote: Total 355 (delta 0), reused 1 (delta 0), pack-reused 272 (from 2)
Receiving objects: 100% (355/355), 62.25 KiB | 204.00 KiB/s, done.
Resolving deltas: 100% (1/1), done.
remote: Enumerating objects: 1207, done.
remote: Counting objects: 100% (359/359), done.
remote: Compressing objects: 100% (258/258), done.
remote: Total 1207 (delta 176), reused 101 (delta 101), pack-reused 848 (from 3)
Receiving objects: 100% (1207/1207), 9.39 MiB | 10.85 MiB/s, done.
Resolving deltas: 100% (439/439), done.
Updating files: 100% (1399/1399), done.
```

Both options (which is what I think is run with `filter: 'tree:0'`):

```
% git clone --filter=tree:0 --depth=1 git@github.com:open-telemetry/opentelemetry-js-contrib.git ojc-filtertree0-depth1
Cloning into 'ojc-filtertree0-depth1'...
remote: Enumerating objects: 1, done.
remote: Counting objects: 100% (1/1), done.
remote: Total 1 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (1/1), done.
remote: Enumerating objects: 355, done.
remote: Counting objects: 100% (355/355), done.
remote: Compressing objects: 100% (307/307), done.
remote: Total 355 (delta 1), reused 273 (delta 1), pack-reused 0 (from 0)
Receiving objects: 100% (355/355), 62.25 KiB | 897.00 KiB/s, done.
Resolving deltas: 100% (1/1), done.
remote: Enumerating objects: 1207, done.
remote: Counting objects: 100% (1207/1207), done.
remote: Compressing objects: 100% (835/835), done.
remote: Total 1207 (delta 409), reused 948 (delta 364), pack-reused 0 (from 0)
Receiving objects: 100% (1207/1207), 9.40 MiB | 8.45 MiB/s, done.
Resolving deltas: 100% (409/409), done.
Updating files: 100% (1399/1399), done.
```

The --depth=1 (the default) is the smallest:

```
% du -sh *
 31M	ojc-depth-1
 33M	ojc-filtertree0
 32M	ojc-filtertree0-depth1
```