### PR TITLE
feat(instrumentation-http)!: pass incoming request as propagation extract carrier

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 * feat(instrumentation-fetch)!: emit only stable HTTP semantic conventions. The `semconvStabilityOptIn` instrumentation config option has been removed; old (v1.7.0) and duplicate semconv outputs are no longer emitted. [#6819](https://github.com/open-telemetry/opentelemetry-js/pull/6819) @maryliag
 * feat(instrumentation-xml-http-request)!: emit only stable HTTP semantic conventions. The `semconvStabilityOptIn` instrumentation config option has been removed; old (v1.7.0) and duplicate semconv outputs are no longer emitted. [#6819](https://github.com/open-telemetry/opentelemetry-js/pull/6819) @maryliag
 * feat(instrumentation-grpc)!: emit only stable network semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable no longer changes attribute emission — `net.peer.name` and `net.peer.port` (old) are no longer set; only `server.address` and `server.port` (stable). [#6819](https://github.com/open-telemetry/opentelemetry-js/pull/6819) @maryliag
+* feat(instrumentation-http)!: pass the incoming `http.IncomingMessage` as the propagation extract carrier (with a custom `TextMapGetter` reading from `request.headers`) instead of the bare headers object. Propagators that use the provided getter are unaffected; propagators accessing the carrier directly must be updated. This allows propagators to make per-request trust decisions (e.g. ignore incoming trace context based on the request's IP address). @matthieusieben
 
 ### :rocket: Features
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -66,6 +66,7 @@ import {
   headerCapture,
   isValidOptionsType,
   parseResponseStatus,
+  requestTextMapGetter,
   setSpanWithError,
 } from './utils';
 import type { Err, Func, Http, HttpRequestArgs, Https } from './internal-types';
@@ -537,8 +538,6 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
         });
       }
 
-      const headers = request.headers;
-
       const spanAttributes = getIncomingRequestAttributes(
         request,
         {
@@ -579,7 +578,11 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
           spanAttributes[ATTR_NETWORK_PROTOCOL_VERSION];
       }
 
-      const ctx = propagation.extract(ROOT_CONTEXT, headers);
+      const ctx = propagation.extract(
+        ROOT_CONTEXT,
+        request,
+        requestTextMapGetter
+      );
       const span = instrumentation._startHttpSpan(method, spanOptions, ctx);
       const rpcMetadata: RPCMetadata = {
         type: RPCType.HTTP,

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -2,13 +2,20 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
+import type * as http from 'http';
 import type {
   Attributes,
   Span,
   DiagLogger,
   AttributeValue,
+  TextMapGetter,
 } from '@opentelemetry/api';
-import { SpanStatusCode, context, SpanKind } from '@opentelemetry/api';
+import {
+  SpanStatusCode,
+  context,
+  SpanKind,
+  defaultTextMapGetter,
+} from '@opentelemetry/api';
 import {
   ATTR_CLIENT_ADDRESS,
   ATTR_ERROR_TYPE,
@@ -54,6 +61,15 @@ import {
 } from './internal-types';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import forwardedParse = require('forwarded-parse');
+
+export const requestTextMapGetter: TextMapGetter<http.IncomingMessage> = {
+  keys(carrier) {
+    return defaultTextMapGetter.keys(carrier.headers);
+  },
+  get(carrier, key) {
+    return defaultTextMapGetter.get(carrier.headers, key);
+  },
+};
 
 /**
  * Get an absolute url

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
@@ -1367,6 +1367,81 @@ describe('HttpInstrumentation', () => {
         assert.strictEqual(spans[0].attributes.key, 'value');
       });
     });
+
+    describe('propagation carrier', () => {
+      beforeEach(() => {
+        memoryExporter.reset();
+        instrumentation.setConfig({});
+        instrumentation.enable();
+        server = http.createServer((request, response) => {
+          response.end('Test Server Response');
+        });
+      });
+
+      afterEach(() => {
+        server.close();
+        instrumentation.disable();
+        propagation.disable();
+        propagation.setGlobalPropagator(new DummyPropagation());
+      });
+
+      it('should pass the incoming request as extract carrier', async () => {
+        let extractCarrier: unknown;
+        propagation.disable();
+        propagation.setGlobalPropagator({
+          inject: () => {},
+          extract: (context, carrier) => {
+            extractCarrier = carrier;
+            return context;
+          },
+          fields: () => [],
+        });
+
+        await new Promise<void>(resolve => server.listen(serverPort, resolve));
+        await httpRequest.get(`${protocol}://${hostname}:${serverPort}`);
+
+        assert.ok(extractCarrier instanceof http.IncomingMessage);
+      });
+
+      it('should allow a propagator to make trust decisions based on the request', async () => {
+        // A propagator that only extracts the remote context when the
+        // request comes from a trusted IP address.
+        propagation.disable();
+        const dummyPropagation = new DummyPropagation();
+        propagation.setGlobalPropagator({
+          inject: (context, carrier) =>
+            dummyPropagation.inject(
+              context,
+              carrier as { [key: string]: string }
+            ),
+          extract: (context, carrier, getter) => {
+            const request = carrier as http.IncomingMessage;
+            if (request.socket.remoteAddress !== '10.1.2.3') {
+              // untrusted source: ignore incoming propagation headers
+              return context;
+            }
+            return dummyPropagation.extract(context, request, getter);
+          },
+          fields: () => dummyPropagation.fields(),
+        });
+
+        await new Promise<void>(resolve => server.listen(serverPort, resolve));
+        await httpRequest.get(`${protocol}://${hostname}:${serverPort}`);
+
+        const spans = memoryExporter.getFinishedSpans();
+        const incomingSpan = spans.find(s => s.kind === SpanKind.SERVER);
+        const outgoingSpan = spans.find(s => s.kind === SpanKind.CLIENT);
+        assert.ok(incomingSpan);
+        assert.ok(outgoingSpan);
+        // The client sent propagation headers, but the propagator refused
+        // them based on the request's remote address: no remote parent.
+        assert.strictEqual(incomingSpan.parentSpanContext, undefined);
+        assert.notStrictEqual(
+          incomingSpan.spanContext().traceId,
+          outgoingSpan.spanContext().traceId
+        );
+      });
+    });
   });
 
   describe('capturing headers as span attributes', () => {

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -625,4 +625,44 @@ describe('Utility', () => {
       assert.strictEqual(utils.getRemoteClientAddress(request), null);
     });
   });
+
+  describe('requestTextMapGetter', () => {
+    const request = {
+      headers: {
+        traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+        'x-multi-value': ['one', 'two'],
+      },
+      socket: {
+        remoteAddress: '10.1.2.3',
+      },
+    } as unknown as IncomingMessage;
+
+    it('should read header values from the request carrier', () => {
+      assert.strictEqual(
+        utils.requestTextMapGetter.get(request, 'traceparent'),
+        '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01'
+      );
+    });
+
+    it('should return array header values as-is', () => {
+      assert.deepStrictEqual(
+        utils.requestTextMapGetter.get(request, 'x-multi-value'),
+        ['one', 'two']
+      );
+    });
+
+    it('should return undefined for missing headers', () => {
+      assert.strictEqual(
+        utils.requestTextMapGetter.get(request, 'missing'),
+        undefined
+      );
+    });
+
+    it('should list header keys of the request carrier', () => {
+      assert.deepStrictEqual(utils.requestTextMapGetter.keys(request), [
+        'traceparent',
+        'x-multi-value',
+      ]);
+    });
+  });
 });

--- a/experimental/packages/opentelemetry-instrumentation-http/test/utils/DummyPropagation.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/utils/DummyPropagation.ts
@@ -2,17 +2,28 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { Context, TextMapPropagator } from '@opentelemetry/api';
+import type {
+  Context,
+  TextMapGetter,
+  TextMapPropagator,
+} from '@opentelemetry/api';
 import { trace, TraceFlags } from '@opentelemetry/api';
 import type * as http from 'http';
 
 export class DummyPropagation implements TextMapPropagator {
   static TRACE_CONTEXT_KEY = 'x-dummy-trace-id';
   static SPAN_CONTEXT_KEY = 'x-dummy-span-id';
-  extract(context: Context, carrier: http.OutgoingHttpHeaders) {
+  extract(
+    context: Context,
+    carrier: http.IncomingMessage,
+    getter: TextMapGetter<http.IncomingMessage>
+  ) {
     const extractedSpanContext = {
-      traceId: carrier[DummyPropagation.TRACE_CONTEXT_KEY] as string,
-      spanId: carrier[DummyPropagation.SPAN_CONTEXT_KEY] as string,
+      traceId: getter.get(
+        carrier,
+        DummyPropagation.TRACE_CONTEXT_KEY
+      ) as string,
+      spanId: getter.get(carrier, DummyPropagation.SPAN_CONTEXT_KEY) as string,
       traceFlags: TraceFlags.SAMPLED,
       isRemote: true,
     };


### PR DESCRIPTION
## Which problem is this PR solving?

`instrumentation-http` extracts the propagation context from every incoming request's headers, unconditionally trusting `traceparent`/`tracestate`/baggage from any caller — including unauthenticated clients on the public internet. This lets external clients choose the trace ID our server spans are recorded under, causing trace pollution, orphaned traces (`<root span not yet received>`), and oversized merged traces that can exceed backend per-trace limits.

Passing only the headers object as extract carrier also restricts what a propagator can do: it can neither make trust decisions about the request, nor extract context from other parts of the request.

#6901 addresses the trust problem with an instrumentation-scoped `ignoreIncomingPropagationHook` config option. This PR explores the alternative design suggested there: making the decision expressible in the **propagator** itself, by giving it access to the full request.

## Short description of the changes

Passes the incoming `http.IncomingMessage` as the propagation extract **carrier**, along with a custom `TextMapGetter` (`requestTextMapGetter`) that reads from `request.headers`:

```ts
const ctx = propagation.extract(ROOT_CONTEXT, request, requestTextMapGetter);
```

A custom propagator can now use the whole request, enabling e.g.:

- **Per-request trust decisions** — return the context unchanged (no remote parent) when the request comes from an untrusted source:

  ```ts
  extract(context, carrier, getter) {
    const request = carrier as http.IncomingMessage;
    if (!isTrusted(request.socket.remoteAddress)) return context;
    return this._inner.extract(context, carrier, getter);
  }
  ```

- **Extraction from non-header request data** — e.g. trace identifiers carried in the request URL (query parameter or path segment), which is impossible today since the carrier only exposes headers:

  ```ts
  extract(context, carrier, getter) {
    const request = carrier as http.IncomingMessage;
    const url = new URL(request.url ?? '/', 'http://localhost');
    const traceparent = url.searchParams.get('traceparent');
    // ... parse and return trace.setSpanContext(context, ...)
  }
  ```

Compared to #6901, this concentrates the logic in one reusable propagator instead of per-instrumentation hooks, at the cost of a wider breaking surface.

### Breaking change

Propagators that use the provided `getter` (as the `TextMapPropagator` contract prescribes) are **unaffected** — all built-in propagators (W3C, B3, Jaeger, baggage) work unchanged. Propagators that index the carrier directly (`carrier[key]`) will break and must switch to `getter.get(carrier, key)`. (The test suite's own `DummyPropagation` had this shortcut and is fixed here.)

Includes unit tests for `requestTextMapGetter`, integration tests asserting the carrier is the `IncomingMessage` and demonstrating the IP-based trust use case, and a changelog entry.

## Related

- Alternative approach: #6901 (`ignoreIncomingPropagationHook` config option)