### PR TITLE
docs: fix refs to API doc URLs that changed with typedoc build tool update

### DIFF
--- a/doc/context.md
+++ b/doc/context.md
@@ -7,7 +7,7 @@ This document describes the OpenTelemetry context API for JavaScript and how it 
 
 _Context Specification: <https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.0/specification/context/context.md>_
 
-_Context API Reference: <https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.ContextAPI.html>_
+_Context API Reference: <https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.ContextAPI.html>_
 
 - [Context Manager](#context-manager)
 - [Root Context](#root-context)

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -6,7 +6,7 @@ For a high-level overview of OpenTelemetry metrics in general and definitions of
 
 _Metrics API Specification: <https://github.com/open-telemetry/opentelemetry-specification/blob/v1.14.0/specification/metrics/api.md>_
 
-_Metrics API Reference: <https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.MetricsAPI.html>_
+_Metrics API Reference: <https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.MetricsAPI.html>_
 
 - [Getting Started](#getting-started)
 - [Acquiring a Meter](#acquiring-a-meter)

--- a/doc/sdk-registration.md
+++ b/doc/sdk-registration.md
@@ -24,6 +24,6 @@ api.context.setGlobalContextManager(asyncHooksContextManager);
 ```
 
 [opentelemetry-js]: https://github.com/open-telemetry/opentelemetry-js
-[trace-api-docs]: https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.TraceAPI.html
-[propagation-api-docs]: https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.PropagationAPI.html
-[context-api-docs]: https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.ContextAPI.html
+[trace-api-docs]: https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.TraceAPI.html
+[propagation-api-docs]: https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.PropagationAPI.html
+[context-api-docs]: https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.ContextAPI.html

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -6,7 +6,7 @@ For a high-level overview of OpenTelemetry tracing in general and definitions of
 
 _Trace API Specification: <https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.0/specification/trace/api.md>_
 
-_Trace API Reference: <https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.TraceAPI.html>_
+_Trace API Reference: <https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.TraceAPI.html>_
 
 - [Acquiring a Tracer](#acquiring-a-tracer)
 - [Starting and Ending a Span](#starting-and-ending-a-span)
@@ -23,7 +23,7 @@ _Trace API Reference: <https://open-telemetry.github.io/opentelemetry-js/classes
 
 ## Acquiring a Tracer
 
-In OpenTelemetry, tracing operations are performed using methods on a _tracer_. You can get a tracer by calling [`getTracer`](https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.TraceAPI.html#getTracer) on the global tracer provider. `getTracer` takes the name and version of the application or library acquiring the tracer, and provides a tracer which can be used to trace operations.
+In OpenTelemetry, tracing operations are performed using methods on a _tracer_. You can get a tracer by calling [`getTracer`](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.TraceAPI.html#getTracer) on the global tracer provider. `getTracer` takes the name and version of the application or library acquiring the tracer, and provides a tracer which can be used to trace operations.
 
 ```typescript
 import { trace } from '@opentelemetry/api';


### PR DESCRIPTION
Refs: https://github.com/open-telemetry/opentelemetry-js/pull/6746#issuecomment-4871589768

---

I did not go through the `typedoc` changes to form an opinion on whether these API doc changes are *correct*.
I don't think we are making promises for deep URLs in the API docs.