### PR TITLE
fix(sdk-logs): avoid null _currentExport access in _flushAll

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -26,6 +26,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * fix(browser-detector): use the right semantic convention for user agent resource attribute [#6729](https://github.com/open-telemetry/opentelemetry-js/pull/6729) @david-luna
 * fix(browser-detector): user agent resource attribute always [#6754](https://github.com/open-telemetry/opentelemetry-js/pull/6754) @david-luna
 * fix(opentelemetry-exporter-prometheus): handle additional edge cases in metric name conversion [#6727](https://github.com/open-telemetry/opentelemetry-js/pull/6727) @cjihrig
+* fix(sdk-logs): avoid null dereference in `BatchLogRecordProcessor._flushAll` when an in-flight export completes between awaits [#6763](https://github.com/open-telemetry/opentelemetry-js/pull/6763) @Janealter
 
 ### :books: Documentation
 

--- a/experimental/packages/sdk-logs/src/export/BatchLogRecordProcessorBase.ts
+++ b/experimental/packages/sdk-logs/src/export/BatchLogRecordProcessorBase.ts
@@ -209,11 +209,14 @@ export abstract class BatchLogRecordProcessorBase<T extends BufferConfig>
     // Clear timer to prevent concurrent exports
     this._clearTimer();
 
-    // Wait for any in-progress export to complete
-    if (this._currentExport !== null) {
+    // Wait for any in-progress export to complete. Capture the reference
+    // into a local because `_exportOneBatch` may null out `this._currentExport`
+    // from its completion handler while we are awaiting below.
+    const inFlight = this._currentExport;
+    if (inFlight !== null) {
       // speed up execution for current export
       await this._exporter.forceFlush();
-      await this._currentExport.exportCompleted;
+      await inFlight.exportCompleted;
       this._currentExport = null;
     }
 

--- a/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
@@ -537,6 +537,68 @@ describe('BatchLogRecordProcessorBase', () => {
       await processor.shutdown();
     });
 
+    it('should not throw when in-flight export completes between awaits in _flushAll', async () => {
+      // arrange
+      // Reproduces a race in _flushAll: when forceFlush() is called while a
+      // background export is in progress, _flushAll captures the in-flight
+      // export via `this._currentExport`. While awaiting `_exporter.forceFlush()`,
+      // the in-flight export may complete and `_exportOneBatch`'s completion
+      // handler nullifies `_currentExport`. When `_flushAll` resumes and reads
+      // `this._currentExport.exportCompleted`, it would dereference null.
+      let exportCallback: ((result: ExportResult) => void) | undefined;
+      let resolveExporterForceFlush: (() => void) | undefined;
+      const customExporter: LogRecordExporter = {
+        export: (_logs, callback) => {
+          // keep export pending so we can resolve it later
+          exportCallback = callback;
+        },
+        shutdown: async () => {},
+        forceFlush: () =>
+          new Promise<void>(resolve => {
+            // keep exporter.forceFlush() pending so _flushAll stays in await
+            resolveExporterForceFlush = resolve;
+          }),
+      };
+      const processor = new BatchLogRecordProcessor(customExporter, {
+        maxExportBatchSize: 1,
+        scheduledDelayMillis: 2500,
+      });
+
+      // trigger a background export by filling a batch
+      processor.onEmit(createLogRecord());
+      // yield so _exportOneBatch starts and exporter.export() is called
+      await new Promise(resolve => setTimeout(resolve, 0));
+      assert.ok(
+        exportCallback !== undefined,
+        'expected exporter.export() to have been called'
+      );
+
+      // call forceFlush — _flushAll will await exporter.forceFlush()
+      const flushPromise = processor.forceFlush();
+      // yield so _flushAll enters its await on exporter.forceFlush()
+      await new Promise(resolve => setTimeout(resolve, 0));
+      assert.ok(
+        resolveExporterForceFlush !== undefined,
+        'expected exporter.forceFlush() to have been called'
+      );
+
+      // complete the in-flight export — _exportOneBatch's .then handler
+      // will nullify _currentExport before _flushAll resumes
+      exportCallback({ code: ExportResultCode.SUCCESS });
+      // yield to let the .then() handler run and set _currentExport = null
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      // now resume _flushAll by resolving the exporter.forceFlush() promise.
+      // After the bug, _flushAll would read `this._currentExport.exportCompleted`
+      // and throw `Cannot read properties of null (reading 'exportCompleted')`.
+      resolveExporterForceFlush();
+
+      // assert — forceFlush must resolve, not reject with TypeError
+      await flushPromise;
+
+      await processor.shutdown();
+    });
+
     it('should not call forceFlush on exporter when queue is empty and no export in progress', async function () {
       // arrange
       const forceFlushSpy = sinon.spy(exporter, 'forceFlush');


### PR DESCRIPTION
## Which problem is this PR solving?

`BatchLogRecordProcessor._flushAll` can throw `TypeError: Cannot read
properties of null (reading 'exportCompleted')` when a `forceFlush()` call
races against the natural completion of a background export.

### Reproduction

1. The processor has a background export in flight (started by the
   scheduled-delay timer or because a batch filled up). `_exportOneBatch`
   set `this._currentExport = exportOp` and attached
   `exportOp.exportCompleted.then(() => { this._currentExport = null; … })`
   as a fire-and-forget completion handler.
2. `forceFlush()` is called and enters `_flushAll()`. The check
   `if (this._currentExport !== null)` passes, and the code awaits
   `this._exporter.forceFlush()`.
3. **While that await is pending**, the in-flight export completes and the
   `.then` handler above runs, setting `this._currentExport = null`.
4. `_flushAll()` resumes and evaluates
   `await this._currentExport.exportCompleted`. `this._currentExport` is now
   `null`, throwing `TypeError`.

In browsers this surfaces as an *unhandled* rejection because the browser
`BatchLogRecordProcessor` registers `visibilitychange`/`pagehide` listeners
that call `void this.forceFlush()` (no `.catch()` attached). Users
tab-switching during normal usage trigger the race very frequently in
production.

The same race is reachable from `_shutdown()` (which also calls
`_flushAll()`).

### Affected versions

Introduced by #6356 (`feat(sdk-logs)!: invoke exporter forceFlush without
first awaiting export`), shipped in `@opentelemetry/sdk-logs@0.215.0`. The
same code path is unchanged on `main` (verified against `0.215.0` through
`0.218.0` and HEAD).

## Short description of the changes

- Capture `this._currentExport` into a local `inFlight` const **before** the
  awaits, then dereference the local. The trailing
  `this._currentExport = null` is kept so the field still reflects "no
  in-flight" once the wait is done (idempotent if the completion handler
  already nulled it).
- Added a unit test in `test/common/export/BatchLogRecordProcessor.test.ts`
  (`should not throw when in-flight export completes between awaits in
  _flushAll`) that deterministically reproduces the race using a custom
  exporter with controllable `export` and `forceFlush` resolutions.

Without the fix, the new test fails with
`TypeError: Cannot read properties of null (reading 'exportCompleted')`
at the exact line affected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- New unit test added that deterministically interleaves a `forceFlush()`
  call with the completion of a background export. Test fails on `main`
  with the exact upstream error, passes with the fix.
- All existing `@opentelemetry/sdk-logs` common tests still pass
  (`nx run @opentelemetry/sdk-logs:test` — 198 passing).
- `nx run @opentelemetry/sdk-logs:lint` passes.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] CHANGELOG entry added under `experimental/CHANGELOG.md` → Unreleased →
      Bug Fixes