### PR TITLE
refactor(sdk-logs)!: change SimpleLogRecordProcessor constructor signature

### DIFF
--- a/bundler-tests/browser/nextjs-15-edge/middleware.js
+++ b/bundler-tests/browser/nextjs-15-edge/middleware.js
@@ -22,7 +22,7 @@ diag.setLogger(new DiagConsoleLogger());
 
 logs.setGlobalLoggerProvider(
   new LoggerProvider({
-    processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+    processors: [new SimpleLogRecordProcessor({ exporter: new OTLPLogExporter() })],
   })
 );
 

--- a/bundler-tests/browser/nextjs-16-edge/app/api/test/route.js
+++ b/bundler-tests/browser/nextjs-16-edge/app/api/test/route.js
@@ -24,7 +24,7 @@ diag.setLogger(new DiagConsoleLogger());
 
 logs.setGlobalLoggerProvider(
   new LoggerProvider({
-    processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+    processors: [new SimpleLogRecordProcessor({exporter: new OTLPLogExporter()})],
   })
 );
 

--- a/bundler-tests/browser/webpack-5/src/index.js
+++ b/bundler-tests/browser/webpack-5/src/index.js
@@ -22,7 +22,7 @@ diag.setLogger(new DiagConsoleLogger());
 
 logs.setGlobalLoggerProvider(
   new LoggerProvider({
-    processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+    processors: [new SimpleLogRecordProcessor({ exporter: new OTLPLogExporter() })],
   })
 );
 

