### PR TITLE
feat(propagator-jaeger): deprecate JaegerPropagator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :rocket: Features
 
+* feat(propagator-jaeger):  *Notice*: The `@opentelemetry/propagator-jaeger` package will be removed in SDK 3.x, planned for approximately September 2026. @pichlermarc
+  * The Jaeger propagator has been deprecated by the OpenTelemetry specification in favor of `W3CTraceContextPropagator`. This package will be removed in a future release.
+
 ### :bug: Bug Fixes
 
 ### :books: Documentation

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -15,6 +15,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :rocket: Features
 
+* feat(sdk-node): emit a deprecation warning when the `JaegerPropagator` is selected via `OTEL_PROPAGATORS` or declarative config; use `tracecontext` instead. @pichlermarc
+
 ### :bug: Bug Fixes
 
 ### :books: Documentation

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -326,7 +326,15 @@ export function getPropagatorFromEnv(): TextMapPropagator | null | undefined {
       'b3multi',
       () => new B3Propagator({ injectEncoding: B3InjectEncoding.MULTI_HEADER }),
     ],
-    ['jaeger', () => new JaegerPropagator()],
+    [
+      'jaeger',
+      () => {
+        diag.warn(
+          'The Jaeger propagator is deprecated and will be removed in a future release. Use the W3C TraceContext propagator ("tracecontext") instead.'
+        );
+        return new JaegerPropagator();
+      },
+    ],
   ]);
 
   // Values MUST be deduplicated in order to register a Propagator only once.
@@ -429,7 +437,15 @@ export function getPropagatorFromConfiguration(
       'b3multi',
       () => new B3Propagator({ injectEncoding: B3InjectEncoding.MULTI_HEADER }),
     ],
-    ['jaeger', () => new JaegerPropagator()],
+    [
+      'jaeger',
+      () => {
+        diag.warn(
+          'The Jaeger propagator is deprecated and will be removed in a future release. Use the W3C TraceContext propagator ("tracecontext") instead.'
+        );
+        return new JaegerPropagator();
+      },
+    ],
   ]);
 
   const validPropagators: TextMapPropagator[] = [];

--- a/packages/opentelemetry-propagator-jaeger/README.md
+++ b/packages/opentelemetry-propagator-jaeger/README.md
@@ -3,6 +3,8 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
+> **Deprecated:** The Jaeger propagator is deprecated by the OpenTelemetry specification in favor of the [W3C TraceContext propagator](https://opentelemetry.io/docs/specs/otel/context/api-propagators/#propagators-distribution). Use `W3CTraceContextPropagator` from `@opentelemetry/core` instead. This package will be removed in a future major release.
+
 OpenTelemetry Jaeger propagator provides HTTP header propagation for systems that are using Jaeger HTTP header format.
 
 Format:

--- a/packages/opentelemetry-propagator-jaeger/src/JaegerPropagator.ts
+++ b/packages/opentelemetry-propagator-jaeger/src/JaegerPropagator.ts
@@ -31,6 +31,9 @@ export const UBER_BAGGAGE_HEADER_PREFIX = 'uberctx';
  * {flags}
  * One byte bitmap, as two hex digits.
  * Inspired by jaeger-client-node project.
+ * @deprecated Use {@link W3CTraceContextPropagator} from `@opentelemetry/core` instead.
+ * The Jaeger propagator is deprecated by the OpenTelemetry specification.
+ * This package will be removed in a future major release.
  */
 export class JaegerPropagator implements TextMapPropagator {
   private readonly _jaegerTraceHeader: string;

--- a/packages/opentelemetry-shim-opentracing/package.json
+++ b/packages/opentelemetry-shim-opentracing/package.json
@@ -43,7 +43,6 @@
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
     "@opentelemetry/propagator-b3": "2.9.0",
-    "@opentelemetry/propagator-jaeger": "2.9.0",
     "@opentelemetry/sdk-trace": "2.9.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.19.130",

--- a/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
+++ b/packages/opentelemetry-shim-opentracing/test/Shim.test.ts
@@ -26,7 +26,6 @@ import {
 } from '@opentelemetry/api';
 import { performance } from 'perf_hooks';
 import { B3Propagator } from '@opentelemetry/propagator-b3';
-import { JaegerPropagator } from '@opentelemetry/propagator-jaeger';
 import {
   ATTR_EXCEPTION_MESSAGE,
   ATTR_EXCEPTION_STACKTRACE,
@@ -132,13 +131,13 @@ describe('OpenTracing Shim', () => {
     });
 
     describe('propagation using configured propagators', () => {
-      const jaegerPropagator = new JaegerPropagator();
+      const w3cPropagator = new W3CTraceContextPropagator();
       const b3Propagator = new B3Propagator();
       before(() => {
         const provider = new TracerProvider();
         shimTracer = new TracerShim(provider.getTracer('default'), {
           textMapPropagator: b3Propagator,
-          httpHeadersPropagator: jaegerPropagator,
+          httpHeadersPropagator: w3cPropagator,
         });
         opentracing.initGlobalTracer(shimTracer);
       });
@@ -152,7 +151,7 @@ describe('OpenTracing Shim', () => {
         const carrier: { [key: string]: unknown } = {};
         shimTracer.inject(context, opentracing.FORMAT_HTTP_HEADERS, carrier);
         const extractedContext = trace.getSpanContext(
-          jaegerPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
+          w3cPropagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter)
         );
         assert.ok(extractedContext !== null);
         assert.strictEqual(extractedContext?.traceId, context.toTraceId());
@@ -161,7 +160,7 @@ describe('OpenTracing Shim', () => {
 
       it('extracts HTTP carriers', () => {
         const carrier: { [key: string]: unknown } = {};
-        jaegerPropagator.inject(
+        w3cPropagator.inject(
           trace.setSpanContext(
             ROOT_CONTEXT,
             (context as SpanContextShim).getSpanContext()

--- a/packages/opentelemetry-shim-opentracing/tsconfig.json
+++ b/packages/opentelemetry-shim-opentracing/tsconfig.json
@@ -22,9 +22,6 @@
       "path": "../opentelemetry-propagator-b3"
     },
     {
-      "path": "../opentelemetry-propagator-jaeger"
-    },
-    {
       "path": "../sdk-trace"
     }
   ]


### PR DESCRIPTION
## Which problem is this PR solving?

Deprecates the `JaegerPropagator` as it's been deprecated in the spec. This PR adds a warning when the propagator is used through sdk-node (both env var and declarative config paths), and adds `@deprecated` annotation to the type.

Prepares for #6880 
