### PR TITLE
Stop using "any" as propagator generic

### DIFF
--- a/api/src/api/propagation.ts
+++ b/api/src/api/propagation.ts
@@ -105,7 +105,7 @@ export class PropagationAPI {
   public extract<Carrier>(
     context: Context,
     carrier: Carrier,
-    getter: TextMapGetter<Carrier> = defaultTextMapGetter
+    getter: TextMapGetter<Carrier> = defaultTextMapGetter as TextMapGetter<Carrier>
   ): Context {
     return this._getGlobalPropagator().extract(context, carrier, getter);
   }

--- a/api/src/api/propagation.ts
+++ b/api/src/api/propagation.ts
@@ -65,12 +65,22 @@ export class PropagationAPI {
    *
    * @param context Context carrying tracing data to inject
    * @param carrier carrier to inject context into
-   * @param setter Function used to set values on the carrier
+   * @param setter Function used to set values on the carrier. If not provided, the carrier must be a plain object and values will be set by direct object assignment.
    */
   public inject<Carrier>(
     context: Context,
     carrier: Carrier,
-    setter: TextMapSetter<Carrier> = defaultTextMapSetter
+    setter: TextMapSetter<Carrier>
+  ): void;
+  public inject<Carrier extends Record<string, undefined | string | string[]>>(
+    context: Context,
+    carrier: Carrier,
+    setter?: TextMapSetter<Carrier>
+  ): void;
+  public inject<Carrier>(
+    context: Context,
+    carrier: Carrier,
+    setter: TextMapSetter<Carrier> = defaultTextMapSetter as TextMapSetter<Carrier>
   ): void {
     return this._getGlobalPropagator().inject(context, carrier, setter);
   }
@@ -80,8 +90,18 @@ export class PropagationAPI {
    *
    * @param context Context which the newly created context will inherit from
    * @param carrier Carrier to extract context from
-   * @param getter Function used to extract keys from a carrier
+   * @param getter Function used to extract keys from a carrier. If not provided, the carrier must be a plain object and keys will be extracted via direct object access.
    */
+  public extract<Carrier>(
+    context: Context,
+    carrier: Carrier,
+    getter: TextMapGetter<Carrier>
+  ): Context;
+  public extract<Carrier extends Record<string, undefined | string | string[]>>(
+    context: Context,
+    carrier: Carrier,
+    getter?: TextMapGetter<Carrier>
+  ): Context;
   public extract<Carrier>(
     context: Context,
     carrier: Carrier,

--- a/api/src/propagation/TextMapPropagator.ts
+++ b/api/src/propagation/TextMapPropagator.ts
@@ -18,8 +18,7 @@ import type { Context } from '../context/types';
  *
  * @since 1.0.0
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface TextMapPropagator<Carrier = any> {
+export interface TextMapPropagator<TCarrier = unknown> {
   /**
    * Injects values from a given `Context` into a carrier.
    *
@@ -33,7 +32,7 @@ export interface TextMapPropagator<Carrier = any> {
    * @param setter an optional {@link TextMapSetter}. If undefined, values will be
    *     set by direct object assignment.
    */
-  inject(
+  inject<Carrier extends TCarrier>(
     context: Context,
     carrier: Carrier,
     setter: TextMapSetter<Carrier>
@@ -51,7 +50,7 @@ export interface TextMapPropagator<Carrier = any> {
    * @param getter an optional {@link TextMapGetter}. If undefined, keys will be all
    *     own properties, and keys will be accessed by direct object access.
    */
-  extract(
+  extract<Carrier extends TCarrier>(
     context: Context,
     carrier: Carrier,
     getter: TextMapGetter<Carrier>

--- a/api/src/propagation/TextMapPropagator.ts
+++ b/api/src/propagation/TextMapPropagator.ts
@@ -18,7 +18,7 @@ import type { Context } from '../context/types';
  *
  * @since 1.0.0
  */
-export interface TextMapPropagator<TCarrier = unknown> {
+export interface TextMapPropagator {
   /**
    * Injects values from a given `Context` into a carrier.
    *
@@ -32,7 +32,7 @@ export interface TextMapPropagator<TCarrier = unknown> {
    * @param setter an optional {@link TextMapSetter}. If undefined, values will be
    *     set by direct object assignment.
    */
-  inject<Carrier extends TCarrier>(
+  inject<Carrier>(
     context: Context,
     carrier: Carrier,
     setter: TextMapSetter<Carrier>
@@ -50,7 +50,7 @@ export interface TextMapPropagator<TCarrier = unknown> {
    * @param getter an optional {@link TextMapGetter}. If undefined, keys will be all
    *     own properties, and keys will be accessed by direct object access.
    */
-  extract<Carrier extends TCarrier>(
+  extract<Carrier>(
     context: Context,
     carrier: Carrier,
     getter: TextMapGetter<Carrier>
@@ -68,8 +68,7 @@ export interface TextMapPropagator<TCarrier = unknown> {
  *
  * @since 1.0.0
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface TextMapSetter<Carrier = any> {
+export interface TextMapSetter<Carrier = unknown> {
   /**
    * Callback used to set a key/value pair on an object.
    *
@@ -89,8 +88,7 @@ export interface TextMapSetter<Carrier = any> {
  *
  * @since 1.0.0
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface TextMapGetter<Carrier = any> {
+export interface TextMapGetter<Carrier = unknown> {
   /**
    * Get a list of all keys available on the carrier.
    *
@@ -111,7 +109,7 @@ export interface TextMapGetter<Carrier = any> {
  * @since 1.0.0
  */
 export const defaultTextMapGetter: TextMapGetter<
-  Record<string, undefined | string | string[]>
+  undefined | null | Record<string, undefined | string | string[]>
 > = {
   get(carrier, key) {
     if (carrier == null) {
@@ -132,7 +130,7 @@ export const defaultTextMapGetter: TextMapGetter<
  * @since 1.0.0
  */
 export const defaultTextMapSetter: TextMapSetter<
-  Record<string, undefined | string | string[]>
+  undefined | null | Record<string, undefined | string | string[]>
 > = {
   set(carrier, key, value) {
     if (carrier == null) {

--- a/api/src/propagation/TextMapPropagator.ts
+++ b/api/src/propagation/TextMapPropagator.ts
@@ -110,7 +110,9 @@ export interface TextMapGetter<Carrier = any> {
 /**
  * @since 1.0.0
  */
-export const defaultTextMapGetter: TextMapGetter = {
+export const defaultTextMapGetter: TextMapGetter<
+  Record<string, undefined | string | string[]>
+> = {
   get(carrier, key) {
     if (carrier == null) {
       return undefined;
@@ -129,7 +131,9 @@ export const defaultTextMapGetter: TextMapGetter = {
 /**
  * @since 1.0.0
  */
-export const defaultTextMapSetter: TextMapSetter = {
+export const defaultTextMapSetter: TextMapSetter<
+  Record<string, undefined | string | string[]>
+> = {
   set(carrier, key, value) {
     if (carrier == null) {
       return;

--- a/api/src/propagation/TextMapPropagator.ts
+++ b/api/src/propagation/TextMapPropagator.ts
@@ -18,7 +18,7 @@ import type { Context } from '../context/types';
  *
  * @since 1.0.0
  */
-export interface TextMapPropagator {
+export interface TextMapPropagator<BaseCarrier = unknown> {
   /**
    * Injects values from a given `Context` into a carrier.
    *
@@ -32,7 +32,7 @@ export interface TextMapPropagator {
    * @param setter an optional {@link TextMapSetter}. If undefined, values will be
    *     set by direct object assignment.
    */
-  inject<Carrier>(
+  inject<Carrier extends BaseCarrier>(
     context: Context,
     carrier: Carrier,
     setter: TextMapSetter<Carrier>
@@ -50,7 +50,7 @@ export interface TextMapPropagator {
    * @param getter an optional {@link TextMapGetter}. If undefined, keys will be all
    *     own properties, and keys will be accessed by direct object access.
    */
-  extract<Carrier>(
+  extract<Carrier extends BaseCarrier>(
     context: Context,
     carrier: Carrier,
     getter: TextMapGetter<Carrier>

--- a/api/test/common/api/api.test.ts
+++ b/api/test/common/api/api.test.ts
@@ -181,24 +181,24 @@ describe('API', function () {
     describe('should use the global propagation', function () {
       const testKey = Symbol('kTestKey');
 
-      interface Carrier {
-        context?: Context;
-        setter?: TextMapSetter;
-      }
+      class TestTextMapPropagation implements TextMapPropagator {
+        injectedWith?: {
+          context: Context;
+          carrier: unknown;
+          setter: TextMapSetter;
+        };
 
-      class TestTextMapPropagation implements TextMapPropagator<Carrier> {
         inject(
           context: Context,
-          carrier: Carrier,
+          carrier: unknown,
           setter: TextMapSetter
         ): void {
-          carrier.context = context;
-          carrier.setter = setter;
+          this.injectedWith = { context, carrier, setter };
         }
 
         extract(
           context: Context,
-          carrier: Carrier,
+          carrier: unknown,
           getter: TextMapGetter
         ): Context {
           return context.setValue(testKey, {
@@ -214,26 +214,47 @@ describe('API', function () {
       }
 
       it('inject', function () {
-        api.propagation.setGlobalPropagator(new TestTextMapPropagation());
+        const propagator = new TestTextMapPropagation();
+        api.propagation.setGlobalPropagator(propagator);
 
         const context = ROOT_CONTEXT.setValue(testKey, 15);
-        const carrier: Carrier = {};
+        const carrier: Record<string, string> = {};
         api.propagation.inject(context, carrier);
-        assert.strictEqual(carrier.context, context);
-        assert.strictEqual(carrier.setter, defaultTextMapSetter);
+        assert.strictEqual(propagator.injectedWith?.context, context);
+        assert.strictEqual(propagator.injectedWith?.carrier, carrier);
+        assert.strictEqual(
+          propagator.injectedWith?.setter,
+          defaultTextMapSetter
+        );
 
         const setter: TextMapSetter = {
           set: () => {},
         };
         api.propagation.inject(context, carrier, setter);
-        assert.strictEqual(carrier.context, context);
-        assert.strictEqual(carrier.setter, setter);
+        assert.strictEqual(propagator.injectedWith?.context, context);
+        assert.strictEqual(propagator.injectedWith?.carrier, carrier);
+        assert.strictEqual(propagator.injectedWith?.setter, setter);
+      });
+
+      it('inject with a non-record carrier and an explicit setter', function () {
+        const propagator = new TestTextMapPropagation();
+        api.propagation.setGlobalPropagator(propagator);
+
+        const context = ROOT_CONTEXT.setValue(testKey, 15);
+        const carrier: string[] = [];
+        const setter: TextMapSetter<string[]> = {
+          set: () => {},
+        };
+        api.propagation.inject(context, carrier, setter);
+        assert.strictEqual(propagator.injectedWith?.context, context);
+        assert.strictEqual(propagator.injectedWith?.carrier, carrier);
+        assert.strictEqual(propagator.injectedWith?.setter, setter);
       });
 
       it('extract', function () {
         api.propagation.setGlobalPropagator(new TestTextMapPropagation());
 
-        const carrier: Carrier = {};
+        const carrier: Record<string, string> = {};
         let context = api.propagation.extract(ROOT_CONTEXT, carrier);
         let data: any = context.getValue(testKey);
         assert.ok(data != null);
@@ -247,6 +268,22 @@ describe('API', function () {
         };
         context = api.propagation.extract(ROOT_CONTEXT, carrier, getter);
         data = context.getValue(testKey);
+        assert.ok(data != null);
+        assert.strictEqual(data.context, ROOT_CONTEXT);
+        assert.strictEqual(data.carrier, carrier);
+        assert.strictEqual(data.getter, getter);
+      });
+
+      it('extract with a non-record carrier and an explicit getter', function () {
+        api.propagation.setGlobalPropagator(new TestTextMapPropagation());
+
+        const carrier: string[] = [];
+        const getter: TextMapGetter<string[]> = {
+          keys: () => [],
+          get: () => undefined,
+        };
+        const context = api.propagation.extract(ROOT_CONTEXT, carrier, getter);
+        const data: any = context.getValue(testKey);
         assert.ok(data != null);
         assert.strictEqual(data.context, ROOT_CONTEXT);
         assert.strictEqual(data.carrier, carrier);

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -166,7 +166,7 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
         this.getConfig().propagateTraceHeaderCorsUrls
       )
     ) {
-      const headers: Partial<Record<string, unknown>> = {};
+      const headers: Record<string, undefined | string | string[]> = {};
       propagation.inject(context.active(), headers);
       if (Object.keys(headers).length > 0) {
         this._diag.debug('headers inject skipped due to CORS policy');

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -64,7 +64,7 @@ import {
   getOutgoingStableRequestMetricAttributesOnResponse,
   getRequestInfo,
   headerCapture,
-  headersTextMapSetter,
+  requestTextMapSetter,
   isValidOptionsType,
   parseResponseStatus,
   setSpanWithError,
@@ -733,20 +733,7 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
       const parentContext = context.active();
       const requestContext = trace.setSpan(parentContext, span);
 
-      if (!optionsParsed.headers) {
-        optionsParsed.headers = {};
-      } else {
-        // Make a copy of the headers object to avoid mutating an object the
-        // caller might have a reference to.
-        optionsParsed.headers = Array.isArray(optionsParsed.headers)
-          ? optionsParsed.headers.slice()
-          : Object.assign({}, optionsParsed.headers);
-      }
-      propagation.inject(
-        requestContext,
-        optionsParsed.headers,
-        headersTextMapSetter
-      );
+      propagation.inject(requestContext, optionsParsed, requestTextMapSetter);
 
       return context.with(requestContext, () => {
         /*

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -64,7 +64,7 @@ import {
   getOutgoingStableRequestMetricAttributesOnResponse,
   getRequestInfo,
   headerCapture,
-  requestTextMapSetter,
+  requestOptionsTextMapSetter,
   isValidOptionsType,
   parseResponseStatus,
   setSpanWithError,
@@ -733,7 +733,11 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
       const parentContext = context.active();
       const requestContext = trace.setSpan(parentContext, span);
 
-      propagation.inject(requestContext, optionsParsed, requestTextMapSetter);
+      propagation.inject(
+        requestContext,
+        optionsParsed,
+        requestOptionsTextMapSetter
+      );
 
       return context.with(requestContext, () => {
         /*

--- a/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/http.ts
@@ -64,6 +64,7 @@ import {
   getOutgoingStableRequestMetricAttributesOnResponse,
   getRequestInfo,
   headerCapture,
+  headersTextMapSetter,
   isValidOptionsType,
   parseResponseStatus,
   setSpanWithError,
@@ -737,9 +738,15 @@ export class HttpInstrumentation extends InstrumentationBase<HttpInstrumentation
       } else {
         // Make a copy of the headers object to avoid mutating an object the
         // caller might have a reference to.
-        optionsParsed.headers = Object.assign({}, optionsParsed.headers);
+        optionsParsed.headers = Array.isArray(optionsParsed.headers)
+          ? optionsParsed.headers.slice()
+          : Object.assign({}, optionsParsed.headers);
       }
-      propagation.inject(requestContext, optionsParsed.headers);
+      propagation.inject(
+        requestContext,
+        optionsParsed.headers,
+        headersTextMapSetter
+      );
 
       return context.with(requestContext, () => {
         /*

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -59,7 +59,7 @@ import forwardedParse = require('forwarded-parse');
 const isReadOnlyArray = <T>(value: unknown): value is readonly T[] =>
   Array.isArray(value);
 
-export const requestTextMapSetter: TextMapSetter<RequestOptions> = {
+export const requestOptionsTextMapSetter: TextMapSetter<RequestOptions> = {
   set(carrier, key, value) {
     const keyLower = key.toLowerCase();
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -7,8 +7,14 @@ import type {
   Span,
   DiagLogger,
   AttributeValue,
+  TextMapSetter,
 } from '@opentelemetry/api';
-import { SpanStatusCode, context, SpanKind } from '@opentelemetry/api';
+import {
+  SpanStatusCode,
+  context,
+  SpanKind,
+  defaultTextMapSetter,
+} from '@opentelemetry/api';
 import {
   ATTR_CLIENT_ADDRESS,
   ATTR_ERROR_TYPE,
@@ -54,6 +60,28 @@ import {
 } from './internal-types';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import forwardedParse = require('forwarded-parse');
+
+export const headersTextMapSetter: TextMapSetter<
+  // headers <Object> | <Array> An object or an array of strings containing
+  // request headers. The array is in the same format as message.rawHeaders.
+  Record<string, undefined | string | string[]> | string[]
+> = {
+  set(carrier, key, value) {
+    if (Array.isArray(carrier)) {
+      const keyLower = key.toLowerCase();
+      for (let i = 0; i < carrier.length; i += 2) {
+        if (carrier[i].toLowerCase() === keyLower) {
+          carrier[i + 1] = value;
+          return;
+        }
+      }
+
+      carrier.push(key, value);
+    } else {
+      defaultTextMapSetter.set(carrier, key, value);
+    }
+  },
+};
 
 /**
  * Get an absolute url

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -9,12 +9,7 @@ import type {
   AttributeValue,
   TextMapSetter,
 } from '@opentelemetry/api';
-import {
-  SpanStatusCode,
-  context,
-  SpanKind,
-  defaultTextMapSetter,
-} from '@opentelemetry/api';
+import { SpanStatusCode, context, SpanKind } from '@opentelemetry/api';
 import {
   ATTR_CLIENT_ADDRESS,
   ATTR_ERROR_TYPE,
@@ -61,24 +56,45 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import forwardedParse = require('forwarded-parse');
 
-export const headersTextMapSetter: TextMapSetter<
-  // headers <Object> | <Array> An object or an array of strings containing
-  // request headers. The array is in the same format as message.rawHeaders.
-  Record<string, undefined | string | string[]> | string[]
-> = {
+const isReadOnlyArray = <T>(value: unknown): value is readonly T[] =>
+  Array.isArray(value);
+
+export const requestTextMapSetter: TextMapSetter<RequestOptions> = {
   set(carrier, key, value) {
-    if (Array.isArray(carrier)) {
-      const keyLower = key.toLowerCase();
-      for (let i = 0; i < carrier.length; i += 2) {
-        if (carrier[i].toLowerCase() === keyLower) {
-          carrier[i + 1] = value;
+    const keyLower = key.toLowerCase();
+
+    // headers <Object> | <Array> An object or an array of strings containing
+    // request headers. The array is in the same format as message.rawHeaders.
+    if (!carrier.headers) {
+      carrier.headers = { [keyLower]: value };
+    } else if (isReadOnlyArray(carrier.headers)) {
+      // Make a copy of the headers object to avoid mutating an object the
+      // caller might have a reference to.
+      const headers = carrier.headers.slice();
+      carrier.headers = headers;
+
+      for (let i = 0; i < headers.length; i += 2) {
+        if (headers[i].toLowerCase() === keyLower) {
+          headers[i + 1] = value;
           return;
         }
       }
 
-      carrier.push(key, value);
+      headers.push(keyLower, value);
     } else {
-      defaultTextMapSetter.set(carrier, key, value);
+      // Make a copy of the headers object to avoid mutating an object the
+      // caller might have a reference to.
+      const headers = Object.assign({}, carrier.headers);
+      carrier.headers = headers;
+
+      for (const headerKey in headers) {
+        if (headerKey.toLowerCase() === keyLower) {
+          headers[headerKey as keyof typeof headers] = value;
+          return;
+        }
+      }
+
+      headers[keyLower] = value;
     }
   },
 };

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -28,6 +28,7 @@ import { RPCType, setRPCMetadata } from '@opentelemetry/core';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { extractHostnameAndPort } from '../../src/utils';
 import type { ParsedUrlQuery } from 'node:querystring';
+import type { RequestOptions } from 'node:http';
 
 describe('Utility', () => {
   describe('parseResponseStatus()', () => {
@@ -56,6 +57,66 @@ describe('Utility', () => {
         const status = utils.parseResponseStatus(SpanKind.SERVER, index);
         assert.notStrictEqual(status, SpanStatusCode.UNSET);
       }
+    });
+  });
+
+  describe('headersTextMapSetter', () => {
+    describe('when carrier is a headers object', () => {
+      it('should set the value on the carrier', () => {
+        const headers = Object.freeze({ 'x-foo': 'bar' });
+        const carrier: RequestOptions = { headers };
+        utils.requestTextMapSetter.set(carrier, 'traceparent', 'some-value');
+        assert.notStrictEqual(carrier.headers, headers);
+        assert.deepStrictEqual(carrier.headers, {
+          'x-foo': 'bar',
+          traceparent: 'some-value',
+        });
+      });
+    });
+
+    describe('when carrier is a raw headers array', () => {
+      it('should append the key and value to the carrier', () => {
+        const carrier: RequestOptions = {
+          headers: ['x-foo', 'bar'],
+        };
+
+        utils.requestTextMapSetter.set(carrier, 'traceparent', 'some-value');
+        assert.deepStrictEqual(carrier.headers, [
+          'x-foo',
+          'bar',
+          'traceparent',
+          'some-value',
+        ]);
+      });
+
+      it('should replace the value of an existing key', () => {
+        const carrier: RequestOptions = {
+          headers: ['x-foo', 'bar', 'traceparent', 'old-value', 'x-baz', 'qux'],
+        };
+        utils.requestTextMapSetter.set(carrier, 'traceparent', 'new-value');
+        assert.deepStrictEqual(carrier.headers, [
+          'x-foo',
+          'bar',
+          'traceparent',
+          'new-value',
+          'x-baz',
+          'qux',
+        ]);
+      });
+
+      it('should replace the value of an existing key regardless of casing', () => {
+        const headers = Object.freeze(['TraceParent', 'old-value']);
+        const carrier: RequestOptions = { headers };
+        utils.requestTextMapSetter.set(carrier, 'traceparent', 'new-value');
+        assert.notStrictEqual(carrier.headers, headers);
+        assert.deepStrictEqual(carrier.headers, ['TraceParent', 'new-value']);
+      });
+
+      it('should append to an empty carrier', () => {
+        const carrier: RequestOptions = { headers: [] };
+        utils.requestTextMapSetter.set(carrier, 'traceparent', 'some-value');
+        assert.deepStrictEqual(carrier.headers, ['traceparent', 'some-value']);
+      });
     });
   });
 

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -65,7 +65,11 @@ describe('Utility', () => {
       it('should set the value on the carrier', () => {
         const headers = Object.freeze({ 'x-foo': 'bar' });
         const carrier: RequestOptions = { headers };
-        utils.requestTextMapSetter.set(carrier, 'traceparent', 'some-value');
+        utils.requestOptionsTextMapSetter.set(
+          carrier,
+          'traceparent',
+          'some-value'
+        );
         assert.notStrictEqual(carrier.headers, headers);
         assert.deepStrictEqual(carrier.headers, {
           'x-foo': 'bar',
@@ -80,7 +84,11 @@ describe('Utility', () => {
           headers: ['x-foo', 'bar'],
         };
 
-        utils.requestTextMapSetter.set(carrier, 'traceparent', 'some-value');
+        utils.requestOptionsTextMapSetter.set(
+          carrier,
+          'traceparent',
+          'some-value'
+        );
         assert.deepStrictEqual(carrier.headers, [
           'x-foo',
           'bar',
@@ -93,7 +101,11 @@ describe('Utility', () => {
         const carrier: RequestOptions = {
           headers: ['x-foo', 'bar', 'traceparent', 'old-value', 'x-baz', 'qux'],
         };
-        utils.requestTextMapSetter.set(carrier, 'traceparent', 'new-value');
+        utils.requestOptionsTextMapSetter.set(
+          carrier,
+          'traceparent',
+          'new-value'
+        );
         assert.deepStrictEqual(carrier.headers, [
           'x-foo',
           'bar',
@@ -107,14 +119,22 @@ describe('Utility', () => {
       it('should replace the value of an existing key regardless of casing', () => {
         const headers = Object.freeze(['TraceParent', 'old-value']);
         const carrier: RequestOptions = { headers };
-        utils.requestTextMapSetter.set(carrier, 'traceparent', 'new-value');
+        utils.requestOptionsTextMapSetter.set(
+          carrier,
+          'traceparent',
+          'new-value'
+        );
         assert.notStrictEqual(carrier.headers, headers);
         assert.deepStrictEqual(carrier.headers, ['TraceParent', 'new-value']);
       });
 
       it('should append to an empty carrier', () => {
         const carrier: RequestOptions = { headers: [] };
-        utils.requestTextMapSetter.set(carrier, 'traceparent', 'some-value');
+        utils.requestOptionsTextMapSetter.set(
+          carrier,
+          'traceparent',
+          'some-value'
+        );
         assert.deepStrictEqual(carrier.headers, ['traceparent', 'some-value']);
       });
     });

--- a/experimental/packages/opentelemetry-instrumentation-http/test/integrations/http-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/integrations/http-enable.test.ts
@@ -31,6 +31,7 @@ import { httpRequest } from '../utils/httpRequest';
 import { DummyPropagation } from '../utils/DummyPropagation';
 import type { Socket } from 'net';
 import { sendRequestTwice } from '../utils/rawRequest';
+import type { RequestOptions } from 'https';
 
 const protocol = 'http';
 const hostname = 'localhost';
@@ -56,6 +57,7 @@ describe('HttpInstrumentation Integration tests', () => {
       res.write(
         JSON.stringify({
           success: true,
+          headers: req.headers,
         })
       );
       res.end();
@@ -257,6 +259,48 @@ describe('HttpInstrumentation Integration tests', () => {
       assert.deepStrictEqual(headers, { 'x-foo': 'foo' });
       assert.ok(result.reqHeaders[DummyPropagation.TRACE_CONTEXT_KEY]);
       assert.ok(result.reqHeaders[DummyPropagation.SPAN_CONTEXT_KEY]);
+    });
+
+    it('should add propagation headers when given headers is an array of raw header strings', async () => {
+      const spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 0);
+
+      const headers = ['x-foo', 'foo'];
+      const result = await httpRequest.get(
+        new URL(`${protocol}://localhost:${mockServerPort}/?query=test`),
+        { headers }
+      );
+
+      // We can't use result.reqHeaders here because Node.js does not reflect
+      // raw headers in the getHeaders() result. See
+      // https://github.com/nodejs/node/issues/64405
+      const header = (result.req as any)._header as string;
+
+      assert.ok(header.includes('x-foo: foo'));
+      assert.ok(header.includes(`${DummyPropagation.TRACE_CONTEXT_KEY}:`));
+      assert.ok(header.includes(`${DummyPropagation.SPAN_CONTEXT_KEY}:`));
+    });
+
+    it('should not mutate given raw headers array when adding propagation headers', async () => {
+      const spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 0);
+
+      const headers = ['x-foo', 'foo'];
+      const options: RequestOptions = { headers };
+      const result = await httpRequest.get(
+        new URL(`${protocol}://localhost:${mockServerPort}/?query=test`),
+        options
+      );
+
+      // We can't use result.reqHeaders here because Node.js does not reflect
+      // raw headers in the getHeaders() result. See
+      // https://github.com/nodejs/node/issues/64405
+      const header = (result.req as any)._header as string;
+
+      assert.ok(header.includes('x-foo: foo'));
+      assert.ok(header.includes(`${DummyPropagation.TRACE_CONTEXT_KEY}:`));
+      assert.ok(header.includes(`${DummyPropagation.SPAN_CONTEXT_KEY}:`));
+      assert.deepStrictEqual(options, { headers: ['x-foo', 'foo'] });
     });
 
     it('should succeed even with malformed Forwarded header', async () => {

--- a/experimental/packages/opentelemetry-instrumentation-http/test/utils/DummyPropagation.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/utils/DummyPropagation.ts
@@ -2,30 +2,54 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import type { Context, TextMapPropagator } from '@opentelemetry/api';
+import type {
+  Context,
+  TextMapGetter,
+  TextMapPropagator,
+  TextMapSetter,
+} from '@opentelemetry/api';
 import { trace, TraceFlags } from '@opentelemetry/api';
-import type * as http from 'http';
 
 export class DummyPropagation implements TextMapPropagator {
   static TRACE_CONTEXT_KEY = 'x-dummy-trace-id';
   static SPAN_CONTEXT_KEY = 'x-dummy-span-id';
-  extract(context: Context, carrier: http.OutgoingHttpHeaders) {
-    const extractedSpanContext = {
-      traceId: carrier[DummyPropagation.TRACE_CONTEXT_KEY] as string,
-      spanId: carrier[DummyPropagation.SPAN_CONTEXT_KEY] as string,
-      traceFlags: TraceFlags.SAMPLED,
-      isRemote: true,
-    };
-    if (extractedSpanContext.traceId && extractedSpanContext.spanId) {
-      return trace.setSpanContext(context, extractedSpanContext);
+  extract<Carrier>(
+    context: Context,
+    carrier: Carrier,
+    getter: TextMapGetter<Carrier>
+  ): Context {
+    const traceIdHeader = getter.get(
+      carrier,
+      DummyPropagation.TRACE_CONTEXT_KEY
+    );
+    const spanIdHeader = getter.get(carrier, DummyPropagation.SPAN_CONTEXT_KEY);
+    const traceId = Array.isArray(traceIdHeader)
+      ? traceIdHeader[0]
+      : traceIdHeader;
+    const spanId = Array.isArray(spanIdHeader) ? spanIdHeader[0] : spanIdHeader;
+    if (traceId && spanId) {
+      return trace.setSpanContext(context, {
+        traceId,
+        spanId,
+        traceFlags: TraceFlags.SAMPLED,
+        isRemote: true,
+      });
     }
     return context;
   }
-  inject(context: Context, headers: { [custom: string]: string }): void {
+  inject<Carrier>(
+    context: Context,
+    carrier: Carrier,
+    setter: TextMapSetter<Carrier>
+  ): void {
     const spanContext = trace.getSpanContext(context);
     if (!spanContext) return;
-    headers[DummyPropagation.TRACE_CONTEXT_KEY] = spanContext.traceId;
-    headers[DummyPropagation.SPAN_CONTEXT_KEY] = spanContext.spanId;
+    setter.set(
+      carrier,
+      DummyPropagation.TRACE_CONTEXT_KEY,
+      spanContext.traceId
+    );
+    setter.set(carrier, DummyPropagation.SPAN_CONTEXT_KEY, spanContext.spanId);
   }
   fields(): string[] {
     return [

--- a/experimental/packages/opentelemetry-instrumentation-http/test/utils/httpRequest.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/utils/httpRequest.ts
@@ -31,6 +31,7 @@ function get(input: any, options?: any): GetResult {
       };
       let data = '';
       resp.on('data', chunk => {
+        console.error('chunk', chunk);
         data += chunk;
       });
       resp.on('end', () => {

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -122,14 +122,14 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
         this.getConfig().propagateTraceHeaderCorsUrls
       )
     ) {
-      const headers: Partial<Record<string, unknown>> = {};
+      const headers: Record<string, undefined | string | string[]> = {};
       api.propagation.inject(api.context.active(), headers);
       if (Object.keys(headers).length > 0) {
         this._diag.debug('headers inject skipped due to CORS policy');
       }
       return;
     }
-    const headers: { [key: string]: unknown } = {};
+    const headers: Record<string, undefined | string | string[]> = {};
     api.propagation.inject(api.context.active(), headers);
     Object.keys(headers).forEach(key => {
       xhr.setRequestHeader(key, String(headers[key]));

--- a/packages/opentelemetry-propagator-b3/src/B3MultiPropagator.ts
+++ b/packages/opentelemetry-propagator-b3/src/B3MultiPropagator.ts
@@ -84,7 +84,11 @@ function getTraceFlags(
  * Based on: https://github.com/openzipkin/b3-propagation
  */
 export class B3MultiPropagator implements TextMapPropagator {
-  inject(context: Context, carrier: unknown, setter: TextMapSetter): void {
+  inject<Carrier>(
+    context: Context,
+    carrier: Carrier,
+    setter: TextMapSetter<Carrier>
+  ): void {
     const spanContext = trace.getSpanContext(context);
     if (
       !spanContext ||
@@ -113,7 +117,11 @@ export class B3MultiPropagator implements TextMapPropagator {
     }
   }
 
-  extract(context: Context, carrier: unknown, getter: TextMapGetter): Context {
+  extract<Carrier>(
+    context: Context,
+    carrier: Carrier,
+    getter: TextMapGetter<Carrier>
+  ): Context {
     const traceId = getTraceId(carrier, getter);
     const spanId = getSpanId(carrier, getter);
     const traceFlags = getTraceFlags(carrier, getter) as TraceFlags;

--- a/packages/opentelemetry-propagator-b3/src/B3Propagator.ts
+++ b/packages/opentelemetry-propagator-b3/src/B3Propagator.ts
@@ -45,14 +45,22 @@ export class B3Propagator implements TextMapPropagator {
     }
   }
 
-  inject(context: Context, carrier: unknown, setter: TextMapSetter): void {
+  inject<Carrier>(
+    context: Context,
+    carrier: Carrier,
+    setter: TextMapSetter<Carrier>
+  ): void {
     if (isTracingSuppressed(context)) {
       return;
     }
     this._inject(context, carrier, setter);
   }
 
-  extract(context: Context, carrier: unknown, getter: TextMapGetter): Context {
+  extract<Carrier>(
+    context: Context,
+    carrier: Carrier,
+    getter: TextMapGetter<Carrier>
+  ): Context {
     const header = getter.get(carrier, B3_CONTEXT_HEADER);
     const b3Context = Array.isArray(header) ? header[0] : header;
 

--- a/packages/opentelemetry-propagator-b3/src/B3SinglePropagator.ts
+++ b/packages/opentelemetry-propagator-b3/src/B3SinglePropagator.ts
@@ -42,7 +42,11 @@ function convertToTraceFlags(samplingState: string | undefined): TraceFlags {
  * Based on: https://github.com/openzipkin/b3-propagation
  */
 export class B3SinglePropagator implements TextMapPropagator {
-  inject(context: Context, carrier: unknown, setter: TextMapSetter): void {
+  inject<Carrier>(
+    context: Context,
+    carrier: Carrier,
+    setter: TextMapSetter<Carrier>
+  ): void {
     const spanContext = trace.getSpanContext(context);
     if (
       !spanContext ||
@@ -57,7 +61,11 @@ export class B3SinglePropagator implements TextMapPropagator {
     setter.set(carrier, B3_CONTEXT_HEADER, value);
   }
 
-  extract(context: Context, carrier: unknown, getter: TextMapGetter): Context {
+  extract<Carrier>(
+    context: Context,
+    carrier: Carrier,
+    getter: TextMapGetter<Carrier>
+  ): Context {
     const header = getter.get(carrier, B3_CONTEXT_HEADER);
     const b3Context = Array.isArray(header) ? header[0] : header;
     if (typeof b3Context !== 'string') return context;

--- a/packages/opentelemetry-propagator-b3/test/B3Propagator.test.ts
+++ b/packages/opentelemetry-propagator-b3/test/B3Propagator.test.ts
@@ -144,13 +144,21 @@ describe('B3Propagator', () => {
     it('extracts multi header b3 using array getter', () => {
       const context = propagator.extract(ROOT_CONTEXT, b3MultiCarrier, {
         get(carrier, key) {
-          if (carrier == null || carrier[key] === undefined) {
+          if (
+            carrier == null ||
+            (key !== 'x-b3-traceid' &&
+              key !== 'x-b3-spanid' &&
+              key !== 'x-b3-sampled') ||
+            carrier[key] == null
+          ) {
             return [];
           }
           return [carrier[key]];
         },
 
-        keys: defaultTextMapGetter.keys,
+        keys(carrier) {
+          return defaultTextMapGetter.keys(carrier);
+        },
       });
 
       const extractedSpanContext = trace.getSpanContext(context);


### PR DESCRIPTION
The current implementation of the `http` instrumentation incorrectly assumes that a request headers is always an object. However, NodeJS also allows using an array of strings as `request.headers`.

The `any` generic of the propagator classes hides the typing error this should normally generate:

<img width="1332" height="284" alt="Capture d’écran 2026-07-09 à 18 00 22" src="https://github.com/user-attachments/assets/cb267633-d10c-4152-be96-4cecba6640ed" />

This PR fixes several things:

1) It changes the typing of the propagation utilities to not rely on `any` as it may cause invisible issues
2) It fixes the injection of propagation headers when the request options is an array
3) It accounts for the fact that header names are case insensitive when setting propagation headers.
