### PR TITLE
feat(sdk-node): wire up tracer_provider.sampler from declarative config

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -18,7 +18,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 * feat(configuration): bump config schema to v1.1.0; rename `without_scope_info` → `scope_info_enabled` and `without_target_info/development` → `target_info_enabled/development` on the Prometheus pull exporter (semantics inverted), rename `with_resource_constant_labels` → `resource_constant_labels`. Validate `file_format` per the configuration versioning spec: accept any minor version of major `1` (e.g. `1.0`, `1.1`), warn when the minor version is newer than supported, and reject other major versions. [#6781](https://github.com/open-telemetry/opentelemetry-js/pull/6781) @MikeGoldsmith
 * feat(sdk-node): wire up `id_generator` from declarative config [#6782](https://github.com/open-telemetry/opentelemetry-js/pull/6782) @MikeGoldsmith
-* feat(sdk-node): wire up `tracer_provider.sampler` from declarative config (always_on, always_off, trace_id_ratio_based, parent_based); experimental sampler variants warn and fall back to default [#6506](https://github.com/open-telemetry/opentelemetry-js/issues/6506) @MikeGoldsmith
+* feat(sdk-node): wire up `tracer_provider.sampler` from declarative config (always_on, always_off, trace_id_ratio_based, parent_based); unrecognized variants warn and fall back to ParentBased(AlwaysOn) [#6506](https://github.com/open-telemetry/opentelemetry-js/issues/6506) @MikeGoldsmith
 * feat(propagator-env-carrier): empty name normalization [#6827](https://github.com/open-telemetry/opentelemetry-js/pull/6827) @pellared
 
 ### :bug: Bug Fixes

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -18,6 +18,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 * feat(configuration): bump config schema to v1.1.0; rename `without_scope_info` → `scope_info_enabled` and `without_target_info/development` → `target_info_enabled/development` on the Prometheus pull exporter (semantics inverted), rename `with_resource_constant_labels` → `resource_constant_labels`. Validate `file_format` per the configuration versioning spec: accept any minor version of major `1` (e.g. `1.0`, `1.1`), warn when the minor version is newer than supported, and reject other major versions. [#6781](https://github.com/open-telemetry/opentelemetry-js/pull/6781) @MikeGoldsmith
 * feat(sdk-node): wire up `id_generator` from declarative config [#6782](https://github.com/open-telemetry/opentelemetry-js/pull/6782) @MikeGoldsmith
+* feat(sdk-node): wire up `tracer_provider.sampler` from declarative config (always_on, always_off, trace_id_ratio_based, parent_based); experimental sampler variants warn and fall back to default [#6506](https://github.com/open-telemetry/opentelemetry-js/issues/6506) @MikeGoldsmith
 * feat(propagator-env-carrier): empty name normalization [#6827](https://github.com/open-telemetry/opentelemetry-js/pull/6827) @pellared
 
 ### :bug: Bug Fixes

--- a/experimental/packages/opentelemetry-sdk-node/src/start.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/start.ts
@@ -17,6 +17,7 @@ import {
 } from '@opentelemetry/api';
 import {
   getIdGeneratorFromConfiguration,
+  getSamplerFromConfiguration,
   getInstanceID,
   createLoggerProviderFromConfig,
   getMeterReadersFromConfiguration,
@@ -168,11 +169,12 @@ function create(
     const spanProcessors = getSpanProcessorsFromConfiguration(config);
     if (spanProcessors) {
       const idGenerator = getIdGeneratorFromConfiguration(config);
-      // TODO (6506): support sampler configuration from config
+      const sampler = getSamplerFromConfiguration(config);
       const tracerProvider = new TracerProvider({
         resource,
         spanProcessors,
         idGenerator,
+        sampler,
         spanLimits: createSpanLimitsFromConfig(
           config.tracer_provider?.limits,
           config.attribute_limits

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -1273,6 +1273,27 @@ export function getInstanceID(config: ConfigurationModel): string | undefined {
 
 const DEFAULT_RATIO = 1;
 
+const EXPERIMENTAL_SAMPLER_KEYS = [
+  'jaeger_remote/development',
+  'probability/development',
+  'composite/development',
+];
+
+/**
+ * Returns the {@link Sampler} configured under `tracer_provider.sampler` in
+ * the declarative configuration, or `undefined` if none is set (in which case
+ * the SDK applies its default sampler).
+ */
+export function getSamplerFromConfiguration(
+  config: ConfigurationModel
+): Sampler | undefined {
+  const samplerConfig = config.tracer_provider?.sampler;
+  if (!samplerConfig) {
+    return undefined;
+  }
+  return buildSamplerFromConfig(samplerConfig);
+}
+
 /**
  * Builds a {@link Sampler} from a {@link SamplerConfigModel} data model.
  * This allows sampler construction from declarative configuration.
@@ -1309,7 +1330,16 @@ export function buildSamplerFromConfig(
         : undefined,
     });
   }
-  diag.error('Unknown sampler config, defaulting to ParentBased(AlwaysOn).');
+  const experimentalKeys = EXPERIMENTAL_SAMPLER_KEYS.filter(
+    k => samplerConfig[k] !== undefined
+  );
+  if (experimentalKeys.length > 0) {
+    diag.warn(
+      `Experimental sampler type(s) ${experimentalKeys.join(', ')} are not yet supported; defaulting to ParentBased(AlwaysOn).`
+    );
+  } else {
+    diag.error('Unknown sampler config, defaulting to ParentBased(AlwaysOn).');
+  }
   return new ParentBasedSampler({ root: new AlwaysOnSampler() });
 }
 

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -1273,12 +1273,6 @@ export function getInstanceID(config: ConfigurationModel): string | undefined {
 
 const DEFAULT_RATIO = 1;
 
-const EXPERIMENTAL_SAMPLER_KEYS = [
-  'jaeger_remote/development',
-  'probability/development',
-  'composite/development',
-];
-
 /**
  * Returns the {@link Sampler} configured under `tracer_provider.sampler` in
  * the declarative configuration, or `undefined` if none is set (in which case
@@ -1330,16 +1324,7 @@ export function buildSamplerFromConfig(
         : undefined,
     });
   }
-  const experimentalKeys = EXPERIMENTAL_SAMPLER_KEYS.filter(
-    k => samplerConfig[k] !== undefined
-  );
-  if (experimentalKeys.length > 0) {
-    diag.warn(
-      `Experimental sampler type(s) ${experimentalKeys.join(', ')} are not yet supported; defaulting to ParentBased(AlwaysOn).`
-    );
-  } else {
-    diag.error('Unknown sampler config, defaulting to ParentBased(AlwaysOn).');
-  }
+  diag.warn('Unknown sampler config, defaulting to ParentBased(AlwaysOn).');
   return new ParentBasedSampler({ root: new AlwaysOnSampler() });
 }
 

--- a/experimental/packages/opentelemetry-sdk-node/test/buildSamplerFromConfig.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/buildSamplerFromConfig.test.ts
@@ -4,8 +4,6 @@
  */
 
 import * as assert from 'assert';
-import * as sinon from 'sinon';
-import { diag } from '@opentelemetry/api';
 import type { ConfigurationModel } from '@opentelemetry/configuration';
 import {
   AlwaysOffSampler,
@@ -111,25 +109,6 @@ describe('buildSamplerFromConfig()', () => {
       sampler.toString(),
       'ParentBased{root=AlwaysOnSampler, remoteParentSampled=AlwaysOnSampler, remoteParentNotSampled=AlwaysOffSampler, localParentSampled=AlwaysOnSampler, localParentNotSampled=AlwaysOffSampler}'
     );
-  });
-
-  it('warns and defaults for experimental sampler variants', () => {
-    const warnStub = sinon.stub(diag, 'warn');
-    try {
-      const sampler = buildSamplerFromConfig({
-        'probability/development': { ratio: 0.1 },
-      });
-      assert.ok(sampler instanceof ParentBasedSampler);
-      assert.ok(
-        warnStub.args.some(args =>
-          String(args[0]).includes(
-            'Experimental sampler type(s) probability/development'
-          )
-        )
-      );
-    } finally {
-      warnStub.restore();
-    }
   });
 });
 

--- a/experimental/packages/opentelemetry-sdk-node/test/buildSamplerFromConfig.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/buildSamplerFromConfig.test.ts
@@ -4,13 +4,19 @@
  */
 
 import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { diag } from '@opentelemetry/api';
+import type { ConfigurationModel } from '@opentelemetry/configuration';
 import {
   AlwaysOffSampler,
   AlwaysOnSampler,
   ParentBasedSampler,
   TraceIdRatioBasedSampler,
 } from '@opentelemetry/sdk-trace';
-import { buildSamplerFromConfig } from '../src/utils';
+import {
+  buildSamplerFromConfig,
+  getSamplerFromConfiguration,
+} from '../src/utils';
 
 describe('buildSamplerFromConfig()', () => {
   it('should return AlwaysOnSampler for always_on config', () => {
@@ -104,6 +110,65 @@ describe('buildSamplerFromConfig()', () => {
     assert.strictEqual(
       sampler.toString(),
       'ParentBased{root=AlwaysOnSampler, remoteParentSampled=AlwaysOnSampler, remoteParentNotSampled=AlwaysOffSampler, localParentSampled=AlwaysOnSampler, localParentNotSampled=AlwaysOffSampler}'
+    );
+  });
+
+  it('warns and defaults for experimental sampler variants', () => {
+    const warnStub = sinon.stub(diag, 'warn');
+    try {
+      const sampler = buildSamplerFromConfig({
+        'probability/development': { ratio: 0.1 },
+      });
+      assert.ok(sampler instanceof ParentBasedSampler);
+      assert.ok(
+        warnStub.args.some(args =>
+          String(args[0]).includes(
+            'Experimental sampler type(s) probability/development'
+          )
+        )
+      );
+    } finally {
+      warnStub.restore();
+    }
+  });
+});
+
+describe('getSamplerFromConfiguration()', () => {
+  it('returns undefined when tracer_provider.sampler is omitted', () => {
+    assert.strictEqual(
+      getSamplerFromConfiguration({} as ConfigurationModel),
+      undefined
+    );
+    assert.strictEqual(
+      getSamplerFromConfiguration({
+        tracer_provider: { processors: [] },
+      } as ConfigurationModel),
+      undefined
+    );
+  });
+
+  it('returns the sampler defined under tracer_provider.sampler', () => {
+    const sampler = getSamplerFromConfiguration({
+      tracer_provider: {
+        processors: [],
+        sampler: { always_off: {} },
+      },
+    } as ConfigurationModel);
+    assert.ok(sampler instanceof AlwaysOffSampler);
+  });
+
+  it('builds a parent_based sampler from configuration', () => {
+    const sampler = getSamplerFromConfiguration({
+      tracer_provider: {
+        processors: [],
+        sampler: {
+          parent_based: { root: { trace_id_ratio_based: { ratio: 0.25 } } },
+        },
+      },
+    } as ConfigurationModel);
+    assert.ok(sampler instanceof ParentBasedSampler);
+    assert.ok(
+      sampler.toString().startsWith('ParentBased{root=TraceIdRatioBased{0.25}')
     );
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

`tracer_provider.sampler` in a declarative-config YAML is parsed and validated today but never applied to the SDK so `startNodeSDK()` falls back to the default sampler regardless of what the YAML asks for. This is the last gating wiring gap for declarative config in JS.

Fixes #6506.

## Short description of the changes

- New `getSamplerFromConfiguration(config)` helper in `sdk-node/src/utils.ts` that returns `undefined` when no sampler is configured (letting `TracerProvider` use its default) or builds a `Sampler` via the existing `buildSamplerFromConfig` otherwise.
- `start.ts` now passes the resolved sampler to `TracerProvider` and drops the `TODO (6506)` comment.
- `buildSamplerFromConfig` distinguishes experimental variants (`jaeger_remote/development`, `probability/development`, `composite/development`) from truly unknown keys in its fallback warning. Both still fall back to `ParentBased(AlwaysOn)`.
- Tests for `getSamplerFromConfiguration` and for the experimental-variant warn path.
- Changelog entry under Features.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- `npm test` - 234 tests pass, including new coverage
- `npm run lint` clean
- Locally exercised against the declarative-config example in #6834
  - a sampler configured in YAML now configures the selected sampler instead of ignoring it and always returning adefault

## Out of scope

- `opentelemetry-sdk-trace-base/src/config.ts` (`loadDefaultConfig` / `buildSamplerFromEnv`) is the env-var path used by the legacy `BasicTracerProvider` shim. It's still load-bearing for users not going through `startNodeSDK()` and is publicly exported. Rewriting it to use the configuration package is a separate breaking change and isn't required to unblock declarative-config.
