### PR TITLE
ESM support documentation update: use --import for Node v24

### DIFF
--- a/doc/esm-support.md
+++ b/doc/esm-support.md
@@ -115,7 +115,7 @@ node --require ./telemetry.js app.js
 Startup command for compiled ESM:
 
 ```sh
-node --experimental-loader=@opentelemetry/instrumentation/hook.mjs --import ./telemetry.js app.js
+node --import @opentelemetry/instrumentation/hook.mjs --import ./telemetry.js app.js
 ```
 
 ### ESM Options for Different Versions of Node.js
@@ -129,3 +129,4 @@ The entire startup command should include the following `NODE_OPTIONS`:
 | ^18.19.0          | `--import ./telemetry.mjs --experimental-loader=@opentelemetry/instrumentation/hook.mjs`  |
 | 20.x              | `--import ./telemetry.mjs --experimental-loader=@opentelemetry/instrumentation/hook.mjs`  |
 | 22.x              | `--import ./telemetry.mjs --experimental-loader=@opentelemetry/instrumentation/hook.mjs`  |
+| 24.x              | `--import ./telemetry.mjs --import @opentelemetry/instrumentation/hook.mjs`               |


### PR DESCRIPTION
`node --import @opentelemetry/instrumentation/hook.mjs` works in Node v24, and some newer versions of v22.

I successfully verified this on these versions of node:
* v26.5.0
* v24.18.0
* v18.20.8

`@opentelemetry/instrumentation@0.219.0`
