### PR TITLE
fix(ci): supply-chain sec: disable caching in release-related workflow

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -22,6 +22,8 @@ jobs:
           # Require npm 11.5.1 or later for https://docs.npmjs.com/trusted-publishers.
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
+          # Disable caching in release workflows (https://docs.zizmor.sh/audits/#cache-poisoning).
+          package-manager-cache: false
       - run: npm ci --ignore-scripts
       - run: npm run compile
       # Release Please has already incremented versions and published tags, so we just


### PR DESCRIPTION
I'd done similar earlier for other workflows that release artifacts:

```
% rg package-manager-cache
docs.yaml
25:          package-manager-cache: false

sbom.yml
26:          package-manager-cache: false
```

but for some reason neglected this workflow that does the primary `npm publish` releasing.