### PR TITLE
doc(sdk-node): encourage configuration of NodeSDK that does not result in default resource attributes being excluded by accident

### DIFF
--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -103,11 +103,6 @@ Deprecated, please use [logRecordProcessors](#logrecordprocessors) instead.
 
 An array of log record processors to register to the logger provider.
 
-### mergeResourceWithDefaults
-
-Merge user-provided resources with the default resource. Default `true`.
-The default will change to `false` in a future iteration of this package.
-
 ### metricReader
 
 Add a [MetricReader](../../../packages/sdk-metrics/src/export/MetricReader.ts)

--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -128,7 +128,6 @@ or configure each instrumentation individually.
 
 ### resource
 
-Configure a resource. Resources may also be detected by using the `autoDetectResources` method of the SDK.
 A [Resource](https://opentelemetry.io/docs/specs/otel/resource/sdk/) to associate with generated telemetry.
 This resource will be use as the basis for additional resource attributes determined by [resource detectors](#resourcedetectors).
 See also the [`autoDetectResources` setting](#autodetectresources).

--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -129,6 +129,35 @@ or configure each instrumentation individually.
 ### resource
 
 Configure a resource. Resources may also be detected by using the `autoDetectResources` method of the SDK.
+A [Resource](https://opentelemetry.io/docs/specs/otel/resource/sdk/) to associate with generated telemetry.
+This resource will be use as the basis for additional resource attributes determined by [resource detectors](#resourcedetectors).
+See also the [`autoDetectResources` setting](#autodetectresources).
+
+If not specified, the [default resource](https://opentelemetry.io/docs/specs/semconv/resource/#semantic-attributes-with-sdk-provided-default-value) will be used.
+
+> [!WARNING]
+> If specifying the `resource` option, it is recommended that the default resource be included.
+> Otherwise the important `service.name` and `telemetry.sdk.*` resource attributes might not be included on telemetry,
+> which can adversely impact downstream processing or visualization.
+> The default resource can be include as follows:
+>
+> ```js
+> import { NodeSDK } from '@opentelemetry/sdk-node';
+> import { resourceFromAttributes, defaultResource } from '@opentelemetry/resources';
+> const sdk = new NodeSDK({
+>   resource: defaultResource().merge(
+>     resourceFromAttributes({
+>       'my.custom.attr': 'some value',
+>     })
+>   ),
+>   // ...
+> });
+> ```
+>
+> Alternatively, consider setting custom resource attributes via the
+> [`OTEL_RESOURCE_ATTRIBUTES`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration)
+> environment variable.
+
 
 ### resourceDetectors
 

--- a/experimental/packages/opentelemetry-sdk-node/README.md
+++ b/experimental/packages/opentelemetry-sdk-node/README.md
@@ -157,7 +157,6 @@ If not specified, the [default resource](https://opentelemetry.io/docs/specs/sem
 > [`OTEL_RESOURCE_ATTRIBUTES`](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration)
 > environment variable.
 
-
 ### resourceDetectors
 
 Configure resource detectors. By default, the resource detectors are [envDetector, processDetector, hostDetector].

--- a/experimental/packages/opentelemetry-sdk-node/src/types.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/types.ts
@@ -34,6 +34,14 @@ export interface NodeSDKConfiguration {
   metricReaders?: IMetricReader[];
   views: ViewOptions[];
   instrumentations: (Instrumentation | Instrumentation[])[];
+  /**
+   * Custom resource to attach to telemetry.
+   * It is recommended to merge with the default resource via:
+   *
+   *     resource: defaultResource().merge(
+   *       resourceFromAttributes({ foo: 'bar' })
+   *     )
+   */
   resource: Resource;
   resourceDetectors: Array<ResourceDetector>;
   sampler: Sampler;


### PR DESCRIPTION
A user case I saw recently involved configuring NodeSDK similar to this:

```js
  const sdk = new NodeSDK({
    resource: resourceFromAttributes({
      'service.name': packageJson.name,
      'service.version': packageJson.version,
      'deployment.environment.name': process.env.MY_DEPLOYMENT_ENVIRONMENT || 'local',
    }),
    // ...
```

There was confusion in downstream visualization that attempts to do a
language-specific visualization based on the `telemetry.sdk.language` resource attribute.

It isn't obvious from the current NodeSDK docs that specifying
`resource` will result in not having the "default resource attributes".
