### PR TITLE
chore: clean up some deps and devDeps in exporter packages

### DIFF
--- a/experimental/packages/exporter-logs-otlp-grpc/package.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/package.json
@@ -47,6 +47,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/api-logs": "0.220.0",
@@ -64,8 +65,6 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.14.3",
-    "@opentelemetry/core": "2.9.0",
     "@opentelemetry/otlp-exporter-base": "0.220.0",
     "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
     "@opentelemetry/otlp-transformer": "0.220.0",

--- a/experimental/packages/exporter-logs-otlp-grpc/tsconfig.json
+++ b/experimental/packages/exporter-logs-otlp-grpc/tsconfig.json
@@ -13,9 +13,6 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
       "path": "../../../packages/opentelemetry-resources"
     },
     {

--- a/experimental/packages/exporter-logs-otlp-http/package.json
+++ b/experimental/packages/exporter-logs-otlp-http/package.json
@@ -97,8 +97,6 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "0.220.0",
-    "@opentelemetry/core": "2.9.0",
     "@opentelemetry/otlp-exporter-base": "0.220.0",
     "@opentelemetry/otlp-transformer": "0.220.0",
     "@opentelemetry/sdk-logs": "0.220.0"

--- a/experimental/packages/exporter-logs-otlp-http/tsconfig.esm.json
+++ b/experimental/packages/exporter-logs-otlp-http/tsconfig.esm.json
@@ -18,13 +18,7 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
       "path": "../../../packages/opentelemetry-resources"
-    },
-    {
-      "path": "../api-logs"
     },
     {
       "path": "../otlp-exporter-base"

--- a/experimental/packages/exporter-logs-otlp-http/tsconfig.esnext.json
+++ b/experimental/packages/exporter-logs-otlp-http/tsconfig.esnext.json
@@ -18,13 +18,7 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
       "path": "../../../packages/opentelemetry-resources"
-    },
-    {
-      "path": "../api-logs"
     },
     {
       "path": "../otlp-exporter-base"

--- a/experimental/packages/exporter-logs-otlp-http/tsconfig.json
+++ b/experimental/packages/exporter-logs-otlp-http/tsconfig.json
@@ -18,13 +18,7 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
       "path": "../../../packages/opentelemetry-resources"
-    },
-    {
-      "path": "../api-logs"
     },
     {
       "path": "../otlp-exporter-base"

--- a/experimental/packages/exporter-trace-otlp-grpc/package.json
+++ b/experimental/packages/exporter-trace-otlp-grpc/package.json
@@ -46,6 +46,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
     "@opentelemetry/api": "1.9.1",
     "@types/mocha": "10.0.10",
@@ -61,7 +62,6 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.14.3",
     "@opentelemetry/otlp-exporter-base": "0.220.0",
     "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
     "@opentelemetry/otlp-transformer": "0.220.0",

--- a/experimental/packages/exporter-trace-otlp-http/package.json
+++ b/experimental/packages/exporter-trace-otlp-http/package.json
@@ -88,10 +88,8 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "2.9.0",
     "@opentelemetry/otlp-exporter-base": "0.220.0",
     "@opentelemetry/otlp-transformer": "0.220.0",
-    "@opentelemetry/resources": "2.9.0",
     "@opentelemetry/sdk-trace": "2.9.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http",

--- a/experimental/packages/exporter-trace-otlp-http/tsconfig.esm.json
+++ b/experimental/packages/exporter-trace-otlp-http/tsconfig.esm.json
@@ -18,12 +18,6 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
-      "path": "../../../packages/opentelemetry-resources"
-    },
-    {
       "path": "../../../packages/sdk-trace"
     },
     {

--- a/experimental/packages/exporter-trace-otlp-http/tsconfig.esnext.json
+++ b/experimental/packages/exporter-trace-otlp-http/tsconfig.esnext.json
@@ -18,12 +18,6 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
-      "path": "../../../packages/opentelemetry-resources"
-    },
-    {
       "path": "../../../packages/sdk-trace"
     },
     {

--- a/experimental/packages/exporter-trace-otlp-http/tsconfig.json
+++ b/experimental/packages/exporter-trace-otlp-http/tsconfig.json
@@ -19,12 +19,6 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
-      "path": "../../../packages/opentelemetry-resources"
-    },
-    {
       "path": "../../../packages/sdk-trace"
     },
     {

--- a/experimental/packages/exporter-trace-otlp-proto/package.json
+++ b/experimental/packages/exporter-trace-otlp-proto/package.json
@@ -86,10 +86,8 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "2.9.0",
     "@opentelemetry/otlp-exporter-base": "0.220.0",
     "@opentelemetry/otlp-transformer": "0.220.0",
-    "@opentelemetry/resources": "2.9.0",
     "@opentelemetry/sdk-trace": "2.9.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-proto",

--- a/experimental/packages/exporter-trace-otlp-proto/tsconfig.esm.json
+++ b/experimental/packages/exporter-trace-otlp-proto/tsconfig.esm.json
@@ -18,12 +18,6 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
-      "path": "../../../packages/opentelemetry-resources"
-    },
-    {
       "path": "../../../packages/sdk-trace"
     },
     {

--- a/experimental/packages/exporter-trace-otlp-proto/tsconfig.esnext.json
+++ b/experimental/packages/exporter-trace-otlp-proto/tsconfig.esnext.json
@@ -18,12 +18,6 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
-      "path": "../../../packages/opentelemetry-resources"
-    },
-    {
       "path": "../../../packages/sdk-trace"
     },
     {

--- a/experimental/packages/exporter-trace-otlp-proto/tsconfig.json
+++ b/experimental/packages/exporter-trace-otlp-proto/tsconfig.json
@@ -18,12 +18,6 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
-      "path": "../../../packages/opentelemetry-resources"
-    },
-    {
       "path": "../../../packages/sdk-trace"
     },
     {

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -46,8 +46,10 @@
     "access": "public"
   },
   "devDependencies": {
+    "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
     "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/sdk-metrics": "2.9.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.19.130",
     "@types/sinon": "17.0.4",
@@ -61,14 +63,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.14.3",
-    "@opentelemetry/core": "2.9.0",
     "@opentelemetry/exporter-metrics-otlp-http": "0.220.0",
-    "@opentelemetry/otlp-exporter-base": "0.220.0",
     "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
-    "@opentelemetry/otlp-transformer": "0.220.0",
-    "@opentelemetry/resources": "2.9.0",
-    "@opentelemetry/sdk-metrics": "2.9.0"
+    "@opentelemetry/otlp-transformer": "0.220.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/tsconfig.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/tsconfig.json
@@ -13,19 +13,10 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
-      "path": "../../../packages/opentelemetry-resources"
-    },
-    {
       "path": "../../../packages/sdk-metrics"
     },
     {
       "path": "../opentelemetry-exporter-metrics-otlp-http"
-    },
-    {
-      "path": "../otlp-exporter-base"
     },
     {
       "path": "../otlp-grpc-exporter-base"

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -64,6 +64,7 @@
     "@babel/core": "7.29.7",
     "@babel/preset-env": "7.29.7",
     "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/sdk-metrics": "2.9.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.19.130",
     "@types/sinon": "17.0.4",
@@ -88,12 +89,9 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "2.9.0",
     "@opentelemetry/exporter-metrics-otlp-http": "0.220.0",
     "@opentelemetry/otlp-exporter-base": "0.220.0",
-    "@opentelemetry/otlp-transformer": "0.220.0",
-    "@opentelemetry/resources": "2.9.0",
-    "@opentelemetry/sdk-metrics": "2.9.0"
+    "@opentelemetry/otlp-transformer": "0.220.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/tsconfig.esm.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/tsconfig.esm.json
@@ -18,12 +18,6 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
-      "path": "../../../packages/opentelemetry-resources"
-    },
-    {
       "path": "../../../packages/sdk-metrics"
     },
     {

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/tsconfig.esnext.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/tsconfig.esnext.json
@@ -18,12 +18,6 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
-      "path": "../../../packages/opentelemetry-resources"
-    },
-    {
       "path": "../../../packages/sdk-metrics"
     },
     {

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/tsconfig.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/tsconfig.json
@@ -18,12 +18,6 @@
       "path": "../../../api"
     },
     {
-      "path": "../../../packages/opentelemetry-core"
-    },
-    {
-      "path": "../../../packages/opentelemetry-resources"
-    },
-    {
       "path": "../../../packages/sdk-metrics"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1252,14 +1252,13 @@
       "version": "0.220.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.9.0",
         "@opentelemetry/otlp-exporter-base": "0.220.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
         "@opentelemetry/otlp-transformer": "0.220.0",
         "@opentelemetry/sdk-logs": "0.220.0"
       },
       "devDependencies": {
+        "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
         "@opentelemetry/api": "1.9.1",
         "@opentelemetry/api-logs": "0.220.0",
@@ -1285,8 +1284,6 @@
       "version": "0.220.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.220.0",
-        "@opentelemetry/core": "2.9.0",
         "@opentelemetry/otlp-exporter-base": "0.220.0",
         "@opentelemetry/otlp-transformer": "0.220.0",
         "@opentelemetry/sdk-logs": "0.220.0"
@@ -1366,13 +1363,13 @@
       "version": "0.220.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.14.3",
         "@opentelemetry/otlp-exporter-base": "0.220.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
         "@opentelemetry/otlp-transformer": "0.220.0",
         "@opentelemetry/sdk-trace": "2.9.0"
       },
       "devDependencies": {
+        "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
         "@opentelemetry/api": "1.9.1",
         "@types/mocha": "10.0.10",
@@ -1396,10 +1393,8 @@
       "version": "0.220.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
         "@opentelemetry/otlp-exporter-base": "0.220.0",
         "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/resources": "2.9.0",
         "@opentelemetry/sdk-trace": "2.9.0"
       },
       "devDependencies": {
@@ -1438,10 +1433,8 @@
       "version": "0.220.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
         "@opentelemetry/otlp-exporter-base": "0.220.0",
         "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/resources": "2.9.0",
         "@opentelemetry/sdk-trace": "2.9.0"
       },
       "devDependencies": {
@@ -1515,18 +1508,15 @@
       "version": "0.220.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.9.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.220.0",
-        "@opentelemetry/otlp-exporter-base": "0.220.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-metrics": "2.9.0"
+        "@opentelemetry/otlp-transformer": "0.220.0"
       },
       "devDependencies": {
+        "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
         "@opentelemetry/api": "1.9.1",
+        "@opentelemetry/sdk-metrics": "2.9.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.19.130",
         "@types/sinon": "17.0.4",
@@ -1590,17 +1580,15 @@
       "version": "0.220.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.9.0",
         "@opentelemetry/exporter-metrics-otlp-http": "0.220.0",
         "@opentelemetry/otlp-exporter-base": "0.220.0",
-        "@opentelemetry/otlp-transformer": "0.220.0",
-        "@opentelemetry/resources": "2.9.0",
-        "@opentelemetry/sdk-metrics": "2.9.0"
+        "@opentelemetry/otlp-transformer": "0.220.0"
       },
       "devDependencies": {
         "@babel/core": "7.29.7",
         "@babel/preset-env": "7.29.7",
         "@opentelemetry/api": "1.9.1",
+        "@opentelemetry/sdk-metrics": "2.9.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.19.130",
         "@types/sinon": "17.0.4",


### PR DESCRIPTION
I noticed that some "dependencies" in some of the exporter packages are unused in runtime code. I think a lot of this is from refactoring of the exporter packages overtime. (Our `knip` usage doesn't help identify these, unfortunately.)