### PR TITLE
fix(sdk-node)!: remove `buildSamplerFromConfig` export

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
   * It is now the responsibility of the user of a parsed declarative config object, typically just the `sdk-node` package, to handle `null` values.
 * fix(api-logs)!: Removed `NOOP_LOGGER` and `NoopLogger` exports from `@opentelemetry/api-logs`. Use `createNoopLogger(): Logger` instead. [#6713](https://github.com/open-telemetry/opentelemetry-js/pull/6713) @dyladan
 * feat(api-logs)!: rename scopeAttributes to attributes in LoggerOptions [#6573](https://github.com/open-telemetry/opentelemetry-js/pull/6573) @pichlermarc
+* fix(sdk-node)!: remove `buildSamplerFromConfig` export
 
 ### :rocket: Features
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,7 +12,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
   * It is now the responsibility of the user of a parsed declarative config object, typically just the `sdk-node` package, to handle `null` values.
 * fix(api-logs)!: Removed `NOOP_LOGGER` and `NoopLogger` exports from `@opentelemetry/api-logs`. Use `createNoopLogger(): Logger` instead. [#6713](https://github.com/open-telemetry/opentelemetry-js/pull/6713) @dyladan
 * feat(api-logs)!: rename scopeAttributes to attributes in LoggerOptions [#6573](https://github.com/open-telemetry/opentelemetry-js/pull/6573) @pichlermarc
-* fix(sdk-node)!: remove `buildSamplerFromConfig` export
+* fix(sdk-node)!: remove `buildSamplerFromConfig` export [#6784](https://github.com/open-telemetry/opentelemetry-js/pull/6784) @trentm
 
 ### :rocket: Features
 

--- a/experimental/packages/opentelemetry-sdk-node/src/index.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/index.ts
@@ -23,4 +23,3 @@ export { NodeSDK } from './sdk';
 export type { LoggerProviderConfig, MeterProviderConfig } from './sdk';
 export type { NodeSDKConfiguration } from './types';
 export { startNodeSDK } from './start';
-export { buildSamplerFromConfig } from './utils';


### PR DESCRIPTION
This export was added in https://github.com/open-telemetry/opentelemetry-js/pull/6536
In early commits on that PR the functionality was added to the
sdk-trace-base package, where an export would be necessary for sdk-node
to use it for declarative config "create()".
However, buildSamplerFromConfig was ultimately placed in sdk-node,
which is the only expected place it will be used, at least currently.

I don't think we need to export "build an SDK element from declarative
Configuration properties" utilities *yet*. Not until there is an
expectation of their being used outside of sdk-node, and us wanting
to accept the extra maintenance surface area.
