### PR TITLE
fix(sdk-trace): sample ratio 1 upper-bound trace IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-trace): include trace IDs at the ratio 1 upper bound in `TraceIdRatioBasedSampler` [#6890](https://github.com/open-telemetry/opentelemetry-js/pull/6890) @LarryHu0217
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/packages/sdk-trace/src/sampler/TraceIdRatioBasedSampler.ts
+++ b/packages/sdk-trace/src/sampler/TraceIdRatioBasedSampler.ts
@@ -14,7 +14,8 @@ export class TraceIdRatioBasedSampler implements Sampler {
 
   constructor(ratio = 0) {
     this._ratio = this._normalize(ratio);
-    this._upperBound = Math.floor(this._ratio * 0xffffffff);
+    this._upperBound =
+      this._ratio === 1 ? 0x100000000 : Math.floor(this._ratio * 0xffffffff);
   }
 
   shouldSample(context: unknown, traceId: string): SamplingResult {

--- a/packages/sdk-trace/test/common/sampler/TraceIdRatioBasedSampler.test.ts
+++ b/packages/sdk-trace/test/common/sampler/TraceIdRatioBasedSampler.test.ts
@@ -50,6 +50,16 @@ describe('TraceIdRatioBasedSampler', () => {
         decision: api.SamplingDecision.RECORD_AND_SAMPLED,
       }
     );
+
+    assert.deepStrictEqual(
+      sampler.shouldSample(
+        spanContext(traceId('ffffffff')),
+        traceId('ffffffff')
+      ),
+      {
+        decision: api.SamplingDecision.RECORD_AND_SAMPLED,
+      }
+    );
   });
 
   it('should return a always sampler for >1', () => {


### PR DESCRIPTION
## Summary
- Fix `TraceIdRatioBasedSampler(1)` so trace IDs whose accumulated value is `0xffffffff` are sampled.
- Keep the existing strict `<` comparison by using an exclusive upper bound of `0x100000000` when the normalized ratio is `1`.
- Add a regression assertion for the `ffffffff` boundary trace ID.

Fixes #6879.

## Testing
- `npm run compile --workspace @opentelemetry/sdk-trace`
- `npm run test --workspace @opentelemetry/sdk-trace -- --grep TraceIdRatioBasedSampler`
- `npm run lint --workspace @opentelemetry/sdk-trace` (passes with existing no-console warnings in benchmark files)