### PR TITLE
Update otelbot token workflows to use client IDs

### DIFF
--- a/.github/workflows/create-or-update-release-pr.yml
+++ b/.github/workflows/create-or-update-release-pr.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          app-id: ${{ vars.OTELBOT_JS_APP_ID }}
+          client-id: ${{ vars.OTELBOT_JS_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_JS_PRIVATE_KEY }}
           # Scope to just the permissions required by the "Create/Update Release PR" step below.
           permission-contents: write


### PR DESCRIPTION
Update otelbot token creation to use GitHub App client IDs.

The `app-id` input for `actions/create-github-app-token` is deprecated in favor of `client-id`. The matching `OTELBOT_*_CLIENT_ID` organization variables have been provisioned, so this updates direct token creation from `app-id` / `*_APP_ID` to `client-id` / `*_CLIENT_ID`.

Survey-on-merged-PR workflow changes are intentionally left out because those are being migrated separately to `open-telemetry/shared-workflows`.

Tracking issue: https://github.com/open-telemetry/admin/issues/744