### PR TITLE
fix(sdk-logs): default BatchLogRecordProcessor `scheduleDelayMillis` is 1000

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-logs): default BatchLogRecordProcessor `scheduleDelayMillis` is 1000
 * fix(configuration): percent-decode keys and values in `resource.attributes_list` per spec [#6787](https://github.com/open-telemetry/opentelemetry-js/pull/6787) @MikeGoldsmith
 * fix(sdk-node): apply spec-defined `schedule_delay: 1000` default for BatchLogRecordProcessor from declarative config (SDK defaults to 5000) [#6788](https://github.com/open-telemetry/opentelemetry-js/pull/6788) @MikeGoldsmith
 * fix(configuration): default `log_level` to `info` in env-based config initialization for consistency with file-based config [#6788](https://github.com/open-telemetry/opentelemetry-js/pull/6788) @MikeGoldsmith

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -708,10 +708,7 @@ export function getLogRecordProcessorsFromConfiguration(
             maxQueueSize: processor.batch.max_queue_size ?? undefined,
             maxExportBatchSize:
               processor.batch.max_export_batch_size ?? undefined,
-            // The SDK's BatchLogRecordProcessor defaults schedule_delay to
-            // 5000ms (same as BSP), but the OTel config spec says BLRP
-            // defaults to 1000ms. Apply the spec-defined default here.
-            scheduledDelayMillis: processor.batch.schedule_delay ?? 1000,
+            scheduledDelayMillis: processor.batch.schedule_delay ?? undefined,
             exportTimeoutMillis: processor.batch.export_timeout ?? undefined,
           })
         );

--- a/experimental/packages/sdk-logs/src/export/BatchLogRecordProcessorBase.ts
+++ b/experimental/packages/sdk-logs/src/export/BatchLogRecordProcessorBase.ts
@@ -142,7 +142,7 @@ export abstract class BatchLogRecordProcessorBase<T extends BufferConfig>
     this._exporter = exporter;
     this._maxExportBatchSize = config?.maxExportBatchSize ?? 512;
     this._maxQueueSize = config?.maxQueueSize ?? 2048;
-    this._scheduledDelayMillis = config?.scheduledDelayMillis ?? 5000;
+    this._scheduledDelayMillis = config?.scheduledDelayMillis ?? 1000;
     this._exportTimeoutMillis = config?.exportTimeoutMillis ?? 30000;
 
     this._shutdownOnce = new BindOnceFuture(this._shutdown, this);

--- a/experimental/packages/sdk-logs/src/types.ts
+++ b/experimental/packages/sdk-logs/src/types.ts
@@ -112,7 +112,7 @@ export interface BufferConfig {
   maxExportBatchSize?: number;
 
   /** The delay interval in milliseconds between two consecutive exports.
-   *  The default value is 5000ms. */
+   *  The default value is 1000ms. */
   scheduledDelayMillis?: number;
 
   /** How long the export can run before it is cancelled.

--- a/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
@@ -113,7 +113,7 @@ describe('BatchLogRecordProcessorBase', () => {
       assert.ok(processor instanceof BatchLogRecordProcessor);
       assert.strictEqual(processor['_maxExportBatchSize'], 512);
       assert.strictEqual(processor['_maxQueueSize'], 2048);
-      assert.strictEqual(processor['_scheduledDelayMillis'], 5000);
+      assert.strictEqual(processor['_scheduledDelayMillis'], 1000);
       assert.strictEqual(processor['_exportTimeoutMillis'], 30000);
       processor.shutdown();
     });


### PR DESCRIPTION
Spec: https://opentelemetry.io/docs/specs/otel/logs/sdk/#batching-processor
(The 5000ms value being used earlier was copied from BatchSpanProcessor.)

After this change, the override value of 1000 in the declarative config
handling in sdk-node is no longer necessary. This reverts part of
https://github.com/open-telemetry/opentelemetry-js/pull/6788


See https://github.com/open-telemetry/opentelemetry-js/pull/6788#issuecomment-4711046649 