### PR TITLE
fix(sdk-trace): reject failed SimpleSpanProcessor flushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-trace): reject `SimpleSpanProcessor.forceFlush()` when a pending export fails [#6771](https://github.com/open-telemetry/opentelemetry-js/issues/6771) @LarryHu0217
 * fix(sdk-trace): include trace IDs at the ratio 1 upper bound in `TraceIdRatioBasedSampler` [#6890](https://github.com/open-telemetry/opentelemetry-js/pull/6890) @LarryHu0217
 
 ### :books: Documentation

--- a/packages/sdk-trace/src/export/SimpleSpanProcessor.ts
+++ b/packages/sdk-trace/src/export/SimpleSpanProcessor.ts
@@ -48,9 +48,19 @@ export class SimpleSpanProcessor implements SpanProcessor {
   }
 
   async forceFlush(): Promise<void> {
-    await Promise.all(Array.from(this._pendingExports));
+    let pendingExportError: unknown;
+    let pendingExportRejected = false;
+    try {
+      await Promise.all(Array.from(this._pendingExports));
+    } catch (err) {
+      pendingExportError = err;
+      pendingExportRejected = true;
+    }
     if (this._exporter.forceFlush) {
       await this._exporter.forceFlush();
+    }
+    if (pendingExportRejected) {
+      throw pendingExportError;
     }
   }
 
@@ -65,13 +75,17 @@ export class SimpleSpanProcessor implements SpanProcessor {
       return;
     }
 
-    const pendingExport = this._doExport(span).catch(err =>
-      globalErrorHandler(err)
-    );
+    const pendingExport = this._doExport(span);
     // Enqueue this export to the pending list so it can be flushed by the user.
     this._pendingExports.add(pendingExport);
-    void pendingExport.finally(() =>
-      this._pendingExports.delete(pendingExport)
+    void pendingExport.then(
+      () => {
+        this._pendingExports.delete(pendingExport);
+      },
+      err => {
+        globalErrorHandler(err);
+        this._pendingExports.delete(pendingExport);
+      }
     );
   }
 

--- a/packages/sdk-trace/test/common/export/SimpleSpanProcessor.test.ts
+++ b/packages/sdk-trace/test/common/export/SimpleSpanProcessor.test.ts
@@ -239,6 +239,54 @@ describe('SimpleSpanProcessor', () => {
       assert.strictEqual(exportedSpans.length, 1);
     });
 
+    it('should reject when a pending export fails', async () => {
+      const expectedError = new Error('Exporter failed');
+      const processor = new SimpleSpanProcessor({ exporter });
+      const exporterForceFlushSpy = sinon.spy(exporter, 'forceFlush');
+      const spanContext: SpanContext = {
+        traceId: 'a3cda95b652f4a1592b449d5929fda1b',
+        spanId: '5e0c63257de34c92',
+        traceFlags: TraceFlags.SAMPLED,
+      };
+      const tracer = provider.getTracer('default') as Tracer;
+      const span = new SpanImpl({
+        scope: tracer.instrumentationScope,
+        resource: tracer['_resource'],
+        context: ROOT_CONTEXT,
+        spanContext,
+        name: 'span-name',
+        kind: SpanKind.CLIENT,
+        spanLimits: cheatSpanLimitsFromTracer(tracer),
+        spanProcessor: tracer['_spanProcessor'],
+      });
+      processor.onStart(span, ROOT_CONTEXT);
+
+      sinon.stub(exporter, 'export').callsFake((_, callback) => {
+        setTimeout(() => {
+          callback({ code: ExportResultCode.FAILED, error: expectedError });
+        }, 0);
+      });
+
+      const errorHandlerSpy = sinon.spy();
+      setGlobalErrorHandler(errorHandlerSpy);
+
+      try {
+        processor.onEnd(span);
+
+        await assert.rejects(processor.forceFlush(), err => {
+          assert.strictEqual(err, expectedError);
+          return true;
+        });
+
+        assert.strictEqual(errorHandlerSpy.callCount, 1);
+        assert.strictEqual(exporterForceFlushSpy.callCount, 1);
+        assert.strictEqual(processor['_pendingExports'].size, 0);
+      } finally {
+        // reset global error handler
+        setGlobalErrorHandler(loggingErrorHandler());
+      }
+    });
+
     it('should await doExport() and delete from _pendingExports with async resource', async () => {
       const testExporterWithDelay = new TestExporterWithDelay();
       const processor = new SimpleSpanProcessor({
@@ -353,6 +401,8 @@ describe('SimpleSpanProcessor', () => {
         exporter,
         selfObsMeterProvider: meterProvider,
       });
+      const exportError = new Error('Export failed');
+      exportError.name = 'SystemError';
 
       const exportStub = sinon.stub(exporter, 'export');
       exportStub
@@ -362,9 +412,7 @@ describe('SimpleSpanProcessor', () => {
         })
         .onSecondCall()
         .callsFake((_spans, resultCallback: (result: ExportResult) => void) => {
-          const error = new Error('Export failed');
-          error.name = 'SystemError';
-          resultCallback({ code: ExportResultCode.FAILED, error });
+          resultCallback({ code: ExportResultCode.FAILED, error: exportError });
         });
 
       const spanContext: SpanContext = {
@@ -388,7 +436,10 @@ describe('SimpleSpanProcessor', () => {
       processor.onStart(span, ROOT_CONTEXT);
       processor.onEnd(span);
 
-      await processor.forceFlush();
+      await assert.rejects(processor.forceFlush(), err => {
+        assert.strictEqual(err, exportError);
+        return true;
+      });
 
       const { resourceMetrics } = await metricReader.collect();
       const scopeMetrics = resourceMetrics.scopeMetrics.find(


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #6771.

`SimpleSpanProcessor._doExport()` already rejects when the exporter reports `ExportResultCode.FAILED`, but `onEnd()` converted that rejection into a resolved pending export after calling `globalErrorHandler`. As a result, `forceFlush()` could resolve even when the pending export it waited on had failed.

## Short description of the changes

- Keep the original export promise in `_pendingExports` so `forceFlush()` observes pending export failures.
- Attach background error handling separately so normal `onEnd()` export failures still go through `globalErrorHandler`.
- Preserve the exporter `forceFlush()` call before rethrowing a pending export failure.
- Add regression coverage for failed pending exports and update the metrics test expectation.

## How was this tested?

- `npm run compile --workspace @opentelemetry/sdk-trace`
- `npm run test --workspace @opentelemetry/sdk-trace -- --grep "SimpleSpanProcessor"`
- `npm run test --workspace @opentelemetry/sdk-trace`
- `npm run lint --workspace @opentelemetry/sdk-trace`
- `npx prettier --check packages/sdk-trace/src/export/SimpleSpanProcessor.ts packages/sdk-trace/test/common/export/SimpleSpanProcessor.test.ts`
- `npx markdownlint-cli2 CHANGELOG.md`
- `git diff --check`

## AI assistance disclosure

ChatGPT was used to assist with code exploration, implementation, and test preparation. I reviewed the changes and validation results.