### PR TITLE
chore(ci): drop Node.js v25 testing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,6 @@ jobs:
           - "20"
           - "22"
           - "24"
-          - "25"
           - "26"
     runs-on: ubuntu-latest
     steps:
@@ -49,7 +48,6 @@ jobs:
           matrix.node_version == '20' ||
           matrix.node_version == '22' ||
           matrix.node_version == '24' ||
-          matrix.node_version == '25' ||
           matrix.node_version == '26'
           }}
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,7 +21,6 @@ jobs:
           - "20"
           - "22"
           - "24"
-          - "25"
           - "26"
     runs-on: ubuntu-latest
     steps:
@@ -51,7 +50,6 @@ jobs:
           matrix.node_version == '20' ||
           matrix.node_version == '22' ||
           matrix.node_version == '24' ||
-          matrix.node_version == '25' ||
           matrix.node_version == '26'
           }}
 


### PR DESCRIPTION
v25 isn't a current release anymore, now that v26 has been out for a bit
https://github.com/nodejs/release#release-schedule
