### PR TITLE
chore: bump to typescript@5.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :house: Internal
 
 * chore: build on Node 26 in CI [#6887](https://github.com/open-telemetry/opentelemetry-js/pull/6887) @overbalance
+* chore: bump to typescript@5.2.2 @pichlermarc
 
 ## 2.9.0
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ This minimum support level is subject to change as the project evolves and as th
 
 ## TypeScript Support
 
-OpenTelemetry JavaScript is built with TypeScript `v5.0.4`. If you have a TypeScript project (app, library, instrumentation, etc.)
+OpenTelemetry JavaScript is built with TypeScript `v5.2.2`. If you have a TypeScript project (app, library, instrumentation, etc.)
 that depends on it, we recommend using same or higher version to compile the project.
 
 OpenTelemetry JavaScript will follow DefinitelyType's [support policy for TypeScript](https://github.com/DefinitelyTyped/DefinitelyTyped#support-window) which sets a support window of 2 years. Support for TypeScript versions older than 2 years will be dropped in minor releases of OpenTelemetry JavaScript.

--- a/api/package.json
+++ b/api/package.json
@@ -86,7 +86,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "unionfs": "4.5.4",
     "webpack": "5.104.1"
   },

--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -36,7 +36,7 @@
     "@babel/preset-env": "^7.22.20",
     "babel-loader": "^10.0.0",
     "ts-loader": "^9.2.6",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "^5.89.0",
     "webpack-cli": "^7.0.0",
     "webpack-dev-server": "^5.2.0",

--- a/experimental/packages/api-logs/package.json
+++ b/experimental/packages/api-logs/package.json
@@ -69,7 +69,7 @@
     "mocha": "11.7.6",
     "nyc": "17.1.0",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/api-logs",

--- a/experimental/packages/configuration/package.json
+++ b/experimental/packages/configuration/package.json
@@ -56,7 +56,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/configuration",
   "sideEffects": false

--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -58,7 +58,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -89,7 +89,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/experimental/packages/exporter-logs-otlp-proto/package.json
+++ b/experimental/packages/exporter-logs-otlp-proto/package.json
@@ -79,7 +79,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -55,7 +55,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -80,7 +80,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -78,7 +78,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/experimental/packages/opentelemetry-browser-detector/package.json
+++ b/experimental/packages/opentelemetry-browser-detector/package.json
@@ -69,7 +69,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -55,7 +55,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/package.json
@@ -80,7 +80,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -80,7 +80,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/experimental/packages/opentelemetry-exporter-prometheus/package.json
+++ b/experimental/packages/opentelemetry-exporter-prometheus/package.json
@@ -49,7 +49,7 @@
     "mocha": "11.7.6",
     "nyc": "17.1.0",
     "sinon": "18.0.1",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/opentelemetry-instrumentation-fetch/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/package.json
@@ -76,7 +76,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/experimental/packages/opentelemetry-instrumentation-grpc/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-grpc/package.json
@@ -64,7 +64,7 @@
     "mocha": "11.7.6",
     "nyc": "17.1.0",
     "sinon": "18.0.1",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/opentelemetry-instrumentation-http/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-http/package.json
@@ -63,7 +63,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "superagent": "10.3.0",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/package.json
@@ -75,7 +75,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/experimental/packages/opentelemetry-instrumentation/package.json
+++ b/experimental/packages/opentelemetry-instrumentation/package.json
@@ -98,7 +98,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/experimental/packages/opentelemetry-propagator-env-carrier/package.json
+++ b/experimental/packages/opentelemetry-propagator-env-carrier/package.json
@@ -57,7 +57,7 @@
     "@types/node": "18.19.130",
     "mocha": "11.7.6",
     "nyc": "17.1.0",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-propagator-env-carrier",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-sdk-node/package.json
+++ b/experimental/packages/opentelemetry-sdk-node/package.json
@@ -83,7 +83,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-sdk-node",
   "sideEffects": false

--- a/experimental/packages/otlp-exporter-base/package.json
+++ b/experimental/packages/otlp-exporter-base/package.json
@@ -95,7 +95,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/experimental/packages/otlp-grpc-exporter-base/package.json
+++ b/experimental/packages/otlp-grpc-exporter-base/package.json
@@ -53,7 +53,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/otlp-transformer/package.json
+++ b/experimental/packages/otlp-transformer/package.json
@@ -82,7 +82,7 @@
     "protobufjs": "8.6.6",
     "protobufjs-cli": "2.5.7",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1"
   },
   "dependencies": {

--- a/experimental/packages/sampler-jaeger-remote/package.json
+++ b/experimental/packages/sampler-jaeger-remote/package.json
@@ -59,7 +59,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/sampler-jaeger-remote",
   "sideEffects": false

--- a/experimental/packages/sdk-logs/package.json
+++ b/experimental/packages/sdk-logs/package.json
@@ -88,7 +88,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/experimental/packages/shim-opencensus/package.json
+++ b/experimental/packages/shim-opencensus/package.json
@@ -57,7 +57,7 @@
     "mocha": "11.7.6",
     "nyc": "17.1.0",
     "sinon": "18.0.1",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "@opencensus/core": "^0.1.0",

--- a/experimental/packages/web-common/package.json
+++ b/experimental/packages/web-common/package.json
@@ -87,7 +87,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   }

