### PR TITLE
fix: apply spec-defined BLRP schedule_delay default in sdk-node, default log_level in env config

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -21,6 +21,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-node): apply spec-defined `schedule_delay: 1000` default for BatchLogRecordProcessor from declarative config (SDK defaults to 5000) [#TBD] @MikeGoldsmith
+* fix(configuration): default `log_level` to `info` in env-based config initialization for consistency with file-based config [#TBD] @MikeGoldsmith
 * fix(sdk-node): pass all config properties to log record exporters in declarative config [#6708](https://github.com/open-telemetry/opentelemetry-js/pull/6708) @MikeGoldsmith
 * fix(sdk-node): warn and ignore zero exporter timeout in declarative config [#6711](https://github.com/open-telemetry/opentelemetry-js/pull/6711) @MikeGoldsmith
 * fix(sdk-node): pass gRPC credentials and headers to span exporter in declarative config [#6705](https://github.com/open-telemetry/opentelemetry-js/pull/6705) @MikeGoldsmith

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -21,8 +21,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
-* fix(sdk-node): apply spec-defined `schedule_delay: 1000` default for BatchLogRecordProcessor from declarative config (SDK defaults to 5000) [#TBD] @MikeGoldsmith
-* fix(configuration): default `log_level` to `info` in env-based config initialization for consistency with file-based config [#TBD] @MikeGoldsmith
+* fix(sdk-node): apply spec-defined `schedule_delay: 1000` default for BatchLogRecordProcessor from declarative config (SDK defaults to 5000) [#6788](https://github.com/open-telemetry/opentelemetry-js/pull/6788) @MikeGoldsmith
+* fix(configuration): default `log_level` to `info` in env-based config initialization for consistency with file-based config [#6788](https://github.com/open-telemetry/opentelemetry-js/pull/6788) @MikeGoldsmith
 * fix(sdk-node): pass all config properties to log record exporters in declarative config [#6708](https://github.com/open-telemetry/opentelemetry-js/pull/6708) @MikeGoldsmith
 * fix(sdk-node): warn and ignore zero exporter timeout in declarative config [#6711](https://github.com/open-telemetry/opentelemetry-js/pull/6711) @MikeGoldsmith
 * fix(sdk-node): pass gRPC credentials and headers to span exporter in declarative config [#6705](https://github.com/open-telemetry/opentelemetry-js/pull/6705) @MikeGoldsmith

--- a/experimental/packages/configuration/src/utils.ts
+++ b/experimental/packages/configuration/src/utils.ts
@@ -58,6 +58,7 @@ export function getGrpcTlsConfig(
 export function initializeDefaultConfiguration(): ConfigurationModel {
   return {
     disabled: false,
+    log_level: 'info',
     resource: {},
     attribute_limits: {
       attribute_count_limit: 128,

--- a/experimental/packages/configuration/test/EnvironmentConfigFactory.test.ts
+++ b/experimental/packages/configuration/test/EnvironmentConfigFactory.test.ts
@@ -17,6 +17,7 @@ import {
 
 const defaultConfig: ConfigurationModel = {
   disabled: false,
+  log_level: 'info',
   resource: {},
   attribute_limits: {
     attribute_count_limit: 128,

--- a/experimental/packages/configuration/test/FileConfigFactory.test.ts
+++ b/experimental/packages/configuration/test/FileConfigFactory.test.ts
@@ -11,6 +11,7 @@ import { parseConfigFile } from '../src/FileConfigFactory';
 
 const defaultConfig: ConfigurationModel = {
   disabled: false,
+  log_level: 'info',
   resource: {},
   attribute_limits: {
     attribute_count_limit: 128,

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -708,7 +708,10 @@ export function getLogRecordProcessorsFromConfiguration(
             maxQueueSize: processor.batch.max_queue_size ?? undefined,
             maxExportBatchSize:
               processor.batch.max_export_batch_size ?? undefined,
-            scheduledDelayMillis: processor.batch.schedule_delay ?? undefined,
+            // The SDK's BatchLogRecordProcessor defaults schedule_delay to
+            // 5000ms (same as BSP), but the OTel config spec says BLRP
+            // defaults to 1000ms. Apply the spec-defined default here.
+            scheduledDelayMillis: processor.batch.schedule_delay ?? 1000,
             exportTimeoutMillis: processor.batch.export_timeout ?? undefined,
           })
         );


### PR DESCRIPTION
## Which problem is this PR solving?

Two small fixes for spec-conformance gaps, split out from #6717 (now closed) per Trent's preferred direction in #6765: defaults should be applied at the consumer boundary (sdk-node), not in the parse step of the `configuration` package.

### 1. BatchLogRecordProcessor schedule_delay

The OTel config spec defines `schedule_delay` for `BatchLogRecordProcessor` as 1000ms. The JS SDK's `BatchLogRecordProcessorBase` defaults it to 5000ms (same as BSP), which is an SDK-level divergence from spec. Apply the correct 1000ms default at the consumer boundary in `getLogRecordProcessorsFromConfiguration`.

### 2. log_level default for env config

`FileConfigFactory.parseConfigFile()` produces a model with `log_level: 'info'` when the field is absent from the YAML. `EnvironmentConfigFactory` did not have a matching default, so env-based configs produced models without `log_level` set unless `OTEL_LOG_LEVEL` was provided. Adding the default in `initializeDefaultConfiguration()` makes env and file config consistent.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- 82 configuration package tests pass
- 195 sdk-node tests pass
- Full lint passes