### PR TITLE
refactor(sdk-logs, sdk-trace)!: refactor BatchSpanProcessor and BatchLogRecordProcessor constructor signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 * feat(sdk-trace): add a new "sdk-trace" package to hold the Trace SDK, without environment variable configuration handling that belongs elsewhere [#6775](https://github.com/open-telemetry/opentelemetry-js/pull/6775) @trentm
   * "sdk-trace" will eventually replace all of "sdk-trace-base", "sdk-trace-node", and "sdk-trace-web".
+  * The `BatchSpanProcessor` constructor call signature has changed in "sdk-trace".  For example, before `new BatchSpanProcessor(exporter, { maxQueueSize: 1000 })`, after `new BatchSpanProcessor({ exporter, maxQueueSize: 1000 })`. [#6817](https://github.com/open-telemetry/opentelemetry-js/pull/6817)
 
 ### :bug: Bug Fixes
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,6 +44,7 @@ export default tseslint.config(
       // tsd-style negative type-check fixtures, intentionally outside tsconfig.
       'experimental/packages/configuration/test/fixtures/types/**',
       'experimental/packages/otlp-transformer/src/generated/**',
+      'experimental/packages/otlp-transformer/test/generated/**',
       // protobuf-ts generated test fixtures (buf generate output, gitignored).
       'experimental/packages/opentelemetry-instrumentation-grpc/test/proto/**',
       // protobuf-generated example sources.

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -8,6 +8,11 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :boom: Breaking Changes
 
+* refactor(sdk-logs)!: refactor BatchLogRecordProcessor constructor signature [#6817](https://github.com/open-telemetry/opentelemetry-js/pull/6817) @trentm
+  * (user-facing): `BatchLogRecordProcessor` now takes a single options object will all possible properties, instead of two separate arguments. For example, before `new BatchLogRecordProcessor(exporter, { maxQueueSize: 1000 })`, after `new BatchLogRecordProcessor({ exporter, maxQueueSize: 1000 })`.
+  * `interface BufferConfig` -> `interface BatchLogRecordProcessorOptions`, and now includes the `exporter` property
+  * `interface BatchLogRecordProcessorBrowserConfig` -> `interface BatchLogRecordProcessorBrowserOptions`
+
 ### :rocket: Features
 
 ### :bug: Bug Fixes

--- a/experimental/packages/exporter-logs-otlp-grpc/README.md
+++ b/experimental/packages/exporter-logs-otlp-grpc/README.md
@@ -40,7 +40,7 @@ const collectorOptions = {
 
 const loggerExporter = new OTLPLogExporter(collectorOptions);
 const loggerProvider = new LoggerProvider({
-  processors: [new BatchLogRecordProcessor(loggerExporter)]
+  processors: [new BatchLogRecordProcessor({ exporter: loggerExporter })]
 });
 
 ['SIGINT', 'SIGTERM'].forEach(signal => {
@@ -67,7 +67,7 @@ const collectorOptions = {
 
 const loggerExporter = new OTLPLogExporter(collectorOptions);
 const loggerProvider = new LoggerProvider({
-  processors: [new BatchLogRecordProcessor(loggerExporter)]
+  processors: [new BatchLogRecordProcessor({ exporter: loggerExporter })]
 });
 ```
 
@@ -88,7 +88,7 @@ const collectorOptions = {
 
 const loggerExporter = new OTLPLogExporter(collectorOptions);
 const loggerProvider = new LoggerProvider({
-  processors: [new BatchLogRecordProcessor(loggerExporter)]
+  processors: [new BatchLogRecordProcessor({ exporter: loggerExporter })]
 });
 ```
 

--- a/experimental/packages/exporter-logs-otlp-http/README.md
+++ b/experimental/packages/exporter-logs-otlp-http/README.md
@@ -38,7 +38,7 @@ const collectorOptions = {
 };
 const logExporter = new OTLPLogExporter(collectorOptions);
 const loggerProvider = new LoggerProvider({
-  processors: [new BatchRecordProcessor(logExporter)]
+  processors: [new BatchLogRecordProcessor({ exporter: logExporter })]
 });
 
 const logger = loggerProvider.getLogger('default', '1.0.0');
@@ -67,7 +67,7 @@ const collectorOptions = {
 };
 const logExporter = new OTLPLogExporter(collectorOptions);
 const loggerProvider = new LoggerProvider({
-  processors: [new BatchRecordProcessor(logExporter)]
+  processors: [new BatchLogRecordProcessor({ exporter: logExporter })]
 });
 
 const logger = loggerProvider.getLogger('default', '1.0.0');

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -89,7 +89,7 @@ import { OTLPMetricExporter as OTLPGrpcMetricExporter } from '@opentelemetry/exp
 import { OTLPMetricExporter as OTLPHttpMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import { OTLPMetricExporter as OTLPProtoMetricExporter } from '@opentelemetry/exporter-metrics-otlp-proto';
 import type {
-  BufferConfig,
+  BatchLogRecordProcessorOptions,
   LogRecordExporter,
   LoggerProviderOptions,
   LogRecordProcessor,
@@ -626,7 +626,10 @@ export function getLoggerProviderConfigFromEnv(): LoggerProviderOptions {
 /**
  * Get configuration for BatchLogRecordProcessor from environment variables.
  */
-export function getBatchLogRecordProcessorConfigFromEnv(): BufferConfig {
+export function getBatchLogRecordProcessorConfigFromEnv(): Omit<
+  BatchLogRecordProcessorOptions,
+  'exporter'
+> {
   return {
     maxQueueSize: getNonNegativeNumberFromEnv('OTEL_BLRP_MAX_QUEUE_SIZE'),
     scheduledDelayMillis: getNonNegativeNumberFromEnv(
@@ -644,10 +647,10 @@ export function getBatchLogRecordProcessorConfigFromEnv(): BufferConfig {
 export function getBatchLogRecordProcessorFromEnv(
   exporter: LogRecordExporter
 ): BatchLogRecordProcessor {
-  return new BatchLogRecordProcessor(
+  return new BatchLogRecordProcessor({
     exporter,
-    getBatchLogRecordProcessorConfigFromEnv()
-  );
+    ...getBatchLogRecordProcessorConfigFromEnv(),
+  });
 }
 
 export function getLogRecordExporter(
@@ -704,7 +707,8 @@ export function getLogRecordProcessorsFromConfiguration(
       const exporter = getLogRecordExporter(processor.batch.exporter);
       if (exporter) {
         logRecordProcessors.push(
-          new BatchLogRecordProcessor(exporter, {
+          new BatchLogRecordProcessor({
+            exporter,
             maxQueueSize: processor.batch.max_queue_size ?? undefined,
             maxExportBatchSize:
               processor.batch.max_export_batch_size ?? undefined,

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -533,9 +533,9 @@ describe('Node SDK', () => {
       const simpleLogRecordProcessor = new SimpleLogRecordProcessor(
         logRecordExporter
       );
-      const batchLogRecordProcessor = new BatchLogRecordProcessor(
-        logRecordExporter
-      );
+      const batchLogRecordProcessor = new BatchLogRecordProcessor({
+        exporter: logRecordExporter,
+      });
       const sdk = new NodeSDK({
         logRecordProcessors: [
           simpleLogRecordProcessor,

--- a/experimental/packages/sdk-logs/src/export/BatchLogRecordProcessorBase.ts
+++ b/experimental/packages/sdk-logs/src/export/BatchLogRecordProcessorBase.ts
@@ -141,10 +141,10 @@ export abstract class BatchLogRecordProcessorBase<
 
   constructor(options: T) {
     this._exporter = options.exporter;
-    this._maxExportBatchSize = options?.maxExportBatchSize ?? 512;
-    this._maxQueueSize = options?.maxQueueSize ?? 2048;
-    this._scheduledDelayMillis = options?.scheduledDelayMillis ?? 1000;
-    this._exportTimeoutMillis = options?.exportTimeoutMillis ?? 30000;
+    this._maxExportBatchSize = options.maxExportBatchSize ?? 512;
+    this._maxQueueSize = options.maxQueueSize ?? 2048;
+    this._scheduledDelayMillis = options.scheduledDelayMillis ?? 1000;
+    this._exportTimeoutMillis = options.exportTimeoutMillis ?? 30000;
 
     this._shutdownOnce = new BindOnceFuture(this._shutdown, this);
 

--- a/experimental/packages/sdk-logs/src/export/BatchLogRecordProcessorBase.ts
+++ b/experimental/packages/sdk-logs/src/export/BatchLogRecordProcessorBase.ts
@@ -11,7 +11,7 @@ import {
   suppressTracing,
 } from '@opentelemetry/core';
 
-import type { BufferConfig } from '../types';
+import type { BatchLogRecordProcessorOptions } from '../types';
 import type { SdkLogRecord } from './SdkLogRecord';
 import type { LogRecordExporter } from './LogRecordExporter';
 import type { LogRecordProcessor } from '../LogRecordProcessor';
@@ -123,8 +123,9 @@ class ExportOperation {
   }
 }
 
-export abstract class BatchLogRecordProcessorBase<T extends BufferConfig>
-  implements LogRecordProcessor
+export abstract class BatchLogRecordProcessorBase<
+  T extends BatchLogRecordProcessorOptions,
+> implements LogRecordProcessor
 {
   private readonly _maxExportBatchSize: number;
   private readonly _maxQueueSize: number;
@@ -138,12 +139,12 @@ export abstract class BatchLogRecordProcessorBase<T extends BufferConfig>
   private _shutdownOnce: BindOnceFuture<void>;
   private _flushing: boolean = false;
 
-  constructor(exporter: LogRecordExporter, config?: T) {
-    this._exporter = exporter;
-    this._maxExportBatchSize = config?.maxExportBatchSize ?? 512;
-    this._maxQueueSize = config?.maxQueueSize ?? 2048;
-    this._scheduledDelayMillis = config?.scheduledDelayMillis ?? 1000;
-    this._exportTimeoutMillis = config?.exportTimeoutMillis ?? 30000;
+  constructor(options: T) {
+    this._exporter = options.exporter;
+    this._maxExportBatchSize = options?.maxExportBatchSize ?? 512;
+    this._maxQueueSize = options?.maxQueueSize ?? 2048;
+    this._scheduledDelayMillis = options?.scheduledDelayMillis ?? 1000;
+    this._exportTimeoutMillis = options?.exportTimeoutMillis ?? 30000;
 
     this._shutdownOnce = new BindOnceFuture(this._shutdown, this);
 

--- a/experimental/packages/sdk-logs/src/index.ts
+++ b/experimental/packages/sdk-logs/src/index.ts
@@ -9,8 +9,8 @@ export type {
   LoggerConfig,
   LoggerConfigurator,
   LogRecordLimits,
-  BufferConfig,
-  BatchLogRecordProcessorBrowserConfig,
+  BatchLogRecordProcessorOptions,
+  BatchLogRecordProcessorBrowserOptions,
 } from './types';
 export { LoggerProvider } from './LoggerProvider';
 export type { SdkLogRecord } from './export/SdkLogRecord';

--- a/experimental/packages/sdk-logs/src/platform/browser/export/BatchLogRecordProcessor.ts
+++ b/experimental/packages/sdk-logs/src/platform/browser/export/BatchLogRecordProcessor.ts
@@ -32,7 +32,7 @@ export class BatchLogRecordProcessor extends BatchLogRecordProcessorBase<BatchLo
 
   private _onInit(options: BatchLogRecordProcessorBrowserOptions): void {
     if (
-      options?.disableAutoFlushOnDocumentHide === true ||
+      options.disableAutoFlushOnDocumentHide === true ||
       typeof document === 'undefined'
     ) {
       return;

--- a/experimental/packages/sdk-logs/src/platform/browser/export/BatchLogRecordProcessor.ts
+++ b/experimental/packages/sdk-logs/src/platform/browser/export/BatchLogRecordProcessor.ts
@@ -3,20 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { LogRecordExporter } from './../../../export/LogRecordExporter';
-import type { BatchLogRecordProcessorBrowserConfig } from '../../../types';
+import type { BatchLogRecordProcessorBrowserOptions } from '../../../types';
 import { BatchLogRecordProcessorBase } from '../../../export/BatchLogRecordProcessorBase';
 
-export class BatchLogRecordProcessor extends BatchLogRecordProcessorBase<BatchLogRecordProcessorBrowserConfig> {
+export class BatchLogRecordProcessor extends BatchLogRecordProcessorBase<BatchLogRecordProcessorBrowserOptions> {
   private _visibilityChangeListener?: () => void;
   private _pageHideListener?: () => void;
 
-  constructor(
-    exporter: LogRecordExporter,
-    config?: BatchLogRecordProcessorBrowserConfig
-  ) {
-    super(exporter, config);
-    this._onInit(config);
+  constructor(options: BatchLogRecordProcessorBrowserOptions) {
+    super(options);
+    this._onInit(options);
   }
 
   protected onShutdown(): void {
@@ -34,9 +30,9 @@ export class BatchLogRecordProcessor extends BatchLogRecordProcessorBase<BatchLo
     }
   }
 
-  private _onInit(config?: BatchLogRecordProcessorBrowserConfig): void {
+  private _onInit(options: BatchLogRecordProcessorBrowserOptions): void {
     if (
-      config?.disableAutoFlushOnDocumentHide === true ||
+      options?.disableAutoFlushOnDocumentHide === true ||
       typeof document === 'undefined'
     ) {
       return;

--- a/experimental/packages/sdk-logs/src/platform/node/export/BatchLogRecordProcessor.ts
+++ b/experimental/packages/sdk-logs/src/platform/node/export/BatchLogRecordProcessor.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { BufferConfig } from '../../../types';
+import type { BatchLogRecordProcessorOptions } from '../../../types';
 import { BatchLogRecordProcessorBase } from '../../../export/BatchLogRecordProcessorBase';
 
-export class BatchLogRecordProcessor extends BatchLogRecordProcessorBase<BufferConfig> {
+export class BatchLogRecordProcessor extends BatchLogRecordProcessorBase<BatchLogRecordProcessorOptions> {
   protected onShutdown(): void {}
 }

--- a/experimental/packages/sdk-logs/src/types.ts
+++ b/experimental/packages/sdk-logs/src/types.ts
@@ -8,6 +8,7 @@ import type { SeverityNumber } from '@opentelemetry/api-logs';
 import type { InstrumentationScope } from '@opentelemetry/core';
 import type { MeterProvider } from '@opentelemetry/api';
 import type { LogRecordProcessor } from './LogRecordProcessor';
+import type { LogRecordExporter } from './export/LogRecordExporter';
 
 /**
  * A LoggerConfig defines various configurable aspects of a Logger's behavior.
@@ -105,8 +106,9 @@ export interface LogRecordLimits {
   attributeCountLimit?: number;
 }
 
-/** Interface configuration for a buffer. */
-export interface BufferConfig {
+export interface BatchLogRecordProcessorOptions {
+  exporter: LogRecordExporter;
+
   /** The maximum batch size of every export. It must be smaller or equal to
    * maxQueueSize. The default value is 512. */
   maxExportBatchSize?: number;
@@ -124,7 +126,8 @@ export interface BufferConfig {
   maxQueueSize?: number;
 }
 
-export interface BatchLogRecordProcessorBrowserConfig extends BufferConfig {
+export interface BatchLogRecordProcessorBrowserOptions
+  extends BatchLogRecordProcessorOptions {
   /** Disable flush when a user navigates to a new page, closes the tab or the browser, or,
    * on mobile, switches to a different app. Auto flush is enabled by default. */
   disableAutoFlushOnDocumentHide?: boolean;

--- a/experimental/packages/sdk-logs/test/browser/export/BatchLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/browser/export/BatchLogRecordProcessor.test.ts
@@ -31,7 +31,7 @@ describeDocument('BatchLogRecordProcessor - web main context', () => {
     sinon.replaceGetter(document, 'visibilityState', () => visibilityState);
     visibilityState = 'visible';
     exporter = new InMemoryLogRecordExporter();
-    processor = new BatchLogRecordProcessor(exporter, {});
+    processor = new BatchLogRecordProcessor({ exporter });
     forceFlushSpy = sinon.stub(processor, 'forceFlush');
     visibilityChangeEvent = new Event('visibilitychange');
     pageHideEvent = new Event('pagehide');
@@ -60,7 +60,8 @@ describeDocument('BatchLogRecordProcessor - web main context', () => {
 
       describe('AND disableAutoFlushOnDocumentHide configuration option', () => {
         it('set to false should force flush log records', () => {
-          processor = new BatchLogRecordProcessor(exporter, {
+          processor = new BatchLogRecordProcessor({
+            exporter,
             disableAutoFlushOnDocumentHide: false,
           });
           forceFlushSpy = sinon.stub(processor, 'forceFlush');
@@ -70,7 +71,8 @@ describeDocument('BatchLogRecordProcessor - web main context', () => {
         });
 
         it('set to true should NOT force flush log records', () => {
-          processor = new BatchLogRecordProcessor(exporter, {
+          processor = new BatchLogRecordProcessor({
+            exporter,
             disableAutoFlushOnDocumentHide: true,
           });
           forceFlushSpy = sinon.stub(processor, 'forceFlush');
@@ -107,7 +109,7 @@ describeDocument('BatchLogRecordProcessor - web main context', () => {
 describe('BatchLogRecordProcessor', () => {
   it('without exception', async () => {
     const exporter = new InMemoryLogRecordExporter();
-    const logRecordProcessor = new BatchLogRecordProcessor(exporter);
+    const logRecordProcessor = new BatchLogRecordProcessor({ exporter });
     assert.ok(logRecordProcessor instanceof BatchLogRecordProcessor);
 
     await logRecordProcessor.forceFlush();

--- a/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
@@ -13,7 +13,7 @@ import {
 } from '@opentelemetry/core';
 
 import type {
-  BufferConfig,
+  BatchLogRecordProcessorOptions,
   LogRecordLimits,
   SdkLogRecord,
   LogRecordExporter,
@@ -28,7 +28,7 @@ import {
 } from '@opentelemetry/resources';
 import { LogRecordImpl } from '../../../src/LogRecordImpl';
 
-class BatchLogRecordProcessor extends BatchLogRecordProcessorBase<BufferConfig> {
+class BatchLogRecordProcessor extends BatchLogRecordProcessorBase<BatchLogRecordProcessorOptions> {
   onShutdown() {}
 }
 
@@ -77,7 +77,7 @@ describe('BatchLogRecordProcessorBase', () => {
 
   describe('constructor', () => {
     it('should create a BatchLogRecordProcessor instance', () => {
-      const processor = new BatchLogRecordProcessor(exporter);
+      const processor = new BatchLogRecordProcessor({ exporter });
       assert.ok(processor instanceof BatchLogRecordProcessor);
       processor.shutdown();
     });
@@ -89,7 +89,10 @@ describe('BatchLogRecordProcessorBase', () => {
         exportTimeoutMillis: 2000,
         maxQueueSize: 200,
       };
-      const processor = new BatchLogRecordProcessor(exporter, bufferConfig);
+      const processor = new BatchLogRecordProcessor({
+        exporter,
+        ...bufferConfig,
+      });
       assert.ok(processor instanceof BatchLogRecordProcessor);
       assert.strictEqual(
         processor['_maxExportBatchSize'],
@@ -108,7 +111,7 @@ describe('BatchLogRecordProcessorBase', () => {
     });
 
     it('should create a BatchLogRecordProcessor instance with empty config', () => {
-      const processor = new BatchLogRecordProcessor(exporter);
+      const processor = new BatchLogRecordProcessor({ exporter });
 
       assert.ok(processor instanceof BatchLogRecordProcessor);
       assert.strictEqual(processor['_maxExportBatchSize'], 512);
@@ -123,7 +126,10 @@ describe('BatchLogRecordProcessorBase', () => {
         maxExportBatchSize: 200,
         maxQueueSize: 100,
       };
-      const processor = new BatchLogRecordProcessor(exporter, bufferConfig);
+      const processor = new BatchLogRecordProcessor({
+        exporter,
+        ...bufferConfig,
+      });
       assert.strictEqual(
         processor['_maxExportBatchSize'],
         processor['_maxQueueSize']
@@ -133,10 +139,10 @@ describe('BatchLogRecordProcessorBase', () => {
 
   describe('onEmit', () => {
     it('should export the log records with buffer size reached', done => {
-      const processor = new BatchLogRecordProcessor(
+      const processor = new BatchLogRecordProcessor({
         exporter,
-        defaultBufferConfig
-      );
+        ...defaultBufferConfig,
+      });
       // Add logs up to maxExportBatchSize - 1 (should not trigger export yet)
       for (let i = 0; i < defaultBufferConfig.maxExportBatchSize - 1; i++) {
         const logRecord = createLogRecord();
@@ -160,10 +166,10 @@ describe('BatchLogRecordProcessorBase', () => {
     });
 
     it('should export immediately when maxExportBatchSize is reached', async () => {
-      const processor = new BatchLogRecordProcessor(
+      const processor = new BatchLogRecordProcessor({
         exporter,
-        defaultBufferConfig
-      );
+        ...defaultBufferConfig,
+      });
       const exportSpy = sinon.spy(exporter, 'export');
 
       // Add logs up to maxExportBatchSize - 1
@@ -192,10 +198,11 @@ describe('BatchLogRecordProcessorBase', () => {
     });
 
     it('should export immediately without waiting for timer when batch size reached', async () => {
-      const processor = new BatchLogRecordProcessor(
+      const processor = new BatchLogRecordProcessor({
         exporter,
-        { ...defaultBufferConfig, scheduledDelayMillis: 10000 } // Long delay
-      );
+        ...defaultBufferConfig,
+        scheduledDelayMillis: 10000, // Long delay
+      });
       const exportSpy = sinon.spy(exporter, 'export');
 
       // Fill the batch completely
@@ -218,10 +225,10 @@ describe('BatchLogRecordProcessorBase', () => {
     });
 
     it('should handle multiple immediate exports when batches fill up', async () => {
-      const processor = new BatchLogRecordProcessor(
+      const processor = new BatchLogRecordProcessor({
         exporter,
-        defaultBufferConfig
-      );
+        ...defaultBufferConfig,
+      });
       const exportSpy = sinon.spy(exporter, 'export');
 
       // Fill up exactly 2 batches worth of logs
@@ -242,10 +249,11 @@ describe('BatchLogRecordProcessorBase', () => {
     });
 
     it('should still use timer for partial batches after immediate export', async () => {
-      const processor = new BatchLogRecordProcessor(
+      const processor = new BatchLogRecordProcessor({
         exporter,
-        { ...defaultBufferConfig, scheduledDelayMillis: 100 } // Shorter delay for testing
-      );
+        ...defaultBufferConfig,
+        scheduledDelayMillis: 100, // Shorter delay for testing
+      });
       const exportSpy = sinon.spy(exporter, 'export');
 
       // Fill one complete batch - should trigger immediate export
@@ -285,10 +293,10 @@ describe('BatchLogRecordProcessorBase', () => {
     it('should force flush when timeout exceeded for partial batches', async function () {
       // arrange
       const clock = sinon.useFakeTimers();
-      const processor = new BatchLogRecordProcessor(
+      const processor = new BatchLogRecordProcessor({
         exporter,
-        defaultBufferConfig
-      );
+        ...defaultBufferConfig,
+      });
 
       // act
       // Add only a partial batch (less than maxExportBatchSize)
@@ -314,7 +322,7 @@ describe('BatchLogRecordProcessorBase', () => {
     it('should not export empty log record lists', done => {
       const spy = sinon.spy(exporter, 'export');
       const clock = sinon.useFakeTimers();
-      new BatchLogRecordProcessor(exporter, defaultBufferConfig);
+      new BatchLogRecordProcessor({ exporter, ...defaultBufferConfig });
       setTimeout(() => {
         assert.strictEqual(exporter.getFinishedLogRecords().length, 0);
         sinon.assert.notCalled(spy);
@@ -329,10 +337,10 @@ describe('BatchLogRecordProcessorBase', () => {
     it('should export each log record exactly once with buffer size  reached multiple times', done => {
       const originalTimeout = setTimeout;
       const clock = sinon.useFakeTimers();
-      const processor = new BatchLogRecordProcessor(
+      const processor = new BatchLogRecordProcessor({
         exporter,
-        defaultBufferConfig
-      );
+        ...defaultBufferConfig,
+      });
       const totalLogRecords = defaultBufferConfig.maxExportBatchSize * 2;
       for (let i = 0; i < totalLogRecords; i++) {
         const logRecord = createLogRecord();
@@ -368,10 +376,10 @@ describe('BatchLogRecordProcessorBase', () => {
       });
       const errorHandlerSpy = sinon.spy();
       setGlobalErrorHandler(errorHandlerSpy);
-      const processor = new BatchLogRecordProcessor(
+      const processor = new BatchLogRecordProcessor({
         exporter,
-        defaultBufferConfig
-      );
+        ...defaultBufferConfig,
+      });
 
       // act
       for (let i = 0; i < defaultBufferConfig.maxExportBatchSize; i++) {
@@ -396,7 +404,8 @@ describe('BatchLogRecordProcessorBase', () => {
       });
       const errorHandlerSpy = sinon.spy();
       setGlobalErrorHandler(errorHandlerSpy);
-      const processor = new BatchLogRecordProcessor(exporter, {
+      const processor = new BatchLogRecordProcessor({
+        exporter,
         maxExportBatchSize: 1,
         scheduledDelayMillis: 2500,
         exportTimeoutMillis,
@@ -421,7 +430,8 @@ describe('BatchLogRecordProcessorBase', () => {
       // Use a large batch size to prevent automatic exports during this test
       const maxQueueSize = 6;
       const maxExportBatchSize = 20; // Will be clamped to maxQueueSize (6) by constructor
-      const processor = new BatchLogRecordProcessor(exporter, {
+      const processor = new BatchLogRecordProcessor({
+        exporter,
         maxQueueSize,
         maxExportBatchSize,
       });
@@ -452,10 +462,10 @@ describe('BatchLogRecordProcessorBase', () => {
 
   describe('forceFlush', () => {
     it('should force flush on demand', async () => {
-      const processor = new BatchLogRecordProcessor(
+      const processor = new BatchLogRecordProcessor({
         exporter,
-        defaultBufferConfig
-      );
+        ...defaultBufferConfig,
+      });
       // Add partial batch (less than maxExportBatchSize) so it doesn't export automatically
       const partialBatchSize = Math.floor(
         defaultBufferConfig.maxExportBatchSize / 2
@@ -473,7 +483,7 @@ describe('BatchLogRecordProcessorBase', () => {
     });
 
     it('should call an async callback when flushing is complete', async () => {
-      const processor = new BatchLogRecordProcessor(exporter);
+      const processor = new BatchLogRecordProcessor({ exporter });
       const logRecord = createLogRecord();
       processor.onEmit(logRecord);
       await processor.forceFlush();
@@ -481,7 +491,7 @@ describe('BatchLogRecordProcessorBase', () => {
     });
 
     it('should wait for pending resource on flush', async () => {
-      const processor = new BatchLogRecordProcessor(exporter);
+      const processor = new BatchLogRecordProcessor({ exporter });
       const asyncResource = resourceFromAttributes({
         async: new Promise<string>(resolve =>
           setTimeout(() => resolve('fromasync'), 1)
@@ -510,7 +520,8 @@ describe('BatchLogRecordProcessorBase', () => {
         forceFlush: async () => {},
       };
       const forceFlushSpy = sinon.spy(customExporter, 'forceFlush');
-      const processor = new BatchLogRecordProcessor(customExporter, {
+      const processor = new BatchLogRecordProcessor({
+        exporter: customExporter,
         maxExportBatchSize: 1,
         scheduledDelayMillis: 2500,
       });
@@ -559,7 +570,8 @@ describe('BatchLogRecordProcessorBase', () => {
             resolveExporterForceFlush = resolve;
           }),
       };
-      const processor = new BatchLogRecordProcessor(customExporter, {
+      const processor = new BatchLogRecordProcessor({
+        exporter: customExporter,
         maxExportBatchSize: 1,
         scheduledDelayMillis: 2500,
       });
@@ -602,7 +614,7 @@ describe('BatchLogRecordProcessorBase', () => {
     it('should not call forceFlush on exporter when queue is empty and no export in progress', async function () {
       // arrange
       const forceFlushSpy = sinon.spy(exporter, 'forceFlush');
-      const processor = new BatchLogRecordProcessor(exporter);
+      const processor = new BatchLogRecordProcessor({ exporter });
 
       // act - nothing in the queue and no export in progress
       await processor.forceFlush();
@@ -615,7 +627,7 @@ describe('BatchLogRecordProcessorBase', () => {
 
   describe('shutdown', () => {
     it('should call onShutdown', async () => {
-      const processor = new BatchLogRecordProcessor(exporter);
+      const processor = new BatchLogRecordProcessor({ exporter });
       const onShutdownSpy = sinon.stub(processor, 'onShutdown');
       assert.strictEqual(onShutdownSpy.callCount, 0);
       await processor.shutdown();
@@ -630,7 +642,7 @@ describe('BatchLogRecordProcessorBase', () => {
           callback({ code: ExportResultCode.SUCCESS });
         }, 0);
       });
-      const processor = new BatchLogRecordProcessor(exporter);
+      const processor = new BatchLogRecordProcessor({ exporter });
       const logRecord = createLogRecord();
       processor.onEmit(logRecord);
       await processor.shutdown();
@@ -655,7 +667,8 @@ describe('BatchLogRecordProcessorBase', () => {
         shutdown: async () => {},
         forceFlush: async () => {},
       };
-      const processor = new BatchLogRecordProcessor(exporter, {
+      const processor = new BatchLogRecordProcessor({
+        exporter,
         maxExportBatchSize: 5,
         maxQueueSize: 6,
       });

--- a/packages/opentelemetry-sdk-trace-base/src/BatchSpanProcessor-shim.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/BatchSpanProcessor-shim.ts
@@ -4,12 +4,12 @@
  */
 
 import { getNumberFromEnv } from '@opentelemetry/core';
+import type { SpanExporter } from '@opentelemetry/sdk-trace';
+import { BatchSpanProcessor as BatchSpanProcessNoEnvConfig } from '@opentelemetry/sdk-trace';
 import type {
   BatchSpanProcessorBrowserConfig,
   BufferConfig,
-  SpanExporter,
-} from '@opentelemetry/sdk-trace';
-import { BatchSpanProcessor as BatchSpanProcessNoEnvConfig } from '@opentelemetry/sdk-trace';
+} from './types-shim';
 
 /**
  * A BatchSpanProcessor that applies `OTEL_*` environment variable fallbacks per
@@ -38,6 +38,6 @@ export class BatchSpanProcessor extends BatchSpanProcessNoEnvConfig {
       }
     }
 
-    super(exporter, config);
+    super({ exporter, ...config });
   }
 }

--- a/packages/opentelemetry-sdk-trace-base/src/index-shim.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/index-shim.ts
@@ -5,6 +5,8 @@
 
 export { BasicTracerProvider } from './BasicTracerProvider-shim';
 export type {
+  BufferConfig,
+  BatchSpanProcessorBrowserConfig,
   GeneralLimits,
   TracerConfig,
   SDKRegistrationConfig,
@@ -31,8 +33,6 @@ export type {
   Span,
   SpanProcessor,
   TimedEvent,
-  BatchSpanProcessorBrowserConfig,
-  BufferConfig,
   SpanLimits,
   IdGenerator,
 } from '@opentelemetry/sdk-trace';

--- a/packages/opentelemetry-sdk-trace-base/src/types-shim.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/types-shim.ts
@@ -34,3 +34,29 @@ export interface SDKRegistrationConfig {
   /** Context manager to register as the global context manager */
   contextManager?: ContextManager | null;
 }
+
+/** Interface configuration for a buffer. */
+export interface BufferConfig {
+  /** The maximum batch size of every export. It must be smaller or equal to
+   * maxQueueSize. The default value is 512. */
+  maxExportBatchSize?: number;
+
+  /** The delay interval in milliseconds between two consecutive exports.
+   *  The default value is 5000ms. */
+  scheduledDelayMillis?: number;
+
+  /** How long the export can run before it is cancelled.
+   * The default value is 30000ms */
+  exportTimeoutMillis?: number;
+
+  /** The maximum queue size. After the size is reached spans are dropped.
+   * The default value is 2048. */
+  maxQueueSize?: number;
+}
+
+/** Interface configuration for BatchSpanProcessor on browser */
+export interface BatchSpanProcessorBrowserConfig extends BufferConfig {
+  /** Disable flush when a user navigates to a new page, closes the tab or the browser, or,
+   * on mobile, switches to a different app. Auto flush is enabled by default. */
+  disableAutoFlushOnDocumentHide?: boolean;
+}

--- a/packages/sdk-trace/src/export/BatchSpanProcessorBase.ts
+++ b/packages/sdk-trace/src/export/BatchSpanProcessorBase.ts
@@ -13,7 +13,7 @@ import {
 } from '@opentelemetry/core';
 import type { Span } from '../Span';
 import type { SpanProcessor } from '../SpanProcessor';
-import type { BufferConfig } from '../types';
+import type { BatchSpanProcessorOptions } from '../types';
 import type { ReadableSpan } from './ReadableSpan';
 import type { SpanExporter } from './SpanExporter';
 
@@ -21,8 +21,9 @@ import type { SpanExporter } from './SpanExporter';
  * Implementation of the {@link SpanProcessor} that batches spans exported by
  * the SDK then pushes them to the exporter pipeline.
  */
-export abstract class BatchSpanProcessorBase<T extends BufferConfig>
-  implements SpanProcessor
+export abstract class BatchSpanProcessorBase<
+  T extends BatchSpanProcessorOptions,
+> implements SpanProcessor
 {
   private readonly _maxExportBatchSize: number;
   private readonly _maxQueueSize: number;
@@ -36,12 +37,12 @@ export abstract class BatchSpanProcessorBase<T extends BufferConfig>
   private _shutdownOnce: BindOnceFuture<void>;
   private _droppedSpansCount: number = 0;
 
-  constructor(exporter: SpanExporter, config?: T) {
-    this._exporter = exporter;
-    this._maxExportBatchSize = config?.maxExportBatchSize ?? 512;
-    this._maxQueueSize = config?.maxQueueSize ?? 2048;
-    this._scheduledDelayMillis = config?.scheduledDelayMillis ?? 5000;
-    this._exportTimeoutMillis = config?.exportTimeoutMillis ?? 30000;
+  constructor(options: T) {
+    this._exporter = options.exporter;
+    this._maxExportBatchSize = options?.maxExportBatchSize ?? 512;
+    this._maxQueueSize = options?.maxQueueSize ?? 2048;
+    this._scheduledDelayMillis = options?.scheduledDelayMillis ?? 5000;
+    this._exportTimeoutMillis = options?.exportTimeoutMillis ?? 30000;
 
     this._shutdownOnce = new BindOnceFuture(this._shutdown, this);
 

--- a/packages/sdk-trace/src/export/BatchSpanProcessorBase.ts
+++ b/packages/sdk-trace/src/export/BatchSpanProcessorBase.ts
@@ -39,10 +39,10 @@ export abstract class BatchSpanProcessorBase<
 
   constructor(options: T) {
     this._exporter = options.exporter;
-    this._maxExportBatchSize = options?.maxExportBatchSize ?? 512;
-    this._maxQueueSize = options?.maxQueueSize ?? 2048;
-    this._scheduledDelayMillis = options?.scheduledDelayMillis ?? 5000;
-    this._exportTimeoutMillis = options?.exportTimeoutMillis ?? 30000;
+    this._maxExportBatchSize = options.maxExportBatchSize ?? 512;
+    this._maxQueueSize = options.maxQueueSize ?? 2048;
+    this._scheduledDelayMillis = options.scheduledDelayMillis ?? 5000;
+    this._exportTimeoutMillis = options.exportTimeoutMillis ?? 30000;
 
     this._shutdownOnce = new BindOnceFuture(this._shutdown, this);
 

--- a/packages/sdk-trace/src/index.ts
+++ b/packages/sdk-trace/src/index.ts
@@ -21,8 +21,8 @@ export type { Span } from './Span';
 export type { SpanProcessor } from './SpanProcessor';
 export type { TimedEvent } from './TimedEvent';
 export type {
-  BatchSpanProcessorBrowserConfig,
-  BufferConfig,
+  BatchSpanProcessorOptions,
+  BatchSpanProcessorBrowserOptions,
   SpanLimits,
   TracerProviderOptions,
 } from './types';

--- a/packages/sdk-trace/src/platform/browser/export/BatchSpanProcessor.ts
+++ b/packages/sdk-trace/src/platform/browser/export/BatchSpanProcessor.ts
@@ -4,25 +4,21 @@
  */
 
 import { BatchSpanProcessorBase } from '../../../export/BatchSpanProcessorBase';
-import type { SpanExporter } from '../../../export/SpanExporter';
-import type { BatchSpanProcessorBrowserConfig } from '../../../types';
+import type { BatchSpanProcessorBrowserOptions } from '../../../types';
 import { globalErrorHandler } from '@opentelemetry/core';
 
-export class BatchSpanProcessor extends BatchSpanProcessorBase<BatchSpanProcessorBrowserConfig> {
+export class BatchSpanProcessor extends BatchSpanProcessorBase<BatchSpanProcessorBrowserOptions> {
   private _visibilityChangeListener?: () => void;
   private _pageHideListener?: () => void;
 
-  constructor(
-    _exporter: SpanExporter,
-    config?: BatchSpanProcessorBrowserConfig
-  ) {
-    super(_exporter, config);
-    this.onInit(config);
+  constructor(options: BatchSpanProcessorBrowserOptions) {
+    super(options);
+    this.onInit(options);
   }
 
-  private onInit(config?: BatchSpanProcessorBrowserConfig): void {
+  private onInit(options: BatchSpanProcessorBrowserOptions): void {
     if (
-      config?.disableAutoFlushOnDocumentHide !== true &&
+      options?.disableAutoFlushOnDocumentHide !== true &&
       typeof document !== 'undefined'
     ) {
       this._visibilityChangeListener = () => {

--- a/packages/sdk-trace/src/platform/browser/export/BatchSpanProcessor.ts
+++ b/packages/sdk-trace/src/platform/browser/export/BatchSpanProcessor.ts
@@ -18,7 +18,7 @@ export class BatchSpanProcessor extends BatchSpanProcessorBase<BatchSpanProcesso
 
   private onInit(options: BatchSpanProcessorBrowserOptions): void {
     if (
-      options?.disableAutoFlushOnDocumentHide !== true &&
+      options.disableAutoFlushOnDocumentHide !== true &&
       typeof document !== 'undefined'
     ) {
       this._visibilityChangeListener = () => {

--- a/packages/sdk-trace/src/platform/node/export/BatchSpanProcessor.ts
+++ b/packages/sdk-trace/src/platform/node/export/BatchSpanProcessor.ts
@@ -4,8 +4,8 @@
  */
 
 import { BatchSpanProcessorBase } from '../../../export/BatchSpanProcessorBase';
-import type { BufferConfig } from '../../../types';
+import type { BatchSpanProcessorOptions } from '../../../types';
 
-export class BatchSpanProcessor extends BatchSpanProcessorBase<BufferConfig> {
+export class BatchSpanProcessor extends BatchSpanProcessorBase<BatchSpanProcessorOptions> {
   protected onShutdown(): void {}
 }

--- a/packages/sdk-trace/src/types.ts
+++ b/packages/sdk-trace/src/types.ts
@@ -8,6 +8,7 @@ import type { Resource } from '@opentelemetry/resources';
 import type { IdGenerator } from './IdGenerator';
 import type { Sampler } from './Sampler';
 import type { SpanProcessor } from './SpanProcessor';
+import type { SpanExporter } from './export/SpanExporter';
 
 export interface TracerProviderOptions {
   /**
@@ -76,8 +77,9 @@ export interface SpanLimits {
   attributePerLinkCountLimit?: number;
 }
 
-/** Interface configuration for a buffer. */
-export interface BufferConfig {
+export interface BatchSpanProcessorOptions {
+  exporter: SpanExporter;
+
   /** The maximum batch size of every export. It must be smaller or equal to
    * maxQueueSize. The default value is 512. */
   maxExportBatchSize?: number;
@@ -96,7 +98,8 @@ export interface BufferConfig {
 }
 
 /** Interface configuration for BatchSpanProcessor on browser */
-export interface BatchSpanProcessorBrowserConfig extends BufferConfig {
+export interface BatchSpanProcessorBrowserOptions
+  extends BatchSpanProcessorOptions {
   /** Disable flush when a user navigates to a new page, closes the tab or the browser, or,
    * on mobile, switches to a different app. Auto flush is enabled by default. */
   disableAutoFlushOnDocumentHide?: boolean;

--- a/packages/sdk-trace/test/browser/export/BatchSpanProcessor.bench.ts
+++ b/packages/sdk-trace/test/browser/export/BatchSpanProcessor.bench.ts
@@ -27,7 +27,7 @@ class NoopExporter implements SpanExporter {
 }
 
 const tracerProvider = new TracerProvider({
-  spanProcessors: [new BatchSpanProcessor(new NoopExporter())],
+  spanProcessors: [new BatchSpanProcessor({ exporter: new NoopExporter() })],
 });
 const tracer = tracerProvider.getTracer('test');
 

--- a/packages/sdk-trace/test/browser/export/BatchSpanProcessor.test.ts
+++ b/packages/sdk-trace/test/browser/export/BatchSpanProcessor.test.ts
@@ -38,7 +38,7 @@ describeBrowser('BatchSpanProcessor', () => {
     sinon.replaceGetter(document, 'visibilityState', () => visibilityState);
     visibilityState = 'visible';
     exporter = new TestTracingSpanExporter();
-    processor = new BatchSpanProcessor(exporter, {});
+    processor = new BatchSpanProcessor({ exporter });
     forceFlushSpy = sinon
       .stub(processor, 'forceFlush')
       .returns(Promise.resolve());
@@ -92,7 +92,8 @@ describeBrowser('BatchSpanProcessor', () => {
 
       describe('AND disableAutoFlushOnDocumentHide configuration option', () => {
         it('set to false should force flush spans', () => {
-          processor = new BatchSpanProcessor(exporter, {
+          processor = new BatchSpanProcessor({
+            exporter,
             disableAutoFlushOnDocumentHide: false,
           });
           forceFlushSpy = sinon.stub(processor, 'forceFlush').resolves();
@@ -102,7 +103,8 @@ describeBrowser('BatchSpanProcessor', () => {
         });
 
         it('set to true should NOT force flush spans', () => {
-          processor = new BatchSpanProcessor(exporter, {
+          processor = new BatchSpanProcessor({
+            exporter,
             disableAutoFlushOnDocumentHide: true,
           });
           forceFlushSpy = sinon.stub(processor, 'forceFlush').resolves();
@@ -139,7 +141,7 @@ describeBrowser('BatchSpanProcessor', () => {
 describe('BatchSpanProcessor', () => {
   it('without exception', async () => {
     const exporter = new TestTracingSpanExporter();
-    const spanProcessor = new BatchSpanProcessor(exporter);
+    const spanProcessor = new BatchSpanProcessor({ exporter });
     assert.ok(spanProcessor instanceof BatchSpanProcessor);
 
     await spanProcessor.forceFlush();

--- a/packages/sdk-trace/test/common/export/BatchSpanProcessorBase.test.ts
+++ b/packages/sdk-trace/test/common/export/BatchSpanProcessorBase.test.ts
@@ -45,7 +45,7 @@ function createUnsampledSpan(spanName: string): Span {
 
 describe('BatchSpanProcessorBase', () => {
   const name = 'span-name';
-  const defaultBufferConfig = {
+  const defaultBSPOptions = {
     maxExportBatchSize: 5,
     scheduledDelayMillis: 2500,
   };
@@ -62,19 +62,22 @@ describe('BatchSpanProcessorBase', () => {
 
   describe('constructor', () => {
     it('should create a BatchSpanProcessor instance', () => {
-      const processor = new BatchSpanProcessor(exporter);
+      const processor = new BatchSpanProcessor({ exporter });
       assert.ok(processor instanceof BatchSpanProcessor);
       processor.shutdown();
     });
 
-    it('should create a BatchSpanProcessor instance with config', () => {
-      const processor = new BatchSpanProcessor(exporter, defaultBufferConfig);
+    it('should create a BatchSpanProcessor instance with options', () => {
+      const processor = new BatchSpanProcessor({
+        exporter,
+        ...defaultBSPOptions,
+      });
       assert.ok(processor instanceof BatchSpanProcessor);
       processor.shutdown();
     });
 
-    it('should create a BatchSpanProcessor instance with empty config', () => {
-      const processor = new BatchSpanProcessor(exporter, {});
+    it('should create a BatchSpanProcessor instance with default options', () => {
+      const processor = new BatchSpanProcessor({ exporter });
       assert.ok(processor instanceof BatchSpanProcessor);
       processor.shutdown();
     });
@@ -82,10 +85,10 @@ describe('BatchSpanProcessorBase', () => {
 
   describe('.onStart/.onEnd/.shutdown', () => {
     it('should call onShutdown', async () => {
-      const processor = new BatchSpanProcessor(
+      const processor = new BatchSpanProcessor({
         exporter,
-        defaultBufferConfig
-      ) as any;
+        ...defaultBSPOptions,
+      }) as any;
       const onShutdownSpy = sinon.stub(processor, 'onShutdown');
       assert.strictEqual(onShutdownSpy.callCount, 0);
       await processor.shutdown();
@@ -93,7 +96,10 @@ describe('BatchSpanProcessorBase', () => {
     });
 
     it('should do nothing after processor is shutdown', async () => {
-      const processor = new BatchSpanProcessor(exporter, defaultBufferConfig);
+      const processor = new BatchSpanProcessor({
+        exporter,
+        ...defaultBSPOptions,
+      });
       const spy: sinon.SinonSpy = sinon.spy(exporter, 'export') as any;
 
       const span = createSampledSpan(`${name}_0`);
@@ -122,7 +128,10 @@ describe('BatchSpanProcessorBase', () => {
     });
 
     it('should not export unsampled spans', async () => {
-      const processor = new BatchSpanProcessor(exporter, defaultBufferConfig);
+      const processor = new BatchSpanProcessor({
+        exporter,
+        ...defaultBSPOptions,
+      });
       const spy: sinon.SinonSpy = sinon.spy(exporter, 'export') as any;
 
       const span = createUnsampledSpan(`${name}_0`);
@@ -137,9 +146,12 @@ describe('BatchSpanProcessorBase', () => {
     });
 
     it('should export the sampled spans with buffer size reached', async () => {
-      const processor = new BatchSpanProcessor(exporter, defaultBufferConfig);
+      const processor = new BatchSpanProcessor({
+        exporter,
+        ...defaultBSPOptions,
+      });
       const span = createSampledSpan(name);
-      for (let i = 1; i < defaultBufferConfig.maxExportBatchSize; i++) {
+      for (let i = 1; i < defaultBSPOptions.maxExportBatchSize; i++) {
         processor.onStart(span, ROOT_CONTEXT);
         assert.strictEqual(exporter.getFinishedSpans().length, 0);
 
@@ -155,9 +167,12 @@ describe('BatchSpanProcessorBase', () => {
 
     it('should force flush when timeout exceeded', done => {
       const clock = sinon.useFakeTimers();
-      const processor = new BatchSpanProcessor(exporter, defaultBufferConfig);
+      const processor = new BatchSpanProcessor({
+        exporter,
+        ...defaultBSPOptions,
+      });
       const span = createSampledSpan(name);
-      for (let i = 1; i < defaultBufferConfig.maxExportBatchSize; i++) {
+      for (let i = 1; i < defaultBSPOptions.maxExportBatchSize; i++) {
         processor.onStart(span, ROOT_CONTEXT);
         processor.onEnd(span);
         assert.strictEqual(exporter.getFinishedSpans().length, 0);
@@ -166,17 +181,20 @@ describe('BatchSpanProcessorBase', () => {
       setTimeout(() => {
         assert.strictEqual(exporter.getFinishedSpans().length, 4);
         done();
-      }, defaultBufferConfig.scheduledDelayMillis + 1000);
+      }, defaultBSPOptions.scheduledDelayMillis + 1000);
 
-      clock.tick(defaultBufferConfig.scheduledDelayMillis + 1000);
+      clock.tick(defaultBSPOptions.scheduledDelayMillis + 1000);
 
       clock.restore();
     });
 
     it('should force flush on demand', () => {
-      const processor = new BatchSpanProcessor(exporter, defaultBufferConfig);
+      const processor = new BatchSpanProcessor({
+        exporter,
+        ...defaultBSPOptions,
+      });
       const span = createSampledSpan(name);
-      for (let i = 1; i < defaultBufferConfig.maxExportBatchSize; i++) {
+      for (let i = 1; i < defaultBSPOptions.maxExportBatchSize; i++) {
         processor.onStart(span, ROOT_CONTEXT);
         processor.onEnd(span);
       }
@@ -192,10 +210,13 @@ describe('BatchSpanProcessorBase', () => {
       const tracer = new TracerProvider({
         sampler: new AlwaysOnSampler(),
       }).getTracer('default');
-      const processor = new BatchSpanProcessor(exporter, defaultBufferConfig);
+      const processor = new BatchSpanProcessor({
+        exporter,
+        ...defaultBSPOptions,
+      });
 
       // start but do not end spans
-      for (let i = 0; i < defaultBufferConfig.maxExportBatchSize; i++) {
+      for (let i = 0; i < defaultBSPOptions.maxExportBatchSize; i++) {
         const span = tracer.startSpan('spanName');
         processor.onStart(span as Span, ROOT_CONTEXT);
       }
@@ -206,11 +227,11 @@ describe('BatchSpanProcessorBase', () => {
         // because no spans are ended
         sinon.assert.notCalled(spy);
         done();
-      }, defaultBufferConfig.scheduledDelayMillis + 1000);
+      }, defaultBSPOptions.scheduledDelayMillis + 1000);
 
       // no spans have been finished
       assert.strictEqual(exporter.getFinishedSpans().length, 0);
-      clock.tick(defaultBufferConfig.scheduledDelayMillis + 1000);
+      clock.tick(defaultBSPOptions.scheduledDelayMillis + 1000);
 
       clock.restore();
     });
@@ -221,8 +242,11 @@ describe('BatchSpanProcessorBase', () => {
       done => {
         const originalTimeout = setTimeout;
         const clock = sinon.useFakeTimers({ shouldClearNativeTimers: true });
-        const processor = new BatchSpanProcessor(exporter, defaultBufferConfig);
-        const totalSpans = defaultBufferConfig.maxExportBatchSize * 2;
+        const processor = new BatchSpanProcessor({
+          exporter,
+          ...defaultBSPOptions,
+        });
+        const totalSpans = defaultBSPOptions.maxExportBatchSize * 2;
         for (let i = 0; i < totalSpans; i++) {
           const span = createSampledSpan(`${name}_${i}`);
           processor.onStart(span, ROOT_CONTEXT);
@@ -231,14 +255,14 @@ describe('BatchSpanProcessorBase', () => {
         const span = createSampledSpan(`${name}_last`);
         processor.onStart(span, ROOT_CONTEXT);
         processor.onEnd(span);
-        clock.tick(defaultBufferConfig.scheduledDelayMillis + 10);
+        clock.tick(defaultBSPOptions.scheduledDelayMillis + 10);
 
         // because there is an async promise that will be trigger original
         // timeout is needed to simulate a real tick to the next
         originalTimeout(() => {
-          clock.tick(defaultBufferConfig.scheduledDelayMillis + 10);
+          clock.tick(defaultBSPOptions.scheduledDelayMillis + 10);
           originalTimeout(async () => {
-            clock.tick(defaultBufferConfig.scheduledDelayMillis + 10);
+            clock.tick(defaultBSPOptions.scheduledDelayMillis + 10);
             clock.restore();
 
             diag.info(
@@ -262,14 +286,14 @@ describe('BatchSpanProcessorBase', () => {
   describe('force flush', () => {
     describe('no waiting spans', () => {
       it('should call an async callback when flushing is complete', done => {
-        const processor = new BatchSpanProcessor(exporter);
+        const processor = new BatchSpanProcessor({ exporter });
         processor.forceFlush().then(() => {
           done();
         });
       });
 
       it('should call an async callback when shutdown is complete', done => {
-        const processor = new BatchSpanProcessor(exporter);
+        const processor = new BatchSpanProcessor({ exporter });
         processor.shutdown().then(() => {
           done();
         });
@@ -280,7 +304,7 @@ describe('BatchSpanProcessorBase', () => {
       let processor: BatchSpanProcessor;
 
       beforeEach(() => {
-        processor = new BatchSpanProcessor(exporter, defaultBufferConfig);
+        processor = new BatchSpanProcessor({ exporter, ...defaultBSPOptions });
       });
 
       it('should call an async callback when flushing is complete', done => {
@@ -324,13 +348,13 @@ describe('BatchSpanProcessorBase', () => {
 
         setGlobalErrorHandler(errorHandlerSpy);
 
-        for (let i = 0; i < defaultBufferConfig.maxExportBatchSize; i++) {
+        for (let i = 0; i < defaultBSPOptions.maxExportBatchSize; i++) {
           const span = createSampledSpan('test');
           processor.onStart(span, ROOT_CONTEXT);
           processor.onEnd(span);
         }
 
-        clock.tick(defaultBufferConfig.scheduledDelayMillis + 1000);
+        clock.tick(defaultBSPOptions.scheduledDelayMillis + 1000);
         clock.restore();
         setTimeout(async () => {
           assert.strictEqual(errorHandlerSpy.callCount, 1);
@@ -429,7 +453,9 @@ describe('BatchSpanProcessorBase', () => {
 
       it('should prevent instrumentation prior to export', done => {
         const testTracingExporter = new TestTracingSpanExporter();
-        const processor = new BatchSpanProcessor(testTracingExporter);
+        const processor = new BatchSpanProcessor({
+          exporter: testTracingExporter,
+        });
 
         const span = createSampledSpan('test');
         processor.onStart(span, ROOT_CONTEXT);
@@ -445,17 +471,17 @@ describe('BatchSpanProcessorBase', () => {
       });
     });
   });
+
   describe('maxQueueSize', () => {
     let processor: BatchSpanProcessor;
 
     describe('when there are more spans then "maxQueueSize"', () => {
       beforeEach(() => {
-        processor = new BatchSpanProcessor(
+        processor = new BatchSpanProcessor({
           exporter,
-          Object.assign({}, defaultBufferConfig, {
-            maxQueueSize: 6,
-          })
-        );
+          ...defaultBSPOptions,
+          maxQueueSize: 6,
+        });
       });
       it('should drop spans', () => {
         const span = createSampledSpan('test');
@@ -500,7 +526,8 @@ describe('BatchSpanProcessorBase', () => {
 
     describe('when "maxExportBatchSize" is greater than "maxQueueSize"', () => {
       beforeEach(() => {
-        processor = new BatchSpanProcessor(exporter, {
+        processor = new BatchSpanProcessor({
+          exporter,
           maxExportBatchSize: 7,
           maxQueueSize: 6,
         });
@@ -528,7 +555,8 @@ describe('BatchSpanProcessorBase', () => {
         },
         shutdown: async () => {},
       };
-      const processor = new BatchSpanProcessor(exporter, {
+      const processor = new BatchSpanProcessor({
+        exporter,
         maxExportBatchSize: 5,
         maxQueueSize: 6,
       });

--- a/packages/sdk-trace/test/node/export/BatchSpanProcessor.bench.ts
+++ b/packages/sdk-trace/test/node/export/BatchSpanProcessor.bench.ts
@@ -27,7 +27,7 @@ class NoopExporter implements SpanExporter {
 }
 
 const tracerProvider = new TracerProvider({
-  spanProcessors: [new BatchSpanProcessor(new NoopExporter())],
+  spanProcessors: [new BatchSpanProcessor({ exporter: new NoopExporter() })],
 });
 const tracer = tracerProvider.getTracer('test');
 


### PR DESCRIPTION
Note: The `BatchSpanProcessor` from sdk-trace-base is *not* being changed.
A breaking change on sdk-trace is allowed because sdk-trace hasn't been published yet.

This changes BatchSpanProcessor and BatchLogRecordProcessor to take a single `options` argument, and changes the name of `BufferConfig` type to `BatchLogRecordProcessorOptions`.

Before (effectively):

```ts
// in sdk-logs
class BatchLogRecordProcessor implements LogRecordProcessor {
  constructor(exporter: LogRecordExporter, config: BufferConfig) { ... }
}

// in sdk-trace
class BatchSpanProcessor implements SpanProcessor {
  constructor(exporter: SpanExporter, config: BufferConfig) { ... }
}

// usage example
const processor = new BatchLogRecordProcessor(exporter, { maxQueueSize: 1000 });
const processor = new BatchSpanProcessor(exporter, { maxQueueSize: 1000 });
```

After (effectively):

```ts
class BatchLogRecordProcessor implements LogRecordProcessor {
  constructor(options: BatchLogRecordProcessorOptions) { ... }
}

class BatchSpanProcessor implements SpanProcessor {
  constructor(options: BatchSpanProcessorOptions) { ... }
}

// usage example
const processor = new BatchLogRecordProcessor({ exporter, maxQueueSize: 1000 });
const processor = new BatchSpanProcessor({ exporter, maxQueueSize: 1000 });
```

# A note on two BatchSpanProcessor classes

With this change the two `BatchSpanProcessor` classes (one in sdk-trace, one in sdk-trace-base) have slightly different call signatures.  That will potentially be confusing to users for a while.

The plan (as discussed in the description of https://github.com/open-telemetry/opentelemetry-js/pull/6775) is to:

- migrate usage of sdk-trace-base, sdk-trace-node, and sdk-trace-web over to sdk-trace (in this repo, the contrib repo, and opentelemetry.io docs),
- then *deprecate* the `sdk-trace-*` packages in favour of `sdk-trace`. I'll add a `@deprecated` to `BatchSpanProcessor` in sdk-trace-base at that point.


# Motivation

The change away from `interface BufferConfig`  was motivated by confusion on this PR: https://github.com/open-telemetry/opentelemetry-js/pull/6504#issuecomment-4635716043
That PR needed to add a `meterProvider` option to a BatchSpanProcessor -- on which self-observability SDK metrics can be added. Adding `meterProvider` to a type called `BufferConfig` feels wrong, even though it belongs on the type that holds all the options for a BatchSpanProcessor.

# Two arguments or one to the constructor?

The interface change could also have been the following. I.e. just change the name of `BufferConfig`.

```ts
class BatchSpanProcessor implements SpanProcessor {
  constructor(exporter: SpanExporter, options?: BatchSpanProcessorOptions) { ... }
}
```

This would have been a smaller change. Also, user code would have have to change how arguments were passed.
Thoughts? Preferences?

There aren't many examples of SDK classes that take *required* arguments and optional arguments to have a clear patterns on which constructor style should be preferred for consistency.
