### PR TITLE
chore(sdk-node)!: Drop support for deprecated OpenCensusMetricProducer from declarative config

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -17,6 +17,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
   * Responsibility for handling [declarative config "nullBehavior" and "defaultBehavior"](https://opentelemetry.io/docs/specs/otel/configuration/sdk/#create) belongs in the "create" handling, currently in the "sdk-node" package.
 * docs(shim-opencensus): *Notice*: The `@opentracing/shim-opencensus` package will be removed in SDK 3.x, planned for approximately September 2026.
   * The [OpenCensus](https://opentelemetry.io/blog/2026/deprecating-opencensus-compatibility/) and [OpenTracing](https://opentelemetry.io/blog/2026/deprecating-opentracing-compatibility/) compatibility requirements in the OpenTelemetry specification have been deprecated.
+* chore(sdk-node)!: Drop support for deprecated OpenCensusMetricProducer from declarative config
 
 ### :rocket: Features
 

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -608,21 +608,11 @@ function getMetricProducersFromConfiguration(
   }
   const result: MetricProducer[] = [];
   for (const producer of producers) {
-    if (producer.opencensus) {
-      try {
-        const {
-          OpenCensusMetricProducer,
-          // eslint-disable-next-line @typescript-eslint/no-require-imports
-        } = require('@opentelemetry/shim-opencensus');
-        result.push(new OpenCensusMetricProducer());
-      } catch {
-        diag.warn(
-          'OpenCensus metric producer configured but @opentelemetry/shim-opencensus is not installed.'
-        );
-      }
-    } else {
-      diag.warn('Unsupported metric producer configured.');
-    }
+    // Note: The "opencensus" MetricProducer is intentionally not supported.
+    // It is deprecated in OpenTelemetry Configuration v1.2.0.
+    diag.warn(
+      `Unsupported metric producer in configuration: "${producer}". Skipping.`
+    );
   }
   return result.length > 0 ? result : undefined;
 }

--- a/experimental/packages/opentelemetry-sdk-node/test/start.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/start.test.ts
@@ -968,21 +968,6 @@ describe('startNodeSDK', function () {
       });
     });
 
-    it('should create metric reader with opencensus producer when shim is available', async () => {
-      const reader = getPeriodicMetricReaderFromConfiguration({
-        exporter: { console: {} },
-        producers: [{ opencensus: {} }],
-      });
-      assert.ok(reader !== undefined);
-      const producers = (reader as any)._metricProducers;
-      assert.ok(producers.length === 1);
-      assert.strictEqual(
-        producers[0].constructor.name,
-        'OpenCensusMetricProducer'
-      );
-      await (reader as PeriodicExportingMetricReader).shutdown();
-    });
-
     it('should warn for unsupported metric producer', async () => {
       const warnSpy = Sinon.spy(diag, 'warn');
       const reader = getPeriodicMetricReaderFromConfiguration({


### PR DESCRIPTION
In OTel Configuration v1.2.0 the OpenCensusMetricProducer config will be
deprecated. The OTel Spec recently deprecated compat requirements for
OpenCensus.

Dropping the lazy `require` in a try/catch also helpfully removes a
pattern that often creates a problem for bundlers.
