### PR TITLE
fix(core): guard timeInputToHrTime against clock-skew misclassification (#6772)

### DIFF
--- a/packages/opentelemetry-core/src/common/time.ts
+++ b/packages/opentelemetry-core/src/common/time.ts
@@ -67,10 +67,9 @@ export function timeInputToHrTime(time: api.TimeInput): api.HrTime {
     // document/process started, so it is bounded by system uptime. No real
     // system has been running long enough for performance.now() to reach half
     // the current epoch time (~1994 in ms terms). We therefore treat any value
-    // that is both less than performance.timeOrigin AND less than half of
-    // performance.timeOrigin as a relative performance.now() reading, and
-    // everything else as an absolute epoch-millisecond timestamp.
-    if (time < performance.timeOrigin && time < performance.timeOrigin / 2) {
+    // below half of performance.timeOrigin as a relative performance.now()
+    // reading, and everything else as an absolute epoch-millisecond timestamp.
+    if (time < performance.timeOrigin / 2) {
       return hrTime(time);
     } else {
       // epoch milliseconds or performance.timeOrigin

--- a/packages/opentelemetry-core/src/common/time.ts
+++ b/packages/opentelemetry-core/src/common/time.ts
@@ -54,8 +54,23 @@ export function timeInputToHrTime(time: api.TimeInput): api.HrTime {
   if (isTimeInputHrTime(time)) {
     return time as api.HrTime;
   } else if (typeof time === 'number') {
-    // Must be a performance.now() if it's smaller than process start time.
-    if (time < performance.timeOrigin) {
+    // Distinguish between a relative performance.now() value and an absolute
+    // epoch-millisecond timestamp.
+    //
+    // performance.timeOrigin uses a monotonic clock that may be slightly ahead
+    // of Date.now() due to clock adjustments (see MDN docs). This means a
+    // real epoch-ms value (e.g. Date.now()) can land just below
+    // performance.timeOrigin, causing it to be misclassified as a relative
+    // performance.now() reading and doubled when timeOrigin is added.
+    //
+    // A genuine performance.now() value represents elapsed time since the
+    // document/process started, so it is bounded by system uptime. No real
+    // system has been running long enough for performance.now() to reach half
+    // the current epoch time (~1994 in ms terms). We therefore treat any value
+    // that is both less than performance.timeOrigin AND less than half of
+    // performance.timeOrigin as a relative performance.now() reading, and
+    // everything else as an absolute epoch-millisecond timestamp.
+    if (time < performance.timeOrigin && time < performance.timeOrigin / 2) {
       return hrTime(time);
     } else {
       // epoch milliseconds or performance.timeOrigin

--- a/packages/opentelemetry-core/test/common/time.test.ts
+++ b/packages/opentelemetry-core/test/common/time.test.ts
@@ -120,6 +120,21 @@ describe('time', () => {
       assert.deepStrictEqual(output, [0, 123400000]);
     });
 
+    it('should treat an epoch-ms timestamp as epoch even when it falls just below performance.timeOrigin due to clock skew', () => {
+      // Simulate the scenario reported in issue #6772: performance.timeOrigin
+      // uses a monotonic clock and can be slightly ahead of Date.now() at page
+      // load, causing a real epoch-ms value to be misclassified as a relative
+      // performance.now() reading and doubled.
+      const epochMs = 1779958953234; // a real Date.now()-style timestamp
+      // Set timeOrigin to a value slightly larger than epochMs to reproduce
+      // the clock-skew window.
+      sinon.stub(performance, 'timeOrigin').value(epochMs + 100);
+
+      const output = timeInputToHrTime(epochMs);
+      // Should decode as epoch seconds + remainder nanoseconds, NOT doubled.
+      assert.deepStrictEqual(output, [1779958953, 234000000]);
+    });
+
     it('should not convert hrtime hrTime', () => {
       sinon.stub(performance, 'timeOrigin').value(111.5);
 


### PR DESCRIPTION
## Which problem is this PR solving?

`timeInputToHrTime` distinguishes a relative `performance.now()` reading
from an absolute epoch-ms timestamp by checking `time < performance.timeOrigin`.
`performance.timeOrigin` uses a monotonic clock that can be slightly ahead of
`Date.now()` at page load. In this narrow skew window, a real epoch-ms value
satisfies the condition, has `timeOrigin` added on top, and the result is roughly
doubled. Users reported `timeUnixNano` values ~2× correct on initial Angular page load.

Fixes #6772

## Short description of the changes

Tighten the `performance.now()` heuristic so a value must also be less than
`performance.timeOrigin / 2` before being treated as relative. A genuine
`performance.now()` value is bounded by system uptime and cannot plausibly
reach half the current epoch (~year 1994).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

New unit test in `packages/opentelemetry-core/test/common/time.test.ts` stubs
`performance.timeOrigin` to 100ms above a realistic `Date.now()` and asserts
`timeInputToHrTime` returns the correct epoch-decomposed value, not a doubled one.
All 33 existing tests in the `#time` suite continue to pass.

- [x] Test added to reproduce the clock-skew misclassification

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated