### PR TITLE
ci: use Node 26 for build tooling

### DIFF
--- a/.github/workflows/backcompat.yml
+++ b/.github/workflows/backcompat.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js (compile)
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: ^26.3.0
           cache: 'npm'
           cache-dependency-path: package-lock.json
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         node_version:
-          - "22"
+          - ^26.3.0
     runs-on: oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     container:
       image: ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
@@ -42,8 +42,6 @@ jobs:
           cache-dependency-path: |
             package-lock.json
           node-version: ${{ matrix.node_version }}
-
-      - run: npm install -g npm@latest
 
       - name: Bootstrap
         run: npm ci --ignore-scripts

--- a/.github/workflows/bundler-tests.yml
+++ b/.github/workflows/bundler-tests.yml
@@ -21,8 +21,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: 24
-      - run: npm install -g npm@latest
+          node-version: ^26.3.0
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: Build TypeScript packages

--- a/.github/workflows/create-or-update-release-pr.yml
+++ b/.github/workflows/create-or-update-release-pr.yml
@@ -63,9 +63,7 @@ jobs:
         with:
           cache: 'npm'
           cache-dependency-path: package-lock.json
-          node-version: 22
-      - run: npm install -g npm@latest
-
+          node-version: ^26.3.0
       - run: npm ci --ignore-scripts
 
       - name: Create/Update Release PR

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
+          node-version: ^26.3.0
           # Disable caching in release workflows (https://docs.zizmor.sh/audits/#cache-poisoning).
           package-manager-cache: false
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,13 +14,13 @@ jobs:
       fail-fast: false
       matrix:
         node_version:
-          - "18.19.0"
-          - "18"
-          - "20.6.0"
-          - "20"
-          - "22"
-          - "24"
-          - "26"
+          - 18.19.0
+          - 18
+          - 20.6.0
+          - 20
+          - 22
+          - 24
+          - 26
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -32,30 +32,20 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: ${{ matrix.node_version }}
-
-      # npm@11.0.0 drops support for Node.js v18
-      # Install the latest npm compatible with this version of Node.js
-      # - npm@11.1.0 supports: {"node":"^20.17.0 || >=22.9.0"}
-      - run: npm install -g npm@"<11.0.0"
-        if: ${{
-          matrix.node_version == '18.19.0' ||
-          matrix.node_version == '18' ||
-          matrix.node_version == '20.6.0'
-          }}
-      - run: npm install -g npm@latest
-        if: ${{
-          matrix.node_version == '20' ||
-          matrix.node_version == '22' ||
-          matrix.node_version == '24' ||
-          matrix.node_version == '26'
-          }}
+          node-version: ^26.3.0
 
       - name: Bootstrap
         run: npm ci --ignore-scripts
 
       - name: Build 🔧
         run: npm run compile
+
+      # The compile above runs on the repo's pinned build Node (^26.3.0).
+      # Switch to the matrix Node version so tests exercise every supported
+      # runtime.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node_version }}
 
       - name: Install collector
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: '22'
+          node-version: ^26.3.0
 
       - name: Bootstrap
         run: npm ci --ignore-scripts

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -17,15 +17,13 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: ^26.3.0
           # Disable caching in release workflows (https://docs.zizmor.sh/audits/#cache-poisoning).
           # Zizmor didn't actually warn about this, but its general advice
           # was to avoid caching in workflows that publish artifacts. While
           # the published SBOM.zip does not include executable code, it is
           # still a published artifact.
           package-manager-cache: false
-
-      - run: npm install -g npm@latest
 
       - name: Bootstrap
         run: npm ci --ignore-scripts

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,13 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         node_version:
-          - "18.19.0"
-          - "18"
-          - "20.6.0"
-          - "20"
-          - "22"
-          - "24"
-          - "26"
+          - 18.19.0
+          - 18
+          - 20.6.0
+          - 20
+          - 22
+          - 24
+          - 26
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -34,30 +34,20 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: ${{ matrix.node_version }}
-
-      # npm@11.0.0 drops support for Node.js v18
-      # Install the latest npm compatible with this version of Node.js
-      # - npm@11.1.0 supports: {"node":"^20.17.0 || >=22.9.0"}
-      - run: npm install -g npm@"<11.0.0"
-        if: ${{
-          matrix.node_version == '18.19.0' ||
-          matrix.node_version == '18' ||
-          matrix.node_version == '20.6.0'
-          }}
-      - run: npm install -g npm@latest
-        if: ${{
-          matrix.node_version == '20' ||
-          matrix.node_version == '22' ||
-          matrix.node_version == '24' ||
-          matrix.node_version == '26'
-          }}
+          node-version: ^26.3.0
 
       - name: Bootstrap
         run: npm ci --ignore-scripts
 
       - name: Build 🔧
         run: npm run compile
+
+      # The compile above runs on the repo's pinned build Node (^26.3.0).
+      # Switch to the matrix Node version so tests exercise every supported
+      # runtime.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node_version }}
 
       - run: npm test
 
@@ -80,9 +70,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: '22'
-
-      - run: npm install -g npm@latest
+          node-version: ^26.3.0
 
       - name: Bootstrap
         run: npm ci --ignore-scripts
@@ -94,6 +82,7 @@ jobs:
 
       - name: Unit tests
         run: npm run test
+
   browser-tests:
     runs-on: ubuntu-latest
     steps:
@@ -107,7 +96,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: 22
+          node-version: ^26.3.0
 
       - name: Bootstrap
         run: npm ci --ignore-scripts
@@ -135,7 +124,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: 22
+          node-version: ^26.3.0
 
       - name: Bootstrap
         run: npm ci --ignore-scripts

--- a/.github/workflows/w3c-integration-test.yml
+++ b/.github/workflows/w3c-integration-test.yml
@@ -24,17 +24,15 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-          node-version: 22
+          node-version: ^26.3.0
 
       - name: Install and Bootstrap 🔧
         run: npm ci --ignore-scripts
 
-      - name: Generate version.ts files
-        run: npm run version:update
-
+      # validation-server.js is plain JS that requires built @opentelemetry/*
+      # packages
       - name: Build 🔧
         run: npm run compile
-        working-directory: ./integration-tests/propagation-validation-server
 
       - name: Run W3C Test harness
         run: ./integration-tests/tracecontext-integration-test.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
+* chore: build on Node 26 and verify packed artifacts in CI [#6887](https://github.com/open-telemetry/opentelemetry-js/pull/6887) @overbalance
+
 ## 2.9.0
 
 ### :boom: Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
-* chore: build on Node 26 and verify packed artifacts in CI [#6887](https://github.com/open-telemetry/opentelemetry-js/pull/6887) @overbalance
+* chore: build on Node 26 in CI [#6887](https://github.com/open-telemetry/opentelemetry-js/pull/6887) @overbalance
 
 ## 2.9.0
 


### PR DESCRIPTION
## Which problem is this PR solving?

Moves the build/CI tooling to Node 26 (`^26.3.0`) and removes the `npm install -g npm@latest` bootstrap shims older Node versions required (Node 26 ships a recent enough npm).

## Short description of the changes

- Bump the build/tooling Node version to `^26.3.0` across the workflows: `backcompat`, `benchmark`, `bundler-tests`, `create-or-update-release-pr`, `docs`, `lint`, `sbom`, `w3c-integration-test`, and the `unit-test`/`e2e` build and non-matrix jobs (windows/browser/webworker).
- Drop the `npm install -g npm@latest` (and `npm@"<11.0.0"`) shims that were only needed for older Node/npm combinations.
- `unit-test.yml` / `e2e.yml`: compile on the build Node (`^26.3.0`), then switch back to the matrix Node version for the actual test run so every supported runtime is still exercised.
- `w3c-integration-test.yml`: build the validation server via the top-level `compile` and drop the separate `version:update` step.

## Type of change

- [x] This change requires a documentation update (CHANGELOG)

## How Has This Been Tested?

CI (this PR's own workflow runs across the full Node matrix).
