### PR TITLE
chore(renovate): set minimumReleaseAge to 3 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -55,5 +55,5 @@
   "labels": ["dependencies"],
   "ignorePaths": ["**/bundler-tests/**"],
   "postUpdateOptions": ["npmDedupe"],
-  "minimumReleaseAge": "1 week"
+  "minimumReleaseAge": "3 days"
 }


### PR DESCRIPTION
Since the min release age is 7 days, we can't merge the lockfile renovate PR becase it gets updated every 7 days.
3 days should be fine. That'll give us enough time to avoid any new issues, but still keep it under the 7 day schedule.