### PR TITLE
test(exporter-metrics-otlp-*): return response to allow process exit

### DIFF
--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/OTLPMetricExporter.test.ts
@@ -181,7 +181,28 @@ describe('OTLPMetricExporter', () => {
         value: function (_timeout: number) {},
       });
 
-      sinon.stub(http, 'request').returns(fakeRequest as any);
+      // callsFake so the response callback is invoked after the request body is
+      // sent, which resolves the sendWithHttp promise and lets the process exit
+      // without waiting for the 30 s export timeout to fire.
+      (sinon.stub(http, 'request') as sinon.SinonStub).callsFake(
+        (...args: unknown[]) => {
+          const callback =
+            typeof args[args.length - 1] === 'function'
+              ? (args[args.length - 1] as (res: unknown) => void)
+              : null;
+          fakeRequest.on('finish', () => {
+            if (callback) {
+              const fakeResponse = new Stream.PassThrough() as any;
+              fakeResponse.statusCode = 200;
+              fakeResponse.statusMessage = 'OK';
+              fakeResponse.headers = {};
+              callback(fakeResponse);
+              fakeResponse.end();
+            }
+          });
+          return fakeRequest as any;
+        }
+      );
       let buff = Buffer.from('');
       fakeRequest.on('finish', () => {
         try {

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/node/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/node/OTLPMetricExporter.test.ts
@@ -34,7 +34,28 @@ describe('OTLPMetricExporter', () => {
         value: function (_timeout: number) {},
       });
 
-      sinon.stub(http, 'request').returns(fakeRequest as any);
+      // callsFake so the response callback is invoked after the request body is
+      // sent, which resolves the sendWithHttp promise and lets the process exit
+      // without waiting for the 30 s export timeout to fire.
+      (sinon.stub(http, 'request') as sinon.SinonStub).callsFake(
+        (...args: unknown[]) => {
+          const callback =
+            typeof args[args.length - 1] === 'function'
+              ? (args[args.length - 1] as (res: unknown) => void)
+              : null;
+          fakeRequest.on('finish', () => {
+            if (callback) {
+              const fakeResponse = new Stream.PassThrough() as any;
+              fakeResponse.statusCode = 200;
+              fakeResponse.statusMessage = 'OK';
+              fakeResponse.headers = {};
+              callback(fakeResponse);
+              fakeResponse.end();
+            }
+          });
+          return fakeRequest as any;
+        }
+      );
       let buff = Buffer.from('');
       fakeRequest.on('finish', () => {
         try {


### PR DESCRIPTION
## Which problem is this PR solving?

The http-based OTLP exporters for metrics still have an unresolved export when the tests pass. That means that while the tests passed, there's still something on the event loop that needs to be resolved and the process takes ~30s to actually shut down. That delays other tests and wastes time in github actions.

This PR just returns something instead, which resolves the export and lets the process exit.