### PR TITLE
docs(shim-opentracing, shim-opencensus): give notice that these packages will be removed with the coming SDK 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :boom: Breaking Changes
 
+* docs(shim-opentracing): *Notice*: The `@opentelemetry/shim-opentracing` package will be removed in SDK 3.x, planned for approximately September 2026.
+  * The [OpenCensus](https://opentelemetry.io/blog/2026/deprecating-opencensus-compatibility/) and [OpenTracing](https://opentelemetry.io/blog/2026/deprecating-opentracing-compatibility/) compatibility requirements in the OpenTelemetry specification have been deprecated.
+
 ### :rocket: Features
 
 * feat(sdk-metrics): add maxExportBatchSize option to PeriodicExportingMetricReader [#6655](https://github.com/open-telemetry/opentelemetry-js/pull/6655) @psx95

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,7 +16,6 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * docs(shim-opencensus): *Notice*: The `@opentracing/shim-opencensus` package will be removed in SDK 3.x, planned for approximately September 2026.
   * The [OpenCensus](https://opentelemetry.io/blog/2026/deprecating-opencensus-compatibility/) and [OpenTracing](https://opentelemetry.io/blog/2026/deprecating-opentracing-compatibility/) compatibility requirements in the OpenTelemetry specification have been deprecated.
 
-
 ### :rocket: Features
 
 * feat(configuration): bump config schema to v1.1.0; rename `without_scope_info` → `scope_info_enabled` and `without_target_info/development` → `target_info_enabled/development` on the Prometheus pull exporter (semantics inverted), rename `with_resource_constant_labels` → `resource_constant_labels`. Validate `file_format` per the configuration versioning spec: accept any minor version of major `1` (e.g. `1.0`, `1.1`), warn when the minor version is newer than supported, and reject other major versions. [#6781](https://github.com/open-telemetry/opentelemetry-js/pull/6781) @MikeGoldsmith

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -13,6 +13,9 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
   * `interface BufferConfig` -> `interface BatchLogRecordProcessorOptions`, and now includes the `exporter` property
   * `interface BatchLogRecordProcessorBrowserConfig` -> `interface BatchLogRecordProcessorBrowserOptions`
   * (user-facing): `SimpleLogRecordProcessor` now takes a single `options` object with all possible properties. For example, before `new SimpleLogRecordProcessor(exporter)`, after `new SimpleLogRecordProcessor({ exporter })`. [#6836](https://github.com/open-telemetry/opentelemetry-js/pull/6836)
+* docs(shim-opencensus): *Notice*: The `@opentracing/shim-opencensus` package will be removed in SDK 3.x, planned for approximately September 2026.
+  * The [OpenCensus](https://opentelemetry.io/blog/2026/deprecating-opencensus-compatibility/) and [OpenTracing](https://opentelemetry.io/blog/2026/deprecating-opentracing-compatibility/) compatibility requirements in the OpenTelemetry specification have been deprecated.
+
 
 ### :rocket: Features
 

--- a/experimental/packages/shim-opencensus/README.md
+++ b/experimental/packages/shim-opencensus/README.md
@@ -3,6 +3,10 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
+> [!IMPORTANT]
+> As of June 2026, OpenCensus compatibility requirements in the OpenTelemetry specification [were deprecated](https://opentelemetry.io/blog/2026/deprecating-opencensus-compatibility/).
+> This package (`@opentelemetry/shim-opencensus`) will be removed in the upcoming [SDK 3.0 milestone](https://github.com/open-telemetry/opentelemetry-js/milestone/20), planned for approximately September 2026.
+
 OpenCensus shim allows existing OpenCensus instrumentation to report to OpenTelemetry. This
 allows you to incrementally migrate your existing OpenCensus instrumentation to OpenTelemetry.
 More details are available in the [OpenCensus Compatibility Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/opencensus.md).
@@ -63,7 +67,7 @@ After:
 ```js
 const { trace } = require('@opentelemetry/api');
 const { ShimTracer } = require('@opentelemetry/shim-opencensus');
-const tracer = new ShimTracer(trace.getTracer('my-module'));  
+const tracer = new ShimTracer(trace.getTracer('my-module'));
 
 // ...
 

--- a/packages/opentelemetry-shim-opentracing/README.md
+++ b/packages/opentelemetry-shim-opentracing/README.md
@@ -3,6 +3,11 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
+> [!IMPORTANT]
+> As of April 2026, OpenTracing compatibility requirements in the OpenTelemetry specification [were deprecated](https://opentelemetry.io/blog/2026/deprecating-opentracing-compatibility/).
+> This package (`@opentelemetry/shim-opentracing`) will be removed in the upcoming [SDK 3.0 milestone](https://github.com/open-telemetry/opentelemetry-js/milestone/20), planned for approximately September 2026.
+> Version 2.x will be maintained for one year, per the [OpenTelemetry stability policy](https://opentelemetry.io/docs/specs/otel/versioning-and-stability/#sdk-support).
+
 OpenTracing shim allows existing OpenTracing instrumentation to report to OpenTelemetry
 
 ## Installation


### PR DESCRIPTION
We discussed (in the OTel JS SIG), removing the opentracing and opencensus shim packages as part of SDK 3.x. The compat requirements for these projects are now deprecated in the OTel spec.

This PR is to attempt to give advance notice to any possible users of these shim packages.