### PR TITLE
feat(sdk-trace): add sampler factory functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 * feat(propagator-jaeger):  *Notice*: The `@opentelemetry/propagator-jaeger` package will be removed in SDK 3.x, planned for approximately September 2026. @pichlermarc
   * The Jaeger propagator has been deprecated by the OpenTelemetry specification in favor of `W3CTraceContextPropagator`. This package will be removed in a future release.
+* feat(sdk-trace): add factory functions for built-in samplers #6907 @LarryHu0217
 
 ### :bug: Bug Fixes
 

--- a/packages/sdk-trace/README.md
+++ b/packages/sdk-trace/README.md
@@ -99,6 +99,10 @@ process.once('beforeExit', async () => {
 
 Sampler is used to make decisions on `Span` sampling.
 
+Factory functions are the preferred way to configure built-in samplers. The
+class constructors remain available for backwards compatibility, but are
+deprecated and will be removed in a future major release.
+
 ### AlwaysOn Sampler
 
 Samples every trace regardless of upstream sampling decisions.
@@ -106,10 +110,13 @@ Samples every trace regardless of upstream sampling decisions.
 > This is used as a default Sampler
 
 ```js
-const { AlwaysOnSampler, TracerProvider } = require("@opentelemetry/sdk-trace");
+const {
+  createAlwaysOnSampler,
+  TracerProvider,
+} = require('@opentelemetry/sdk-trace');
 
 const tracerProvider = new TracerProvider({
-  sampler: new AlwaysOnSampler()
+  sampler: createAlwaysOnSampler(),
 });
 ```
 
@@ -118,10 +125,13 @@ const tracerProvider = new TracerProvider({
 Doesn't sample any trace, regardless of upstream sampling decisions.
 
 ```js
-const { AlwaysOffSampler, TracerProvider } = require("@opentelemetry/sdk-trace");
+const {
+  createAlwaysOffSampler,
+  TracerProvider,
+} = require('@opentelemetry/sdk-trace');
 
 const tracerProvider = new TracerProvider({
-  sampler: new AlwaysOffSampler()
+  sampler: createAlwaysOffSampler(),
 });
 ```
 
@@ -135,24 +145,25 @@ The `TraceIDRatioSampler` may be used with the `ParentBasedSampler` to respect t
 ```js
 const {
   TracerProvider,
-  TraceIdRatioBasedSampler,
-} = require("@opentelemetry/sdk-trace");
+  createParentBasedSampler,
+  createTraceIdRatioBasedSampler,
+} = require('@opentelemetry/sdk-trace');
 
 const tracerProvider = new TracerProvider({
   // See details of ParentBasedSampler below
-  sampler: new ParentBasedSampler({
+  sampler: createParentBasedSampler({
     // Trace ID Ratio Sampler accepts a positional argument
     // which represents the percentage of traces which should
     // be sampled.
-    root: new TraceIdRatioBasedSampler(0.5)
-  });
+    root: createTraceIdRatioBasedSampler(0.5),
+  }),
 });
 ```
 
 ### ParentBased Sampler
 
 - This is a composite sampler. `ParentBased` helps distinguished between the
-following cases:
+  following cases:
   - No parent (root span).
   - Remote parent with `sampled` flag `true`
   - Remote parent with `sampled` flag `false`
@@ -170,24 +181,23 @@ Optional parameters:
 - `localParentSampled(Sampler)` (default: `AlwaysOn`)
 - `localParentNotSampled(Sampler)` (default: `AlwaysOff`)
 
-|Parent|parent.isRemote()|parent.isSampled()|Invoke sampler|
-|---|---|---|---|
-|absent|n/a|n/a|`root()`|
-|present|true|true|`remoteParentSampled()`|
-|present|true|false|`remoteParentNotSampled()`|
-|present|false|true|`localParentSampled()`|
-|present|false|false|`localParentNotSampled()`|
+| Parent  | parent.isRemote() | parent.isSampled() | Invoke sampler             |
+| ------- | ----------------- | ------------------ | -------------------------- |
+| absent  | n/a               | n/a                | `root()`                   |
+| present | true              | true               | `remoteParentSampled()`    |
+| present | true              | false              | `remoteParentNotSampled()` |
+| present | false             | true               | `localParentSampled()`     |
+| present | false             | false              | `localParentNotSampled()`  |
 
 ```js
 const {
-  AlwaysOffSampler,
   TracerProvider,
-  ParentBasedSampler,
-  TraceIdRatioBasedSampler,
-} = require("@opentelemetry/sdk-trace");
+  createParentBasedSampler,
+  createTraceIdRatioBasedSampler,
+} = require('@opentelemetry/sdk-trace');
 
 const tracerProvider = new TracerProvider({
-  sampler: new ParentBasedSampler({
+  sampler: createParentBasedSampler({
     // By default, the ParentBasedSampler will respect the parent span's sampling
     // decision. This is configurable by providing a different sampler to use
     // based on the situation. See configuration details above.
@@ -195,8 +205,8 @@ const tracerProvider = new TracerProvider({
     // This will delegate the sampling decision of all root traces (no parent)
     // to the TraceIdRatioBasedSampler.
     // See details of TraceIdRatioBasedSampler above.
-    root: new TraceIdRatioBasedSampler(0.5)
-  })
+    root: createTraceIdRatioBasedSampler(0.5),
+  }),
 });
 ```
 
@@ -209,15 +219,14 @@ while still controlling export costs through the delegate sampler.
 ```js
 const {
   TracerProvider,
-  ParentBasedSampler,
-  TraceIdRatioBasedSampler,
   createAlwaysRecordSampler,
-} = require("@opentelemetry/sdk-trace");
+  createTraceIdRatioBasedSampler,
+} = require('@opentelemetry/sdk-trace');
 
 const tracerProvider = new TracerProvider({
   // Wraps a 50% TraceIdRatioBased sampler so that dropped spans are still
   // recorded (but not exported by a sampling exporter).
-  sampler: createAlwaysRecordSampler(new TraceIdRatioBasedSampler(0.5))
+  sampler: createAlwaysRecordSampler(createTraceIdRatioBasedSampler(0.5)),
 });
 ```
 

--- a/packages/sdk-trace/src/index.ts
+++ b/packages/sdk-trace/src/index.ts
@@ -11,11 +11,24 @@ export type { ReadableSpan } from './export/ReadableSpan';
 export { SimpleSpanProcessor } from './export/SimpleSpanProcessor';
 export type { SpanExporter } from './export/SpanExporter';
 export { NoopSpanProcessor } from './export/NoopSpanProcessor';
-export { AlwaysOffSampler } from './sampler/AlwaysOffSampler';
-export { AlwaysOnSampler } from './sampler/AlwaysOnSampler';
+export {
+  AlwaysOffSampler,
+  createAlwaysOffSampler,
+} from './sampler/AlwaysOffSampler';
+export {
+  AlwaysOnSampler,
+  createAlwaysOnSampler,
+} from './sampler/AlwaysOnSampler';
 export { createAlwaysRecordSampler } from './sampler/AlwaysRecordSampler';
-export { ParentBasedSampler } from './sampler/ParentBasedSampler';
-export { TraceIdRatioBasedSampler } from './sampler/TraceIdRatioBasedSampler';
+export {
+  ParentBasedSampler,
+  createParentBasedSampler,
+  type ParentBasedSamplerConfig,
+} from './sampler/ParentBasedSampler';
+export {
+  TraceIdRatioBasedSampler,
+  createTraceIdRatioBasedSampler,
+} from './sampler/TraceIdRatioBasedSampler';
 export { SamplingDecision } from './Sampler';
 export type { Sampler, SamplingResult } from './Sampler';
 export type { Span } from './Span';

--- a/packages/sdk-trace/src/index.ts
+++ b/packages/sdk-trace/src/index.ts
@@ -23,7 +23,7 @@ export { createAlwaysRecordSampler } from './sampler/AlwaysRecordSampler';
 export {
   ParentBasedSampler,
   createParentBasedSampler,
-  type ParentBasedSamplerConfig,
+  type ParentBasedSamplerOptions,
 } from './sampler/ParentBasedSampler';
 export {
   TraceIdRatioBasedSampler,

--- a/packages/sdk-trace/src/sampler/AlwaysOffSampler.ts
+++ b/packages/sdk-trace/src/sampler/AlwaysOffSampler.ts
@@ -6,7 +6,18 @@
 import type { Sampler, SamplingResult } from '../Sampler';
 import { SamplingDecision } from '../Sampler';
 
-/** Sampler that samples no traces. */
+/**
+ * Creates a sampler that samples no traces.
+ */
+export function createAlwaysOffSampler(): Sampler {
+  return new AlwaysOffSampler();
+}
+
+/**
+ * Sampler that samples no traces.
+ *
+ * @deprecated Use {@link createAlwaysOffSampler} instead.
+ */
 export class AlwaysOffSampler implements Sampler {
   shouldSample(): SamplingResult {
     return {

--- a/packages/sdk-trace/src/sampler/AlwaysOnSampler.ts
+++ b/packages/sdk-trace/src/sampler/AlwaysOnSampler.ts
@@ -6,7 +6,18 @@
 import type { Sampler, SamplingResult } from '../Sampler';
 import { SamplingDecision } from '../Sampler';
 
-/** Sampler that samples all traces. */
+/**
+ * Creates a sampler that samples all traces.
+ */
+export function createAlwaysOnSampler(): Sampler {
+  return new AlwaysOnSampler();
+}
+
+/**
+ * Sampler that samples all traces.
+ *
+ * @deprecated Use {@link createAlwaysOnSampler} instead.
+ */
 export class AlwaysOnSampler implements Sampler {
   shouldSample(): SamplingResult {
     return {

--- a/packages/sdk-trace/src/sampler/ParentBasedSampler.ts
+++ b/packages/sdk-trace/src/sampler/ParentBasedSampler.ts
@@ -10,9 +10,34 @@ import { AlwaysOffSampler } from './AlwaysOffSampler';
 import { AlwaysOnSampler } from './AlwaysOnSampler';
 import type { Sampler, SamplingResult } from '../Sampler';
 
+export interface ParentBasedSamplerConfig {
+  /** Sampler called for spans with no parent */
+  root: Sampler;
+  /** Sampler called for spans with a remote parent which was sampled. Default AlwaysOn */
+  remoteParentSampled?: Sampler;
+  /** Sampler called for spans with a remote parent which was not sampled. Default AlwaysOff */
+  remoteParentNotSampled?: Sampler;
+  /** Sampler called for spans with a local parent which was sampled. Default AlwaysOn */
+  localParentSampled?: Sampler;
+  /** Sampler called for spans with a local parent which was not sampled. Default AlwaysOff */
+  localParentNotSampled?: Sampler;
+}
+
+/**
+ * Creates a composite sampler that either respects the parent span's sampling
+ * decision or delegates to `root` for root spans.
+ */
+export function createParentBasedSampler(
+  config: ParentBasedSamplerConfig
+): Sampler {
+  return new ParentBasedSampler(config);
+}
+
 /**
  * A composite sampler that either respects the parent span's sampling decision
- * or delegates to `delegateSampler` for root spans.
+ * or delegates to `root` for root spans.
+ *
+ * @deprecated Use {@link createParentBasedSampler} instead.
  */
 export class ParentBasedSampler implements Sampler {
   private _root: Sampler;
@@ -107,17 +132,4 @@ export class ParentBasedSampler implements Sampler {
   toString(): string {
     return `ParentBased{root=${this._root.toString()}, remoteParentSampled=${this._remoteParentSampled.toString()}, remoteParentNotSampled=${this._remoteParentNotSampled.toString()}, localParentSampled=${this._localParentSampled.toString()}, localParentNotSampled=${this._localParentNotSampled.toString()}}`;
   }
-}
-
-interface ParentBasedSamplerConfig {
-  /** Sampler called for spans with no parent */
-  root: Sampler;
-  /** Sampler called for spans with a remote parent which was sampled. Default AlwaysOn */
-  remoteParentSampled?: Sampler;
-  /** Sampler called for spans with a remote parent which was not sampled. Default AlwaysOff */
-  remoteParentNotSampled?: Sampler;
-  /** Sampler called for spans with a local parent which was sampled. Default AlwaysOn */
-  localParentSampled?: Sampler;
-  /** Sampler called for spans with a local parent which was not sampled. Default AlwaysOff */
-  localParentNotSampled?: Sampler;
 }

--- a/packages/sdk-trace/src/sampler/ParentBasedSampler.ts
+++ b/packages/sdk-trace/src/sampler/ParentBasedSampler.ts
@@ -10,7 +10,7 @@ import { AlwaysOffSampler } from './AlwaysOffSampler';
 import { AlwaysOnSampler } from './AlwaysOnSampler';
 import type { Sampler, SamplingResult } from '../Sampler';
 
-export interface ParentBasedSamplerConfig {
+export interface ParentBasedSamplerOptions {
   /** Sampler called for spans with no parent */
   root: Sampler;
   /** Sampler called for spans with a remote parent which was sampled. Default AlwaysOn */
@@ -28,9 +28,9 @@ export interface ParentBasedSamplerConfig {
  * decision or delegates to `root` for root spans.
  */
 export function createParentBasedSampler(
-  config: ParentBasedSamplerConfig
+  options: ParentBasedSamplerOptions
 ): Sampler {
-  return new ParentBasedSampler(config);
+  return new ParentBasedSampler(options);
 }
 
 /**
@@ -46,7 +46,7 @@ export class ParentBasedSampler implements Sampler {
   private _localParentSampled: Sampler;
   private _localParentNotSampled: Sampler;
 
-  constructor(config: ParentBasedSamplerConfig) {
+  constructor(config: ParentBasedSamplerOptions) {
     this._root = config.root;
 
     if (!this._root) {

--- a/packages/sdk-trace/src/sampler/TraceIdRatioBasedSampler.ts
+++ b/packages/sdk-trace/src/sampler/TraceIdRatioBasedSampler.ts
@@ -7,7 +7,20 @@ import { isValidTraceId } from '@opentelemetry/api';
 import type { Sampler, SamplingResult } from '../Sampler';
 import { SamplingDecision } from '../Sampler';
 
-/** Sampler that samples a given fraction of traces based of trace id deterministically. */
+/**
+ * Creates a sampler that samples a given fraction of traces based of trace ID
+ * deterministically.
+ */
+export function createTraceIdRatioBasedSampler(ratio?: number): Sampler {
+  return new TraceIdRatioBasedSampler(ratio);
+}
+
+/**
+ * Sampler that samples a given fraction of traces based of trace ID
+ * deterministically.
+ *
+ * @deprecated Use {@link createTraceIdRatioBasedSampler} instead.
+ */
 export class TraceIdRatioBasedSampler implements Sampler {
   private readonly _ratio;
   private _upperBound: number;

--- a/packages/sdk-trace/test/common/sampler/AlwaysOffSampler.test.ts
+++ b/packages/sdk-trace/test/common/sampler/AlwaysOffSampler.test.ts
@@ -4,7 +4,7 @@
  */
 import * as assert from 'assert';
 import * as api from '@opentelemetry/api';
-import { AlwaysOffSampler } from '../../../src';
+import { AlwaysOffSampler, createAlwaysOffSampler } from '../../../src';
 
 describe('AlwaysOffSampler', () => {
   it('should reflect sampler name', () => {
@@ -17,5 +17,23 @@ describe('AlwaysOffSampler', () => {
     assert.deepStrictEqual(sampler.shouldSample(), {
       decision: api.SamplingDecision.NOT_RECORD,
     });
+  });
+
+  it('should create an always-off sampler with the factory function', () => {
+    const sampler = createAlwaysOffSampler();
+    assert.strictEqual(sampler.toString(), 'AlwaysOffSampler');
+    assert.deepStrictEqual(
+      sampler.shouldSample(
+        api.ROOT_CONTEXT,
+        '0af7651916cd43dd8448eb211c80319c',
+        'spanName',
+        api.SpanKind.INTERNAL,
+        {},
+        []
+      ),
+      {
+        decision: api.SamplingDecision.NOT_RECORD,
+      }
+    );
   });
 });

--- a/packages/sdk-trace/test/common/sampler/AlwaysOnSampler.test.ts
+++ b/packages/sdk-trace/test/common/sampler/AlwaysOnSampler.test.ts
@@ -4,7 +4,7 @@
  */
 import * as assert from 'assert';
 import * as api from '@opentelemetry/api';
-import { AlwaysOnSampler } from '../../../src';
+import { AlwaysOnSampler, createAlwaysOnSampler } from '../../../src';
 
 describe('AlwaysOnSampler', () => {
   it('should reflect sampler name', () => {
@@ -17,5 +17,23 @@ describe('AlwaysOnSampler', () => {
     assert.deepStrictEqual(sampler.shouldSample(), {
       decision: api.SamplingDecision.RECORD_AND_SAMPLED,
     });
+  });
+
+  it('should create an always-on sampler with the factory function', () => {
+    const sampler = createAlwaysOnSampler();
+    assert.strictEqual(sampler.toString(), 'AlwaysOnSampler');
+    assert.deepStrictEqual(
+      sampler.shouldSample(
+        api.ROOT_CONTEXT,
+        '0af7651916cd43dd8448eb211c80319c',
+        'spanName',
+        api.SpanKind.INTERNAL,
+        {},
+        []
+      ),
+      {
+        decision: api.SamplingDecision.RECORD_AND_SAMPLED,
+      }
+    );
   });
 });

--- a/packages/sdk-trace/test/common/sampler/ParentBasedSampler.test.ts
+++ b/packages/sdk-trace/test/common/sampler/ParentBasedSampler.test.ts
@@ -10,6 +10,7 @@ import {
   ParentBasedSampler,
   AlwaysOffSampler,
   TraceIdRatioBasedSampler,
+  createParentBasedSampler,
 } from '../../../src';
 
 const traceId = 'd4cda95b652f4a1592b449d5929fda1b';
@@ -36,6 +37,14 @@ describe('ParentBasedSampler', () => {
     assert.strictEqual(
       sampler.toString(),
       'ParentBased{root=TraceIdRatioBased{0.5}, remoteParentSampled=AlwaysOnSampler, remoteParentNotSampled=AlwaysOffSampler, localParentSampled=AlwaysOnSampler, localParentNotSampled=AlwaysOffSampler}'
+    );
+  });
+
+  it('should create a parent-based sampler with the factory function', () => {
+    const sampler = createParentBasedSampler({ root: new AlwaysOnSampler() });
+    assert.strictEqual(
+      sampler.toString(),
+      'ParentBased{root=AlwaysOnSampler, remoteParentSampled=AlwaysOnSampler, remoteParentNotSampled=AlwaysOffSampler, localParentSampled=AlwaysOnSampler, localParentNotSampled=AlwaysOffSampler}'
     );
   });
 

--- a/packages/sdk-trace/test/common/sampler/TraceIdRatioBasedSampler.test.ts
+++ b/packages/sdk-trace/test/common/sampler/TraceIdRatioBasedSampler.test.ts
@@ -5,7 +5,10 @@
 
 import * as assert from 'assert';
 import * as api from '@opentelemetry/api';
-import { TraceIdRatioBasedSampler } from '../../../src';
+import {
+  TraceIdRatioBasedSampler,
+  createTraceIdRatioBasedSampler,
+} from '../../../src';
 
 const spanContext = (traceId = '1') => ({
   traceId,
@@ -40,6 +43,24 @@ describe('TraceIdRatioBasedSampler', () => {
 
     sampler = new TraceIdRatioBasedSampler(-Infinity);
     assert.strictEqual(sampler.toString(), 'TraceIdRatioBased{0}');
+  });
+
+  it('should create a trace-id-ratio sampler with the factory function', () => {
+    const sampler = createTraceIdRatioBasedSampler(0.5);
+    assert.strictEqual(sampler.toString(), 'TraceIdRatioBased{0.5}');
+    assert.deepStrictEqual(
+      sampler.shouldSample(
+        api.ROOT_CONTEXT,
+        traceId('1'),
+        'spanName',
+        api.SpanKind.INTERNAL,
+        {},
+        []
+      ),
+      {
+        decision: api.SamplingDecision.RECORD_AND_SAMPLED,
+      }
+    );
   });
 
   it('should return a always sampler for 1', () => {


### PR DESCRIPTION
## Summary

Adds factory functions for the built-in SDK trace samplers while retaining the existing classes for backwards compatibility.

- exports factory functions for AlwaysOn, AlwaysOff, ParentBased, and TraceIdRatioBased samplers
- exports `ParentBasedSamplerOptions` for factory configuration
- deprecates direct construction of the corresponding sampler classes
- updates package examples and adds factory coverage

Fixes #6858.

## Validation

- `npm run compile --workspace @opentelemetry/sdk-trace`
- `npm test --workspace @opentelemetry/sdk-trace -- --grep 'Sampler|sampler'` (38 passing)
- `npm run lint --workspace @opentelemetry/sdk-trace` (0 errors; 6 existing benchmark warnings)
- `git diff --check origin/main...HEAD`

## AI assistance disclosure

ChatGPT was used to assist with code exploration, implementation, and test preparation. I reviewed the changes and validation results.