--- a/bundler-tests/node/webpack-5/src/index.js
+++ b/bundler-tests/node/webpack-5/src/index.js
@@ -27,7 +27,7 @@ diag.setLogger({
 
 logs.setGlobalLoggerProvider(
   new LoggerProvider({
-    processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+    processors: [new SimpleLogRecordProcessor({ exporter: new OTLPLogExporter() })],
   })
 );
 

--- a/e2e-tests/test.mjs
+++ b/e2e-tests/test.mjs
@@ -43,7 +43,9 @@ const metricReader = new PeriodicExportingMetricReader({
 const logExporter = new OTLPLogExporter({
   url: `${collectorUrl}/logs`,
 });
-const logRecordProcessors = [new SimpleLogRecordProcessor(logExporter)];
+const logRecordProcessors = [
+  new SimpleLogRecordProcessor({ exporter: logExporter }),
+];
 
 // Set up OpenTelemetry SDK
 const sdk = new NodeSDK({

--- a/examples/opentelemetry-web/examples/session/index.js
+++ b/examples/opentelemetry-web/examples/session/index.js
@@ -48,7 +48,7 @@ const tracer = tracerProvider.getTracer('example');
 const loggerProvider = new LoggerProvider({
   processors: [
     createSessionLogRecordProcessor(sessionManager),
-    new SimpleLogRecordProcessor(new ConsoleLogRecordExporter())
+    new SimpleLogRecordProcessor({ exporter: new ConsoleLogRecordExporter() })
   ]
 });
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
   * (user-facing): `BatchLogRecordProcessor` now takes a single options object will all possible properties, instead of two separate arguments. For example, before `new BatchLogRecordProcessor(exporter, { maxQueueSize: 1000 })`, after `new BatchLogRecordProcessor({ exporter, maxQueueSize: 1000 })`.
   * `interface BufferConfig` -> `interface BatchLogRecordProcessorOptions`, and now includes the `exporter` property
   * `interface BatchLogRecordProcessorBrowserConfig` -> `interface BatchLogRecordProcessorBrowserOptions`
+  * (user-facing): `SimpleLogRecordProcessor` now takes a single options object will all possible properties, instead of two separate arguments. For example, before `new SimpleLogRecordProcessor(exporter)`, after `new SimpleLogRecordProcessor({ exporter })`. [#6836](https://github.com/open-telemetry/opentelemetry-js/pull/6836)
 
 ### :rocket: Features
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -9,10 +9,10 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :boom: Breaking Changes
 
 * refactor(sdk-logs)!: refactor BatchLogRecordProcessor constructor signature [#6817](https://github.com/open-telemetry/opentelemetry-js/pull/6817) @trentm
-  * (user-facing): `BatchLogRecordProcessor` now takes a single options object will all possible properties, instead of two separate arguments. For example, before `new BatchLogRecordProcessor(exporter, { maxQueueSize: 1000 })`, after `new BatchLogRecordProcessor({ exporter, maxQueueSize: 1000 })`.
+  * (user-facing): `BatchLogRecordProcessor` now takes a single `options` object with all possible properties, instead of two separate arguments. For example, before `new BatchLogRecordProcessor(exporter, { maxQueueSize: 1000 })`, after `new BatchLogRecordProcessor({ exporter, maxQueueSize: 1000 })`.
   * `interface BufferConfig` -> `interface BatchLogRecordProcessorOptions`, and now includes the `exporter` property
   * `interface BatchLogRecordProcessorBrowserConfig` -> `interface BatchLogRecordProcessorBrowserOptions`
-  * (user-facing): `SimpleLogRecordProcessor` now takes a single options object will all possible properties, instead of two separate arguments. For example, before `new SimpleLogRecordProcessor(exporter)`, after `new SimpleLogRecordProcessor({ exporter })`. [#6836](https://github.com/open-telemetry/opentelemetry-js/pull/6836)
+  * (user-facing): `SimpleLogRecordProcessor` now takes a single `options` object with all possible properties. For example, before `new SimpleLogRecordProcessor(exporter)`, after `new SimpleLogRecordProcessor({ exporter })`. [#6836](https://github.com/open-telemetry/opentelemetry-js/pull/6836)
 
 ### :rocket: Features
 

--- a/experimental/examples/logs/index.ts
+++ b/experimental/examples/logs/index.ts
@@ -16,9 +16,7 @@ diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 
 const loggerProvider = new LoggerProvider({
   processors: [
-    new SimpleLogRecordProcessor(
-      new ConsoleLogRecordExporter()
-    )
+    new SimpleLogRecordProcessor({ exporter: new ConsoleLogRecordExporter() }),
   ],
 });
 

--- a/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
@@ -70,11 +70,9 @@ describe('OTLPLogExporter', function () {
     // arrange
     const loggerProvider = new LoggerProvider({
       processors: [
-        new SimpleLogRecordProcessor(
-          new OTLPLogExporter({
-            url: 'http://localhost:1503',
-          })
-        ),
+        new SimpleLogRecordProcessor({
+          exporter: new OTLPLogExporter({ url: 'http://localhost:1503' }),
+        }),
       ],
     });
 

--- a/experimental/packages/exporter-logs-otlp-http/test/browser/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-http/test/browser/OTLPLogExporter.test.ts
@@ -30,7 +30,9 @@ describe('OTLPLogExporter', function () {
         .stub(window, 'fetch')
         .resolves(new Response('', { status: 200 }));
       const loggerProvider = new LoggerProvider({
-        processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+        processors: [
+          new SimpleLogRecordProcessor({ exporter: new OTLPLogExporter() }),
+        ],
       });
 
       // act

--- a/experimental/packages/exporter-logs-otlp-http/test/node/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-http/test/node/OTLPLogExporter.test.ts
@@ -52,7 +52,9 @@ describe('OTLPLogExporter', () => {
       });
 
       const loggerProvider = new LoggerProvider({
-        processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+        processors: [
+          new SimpleLogRecordProcessor({ exporter: new OTLPLogExporter() }),
+        ],
       });
 
       loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });

--- a/experimental/packages/exporter-logs-otlp-proto/README.md
+++ b/experimental/packages/exporter-logs-otlp-proto/README.md
@@ -34,7 +34,7 @@ const collectorOptions = {
 const logExporter = new OTLPLogExporter(collectorOptions);
 const logProvider = new LoggerProvider({
   resource: resourceFromAttributes({'service.name': 'testApp'}),
-  processors: [new SimpleLogRecordProcessor(logExporter)]
+  processors: [new SimpleLogRecordProcessor({ exporter: logExporter })]
   });
 
 const logger = logProvider.getLogger('test_log_instrumentation');

--- a/experimental/packages/exporter-logs-otlp-proto/test/browser/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/test/browser/OTLPLogExporter.test.ts
@@ -30,7 +30,9 @@ describe('OTLPLogExporter', function () {
         .stub(window, 'fetch')
         .resolves(new Response('', { status: 200 }));
       const loggerProvider = new LoggerProvider({
-        processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+        processors: [
+          new SimpleLogRecordProcessor({ exporter: new OTLPLogExporter() }),
+        ],
       });
 
       // act

--- a/experimental/packages/exporter-logs-otlp-proto/test/node/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/test/node/OTLPLogExporter.test.ts
@@ -52,7 +52,9 @@ describe('OTLPLogExporter', () => {
       });
 
       const loggerProvider = new LoggerProvider({
-        processors: [new SimpleLogRecordProcessor(new OTLPLogExporter())],
+        processors: [
+          new SimpleLogRecordProcessor({ exporter: new OTLPLogExporter() }),
+        ],
       });
 
       loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -425,7 +425,7 @@ export class NodeSDK {
       this._loggerProviderConfig = {
         logRecordProcessors: exporters.map(exporter => {
           if (exporter instanceof ConsoleLogRecordExporter) {
-            return new SimpleLogRecordProcessor(exporter);
+            return new SimpleLogRecordProcessor({ exporter });
           } else {
             return getBatchLogRecordProcessorFromEnv(exporter);
           }

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -779,7 +779,7 @@ export function createLogRecordProcessorFromConfig(
     case 'simple': {
       const props = properties as SimpleLogRecordProcessorConfigModel;
       const exporter = createLogRecordExporterFromConfig(props.exporter);
-      return new SimpleLogRecordProcessor(exporter);
+      return new SimpleLogRecordProcessor({ exporter });
     }
 
     default:

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -429,7 +429,9 @@ describe('NodeSDK', () => {
         metricReaders: [metricReader],
         traceExporter: new ConsoleSpanExporter(),
         logRecordProcessors: [
-          new SimpleLogRecordProcessor(new InMemoryLogRecordExporter()),
+          new SimpleLogRecordProcessor({
+            exporter: new InMemoryLogRecordExporter(),
+          }),
         ],
         autoDetectResources: false,
       });
@@ -474,7 +476,9 @@ describe('NodeSDK', () => {
         metricReaders: [metricReader],
         traceExporter: new ConsoleSpanExporter(),
         logRecordProcessors: [
-          new SimpleLogRecordProcessor(new InMemoryLogRecordExporter()),
+          new SimpleLogRecordProcessor({
+            exporter: new InMemoryLogRecordExporter(),
+          }),
         ],
         autoDetectResources: false,
       });
@@ -509,9 +513,9 @@ describe('NodeSDK', () => {
 
     it('should register a logger provider if a log record processor is provided', async () => {
       const logRecordExporter = new InMemoryLogRecordExporter();
-      const logRecordProcessor = new SimpleLogRecordProcessor(
-        logRecordExporter
-      );
+      const logRecordProcessor = new SimpleLogRecordProcessor({
+        exporter: logRecordExporter,
+      });
       const sdk = new NodeSDK({
         logRecordProcessor: logRecordProcessor,
         autoDetectResources: false,
@@ -536,9 +540,9 @@ describe('NodeSDK', () => {
 
     it('should register a logger provider if multiple log record processors are provided', async () => {
       const logRecordExporter = new InMemoryLogRecordExporter();
-      const simpleLogRecordProcessor = new SimpleLogRecordProcessor(
-        logRecordExporter
-      );
+      const simpleLogRecordProcessor = new SimpleLogRecordProcessor({
+        exporter: logRecordExporter,
+      });
       const batchLogRecordProcessor = new BatchLogRecordProcessor({
         exporter: logRecordExporter,
       });
@@ -1374,9 +1378,9 @@ describe('NodeSDK', () => {
       process.env.OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT = '10';
 
       const logRecordExporter = new InMemoryLogRecordExporter();
-      const logRecordProcessor = new SimpleLogRecordProcessor(
-        logRecordExporter
-      );
+      const logRecordProcessor = new SimpleLogRecordProcessor({
+        exporter: logRecordExporter,
+      });
       const sdk = new NodeSDK({
         logRecordProcessors: [logRecordProcessor],
         autoDetectResources: false,

--- a/experimental/packages/sdk-logs/README.md
+++ b/experimental/packages/sdk-logs/README.md
@@ -33,7 +33,11 @@ const {
 // To start a logger, you first need to initialize the Logger provider.
 // and add a processor to export log record
 const loggerProvider = new LoggerProvider({
-  processors: [new SimpleLogRecordProcessor(new ConsoleLogRecordExporter())]
+  processors: [
+    new SimpleLogRecordProcessor({
+      exporter: new ConsoleLogRecordExporter()
+    })
+  ]
 });
 
 //  To create a log record, you first need to get a Logger instance
@@ -85,7 +89,7 @@ const loggerProvider = new LoggerProvider({
       }
     }
   ]),
-  processors: [new SimpleLogRecordProcessor(exporter)]
+  processors: [new SimpleLogRecordProcessor({ exporter })]
 });
 ```
 
@@ -109,7 +113,7 @@ const loggerProvider = new LoggerProvider({
       }
     }
   ]),
-  processors: [new SimpleLogRecordProcessor(exporter)]
+  processors: [new SimpleLogRecordProcessor({ exporter })]
 });
 ```
 
@@ -135,7 +139,7 @@ const loggerProvider = new LoggerProvider({
       }
     }
   ]),
-  processors: [new SimpleLogRecordProcessor(exporter)]
+  processors: [new SimpleLogRecordProcessor({ exporter })]
 });
 ```
 
@@ -173,10 +177,10 @@ const defaultLogger = loggerProvider.getLogger('my-service'); // WARN+
 interface LoggerConfig {
   /** Drop logs with severity below this level (default: UNSPECIFIED = no filtering) */
   minimumSeverity?: SeverityNumber;
-  
+
   /** Drop logs from unsampled traces (default: false) */
   traceBased?: boolean;
-  
+
   /** Disable this logger completely (default: false) */
   disabled?: boolean;
 }

--- a/experimental/packages/sdk-logs/src/export/SimpleLogRecordProcessor.ts
+++ b/experimental/packages/sdk-logs/src/export/SimpleLogRecordProcessor.ts
@@ -14,6 +14,7 @@ import type { LogRecordExporter } from './LogRecordExporter';
 import type { LogRecordProcessor } from '../LogRecordProcessor';
 import type { SdkLogRecord } from './SdkLogRecord';
 import type { Context } from '@opentelemetry/api';
+import type { SimpleLogRecordProcessorOptions } from '../types';
 
 /**
  * An implementation of the {@link LogRecordProcessor} interface that exports
@@ -29,8 +30,8 @@ export class SimpleLogRecordProcessor implements LogRecordProcessor {
   private _shutdownOnce: BindOnceFuture<void>;
   private _unresolvedExports: Set<Promise<void>>;
 
-  constructor(exporter: LogRecordExporter) {
-    this._exporter = exporter;
+  constructor(options: SimpleLogRecordProcessorOptions) {
+    this._exporter = options.exporter;
     this._shutdownOnce = new BindOnceFuture(this._shutdown, this);
     this._unresolvedExports = new Set<Promise<void>>();
   }

--- a/experimental/packages/sdk-logs/src/types.ts
+++ b/experimental/packages/sdk-logs/src/types.ts
@@ -106,6 +106,10 @@ export interface LogRecordLimits {
   attributeCountLimit?: number;
 }
 
+export interface SimpleLogRecordProcessorOptions {
+  exporter: LogRecordExporter;
+}
+
 export interface BatchLogRecordProcessorOptions {
   exporter: LogRecordExporter;
 

--- a/experimental/packages/sdk-logs/test/common/Logger.test.ts
+++ b/experimental/packages/sdk-logs/test/common/Logger.test.ts
@@ -25,7 +25,7 @@ function setupLoggerProvider(
   const logExporter = new InMemoryLogRecordExporter();
   const logProcessor = isNoop
     ? new NoopLogRecordProcessor()
-    : new SimpleLogRecordProcessor(logExporter);
+    : new SimpleLogRecordProcessor({ exporter: logExporter });
   const loggerProvider = new LoggerProvider({
     processors: [logProcessor],
     loggerConfigurator: patterns && createLoggerConfigurator(patterns),

--- a/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
@@ -543,9 +543,9 @@ describe('LoggerProvider', () => {
       });
 
       const logRecordExporter = new InMemoryLogRecordExporter();
-      const logRecordProcessor = new SimpleLogRecordProcessor(
-        logRecordExporter
-      );
+      const logRecordProcessor = new SimpleLogRecordProcessor({
+        exporter: logRecordExporter,
+      });
       const provider = new LoggerProvider({
         processors: [logRecordProcessor],
         meterProvider,

--- a/experimental/packages/sdk-logs/test/common/MultiLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/MultiLogRecordProcessor.test.ts
@@ -122,12 +122,12 @@ describe('MultiLogRecordProcessor', () => {
 
     it('should wait for all log record processors to finish flushing', done => {
       let flushed = 0;
-      const processor1 = new SimpleLogRecordProcessor(
-        new InMemoryLogRecordExporter()
-      );
-      const processor2 = new SimpleLogRecordProcessor(
-        new InMemoryLogRecordExporter()
-      );
+      const processor1 = new SimpleLogRecordProcessor({
+        exporter: new InMemoryLogRecordExporter(),
+      });
+      const processor2 = new SimpleLogRecordProcessor({
+        exporter: new InMemoryLogRecordExporter(),
+      });
 
       const spy1 = sinon.stub(processor1, 'forceFlush').callsFake(() => {
         flushed++;

--- a/experimental/packages/sdk-logs/test/common/export/ConsoleLogRecordExporter.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/ConsoleLogRecordExporter.test.ts
@@ -35,7 +35,9 @@ describe('ConsoleLogRecordExporter', () => {
         const spyConsole = sinon.spy(console, 'dir');
         const spyExport = sinon.spy(consoleExporter, 'export');
         const provider = new LoggerProvider({
-          processors: [new SimpleLogRecordProcessor(consoleExporter)],
+          processors: [
+            new SimpleLogRecordProcessor({ exporter: consoleExporter }),
+          ],
         });
 
         provider

--- a/experimental/packages/sdk-logs/test/common/export/InMemoryLogRecordExporter.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/InMemoryLogRecordExporter.test.ts
@@ -17,7 +17,7 @@ import {
 const setup = () => {
   const memoryExporter = new InMemoryLogRecordExporter();
   const provider = new LoggerProvider({
-    processors: [new SimpleLogRecordProcessor(memoryExporter)],
+    processors: [new SimpleLogRecordProcessor({ exporter: memoryExporter })],
   });
   return { provider, memoryExporter };
 };

--- a/experimental/packages/sdk-logs/test/common/export/SimpleLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/SimpleLogRecordProcessor.test.ts
@@ -46,7 +46,7 @@ const setup = (exporter: LogRecordExporter, resource?: Resource) => {
       body: 'body',
     }
   );
-  const processor = new SimpleLogRecordProcessor(exporter);
+  const processor = new SimpleLogRecordProcessor({ exporter });
   return { exporter, processor, logRecord };
 };
 
@@ -142,7 +142,9 @@ describe('SimpleLogRecordProcessor', () => {
           setTimeout(() => resolve('fromasync'), 1)
         ),
       });
-      const processor = new SimpleLogRecordProcessor(testExporterWithDelay);
+      const processor = new SimpleLogRecordProcessor({
+        exporter: testExporterWithDelay,
+      });
       const { logRecord } = setup(testExporterWithDelay, asyncResource);
 
       processor.onEmit(logRecord);

--- a/experimental/packages/web-common/test/SessionLogRecordProcessor.test.ts
+++ b/experimental/packages/web-common/test/SessionLogRecordProcessor.test.ts
@@ -26,7 +26,7 @@ describe('SessionLogRecordProcessor', function () {
     const exporter = new InMemoryLogRecordExporter();
     const processor = new SessionLogRecordProcessor(sessionProvider);
     const provider = new LoggerProvider({
-      processors: [processor, new SimpleLogRecordProcessor(exporter)],
+      processors: [processor, new SimpleLogRecordProcessor({ exporter })],
     });
 
     const logger = provider.getLogger('session-testing');
@@ -46,7 +46,7 @@ describe('SessionLogRecordProcessor', function () {
     const exporter = new InMemoryLogRecordExporter();
     const processor = new SessionLogRecordProcessor(sessionProvider);
     const provider = new LoggerProvider({
-      processors: [processor, new SimpleLogRecordProcessor(exporter)],
+      processors: [processor, new SimpleLogRecordProcessor({ exporter })],
     });
 
     const logger = provider.getLogger('session-testing');
@@ -60,7 +60,7 @@ describe('SessionLogRecordProcessor', function () {
     const exporter = new InMemoryLogRecordExporter();
     const processor = new SessionLogRecordProcessor(null as any);
     const provider = new LoggerProvider({
-      processors: [processor, new SimpleLogRecordProcessor(exporter)],
+      processors: [processor, new SimpleLogRecordProcessor({ exporter })],
     });
 
     const logger = provider.getLogger('session-testing');


### PR DESCRIPTION
This changes SimpleLogRecordProcessor to taking an options *object*.
From this:
```js
    new SimpleLogRecordProcessor(exporter)
```
to this:
```js
    new SimpleLogRecordProcessor({ exporter })
```

This change is being made because:
- the coming work for log record processor self-observability SDK
  metrics (https://github.com/open-telemetry/opentelemetry-js/pull/6554)
  needs to add options to the SimpleLogRecordProcessor constructor, and
- taking an options object will match the recent changes for
  BatchLogRecordProcessor and BatchSpanProcessor in
  https://github.com/open-telemetry/opentelemetry-js/pull/6817,
  and to SimpleSpanProcessor in https://github.com/open-telemetry/opentelemetry-js/pull/6504