--- a/integration-tests/propagation-validation-server/package.json
+++ b/integration-tests/propagation-validation-server/package.json
@@ -20,7 +20,7 @@
     "express": "5.1.0"
   },
   "devDependencies": {
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "engines": {
     "node": "^18.19.0 || >=20.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "ts-node": "10.9.2",
         "typedoc": "0.28.19",
         "typedoc-plugin-missing-exports": "4.1.3",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "typescript-eslint": "8.60.0",
         "util": "0.12.5"
       }
@@ -83,7 +83,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "unionfs": "4.5.4",
         "webpack": "5.104.1"
       },
@@ -1113,7 +1113,7 @@
         "@babel/preset-env": "^7.22.20",
         "babel-loader": "^10.0.0",
         "ts-loader": "^9.2.6",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "^5.89.0",
         "webpack-cli": "^7.0.0",
         "webpack-dev-server": "^5.2.0",
@@ -1205,7 +1205,7 @@
         "mocha": "11.7.6",
         "nyc": "17.1.0",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1"
       },
       "engines": {
@@ -1238,7 +1238,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1271,7 +1271,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1312,7 +1312,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -1350,7 +1350,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -1382,7 +1382,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1422,7 +1422,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -1462,7 +1462,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -1499,7 +1499,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -1534,7 +1534,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1574,7 +1574,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -1617,7 +1617,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -1646,7 +1646,7 @@
         "mocha": "11.7.6",
         "nyc": "17.1.0",
         "sinon": "18.0.1",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1685,7 +1685,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -1730,7 +1730,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -1768,7 +1768,7 @@
         "mocha": "11.7.6",
         "nyc": "17.1.0",
         "sinon": "18.0.1",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1803,7 +1803,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "superagent": "10.3.0",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1845,7 +1845,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -1867,7 +1867,7 @@
         "@types/node": "18.19.130",
         "mocha": "11.7.6",
         "nyc": "17.1.0",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1918,7 +1918,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -1953,7 +1953,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -1983,7 +1983,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2021,7 +2021,7 @@
         "protobufjs": "8.6.6",
         "protobufjs-cli": "2.5.7",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1"
       },
       "engines": {
@@ -2073,7 +2073,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2111,7 +2111,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -2143,7 +2143,7 @@
         "mocha": "11.7.6",
         "nyc": "17.1.0",
         "sinon": "18.0.1",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -2182,7 +2182,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -2222,7 +2222,7 @@
         "express": "5.1.0"
       },
       "devDependencies": {
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -24030,9 +24030,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -24040,7 +24040,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {
@@ -25561,7 +25561,7 @@
         "@types/node": "18.19.130",
         "mocha": "11.7.6",
         "nyc": "17.1.0",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -25579,7 +25579,7 @@
         "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
       },
       "devDependencies": {
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -25610,7 +25610,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3",
         "zone.js": "0.16.2"
@@ -25647,7 +25647,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1"
       },
       "engines": {
@@ -25677,7 +25677,7 @@
         "nock": "13.5.6",
         "nyc": "17.1.0",
         "sinon": "18.0.1",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -25717,7 +25717,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -25742,7 +25742,7 @@
         "mocha": "11.7.6",
         "nyc": "17.1.0",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -25775,7 +25775,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1"
       },
       "engines": {
@@ -25810,7 +25810,7 @@
         "nock": "13.5.6",
         "nyc": "17.1.0",
         "sinon": "18.0.1",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -25852,7 +25852,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1"
       },
       "engines": {
@@ -25881,7 +25881,7 @@
         "mocha": "11.7.6",
         "nyc": "17.1.0",
         "sinon": "18.0.1",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -25924,7 +25924,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -25953,7 +25953,7 @@
         "@types/node": "18.19.130",
         "mocha": "11.7.6",
         "nyc": "17.1.0",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -25988,7 +25988,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1",
         "webpack-cli": "7.0.3"
       },
@@ -26028,7 +26028,7 @@
         "nyc": "17.1.0",
         "sinon": "18.0.1",
         "ts-loader": "9.5.7",
-        "typescript": "5.0.4",
+        "typescript": "5.2.2",
         "webpack": "5.104.1"
       },
       "engines": {
@@ -26044,7 +26044,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "18.19.130",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -26067,7 +26067,7 @@
         "sinon": "18.0.1",
         "size-limit": "^12.0.0",
         "ts-node": "10.9.2",
-        "typescript": "5.0.4"
+        "typescript": "5.2.2"
       },
       "engines": {
         "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "ts-node": "10.9.2",
     "typedoc": "0.28.19",
     "typedoc-plugin-missing-exports": "4.1.3",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "util": "0.12.5"
   },
   "workspaces": [

--- a/packages/opentelemetry-context-async-hooks/package.json
+++ b/packages/opentelemetry-context-async-hooks/package.json
@@ -48,7 +48,7 @@
     "@types/node": "18.19.130",
     "mocha": "11.7.6",
     "nyc": "17.1.0",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0"

--- a/packages/opentelemetry-context-zone-peer-dep/package.json
+++ b/packages/opentelemetry-context-zone-peer-dep/package.json
@@ -72,7 +72,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3",
     "zone.js": "0.16.2"

--- a/packages/opentelemetry-context-zone/package.json
+++ b/packages/opentelemetry-context-zone/package.json
@@ -50,7 +50,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "dependencies": {
     "@opentelemetry/context-zone-peer-dep": "2.9.0",

--- a/packages/opentelemetry-core/package.json
+++ b/packages/opentelemetry-core/package.json
@@ -79,7 +79,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1"
   },
   "peerDependencies": {

--- a/packages/opentelemetry-exporter-jaeger/package.json
+++ b/packages/opentelemetry-exporter-jaeger/package.json
@@ -52,7 +52,7 @@
     "nock": "13.5.6",
     "nyc": "17.1.0",
     "sinon": "18.0.1",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/packages/opentelemetry-exporter-zipkin/package.json
+++ b/packages/opentelemetry-exporter-zipkin/package.json
@@ -78,7 +78,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/packages/opentelemetry-propagator-b3/package.json
+++ b/packages/opentelemetry-propagator-b3/package.json
@@ -62,7 +62,7 @@
     "mocha": "11.7.6",
     "nyc": "17.1.0",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-b3",
   "sideEffects": false

--- a/packages/opentelemetry-propagator-jaeger/package.json
+++ b/packages/opentelemetry-propagator-jaeger/package.json
@@ -69,7 +69,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1"
   },
   "peerDependencies": {

--- a/packages/opentelemetry-resources/package.json
+++ b/packages/opentelemetry-resources/package.json
@@ -74,7 +74,7 @@
     "nock": "13.5.6",
     "nyc": "17.1.0",
     "sinon": "18.0.1",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/packages/opentelemetry-sdk-trace-base/package.json
+++ b/packages/opentelemetry-sdk-trace-base/package.json
@@ -82,7 +82,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1"
   },
   "peerDependencies": {

--- a/packages/opentelemetry-sdk-trace-node/package.json
+++ b/packages/opentelemetry-sdk-trace-node/package.json
@@ -53,7 +53,7 @@
     "mocha": "11.7.6",
     "nyc": "17.1.0",
     "sinon": "18.0.1",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0"

--- a/packages/opentelemetry-sdk-trace-web/package.json
+++ b/packages/opentelemetry-sdk-trace-web/package.json
@@ -78,7 +78,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -49,7 +49,7 @@
     "@types/node": "18.19.130",
     "mocha": "11.7.6",
     "nyc": "17.1.0",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "peerDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0"

--- a/packages/sdk-metrics/package.json
+++ b/packages/sdk-metrics/package.json
@@ -71,7 +71,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1",
     "webpack-cli": "7.0.3"
   },

--- a/packages/sdk-trace/package.json
+++ b/packages/sdk-trace/package.json
@@ -83,7 +83,7 @@
     "nyc": "17.1.0",
     "sinon": "18.0.1",
     "ts-loader": "9.5.7",
-    "typescript": "5.0.4",
+    "typescript": "5.2.2",
     "webpack": "5.104.1"
   },
   "peerDependencies": {

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -77,7 +77,7 @@
   ],
   "devDependencies": {
     "@types/node": "18.19.130",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "Add these to devDependencies for testing": {
     "@types/mocha": "9.1.1",

--- a/semantic-conventions/package.json
+++ b/semantic-conventions/package.json
@@ -74,7 +74,7 @@
     "sinon": "18.0.1",
     "size-limit": "^12.0.0",
     "ts-node": "10.9.2",
-    "typescript": "5.0.4"
+    "typescript": "5.2.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions",
   "sideEffects": false

--- a/tsconfig.base.esm.json
+++ b/tsconfig.base.esm.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "es2022",
-    "moduleResolution": "node16"
+    "moduleResolution": "bundler"
   }
 }

--- a/tsconfig.base.esnext.json
+++ b/tsconfig.base.esnext.json
@@ -4,6 +4,6 @@
     "module": "esnext",
     // target should be aligned with tsconfig.base.json
     "target": "es2022",
-    "moduleResolution": "node16"
+    "moduleResolution": "bundler"
   },
 }


### PR DESCRIPTION
## Which problem is this PR solving?

A common feature request is that we make our APIs implement a disposable pattern so that `using` becomes available on things like context management (ref #6387) and spans. However, we can't do this without bumping TypeScript to 5.2.0, as that's where this feature was added. Our current support policy states that we follow DefinitelyTyped's policy (2 years), 5.2.2 is ~3 years old by now (released Nov 20, 2023).

https://github.com/open-telemetry/opentelemetry-js/blob/9b2dace8a3771d8968a1a0c892f6452ceb8401f0/README.md?plain=1#L164-L169

## Additional context

This is required for disposable tokens returned by `context.attach()`, ref  https://github.com/open-telemetry/opentelemetry-js/pull/6845