### PR TITLE
docs(exporter-trace-otlp-grpc): import CompressionAlgorithm from otlp-exporter-base

### DIFF
--- a/experimental/packages/exporter-trace-otlp-grpc/README.md
+++ b/experimental/packages/exporter-trace-otlp-grpc/README.md
@@ -179,7 +179,7 @@ The OTLPTraceExporter has a timeout configuration option which is the maximum ti
 By default no compression will be used. To use compression, set it programmatically in `collectorOptions` or with environment variables. Supported compression options: `gzip` and `none`.
 
 ```js
-const { CompressionAlgorithm } = require('@opentelemetry/exporter-trace-otlp-grpc');
+const { CompressionAlgorithm } = require('@opentelemetry/otlp-exporter-base');
 
 const collectorOptions = {
   // url is optional and can be omitted - default is http://localhost:4317


### PR DESCRIPTION
The compression example in the gRPC exporter README imports `CompressionAlgorithm` from `@opentelemetry/exporter-trace-otlp-grpc`, but that package only exports `OTLPTraceExporter`, so `CompressionAlgorithm` ends up `undefined` and `CompressionAlgorithm.GZIP` throws. It's exported from `@opentelemetry/otlp-exporter-base`, so I pointed the import there.

Docs-only, no code change.