### PR TITLE
Replace browser fields with browser conditional exports solving the issue #4543

### DIFF
--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -12,11 +12,42 @@
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
   "types": "build/src/index.d.ts",
-  "browser": {
-    "./src/platform/index.ts": "./src/platform/browser/index.ts",
-    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
-    "./build/esnext/platform/index.js": "./build/esnext/platform/browser/index.js",
-    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
+  "exports": {
+    ".": {
+      "types": "./build/src/index.d.ts",
+      "browser": {
+        "esnext": "./build/esnext/platform/browser/index.js",
+        "module": "./build/esm/platform/browser/index.js",
+        "default": "./build/src/platform/browser/index.js"
+      },
+      "esnext": "./build/esnext/index.js",
+      "module": "./build/esm/index.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/src/platform/index.js": {
+      "types": "./build/src/platform/index.d.ts",
+      "browser": "./build/src/platform/browser/index.js",
+      "default": "./build/src/platform/index.js"
+    },
+    "./build/esm/platform/index.js": {
+      "types": "./build/esm/platform/index.d.ts",
+      "browser": "./build/esm/platform/browser/index.js",
+      "default": "./build/esm/platform/index.js"
+    },
+    "./build/esnext/platform/index.js": {
+      "types": "./build/esnext/platform/index.d.ts",
+      "browser": "./build/esnext/platform/browser/index.js",
+      "default": "./build/esnext/platform/index.js"
+    },
+    "./build/src/*": "./build/src/*",
+    "./build/esm/*": "./build/esm/*",
+    "./build/esnext/*": "./build/esnext/*",
+    "./src/platform/index.ts": {
+      "browser": "./src/platform/browser/index.ts",
+      "default": "./src/platform/index.ts"
+    },
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
   },
   "repository": {
     "type": "git",

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -6,13 +6,44 @@
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
   "types": "build/src/index.d.ts",
-  "repository": "open-telemetry/opentelemetry-js",
-  "browser": {
-    "./src/platform/index.ts": "./src/platform/browser/index.ts",
-    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
-    "./build/esnext/platform/index.js": "./build/esnext/platform/browser/index.js",
-    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
+  "exports": {
+    ".": {
+      "types": "./build/src/index.d.ts",
+      "browser": {
+        "esnext": "./build/esnext/platform/browser/index.js",
+        "module": "./build/esm/platform/browser/index.js",
+        "default": "./build/src/platform/browser/index.js"
+      },
+      "esnext": "./build/esnext/index.js",
+      "module": "./build/esm/index.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/src/platform/index.js": {
+      "types": "./build/src/platform/index.d.ts",
+      "browser": "./build/src/platform/browser/index.js",
+      "default": "./build/src/platform/index.js"
+    },
+    "./build/esm/platform/index.js": {
+      "types": "./build/esm/platform/index.d.ts",
+      "browser": "./build/esm/platform/browser/index.js",
+      "default": "./build/esm/platform/index.js"
+    },
+    "./build/esnext/platform/index.js": {
+      "types": "./build/esnext/platform/index.d.ts",
+      "browser": "./build/esnext/platform/browser/index.js",
+      "default": "./build/esnext/platform/index.js"
+    },
+    "./build/src/*": "./build/src/*",
+    "./build/esm/*": "./build/esm/*",
+    "./build/esnext/*": "./build/esnext/*",
+    "./src/platform/index.ts": {
+      "browser": "./src/platform/browser/index.ts",
+      "default": "./src/platform/index.ts"
+    },
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
   },
+  "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "prepublishOnly": "npm run compile",
     "compile": "tsc --build tsconfig.json tsconfig.esm.json tsconfig.esnext.json",

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -6,13 +6,44 @@
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
   "types": "build/src/index.d.ts",
-  "repository": "open-telemetry/opentelemetry-js",
-  "browser": {
-    "./src/platform/index.ts": "./src/platform/browser/index.ts",
-    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
-    "./build/esnext/platform/index.js": "./build/esnext/platform/browser/index.js",
-    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
+  "exports": {
+    ".": {
+      "types": "./build/src/index.d.ts",
+      "browser": {
+        "esnext": "./build/esnext/platform/browser/index.js",
+        "module": "./build/esm/platform/browser/index.js",
+        "default": "./build/src/platform/browser/index.js"
+      },
+      "esnext": "./build/esnext/index.js",
+      "module": "./build/esm/index.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/src/platform/index.js": {
+      "types": "./build/src/platform/index.d.ts",
+      "browser": "./build/src/platform/browser/index.js",
+      "default": "./build/src/platform/index.js"
+    },
+    "./build/esm/platform/index.js": {
+      "types": "./build/esm/platform/index.d.ts",
+      "browser": "./build/esm/platform/browser/index.js",
+      "default": "./build/esm/platform/index.js"
+    },
+    "./build/esnext/platform/index.js": {
+      "types": "./build/esnext/platform/index.d.ts",
+      "browser": "./build/esnext/platform/browser/index.js",
+      "default": "./build/esnext/platform/index.js"
+    },
+    "./build/src/*": "./build/src/*",
+    "./build/esm/*": "./build/esm/*",
+    "./build/esnext/*": "./build/esnext/*",
+    "./src/platform/index.ts": {
+      "browser": "./src/platform/browser/index.ts",
+      "default": "./src/platform/index.ts"
+    },
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
   },
+  "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "prepublishOnly": "npm run compile",
     "compile": "tsc --build tsconfig.json tsconfig.esm.json tsconfig.esnext.json",

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -6,13 +6,44 @@
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
   "types": "build/src/index.d.ts",
-  "repository": "open-telemetry/opentelemetry-js",
-  "browser": {
-    "./src/platform/index.ts": "./src/platform/browser/index.ts",
-    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
-    "./build/esnext/platform/index.js": "./build/esnext/platform/browser/index.js",
-    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
+  "exports": {
+    ".": {
+      "types": "./build/src/index.d.ts",
+      "browser": {
+        "esnext": "./build/esnext/platform/browser/index.js",
+        "module": "./build/esm/platform/browser/index.js",
+        "default": "./build/src/platform/browser/index.js"
+      },
+      "esnext": "./build/esnext/index.js",
+      "module": "./build/esm/index.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/src/platform/index.js": {
+      "types": "./build/src/platform/index.d.ts",
+      "browser": "./build/src/platform/browser/index.js",
+      "default": "./build/src/platform/index.js"
+    },
+    "./build/esm/platform/index.js": {
+      "types": "./build/esm/platform/index.d.ts",
+      "browser": "./build/esm/platform/browser/index.js",
+      "default": "./build/esm/platform/index.js"
+    },
+    "./build/esnext/platform/index.js": {
+      "types": "./build/esnext/platform/index.d.ts",
+      "browser": "./build/esnext/platform/browser/index.js",
+      "default": "./build/esnext/platform/index.js"
+    },
+    "./build/src/*": "./build/src/*",
+    "./build/esm/*": "./build/esm/*",
+    "./build/esnext/*": "./build/esnext/*",
+    "./src/platform/index.ts": {
+      "browser": "./src/platform/browser/index.ts",
+      "default": "./src/platform/index.ts"
+    },
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
   },
+  "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "prepublishOnly": "npm run compile",
     "compile": "tsc --build tsconfig.json tsconfig.esm.json tsconfig.esnext.json",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -6,13 +6,59 @@
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
   "types": "build/src/index.d.ts",
-  "repository": "open-telemetry/opentelemetry-js",
-  "browser": {
-    "./src/platform/index.ts": "./src/platform/browser/index.ts",
-    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
-    "./build/esnext/platform/index.js": "./build/esnext/platform/browser/index.js",
-    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
+  "exports": {
+    ".": {
+      "types": "./build/src/index.d.ts",
+      "browser": {
+        "esnext": "./build/esnext/index.browser.js",
+        "module": "./build/esm/index.browser.js",
+        "default": "./build/src/index.browser.js"
+      },
+      "esnext": "./build/esnext/index.js",
+      "module": "./build/esm/index.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/src/index.js": {
+      "types": "./build/src/index.d.ts",
+      "browser": "./build/src/index.browser.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/esm/index.js": {
+      "types": "./build/esm/index.d.ts",
+      "browser": "./build/esm/index.browser.js",
+      "default": "./build/esm/index.js"
+    },
+    "./build/esnext/index.js": {
+      "types": "./build/esnext/index.d.ts",
+      "browser": "./build/esnext/index.browser.js",
+      "default": "./build/esnext/index.js"
+    },
+    "./build/src/platform/index.js": {
+      "types": "./build/src/platform/index.d.ts",
+      "browser": "./build/src/platform/browser/index.js",
+      "default": "./build/src/platform/index.js"
+    },
+    "./build/esm/platform/index.js": {
+      "types": "./build/esm/platform/index.d.ts",
+      "browser": "./build/esm/platform/browser/index.js",
+      "default": "./build/esm/platform/index.js"
+    },
+    "./build/esnext/platform/index.js": {
+      "types": "./build/esnext/platform/index.d.ts",
+      "browser": "./build/esnext/platform/browser/index.js",
+      "default": "./build/esnext/platform/index.js"
+    },
+    "./build/src/*": "./build/src/*",
+    "./build/esm/*": "./build/esm/*",
+    "./build/esnext/*": "./build/esnext/*",
+    "./src/platform/index.ts": {
+      "browser": "./src/platform/browser/index.ts",
+      "default": "./src/platform/index.ts"
+    },
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
   },
+  "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "prepublishOnly": "npm run compile",
     "compile": "tsc --build tsconfig.json tsconfig.esm.json tsconfig.esnext.json",

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/index.browser.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/index.browser.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { OTLPMetricExporter } from './platform/browser';
+export { AggregationTemporalityPreference } from './OTLPMetricExporterOptions';
+export type { OTLPMetricExporterOptions } from './OTLPMetricExporterOptions';
+export {
+  CumulativeTemporalitySelector,
+  DeltaTemporalitySelector,
+  LowMemoryTemporalitySelector,
+  OTLPMetricExporterBase,
+} from './OTLPMetricExporterBase';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -6,13 +6,44 @@
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
   "types": "build/src/index.d.ts",
-  "repository": "open-telemetry/opentelemetry-js",
-  "browser": {
-    "./src/platform/index.ts": "./src/platform/browser/index.ts",
-    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
-    "./build/esnext/platform/index.js": "./build/esnext/platform/browser/index.js",
-    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
+  "exports": {
+    ".": {
+      "types": "./build/src/index.d.ts",
+      "browser": {
+        "esnext": "./build/esnext/platform/browser/index.js",
+        "module": "./build/esm/platform/browser/index.js",
+        "default": "./build/src/platform/browser/index.js"
+      },
+      "esnext": "./build/esnext/index.js",
+      "module": "./build/esm/index.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/src/platform/index.js": {
+      "types": "./build/src/platform/index.d.ts",
+      "browser": "./build/src/platform/browser/index.js",
+      "default": "./build/src/platform/index.js"
+    },
+    "./build/esm/platform/index.js": {
+      "types": "./build/esm/platform/index.d.ts",
+      "browser": "./build/esm/platform/browser/index.js",
+      "default": "./build/esm/platform/index.js"
+    },
+    "./build/esnext/platform/index.js": {
+      "types": "./build/esnext/platform/index.d.ts",
+      "browser": "./build/esnext/platform/browser/index.js",
+      "default": "./build/esnext/platform/index.js"
+    },
+    "./build/src/*": "./build/src/*",
+    "./build/esm/*": "./build/esm/*",
+    "./build/esnext/*": "./build/esnext/*",
+    "./src/platform/index.ts": {
+      "browser": "./src/platform/browser/index.ts",
+      "default": "./src/platform/index.ts"
+    },
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
   },
+  "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "prepublishOnly": "npm run compile",
     "compile": "tsc --build tsconfig.json tsconfig.esm.json tsconfig.esnext.json",

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -9,18 +9,79 @@
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
   "types": "build/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/src/index.d.ts",
+      "browser": {
+        "esnext": "./build/esnext/index.browser.js",
+        "module": "./build/esm/index.browser.js",
+        "default": "./build/src/index.browser.js"
+      },
+      "esnext": "./build/esnext/index.js",
+      "module": "./build/esm/index.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/src/index.js": {
+      "types": "./build/src/index.d.ts",
+      "browser": "./build/src/index.browser.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/esm/index.js": {
+      "types": "./build/esm/index.d.ts",
+      "browser": "./build/esm/index.browser.js",
+      "default": "./build/esm/index.js"
+    },
+    "./build/esnext/index.js": {
+      "types": "./build/esnext/index.d.ts",
+      "browser": "./build/esnext/index.browser.js",
+      "default": "./build/esnext/index.js"
+    },
+    "./build/src/instrumentationNodeModuleFile.js": {
+      "types": "./build/src/instrumentationNodeModuleFile.d.ts",
+      "browser": "./build/src/instrumentationNodeModuleFile.browser.js",
+      "default": "./build/src/instrumentationNodeModuleFile.js"
+    },
+    "./build/esm/instrumentationNodeModuleFile.js": {
+      "types": "./build/esm/instrumentationNodeModuleFile.d.ts",
+      "browser": "./build/esm/instrumentationNodeModuleFile.browser.js",
+      "default": "./build/esm/instrumentationNodeModuleFile.js"
+    },
+    "./build/esnext/instrumentationNodeModuleFile.js": {
+      "types": "./build/esnext/instrumentationNodeModuleFile.d.ts",
+      "browser": "./build/esnext/instrumentationNodeModuleFile.browser.js",
+      "default": "./build/esnext/instrumentationNodeModuleFile.js"
+    },
+    "./build/src/platform/index.js": {
+      "types": "./build/src/platform/index.d.ts",
+      "browser": "./build/src/platform/browser/index.js",
+      "default": "./build/src/platform/index.js"
+    },
+    "./build/esm/platform/index.js": {
+      "types": "./build/esm/platform/index.d.ts",
+      "browser": "./build/esm/platform/browser/index.js",
+      "default": "./build/esm/platform/index.js"
+    },
+    "./build/esnext/platform/index.js": {
+      "types": "./build/esnext/platform/index.d.ts",
+      "browser": "./build/esnext/platform/browser/index.js",
+      "default": "./build/esnext/platform/index.js"
+    },
+    "./build/src/*": "./build/src/*",
+    "./build/esm/*": "./build/esm/*",
+    "./build/esnext/*": "./build/esnext/*",
+    "./src/platform/index.ts": {
+      "browser": "./src/platform/browser/index.ts",
+      "default": "./src/platform/index.ts"
+    },
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/open-telemetry/opentelemetry-js.git"
-  },
-  "browser": {
-    "./src/platform/index.ts": "./src/platform/browser/index.ts",
-    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
-    "./build/esnext/platform/index.js": "./build/esnext/platform/browser/index.js",
-    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
   },
   "files": [
     "build/esm/**/*.js",

--- a/experimental/packages/opentelemetry-instrumentation/src/index.browser.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/index.browser.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { registerInstrumentations } from './autoLoader';
+export { InstrumentationBase } from './platform/browser/index';
+export { InstrumentationNodeModuleDefinition } from './instrumentationNodeModuleDefinition';
+export { InstrumentationNodeModuleFile } from './instrumentationNodeModuleFile.browser';
+export type {
+  Instrumentation,
+  InstrumentationConfig,
+  InstrumentationModuleDefinition,
+  InstrumentationModuleFile,
+  ShimWrapped,
+  SpanCustomizationHook,
+} from './types';
+export type { AutoLoaderOptions, AutoLoaderResult } from './types_internal';
+export {
+  isWrapped,
+  safeExecuteInTheMiddle,
+  safeExecuteInTheMiddleAsync,
+} from './utils';
+export { SemconvStability, semconvStabilityFromStr } from './semconvStability';

--- a/experimental/packages/opentelemetry-instrumentation/src/instrumentationNodeModuleFile.browser.ts
+++ b/experimental/packages/opentelemetry-instrumentation/src/instrumentationNodeModuleFile.browser.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { InstrumentationModuleFile } from './types';
+import { normalize } from './platform/browser/index';
+
+export class InstrumentationNodeModuleFile
+  implements InstrumentationModuleFile
+{
+  public name: string;
+  public supportedVersions: string[];
+  public patch;
+  public unpatch;
+
+  constructor(
+    name: string,
+    supportedVersions: string[],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    patch: (moduleExports: any, moduleVersion?: string) => any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    unpatch: (moduleExports?: any, moduleVersion?: string) => void
+  ) {
+    this.name = normalize(name);
+    this.supportedVersions = supportedVersions;
+    this.patch = patch;
+    this.unpatch = unpatch;
+  }
+}

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -12,11 +12,57 @@
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
   "types": "build/src/index.d.ts",
-  "browser": {
-    "./src/platform/index.ts": "./src/platform/browser/index.ts",
-    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
-    "./build/esnext/platform/index.js": "./build/esnext/platform/browser/index.js",
-    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
+  "exports": {
+    ".": {
+      "types": "./build/src/index.d.ts",
+      "browser": {
+        "esnext": "./build/esnext/index.browser.js",
+        "module": "./build/esm/index.browser.js",
+        "default": "./build/src/index.browser.js"
+      },
+      "esnext": "./build/esnext/index.js",
+      "module": "./build/esm/index.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/src/index.js": {
+      "types": "./build/src/index.d.ts",
+      "browser": "./build/src/index.browser.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/esm/index.js": {
+      "types": "./build/esm/index.d.ts",
+      "browser": "./build/esm/index.browser.js",
+      "default": "./build/esm/index.js"
+    },
+    "./build/esnext/index.js": {
+      "types": "./build/esnext/index.d.ts",
+      "browser": "./build/esnext/index.browser.js",
+      "default": "./build/esnext/index.js"
+    },
+    "./build/src/platform/index.js": {
+      "types": "./build/src/platform/index.d.ts",
+      "browser": "./build/src/platform/browser/index.js",
+      "default": "./build/src/platform/index.js"
+    },
+    "./build/esm/platform/index.js": {
+      "types": "./build/esm/platform/index.d.ts",
+      "browser": "./build/esm/platform/browser/index.js",
+      "default": "./build/esm/platform/index.js"
+    },
+    "./build/esnext/platform/index.js": {
+      "types": "./build/esnext/platform/index.d.ts",
+      "browser": "./build/esnext/platform/browser/index.js",
+      "default": "./build/esnext/platform/index.js"
+    },
+    "./build/src/*": "./build/src/*",
+    "./build/esm/*": "./build/esm/*",
+    "./build/esnext/*": "./build/esnext/*",
+    "./src/platform/index.ts": {
+      "browser": "./src/platform/browser/index.ts",
+      "default": "./src/platform/index.ts"
+    },
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
   },
   "repository": {
     "type": "git",

--- a/experimental/packages/sdk-logs/src/index.browser.ts
+++ b/experimental/packages/sdk-logs/src/index.browser.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type {
+  LoggerProviderConfig,
+  LoggerProviderOptions,
+  LoggerConfig,
+  LoggerConfigurator,
+  LogRecordLimits,
+  BatchLogRecordProcessorOptions,
+  BatchLogRecordProcessorBrowserOptions,
+} from './types';
+export { LoggerProvider } from './LoggerProvider';
+export type { SdkLogRecord } from './export/SdkLogRecord';
+export type { LogRecordProcessor } from './LogRecordProcessor';
+export type { ReadableLogRecord } from './export/ReadableLogRecord';
+export { ConsoleLogRecordExporter } from './export/ConsoleLogRecordExporter';
+export type { LogRecordExporter } from './export/LogRecordExporter';
+export { SimpleLogRecordProcessor } from './export/SimpleLogRecordProcessor';
+export { InMemoryLogRecordExporter } from './export/InMemoryLogRecordExporter';
+export { BatchLogRecordProcessor } from './platform/browser';
+export {
+  createLoggerConfigurator,
+  type LoggerPattern,
+} from './config/LoggerConfigurators';

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -5,13 +5,74 @@
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
-  "browser": {
-    "./src/platform/index.ts": "./src/platform/browser/index.ts",
-    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
-    "./build/esnext/platform/index.js": "./build/esnext/platform/browser/index.js",
-    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
-  },
   "types": "build/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/src/index.d.ts",
+      "browser": {
+        "esnext": "./build/esnext/index.browser.js",
+        "module": "./build/esm/index.browser.js",
+        "default": "./build/src/index.browser.js"
+      },
+      "esnext": "./build/esnext/index.js",
+      "module": "./build/esm/index.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/src/index.js": {
+      "types": "./build/src/index.d.ts",
+      "browser": "./build/src/index.browser.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/esm/index.js": {
+      "types": "./build/esm/index.d.ts",
+      "browser": "./build/esm/index.browser.js",
+      "default": "./build/esm/index.js"
+    },
+    "./build/esnext/index.js": {
+      "types": "./build/esnext/index.d.ts",
+      "browser": "./build/esnext/index.browser.js",
+      "default": "./build/esnext/index.js"
+    },
+    "./build/src/common/time.js": {
+      "types": "./build/src/common/time.d.ts",
+      "browser": "./build/src/common/time.browser.js",
+      "default": "./build/src/common/time.js"
+    },
+    "./build/esm/common/time.js": {
+      "types": "./build/esm/common/time.d.ts",
+      "browser": "./build/esm/common/time.browser.js",
+      "default": "./build/esm/common/time.js"
+    },
+    "./build/esnext/common/time.js": {
+      "types": "./build/esnext/common/time.d.ts",
+      "browser": "./build/esnext/common/time.browser.js",
+      "default": "./build/esnext/common/time.js"
+    },
+    "./build/src/platform/index.js": {
+      "types": "./build/src/platform/index.d.ts",
+      "browser": "./build/src/platform/browser/index.js",
+      "default": "./build/src/platform/index.js"
+    },
+    "./build/esm/platform/index.js": {
+      "types": "./build/esm/platform/index.d.ts",
+      "browser": "./build/esm/platform/browser/index.js",
+      "default": "./build/esm/platform/index.js"
+    },
+    "./build/esnext/platform/index.js": {
+      "types": "./build/esnext/platform/index.d.ts",
+      "browser": "./build/esnext/platform/browser/index.js",
+      "default": "./build/esnext/platform/index.js"
+    },
+    "./build/src/*": "./build/src/*",
+    "./build/esm/*": "./build/esm/*",
+    "./build/esnext/*": "./build/esnext/*",
+    "./src/platform/index.ts": {
+      "browser": "./src/platform/browser/index.ts",
+      "default": "./src/platform/index.ts"
+    },
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "prepublishOnly": "npm run compile",

--- a/packages/opentelemetry-core/src/common/time.browser.ts
+++ b/packages/opentelemetry-core/src/common/time.browser.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type * as api from '@opentelemetry/api';
+import { otperformance as performance } from '../platform/browser';
+
+const NANOSECOND_DIGITS = 9;
+const NANOSECOND_DIGITS_IN_MILLIS = 6;
+const MILLISECONDS_TO_NANOSECONDS = Math.pow(10, NANOSECOND_DIGITS_IN_MILLIS);
+const SECOND_TO_NANOSECONDS = Math.pow(10, NANOSECOND_DIGITS);
+
+/**
+ * Converts a number of milliseconds from epoch to HrTime([seconds, remainder in nanoseconds]).
+ * @param epochMillis
+ */
+export function millisToHrTime(epochMillis: number): api.HrTime {
+  const epochSeconds = epochMillis / 1000;
+  // Decimals only.
+  const seconds = Math.trunc(epochSeconds);
+  // Round sub-nanosecond accuracy to nanosecond.
+  const nanos = Math.round((epochMillis % 1000) * MILLISECONDS_TO_NANOSECONDS);
+  return [seconds, nanos];
+}
+
+/**
+ * @deprecated Use `performance.timeOrigin` directly.
+ */
+export function getTimeOrigin(): number {
+  return performance.timeOrigin;
+}
+
+/**
+ * Returns an hrtime calculated via performance component.
+ * @param performanceNow
+ */
+export function hrTime(performanceNow?: number): api.HrTime {
+  const timeOrigin = millisToHrTime(performance.timeOrigin);
+  const now = millisToHrTime(
+    typeof performanceNow === 'number' ? performanceNow : performance.now()
+  );
+
+  return addHrTimes(timeOrigin, now);
+}
+
+/**
+ *
+ * Converts a TimeInput to an HrTime, defaults to _hrtime().
+ * @param time
+ */
+export function timeInputToHrTime(time: api.TimeInput): api.HrTime {
+  // process.hrtime
+  if (isTimeInputHrTime(time)) {
+    return time as api.HrTime;
+  } else if (typeof time === 'number') {
+    // Distinguish between a relative performance.now() value and an absolute
+    // epoch-millisecond timestamp.
+    //
+    // performance.timeOrigin uses a monotonic clock that may be slightly ahead
+    // of Date.now() due to clock adjustments (see MDN docs). This means a
+    // real epoch-ms value (e.g. Date.now()) can land just below
+    // performance.timeOrigin, causing it to be misclassified as a relative
+    // performance.now() reading and doubled when timeOrigin is added.
+    //
+    // A genuine performance.now() value represents elapsed time since the
+    // document/process started, so it is bounded by system uptime. No real
+    // system has been running long enough for performance.now() to reach half
+    // the current epoch time (~1994 in ms terms). We therefore treat any value
+    // below half of performance.timeOrigin as a relative performance.now()
+    // reading, and everything else as an absolute epoch-millisecond timestamp.
+    if (time < performance.timeOrigin / 2) {
+      return hrTime(time);
+    } else {
+      // epoch milliseconds or performance.timeOrigin
+      return millisToHrTime(time);
+    }
+  } else if (time instanceof Date) {
+    return millisToHrTime(time.getTime());
+  } else {
+    throw TypeError('Invalid input type');
+  }
+}
+
+/**
+ * Returns a duration of two hrTime.
+ * @param startTime
+ * @param endTime
+ */
+export function hrTimeDuration(
+  startTime: api.HrTime,
+  endTime: api.HrTime
+): api.HrTime {
+  let seconds = endTime[0] - startTime[0];
+  let nanos = endTime[1] - startTime[1];
+
+  // overflow
+  if (nanos < 0) {
+    seconds -= 1;
+    // negate
+    nanos += SECOND_TO_NANOSECONDS;
+  }
+
+  return [seconds, nanos];
+}
+
+/**
+ * Convert hrTime to timestamp, for example "2019-05-14T17:00:00.000123456Z"
+ * @param time
+ */
+export function hrTimeToTimeStamp(time: api.HrTime): string {
+  const precision = NANOSECOND_DIGITS;
+  const tmp = `${'0'.repeat(precision)}${time[1]}Z`;
+  const nanoString = tmp.substring(tmp.length - precision - 1);
+  const date = new Date(time[0] * 1000).toISOString();
+  return date.replace('000Z', nanoString);
+}
+
+/**
+ * Convert hrTime to nanoseconds.
+ * @param time
+ */
+export function hrTimeToNanoseconds(time: api.HrTime): number {
+  return time[0] * SECOND_TO_NANOSECONDS + time[1];
+}
+
+/**
+ * Convert hrTime to microseconds.
+ * @param time
+ */
+export function hrTimeToMicroseconds(time: api.HrTime): number {
+  return time[0] * 1e6 + time[1] / 1e3;
+}
+
+/**
+ * Convert hrTime to milliseconds.
+ * @param time
+ */
+export function hrTimeToMilliseconds(time: api.HrTime): number {
+  return time[0] * 1e3 + time[1] / 1e6;
+}
+
+/**
+ * Convert hrTime to seconds.
+ * @param time
+ */
+export function hrTimeToSeconds(time: api.HrTime): number {
+  return time[0] + time[1] / SECOND_TO_NANOSECONDS;
+}
+/**
+ * check if time is HrTime
+ * @param value
+ */
+export function isTimeInputHrTime(value: unknown): value is api.HrTime {
+  return (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    typeof value[0] === 'number' &&
+    typeof value[1] === 'number'
+  );
+}
+
+/**
+ * check if input value is a correct types.TimeInput
+ * @param value
+ */
+export function isTimeInput(
+  value: unknown
+): value is api.HrTime | number | Date {
+  return (
+    isTimeInputHrTime(value) ||
+    typeof value === 'number' ||
+    value instanceof Date
+  );
+}
+
+/**
+ * Given 2 HrTime formatted times, return their sum as an HrTime.
+ */
+export function addHrTimes(time1: api.HrTime, time2: api.HrTime): api.HrTime {
+  const out = [time1[0] + time2[0], time1[1] + time2[1]] as api.HrTime;
+
+  // Nanoseconds
+  if (out[1] >= SECOND_TO_NANOSECONDS) {
+    out[1] -= SECOND_TO_NANOSECONDS;
+    out[0] += 1;
+  }
+
+  return out;
+}

--- a/packages/opentelemetry-core/src/index.browser.ts
+++ b/packages/opentelemetry-core/src/index.browser.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { W3CBaggagePropagator } from './baggage/propagation/W3CBaggagePropagator';
+export { AnchoredClock } from './common/anchored-clock';
+export type { Clock } from './common/anchored-clock';
+export { isAttributeValue, sanitizeAttributes } from './common/attributes';
+export {
+  globalErrorHandler,
+  setGlobalErrorHandler,
+} from './common/global-error-handler';
+export { loggingErrorHandler } from './common/logging-error-handler';
+export {
+  addHrTimes,
+  getTimeOrigin,
+  hrTime,
+  hrTimeDuration,
+  hrTimeToMicroseconds,
+  hrTimeToMilliseconds,
+  hrTimeToNanoseconds,
+  hrTimeToSeconds,
+  hrTimeToTimeStamp,
+  isTimeInput,
+  isTimeInputHrTime,
+  millisToHrTime,
+  timeInputToHrTime,
+} from './common/time.browser';
+export { unrefTimer } from './common/timer-util';
+export type { ErrorHandler, InstrumentationScope } from './common/types';
+export { ExportResultCode } from './ExportResult';
+export type { ExportResult } from './ExportResult';
+export { parseKeyPairsIntoRecord } from './baggage/utils';
+export {
+  SDK_INFO,
+  _globalThis,
+  getStringFromEnv,
+  getBooleanFromEnv,
+  getNumberFromEnv,
+  getStringListFromEnv,
+  otperformance,
+} from './platform/browser';
+export { CompositePropagator } from './propagation/composite';
+export type { CompositePropagatorConfig } from './propagation/composite';
+export {
+  TRACE_PARENT_HEADER,
+  TRACE_STATE_HEADER,
+  W3CTraceContextPropagator,
+  parseTraceParent,
+} from './trace/W3CTraceContextPropagator';
+export {
+  RPCType,
+  deleteRPCMetadata,
+  getRPCMetadata,
+  setRPCMetadata,
+} from './trace/rpc-metadata';
+export type { RPCMetadata } from './trace/rpc-metadata';
+export {
+  isTracingSuppressed,
+  suppressTracing,
+  unsuppressTracing,
+} from './trace/suppress-tracing';
+export { TraceState } from './trace/TraceState';
+export { merge } from './utils/merge';
+export { TimeoutError, callWithTimeout } from './utils/timeout';
+export { isUrlIgnored, urlMatches } from './utils/url';
+export { BindOnceFuture } from './utils/callback';
+export { diagLogLevelFromString } from './utils/configuration';
+import { _export } from './internal/exporter';
+export const internal = {
+  _export,
+};

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -6,13 +6,74 @@
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
   "types": "build/src/index.d.ts",
-  "repository": "open-telemetry/opentelemetry-js",
-  "browser": {
-    "./src/platform/index.ts": "./src/platform/browser/index.ts",
-    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
-    "./build/esnext/platform/index.js": "./build/esnext/platform/browser/index.js",
-    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
+  "exports": {
+    ".": {
+      "types": "./build/src/index.d.ts",
+      "browser": {
+        "esnext": "./build/esnext/index.browser.js",
+        "module": "./build/esm/index.browser.js",
+        "default": "./build/src/index.browser.js"
+      },
+      "esnext": "./build/esnext/index.js",
+      "module": "./build/esm/index.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/src/index.js": {
+      "types": "./build/src/index.d.ts",
+      "browser": "./build/src/index.browser.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/esm/index.js": {
+      "types": "./build/esm/index.d.ts",
+      "browser": "./build/esm/index.browser.js",
+      "default": "./build/esm/index.js"
+    },
+    "./build/esnext/index.js": {
+      "types": "./build/esnext/index.d.ts",
+      "browser": "./build/esnext/index.browser.js",
+      "default": "./build/esnext/index.js"
+    },
+    "./build/src/zipkin.js": {
+      "types": "./build/src/zipkin.d.ts",
+      "browser": "./build/src/zipkin.browser.js",
+      "default": "./build/src/zipkin.js"
+    },
+    "./build/esm/zipkin.js": {
+      "types": "./build/esm/zipkin.d.ts",
+      "browser": "./build/esm/zipkin.browser.js",
+      "default": "./build/esm/zipkin.js"
+    },
+    "./build/esnext/zipkin.js": {
+      "types": "./build/esnext/zipkin.d.ts",
+      "browser": "./build/esnext/zipkin.browser.js",
+      "default": "./build/esnext/zipkin.js"
+    },
+    "./build/src/platform/index.js": {
+      "types": "./build/src/platform/index.d.ts",
+      "browser": "./build/src/platform/browser/index.js",
+      "default": "./build/src/platform/index.js"
+    },
+    "./build/esm/platform/index.js": {
+      "types": "./build/esm/platform/index.d.ts",
+      "browser": "./build/esm/platform/browser/index.js",
+      "default": "./build/esm/platform/index.js"
+    },
+    "./build/esnext/platform/index.js": {
+      "types": "./build/esnext/platform/index.d.ts",
+      "browser": "./build/esnext/platform/browser/index.js",
+      "default": "./build/esnext/platform/index.js"
+    },
+    "./build/src/*": "./build/src/*",
+    "./build/esm/*": "./build/esm/*",
+    "./build/esnext/*": "./build/esnext/*",
+    "./src/platform/index.ts": {
+      "browser": "./src/platform/browser/index.ts",
+      "default": "./src/platform/index.ts"
+    },
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
   },
+  "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "prepublishOnly": "npm run compile",
     "compile": "tsc --build tsconfig.json tsconfig.esm.json tsconfig.esnext.json",

--- a/packages/opentelemetry-exporter-zipkin/src/index.browser.ts
+++ b/packages/opentelemetry-exporter-zipkin/src/index.browser.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { prepareSend } from './platform/browser';
+export type { ExporterConfig } from './types';
+export { ZipkinExporter } from './zipkin.browser';

--- a/packages/opentelemetry-exporter-zipkin/src/zipkin.browser.ts
+++ b/packages/opentelemetry-exporter-zipkin/src/zipkin.browser.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { diag } from '@opentelemetry/api';
+import type { ExportResult } from '@opentelemetry/core';
+import { ExportResultCode, getStringFromEnv } from '@opentelemetry/core';
+import type { SpanExporter, ReadableSpan } from '@opentelemetry/sdk-trace';
+import { prepareSend } from './platform/browser/index';
+import type * as zipkinTypes from './types';
+import {
+  toZipkinSpan,
+  defaultStatusCodeTagName,
+  defaultStatusErrorTagName,
+} from './transform';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { prepareGetHeaders } from './utils';
+
+/**
+ * Zipkin Exporter
+ */
+export class ZipkinExporter implements SpanExporter {
+  private readonly DEFAULT_SERVICE_NAME = 'OpenTelemetry Service';
+  private readonly _statusCodeTagName: string;
+  private readonly _statusDescriptionTagName: string;
+  private _urlStr: string;
+  private _send: zipkinTypes.SendFunction;
+  private _getHeaders: zipkinTypes.GetHeaders | undefined;
+  private _serviceName?: string;
+  private _isShutdown: boolean;
+  private _sendingPromises: Promise<unknown>[] = [];
+
+  constructor(config: zipkinTypes.ExporterConfig = {}) {
+    this._urlStr =
+      config.url ||
+      (getStringFromEnv('OTEL_EXPORTER_ZIPKIN_ENDPOINT') ??
+        'http://localhost:9411/api/v2/spans');
+    this._send = prepareSend(this._urlStr, config.headers);
+    this._serviceName = config.serviceName;
+    this._statusCodeTagName =
+      config.statusCodeTagName || defaultStatusCodeTagName;
+    this._statusDescriptionTagName =
+      config.statusDescriptionTagName || defaultStatusErrorTagName;
+    this._isShutdown = false;
+    if (typeof config.getExportRequestHeaders === 'function') {
+      this._getHeaders = prepareGetHeaders(config.getExportRequestHeaders);
+    } else {
+      // noop
+      this._beforeSend = function () {};
+    }
+  }
+
+  /**
+   * Export spans.
+   */
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void
+  ): void {
+    const serviceName = String(
+      this._serviceName ||
+        spans[0].resource.attributes[ATTR_SERVICE_NAME] ||
+        this.DEFAULT_SERVICE_NAME
+    );
+
+    diag.debug('Zipkin exporter export');
+    if (this._isShutdown) {
+      setTimeout(() =>
+        resultCallback({
+          code: ExportResultCode.FAILED,
+          error: new Error('Exporter has been shutdown'),
+        })
+      );
+      return;
+    }
+    const promise = new Promise<void>(resolve => {
+      this._sendSpans(spans, serviceName, result => {
+        resolve();
+        resultCallback(result);
+      });
+    });
+
+    this._sendingPromises.push(promise);
+    const popPromise = () => {
+      const index = this._sendingPromises.indexOf(promise);
+      void this._sendingPromises.splice(index, 1);
+    };
+    promise.then(popPromise, popPromise);
+  }
+
+  /**
+   * Shutdown exporter. Noop operation in this exporter.
+   */
+  shutdown(): Promise<void> {
+    diag.debug('Zipkin exporter shutdown');
+    this._isShutdown = true;
+    return this.forceFlush();
+  }
+
+  /**
+   * Exports any pending spans in exporter
+   */
+  forceFlush(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      Promise.all(this._sendingPromises).then(() => {
+        resolve();
+      }, reject);
+    });
+  }
+
+  /**
+   * if user defines getExportRequestHeaders in config then this will be called
+   * every time before send, otherwise it will be replaced with noop in
+   * constructor
+   * @default noop
+   */
+  private _beforeSend() {
+    if (this._getHeaders) {
+      this._send = prepareSend(this._urlStr, this._getHeaders());
+    }
+  }
+
+  /**
+   * Transform spans and sends to Zipkin service.
+   */
+  private _sendSpans(
+    spans: ReadableSpan[],
+    serviceName: string,
+    done?: (result: ExportResult) => void
+  ) {
+    const zipkinSpans = spans.map(span =>
+      toZipkinSpan(
+        span,
+        String(
+          span.attributes[ATTR_SERVICE_NAME] ||
+            span.resource.attributes[ATTR_SERVICE_NAME] ||
+            serviceName
+        ),
+        this._statusCodeTagName,
+        this._statusDescriptionTagName
+      )
+    );
+    this._beforeSend();
+    return this._send(zipkinSpans, (result: ExportResult) => {
+      if (done) {
+        return done(result);
+      }
+    });
+  }
+}

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -5,13 +5,75 @@
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
-  "browser": {
-    "./src/detectors/platform/index.ts": "./src/detectors/platform/browser/index.ts",
-    "./build/esm/detectors/platform/index.js": "./build/esm/detectors/platform/browser/index.js",
-    "./build/esnext/detectors/platform/index.js": "./build/esnext/detectors/platform/browser/index.js",
-    "./build/src/detectors/platform/index.js": "./build/src/detectors/platform/browser/index.js"
-  },
   "types": "build/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/src/index.d.ts",
+      "browser": {
+        "esnext": "./build/esnext/index.browser.js",
+        "module": "./build/esm/index.browser.js",
+        "default": "./build/src/index.browser.js"
+      },
+      "esnext": "./build/esnext/index.js",
+      "module": "./build/esm/index.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/src/index.js": {
+      "types": "./build/src/index.d.ts",
+      "browser": "./build/src/index.browser.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/esm/index.js": {
+      "types": "./build/esm/index.d.ts",
+      "browser": "./build/esm/index.browser.js",
+      "default": "./build/esm/index.js"
+    },
+    "./build/esnext/index.js": {
+      "types": "./build/esnext/index.d.ts",
+      "browser": "./build/esnext/index.browser.js",
+      "default": "./build/esnext/index.js"
+    },
+    "./build/src/detectors/index.js": {
+      "types": "./build/src/detectors/index.d.ts",
+      "browser": "./build/src/detectors/index.browser.js",
+      "default": "./build/src/detectors/index.js"
+    },
+    "./build/esm/detectors/index.js": {
+      "types": "./build/esm/detectors/index.d.ts",
+      "browser": "./build/esm/detectors/index.browser.js",
+      "default": "./build/esm/detectors/index.js"
+    },
+    "./build/esnext/detectors/index.js": {
+      "types": "./build/esnext/detectors/index.d.ts",
+      "browser": "./build/esnext/detectors/index.browser.js",
+      "default": "./build/esnext/detectors/index.js"
+    },
+    "./build/src/detectors/platform/index.js": {
+      "types": "./build/src/detectors/platform/index.d.ts",
+      "browser": "./build/src/detectors/platform/browser/index.js",
+      "default": "./build/src/detectors/platform/index.js"
+    },
+    "./build/esm/detectors/platform/index.js": {
+      "types": "./build/esm/detectors/platform/index.d.ts",
+      "browser": "./build/esm/detectors/platform/browser/index.js",
+      "default": "./build/esm/detectors/platform/index.js"
+    },
+    "./build/esnext/detectors/platform/index.js": {
+      "types": "./build/esnext/detectors/platform/index.d.ts",
+      "browser": "./build/esnext/detectors/platform/browser/index.js",
+      "default": "./build/esnext/detectors/platform/index.js"
+    },
+    "./build/src/*": "./build/src/*",
+    "./build/esm/*": "./build/esm/*",
+    "./build/esnext/*": "./build/esnext/*",
+    "./src/detectors/platform/index.ts": {
+      "browser": "./src/detectors/platform/browser/index.ts",
+      "default": "./src/detectors/platform/index.ts"
+    },
+    "./src/semconv": "./src/semconv.ts",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "prepublishOnly": "npm run compile",

--- a/packages/opentelemetry-resources/src/detectors/index.browser.ts
+++ b/packages/opentelemetry-resources/src/detectors/index.browser.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { envDetector } from './EnvDetector';
+export {
+  hostDetector,
+  osDetector,
+  processDetector,
+  serviceInstanceIdDetector,
+} from './platform/browser';
+export { noopDetector } from './NoopDetector';

--- a/packages/opentelemetry-resources/src/index.browser.ts
+++ b/packages/opentelemetry-resources/src/index.browser.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type { ResourceDetectionConfig } from './config';
+export { detectResources } from './detect-resources';
+export { envDetector } from './detectors/EnvDetector';
+export {
+  hostDetector,
+  osDetector,
+  processDetector,
+  serviceInstanceIdDetector,
+} from './detectors/platform/browser';
+export type { Resource } from './Resource';
+export {
+  resourceFromAttributes,
+  defaultResource,
+  emptyResource,
+} from './ResourceImpl';
+export { defaultServiceName } from './default-service-name';
+export type {
+  ResourceDetector,
+  DetectedResource,
+  DetectedResourceAttributes,
+  RawResourceAttribute,
+  MaybePromise,
+} from './types';

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -5,13 +5,37 @@
   "main": "build/src/index-shim.js",
   "module": "build/esm/index-shim.js",
   "esnext": "build/esnext/index-shim.js",
-  "browser": {
-    "./src/platform/index.ts": "./src/platform/browser/index.ts",
-    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
-    "./build/esnext/platform/index.js": "./build/esnext/platform/browser/index.js",
-    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
-  },
   "types": "build/src/index-shim.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/src/index-shim.d.ts",
+      "browser": {
+        "esnext": "./build/esnext/index-shim.js",
+        "module": "./build/esm/index-shim.js",
+        "default": "./build/src/index-shim.js"
+      },
+      "esnext": "./build/esnext/index-shim.js",
+      "module": "./build/esm/index-shim.js",
+      "default": "./build/src/index-shim.js"
+    },
+    "./build/src/index-shim.js": {
+      "types": "./build/src/index-shim.d.ts",
+      "default": "./build/src/index-shim.js"
+    },
+    "./build/esm/index-shim.js": {
+      "types": "./build/esm/index-shim.d.ts",
+      "default": "./build/esm/index-shim.js"
+    },
+    "./build/esnext/index-shim.js": {
+      "types": "./build/esnext/index-shim.d.ts",
+      "default": "./build/esnext/index-shim.js"
+    },
+    "./build/src/*": "./build/src/*",
+    "./build/esm/*": "./build/esm/*",
+    "./build/esnext/*": "./build/esnext/*",
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "prepublishOnly": "npm run compile",

--- a/packages/sdk-trace/package.json
+++ b/packages/sdk-trace/package.json
@@ -5,13 +5,74 @@
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
   "esnext": "build/esnext/index.js",
-  "browser": {
-    "./src/platform/index.ts": "./src/platform/browser/index.ts",
-    "./build/esm/platform/index.js": "./build/esm/platform/browser/index.js",
-    "./build/esnext/platform/index.js": "./build/esnext/platform/browser/index.js",
-    "./build/src/platform/index.js": "./build/src/platform/browser/index.js"
-  },
   "types": "build/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/src/index.d.ts",
+      "browser": {
+        "esnext": "./build/esnext/index.browser.js",
+        "module": "./build/esm/index.browser.js",
+        "default": "./build/src/index.browser.js"
+      },
+      "esnext": "./build/esnext/index.js",
+      "module": "./build/esm/index.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/src/index.js": {
+      "types": "./build/src/index.d.ts",
+      "browser": "./build/src/index.browser.js",
+      "default": "./build/src/index.js"
+    },
+    "./build/esm/index.js": {
+      "types": "./build/esm/index.d.ts",
+      "browser": "./build/esm/index.browser.js",
+      "default": "./build/esm/index.js"
+    },
+    "./build/esnext/index.js": {
+      "types": "./build/esnext/index.d.ts",
+      "browser": "./build/esnext/index.browser.js",
+      "default": "./build/esnext/index.js"
+    },
+    "./build/src/TracerProvider.js": {
+      "types": "./build/src/TracerProvider.d.ts",
+      "browser": "./build/src/TracerProvider.browser.js",
+      "default": "./build/src/TracerProvider.js"
+    },
+    "./build/esm/TracerProvider.js": {
+      "types": "./build/esm/TracerProvider.d.ts",
+      "browser": "./build/esm/TracerProvider.browser.js",
+      "default": "./build/esm/TracerProvider.js"
+    },
+    "./build/esnext/TracerProvider.js": {
+      "types": "./build/esnext/TracerProvider.d.ts",
+      "browser": "./build/esnext/TracerProvider.browser.js",
+      "default": "./build/esnext/TracerProvider.js"
+    },
+    "./build/src/platform/index.js": {
+      "types": "./build/src/platform/index.d.ts",
+      "browser": "./build/src/platform/browser/index.js",
+      "default": "./build/src/platform/index.js"
+    },
+    "./build/esm/platform/index.js": {
+      "types": "./build/esm/platform/index.d.ts",
+      "browser": "./build/esm/platform/browser/index.js",
+      "default": "./build/esm/platform/index.js"
+    },
+    "./build/esnext/platform/index.js": {
+      "types": "./build/esnext/platform/index.d.ts",
+      "browser": "./build/esnext/platform/browser/index.js",
+      "default": "./build/esnext/platform/index.js"
+    },
+    "./build/src/*": "./build/src/*",
+    "./build/esm/*": "./build/esm/*",
+    "./build/esnext/*": "./build/esnext/*",
+    "./src/platform/index.ts": {
+      "browser": "./src/platform/browser/index.ts",
+      "default": "./src/platform/index.ts"
+    },
+    "./src/*": "./src/*",
+    "./package.json": "./package.json"
+  },
   "repository": "open-telemetry/opentelemetry-js",
   "scripts": {
     "prepublishOnly": "npm run compile",

--- a/packages/sdk-trace/src/TracerProvider.browser.ts
+++ b/packages/sdk-trace/src/TracerProvider.browser.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  TracerProvider as ApiTracerProvider,
+  Tracer as ApiTracer,
+} from '@opentelemetry/api';
+import { createNoopMeter } from '@opentelemetry/api';
+import type { Resource } from '@opentelemetry/resources';
+import { defaultResource } from '@opentelemetry/resources';
+import type { SpanProcessor } from './SpanProcessor';
+import { Tracer } from './Tracer';
+import { MultiSpanProcessor } from './MultiSpanProcessor';
+import type { TracerProviderOptions, TracerOptions } from './types';
+import { ParentBasedSampler } from './sampler/ParentBasedSampler';
+import { AlwaysOnSampler } from './sampler/AlwaysOnSampler';
+import { RandomIdGenerator } from './platform/browser';
+import type { InspectFn, InspectStylizeOptions } from './inspect';
+import {
+  formatInspect,
+  inspectCustom,
+  settledResourceAttributes,
+} from './inspect';
+
+enum ForceFlushState {
+  'resolved',
+  'timeout',
+  'error',
+  'unresolved',
+}
+
+/**
+ * This class represents a basic tracer provider which platform libraries can extend
+ */
+export class TracerProvider implements ApiTracerProvider {
+  private readonly _resource: Resource;
+  private readonly _activeSpanProcessor: MultiSpanProcessor;
+  private readonly _forceFlushTimeoutMillis: number;
+  private readonly _tracerOptions: TracerOptions;
+  private readonly _tracers: Map<string, Tracer> = new Map();
+
+  constructor(options: TracerProviderOptions = {}) {
+    this._forceFlushTimeoutMillis = options.forceFlushTimeoutMillis ?? 30000;
+    this._resource = options.resource ?? defaultResource();
+    const spanProcessors = options.spanProcessors ?? [];
+    this._activeSpanProcessor = new MultiSpanProcessor(spanProcessors);
+
+    this._tracerOptions = {
+      resource: this._resource,
+      sampler:
+        options.sampler ??
+        new ParentBasedSampler({
+          root: new AlwaysOnSampler(),
+        }),
+      spanLimits: {
+        attributeCountLimit: options.spanLimits?.attributeCountLimit ?? 128,
+        attributeValueLengthLimit:
+          options.spanLimits?.attributeValueLengthLimit ?? Infinity,
+        eventCountLimit: options.spanLimits?.eventCountLimit ?? 128,
+        linkCountLimit: options.spanLimits?.linkCountLimit ?? 128,
+        attributePerEventCountLimit:
+          options.spanLimits?.attributePerEventCountLimit ?? 128,
+        attributePerLinkCountLimit:
+          options.spanLimits?.attributePerLinkCountLimit ?? 128,
+      },
+      idGenerator: options.idGenerator || new RandomIdGenerator(),
+      spanProcessor: this._activeSpanProcessor,
+      meterProvider: options.meterProvider ?? {
+        getMeter() {
+          return createNoopMeter();
+        },
+      },
+    };
+  }
+
+  getTracer(
+    name: string,
+    version?: string,
+    options?: { schemaUrl?: string }
+  ): ApiTracer {
+    const key = `${name}@${version || ''}:${options?.schemaUrl || ''}`;
+    if (!this._tracers.has(key)) {
+      this._tracers.set(
+        key,
+        new Tracer(
+          { name, version, schemaUrl: options?.schemaUrl },
+          this._tracerOptions
+        )
+      );
+    }
+
+    return this._tracers.get(key)!;
+  }
+
+  forceFlush(): Promise<void> {
+    const timeout = this._forceFlushTimeoutMillis;
+    const promises = this._activeSpanProcessor['_spanProcessors'].map(
+      (spanProcessor: SpanProcessor) => {
+        return new Promise(resolve => {
+          let state: ForceFlushState;
+          const timeoutInterval = setTimeout(() => {
+            resolve(
+              new Error(
+                `Span processor did not completed within timeout period of ${timeout} ms`
+              )
+            );
+            state = ForceFlushState.timeout;
+          }, timeout);
+
+          spanProcessor
+            .forceFlush()
+            .then(() => {
+              clearTimeout(timeoutInterval);
+              if (state !== ForceFlushState.timeout) {
+                state = ForceFlushState.resolved;
+                resolve(state);
+              }
+            })
+            .catch(error => {
+              clearTimeout(timeoutInterval);
+              state = ForceFlushState.error;
+              resolve(error);
+            });
+        });
+      }
+    );
+
+    return new Promise<void>((resolve, reject) => {
+      Promise.all(promises)
+        .then(results => {
+          const errors = results.filter(
+            result => result !== ForceFlushState.resolved
+          );
+          if (errors.length > 0) {
+            reject(errors);
+          } else {
+            resolve();
+          }
+        })
+        .catch(error => reject([error]));
+    });
+  }
+
+  shutdown(): Promise<void> {
+    return this._activeSpanProcessor.shutdown();
+  }
+
+  [inspectCustom](
+    depth: number,
+    options: InspectStylizeOptions | undefined,
+    inspect: InspectFn | undefined
+  ): unknown {
+    const processors = this._activeSpanProcessor[
+      '_spanProcessors'
+    ] as SpanProcessor[];
+    const payload = {
+      resource: { attributes: settledResourceAttributes(this._resource) },
+      tracers: Array.from(this._tracers.keys()),
+      spanProcessors: processors.map(
+        p => p.constructor?.name ?? 'SpanProcessor'
+      ),
+    };
+    return formatInspect('TracerProvider', payload, depth, options, inspect);
+  }
+}

--- a/packages/sdk-trace/src/index.browser.ts
+++ b/packages/sdk-trace/src/index.browser.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { TracerProvider } from './TracerProvider.browser';
+export { BatchSpanProcessor, RandomIdGenerator } from './platform/browser';
+export { ConsoleSpanExporter } from './export/ConsoleSpanExporter';
+export { InMemorySpanExporter } from './export/InMemorySpanExporter';
+export type { ReadableSpan } from './export/ReadableSpan';
+export { SimpleSpanProcessor } from './export/SimpleSpanProcessor';
+export type { SpanExporter } from './export/SpanExporter';
+export { NoopSpanProcessor } from './export/NoopSpanProcessor';
+export { AlwaysOffSampler } from './sampler/AlwaysOffSampler';
+export { AlwaysOnSampler } from './sampler/AlwaysOnSampler';
+export { createAlwaysRecordSampler } from './sampler/AlwaysRecordSampler';
+export { ParentBasedSampler } from './sampler/ParentBasedSampler';
+export { TraceIdRatioBasedSampler } from './sampler/TraceIdRatioBasedSampler';
+export { SamplingDecision } from './Sampler';
+export type { Sampler, SamplingResult } from './Sampler';
+export type { Span } from './Span';
+export type { SpanProcessor } from './SpanProcessor';
+export type { TimedEvent } from './TimedEvent';
+export type {
+  BatchSpanProcessorOptions,
+  BatchSpanProcessorBrowserOptions,
+  SimpleSpanProcessorOptions,
+  SpanLimits,
+  SpanProcessorOptions,
+  TracerProviderOptions,
+} from './types';
+export type { IdGenerator } from './IdGenerator';


### PR DESCRIPTION
**Which problem is this PR solving?**

Fixes [#4543](https://github.com/open-telemetry/opentelemetry-js/issues/4543).

Several packages used the top-level `browser` field in `package.json` to replace Node-specific platform modules with browser implementations. That field is bundler-specific rather than part of Node/npm package resolution, and can cause incompatibilities with tools such as Jest and other runtimes.

This PR replaces those `browser` field mappings with conditional exports using the `browser` condition.

**Short description of the changes**

- Remove top-level `package.json#browser` from the affected packages.
- Add `package.json#exports` maps with `browser` conditions while preserving:
  - existing `main`, `module`, `esnext`, and `types` entry behavior
  - default Node/CommonJS behavior
  - browser-specific platform implementations
  - existing build subpath compatibility
  - repo-internal `src/*` import compatibility
- Add small browser-specific entry files where the old `browser` field previously rewired internal relative imports.
- Keep `@opentelemetry/sdk-trace-base` on its existing `index-shim` entry and remove stale platform browser mappings for files that no longer exist.

## Changed packages

- `@opentelemetry/core`
- `@opentelemetry/resources`
- `@opentelemetry/sdk-trace`
- `@opentelemetry/sdk-trace-base`
- `@opentelemetry/sdk-logs`
- `@opentelemetry/instrumentation`
- `@opentelemetry/exporter-zipkin`
- `@opentelemetry/exporter-logs-otlp-http`
- `@opentelemetry/exporter-logs-otlp-proto`
- `@opentelemetry/exporter-trace-otlp-http`
- `@opentelemetry/exporter-trace-otlp-proto`
- `@opentelemetry/exporter-metrics-otlp-http`
- `@opentelemetry/exporter-metrics-otlp-proto`

**Testing**

- `npm run compile`
- `npx tsc --build tsconfig.json tsconfig.esm.json tsconfig.esnext.json --force --pretty false`
- Changed-package compile checks for all affected packages
- Changed-package tests using Windows-safe double-quoted Mocha globs
- Changed-package lint checks

**Notes:**
- `npm test` was attempted, but the root Nx test run fails on Windows because package scripts pass single-quoted Mocha globs literally, producing "No test files found" across many projects.
- `npm run lint` was attempted, but root lint failed only on unrelated `@opentelemetry/e2e-test:lint`.
- `npm run test:browser --workspace @opentelemetry/core` was attempted and timed out locally without diagnostics.