### PR TITLE
chore: tsconfig file reformat, follow-up from #6758

### DIFF
--- a/packages/opentelemetry-sdk-trace-web/tsconfig.esm.json
+++ b/packages/opentelemetry-sdk-trace-web/tsconfig.esm.json
@@ -6,10 +6,15 @@
       "dom",
       "dom.iterable"
     ],
-    "types": ["node", "mocha", "webpack-env", "jquery"],
     "outDir": "build/esm",
     "rootDir": "src",
-    "tsBuildInfoFile": "build/esm/tsconfig.esm.tsbuildinfo"
+    "tsBuildInfoFile": "build/esm/tsconfig.esm.tsbuildinfo",
+    "types": [
+      "node",
+      "mocha",
+      "webpack-env",
+      "jquery"
+    ]
   },
   "include": [
     "src/**/*.ts"

--- a/packages/opentelemetry-sdk-trace-web/tsconfig.esnext.json
+++ b/packages/opentelemetry-sdk-trace-web/tsconfig.esnext.json
@@ -6,10 +6,15 @@
       "dom",
       "dom.iterable"
     ],
-    "types": ["node", "mocha", "webpack-env", "jquery"],
     "outDir": "build/esnext",
     "rootDir": "src",
-    "tsBuildInfoFile": "build/esnext/tsconfig.esnext.tsbuildinfo"
+    "tsBuildInfoFile": "build/esnext/tsconfig.esnext.tsbuildinfo",
+    "types": [
+      "node",
+      "mocha",
+      "webpack-env",
+      "jquery"
+    ]
   },
   "include": [
     "src/**/*.ts"

--- a/packages/opentelemetry-sdk-trace-web/tsconfig.json
+++ b/packages/opentelemetry-sdk-trace-web/tsconfig.json
@@ -6,9 +6,14 @@
       "dom",
       "dom.iterable"
     ],
-    "types": ["node", "mocha", "webpack-env", "jquery"],
     "outDir": "build",
-    "rootDir": "."
+    "rootDir": ".",
+    "types": [
+      "node",
+      "mocha",
+      "webpack-env",
+      "jquery"
+    ]
   },
   "files": [],
   "include": [


### PR DESCRIPTION
No functional change.
PR #6758 changed these tsconfig files, but did not re-run
'npm run update-ts-configs' that normalizes these files.
