### PR TITLE
chore(configuration): remove obsolete attribute limits TODO

### DIFF
--- a/experimental/packages/configuration/src/FileConfigFactory.ts
+++ b/experimental/packages/configuration/src/FileConfigFactory.ts
@@ -126,7 +126,6 @@ export function mergeResourceAttributesConfig(
   const mergedAttrs = attributes ? attributes.slice() : [];
   const existingNames = new Set(mergedAttrs.map(a => a.name));
 
-  // TODO(6842): handle attribute limits, if any
   let discard = false;
   const listAttrs: Record<string, string> = {};
   for (const pair of attributes_list.split(',')) {


### PR DESCRIPTION
## What changed

Remove the obsolete `TODO(6842)` comment from resource attribute merging. No resource attribute limit behavior is added.

## Why

The OpenTelemetry specification says resource attributes should be exempt from the general attribute limits. Keeping the TODO implied behavior that should not be implemented, so this PR now removes only that misleading comment and leaves resource behavior unchanged.

Related to #6842.

## Validation

- Prettier check for `experimental/packages/configuration/src/FileConfigFactory.ts`
- `git diff --check`

## AI assistance disclosure

ChatGPT was used to assist with code exploration, implementation, and test preparation. I reviewed the changes and validation results.