### PR TITLE
feat(exporter-prometheus): add aggregationSelector option to configure default aggregation

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -40,6 +40,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :rocket: Features
 
+* feat(exporter-prometheus): add `aggregationSelector` option to `PrometheusExporter` to configure the default aggregation as a function of instrument kind [#6605](https://github.com/open-telemetry/opentelemetry-js/issues/6605) @nissy-dev
 * feat(configuration): bump config schema to v1.1.0; rename `without_scope_info` → `scope_info_enabled` and `without_target_info/development` → `target_info_enabled/development` on the Prometheus pull exporter (semantics inverted), rename `with_resource_constant_labels` → `resource_constant_labels`. Validate `file_format` per the configuration versioning spec: accept any minor version of major `1` (e.g. `1.0`, `1.1`), warn when the minor version is newer than supported, and reject other major versions. [#6781](https://github.com/open-telemetry/opentelemetry-js/pull/6781) @MikeGoldsmith
 * feat(sdk-node): wire up `id_generator` from declarative config [#6782](https://github.com/open-telemetry/opentelemetry-js/pull/6782) @MikeGoldsmith
 * feat(sdk-node): wire up `tracer_provider.sampler` from declarative config (always_on, always_off, trace_id_ratio_based, parent_based); unrecognized variants warn and fall back to ParentBased(AlwaysOn) [#6506](https://github.com/open-telemetry/opentelemetry-js/issues/6506) @MikeGoldsmith

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -40,7 +40,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :rocket: Features
 
-* feat(exporter-prometheus): add `aggregationSelector` option to `PrometheusExporter` to configure the default aggregation as a function of instrument kind [#6605](https://github.com/open-telemetry/opentelemetry-js/issues/6605) @nissy-dev
+* feat(exporter-prometheus): add `aggregationPreference` option to `PrometheusExporter` to configure the default aggregation per instrument kind [#6605](https://github.com/open-telemetry/opentelemetry-js/issues/6605) @nissy-dev
 * feat(configuration): bump config schema to v1.1.0; rename `without_scope_info` → `scope_info_enabled` and `without_target_info/development` → `target_info_enabled/development` on the Prometheus pull exporter (semantics inverted), rename `with_resource_constant_labels` → `resource_constant_labels`. Validate `file_format` per the configuration versioning spec: accept any minor version of major `1` (e.g. `1.0`, `1.1`), warn when the minor version is newer than supported, and reject other major versions. [#6781](https://github.com/open-telemetry/opentelemetry-js/pull/6781) @MikeGoldsmith
 * feat(sdk-node): wire up `id_generator` from declarative config [#6782](https://github.com/open-telemetry/opentelemetry-js/pull/6782) @MikeGoldsmith
 * feat(sdk-node): wire up `tracer_provider.sampler` from declarative config (always_on, always_off, trace_id_ratio_based, parent_based); unrecognized variants warn and fall back to ParentBased(AlwaysOn) [#6506](https://github.com/open-telemetry/opentelemetry-js/issues/6506) @MikeGoldsmith

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -54,11 +54,13 @@ export class PrometheusExporter extends MetricReader {
     callback: (error: Error | void) => void = () => {}
   ) {
     super({
-      aggregationSelector: _instrumentType => {
-        return {
-          type: AggregationType.DEFAULT,
-        };
-      },
+      aggregationSelector:
+        config.aggregationSelector ??
+        (_instrumentType => {
+          return {
+            type: AggregationType.DEFAULT,
+          };
+        }),
       aggregationTemporalitySelector: _instrumentType =>
         AggregationTemporality.CUMULATIVE,
       otelComponentType:

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -55,7 +55,9 @@ export class PrometheusExporter extends MetricReader {
   ) {
     // Copy the preference so that mutating the caller's object after
     // construction cannot change the exporter's configured aggregation.
-    const aggregationPreference = { ...config.aggregationPreference };
+    const aggregationPreference = structuredClone(
+      config.aggregationPreference ?? {}
+    );
     super({
       aggregationSelector: instrumentType =>
         aggregationPreference[instrumentType] ?? {

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusExporter.ts
@@ -53,14 +53,14 @@ export class PrometheusExporter extends MetricReader {
     config: ExporterConfig = {},
     callback: (error: Error | void) => void = () => {}
   ) {
+    // Copy the preference so that mutating the caller's object after
+    // construction cannot change the exporter's configured aggregation.
+    const aggregationPreference = { ...config.aggregationPreference };
     super({
-      aggregationSelector:
-        config.aggregationSelector ??
-        (_instrumentType => {
-          return {
-            type: AggregationType.DEFAULT,
-          };
-        }),
+      aggregationSelector: instrumentType =>
+        aggregationPreference[instrumentType] ?? {
+          type: AggregationType.DEFAULT,
+        },
       aggregationTemporalitySelector: _instrumentType =>
         AggregationTemporality.CUMULATIVE,
       otelComponentType:

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/export/types.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/export/types.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { MetricProducer } from '@opentelemetry/sdk-metrics';
+import type {
+  AggregationSelector,
+  MetricProducer,
+} from '@opentelemetry/sdk-metrics';
 
 /**
  * Configuration interface for prometheus exporter
@@ -75,4 +78,11 @@ export interface ExporterConfig {
    * @default false (target_info metric is included)
    */
   withoutTargetInfo?: boolean;
+
+  /**
+   * Selects the default aggregation as a function of instrument kind for the
+   * underlying {@link https://opentelemetry.io/docs/specs/otel/metrics/sdk/#metricreader | MetricReader}.
+   * @default the SDK's {@link https://opentelemetry.io/docs/specs/otel/metrics/sdk/#default-aggregation | default aggregation}
+   */
+  aggregationSelector?: AggregationSelector;
 }

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/export/types.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/export/types.ts
@@ -4,9 +4,19 @@
  */
 
 import type {
-  AggregationSelector,
+  AggregationOption,
+  InstrumentType,
   MetricProducer,
 } from '@opentelemetry/sdk-metrics';
+
+/**
+ * Configures the default aggregation to use per instrument kind. Any instrument
+ * kind that is not listed falls back to the SDK's
+ * {@link https://opentelemetry.io/docs/specs/otel/metrics/sdk/#default-aggregation | default aggregation}.
+ */
+export type AggregationPreference = Partial<
+  Record<InstrumentType, AggregationOption>
+>;
 
 /**
  * Configuration interface for prometheus exporter
@@ -80,9 +90,11 @@ export interface ExporterConfig {
   withoutTargetInfo?: boolean;
 
   /**
-   * Selects the default aggregation as a function of instrument kind for the
-   * underlying {@link https://opentelemetry.io/docs/specs/otel/metrics/sdk/#metricreader | MetricReader}.
+   * Configures the default aggregation per instrument kind for the underlying
+   * {@link https://opentelemetry.io/docs/specs/otel/metrics/sdk/#metricreader | MetricReader}.
+   * Instrument kinds that are not specified fall back to the SDK's
+   * {@link https://opentelemetry.io/docs/specs/otel/metrics/sdk/#default-aggregation | default aggregation}.
    * @default the SDK's {@link https://opentelemetry.io/docs/specs/otel/metrics/sdk/#default-aggregation | default aggregation}
    */
-  aggregationSelector?: AggregationSelector;
+  aggregationPreference?: AggregationPreference;
 }

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Counter, Meter, ObservableResult } from '@opentelemetry/api';
-import { MeterProvider } from '@opentelemetry/sdk-metrics';
+import { AggregationType, MeterProvider } from '@opentelemetry/sdk-metrics';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as http from 'http';
@@ -596,6 +596,35 @@ describe('PrometheusExporter', () => {
         '# HELP counter_total description missing',
         '# TYPE counter_total counter',
         'counter_total{key1="attributeValue1"} 10',
+        '',
+      ]);
+    });
+
+    it('should use a configured aggregationSelector', async () => {
+      exporter = new PrometheusExporter({
+        aggregationSelector: _instrumentType => ({
+          type: AggregationType.SUM,
+        }),
+      });
+      meterProvider = new MeterProvider({
+        readers: [exporter],
+      });
+      meter = meterProvider.getMeter('test-prometheus');
+      const histogram = meter.createHistogram('test_histogram', {
+        description: 'a test description',
+      });
+      histogram.record(20, { key1: 'attributeValue1' });
+
+      const body = await request('http://localhost:9464/metrics');
+      const lines = body.split('\n');
+
+      // With a SUM aggregation selector, the histogram instrument is exported
+      // as a single summed counter instead of histogram buckets.
+      assert.deepStrictEqual(lines, [
+        ...serializedDefaultResourceLines,
+        '# HELP test_histogram_total a test description',
+        '# TYPE test_histogram_total counter',
+        'test_histogram_total{key1="attributeValue1",otel_scope_name="test-prometheus"} 20',
         '',
       ]);
     });

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -4,7 +4,11 @@
  */
 
 import type { Counter, Meter, ObservableResult } from '@opentelemetry/api';
-import { AggregationType, MeterProvider } from '@opentelemetry/sdk-metrics';
+import {
+  AggregationType,
+  InstrumentType,
+  MeterProvider,
+} from '@opentelemetry/sdk-metrics';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import * as http from 'http';
@@ -600,11 +604,13 @@ describe('PrometheusExporter', () => {
       ]);
     });
 
-    it('should use a configured aggregationSelector', async () => {
+    it('should use a configured aggregationPreference', async () => {
       exporter = new PrometheusExporter({
-        aggregationSelector: _instrumentType => ({
-          type: AggregationType.SUM,
-        }),
+        aggregationPreference: {
+          [InstrumentType.HISTOGRAM]: {
+            type: AggregationType.SUM,
+          },
+        },
       });
       meterProvider = new MeterProvider({
         readers: [exporter],
@@ -618,8 +624,9 @@ describe('PrometheusExporter', () => {
       const body = await request('http://localhost:9464/metrics');
       const lines = body.split('\n');
 
-      // With a SUM aggregation selector, the histogram instrument is exported
-      // as a single summed counter instead of histogram buckets.
+      // With a SUM aggregation preference for histograms, the histogram
+      // instrument is exported as a single summed counter instead of histogram
+      // buckets.
       assert.deepStrictEqual(lines, [
         ...serializedDefaultResourceLines,
         '# HELP test_histogram_total a test description',
@@ -627,6 +634,39 @@ describe('PrometheusExporter', () => {
         'test_histogram_total{key1="attributeValue1",otel_scope_name="test-prometheus"} 20',
         '',
       ]);
+    });
+
+    it('should fall back to the default aggregation for instrument kinds not listed in aggregationPreference', async () => {
+      exporter = new PrometheusExporter({
+        aggregationPreference: {
+          [InstrumentType.HISTOGRAM]: {
+            type: AggregationType.DROP,
+          },
+        },
+      });
+      meterProvider = new MeterProvider({
+        readers: [exporter],
+      });
+      meter = meterProvider.getMeter('test-prometheus');
+      const counter = meter.createCounter('test_counter', {
+        description: 'a test description',
+      });
+      counter.add(10, { key1: 'attributeValue1' });
+      const histogram = meter.createHistogram('test_histogram', {
+        description: 'a test description',
+      });
+      histogram.record(20, { key1: 'attributeValue1' });
+
+      const body = await request('http://localhost:9464/metrics');
+
+      // The histogram is dropped as configured, while the counter is not listed
+      // in the preference and therefore uses the SDK's default aggregation.
+      assert.strictEqual(body.includes('test_histogram'), false);
+      assert.ok(
+        body.includes(
+          'test_counter_total{key1="attributeValue1",otel_scope_name="test-prometheus"} 10'
+        )
+      );
     });
   });
 });

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusExporter.test.ts
@@ -636,6 +636,36 @@ describe('PrometheusExporter', () => {
       ]);
     });
 
+    it('should copy nested aggregationPreference options', () => {
+      const options = {
+        boundaries: [1, 10, 100],
+        recordMinMax: true,
+      };
+      exporter = new PrometheusExporter({
+        preventServerStart: true,
+        aggregationPreference: {
+          [InstrumentType.HISTOGRAM]: {
+            type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,
+            options,
+          },
+        },
+      });
+
+      options.boundaries[0] = 5;
+      options.recordMinMax = false;
+
+      assert.deepStrictEqual(
+        exporter.selectAggregation(InstrumentType.HISTOGRAM),
+        {
+          type: AggregationType.EXPLICIT_BUCKET_HISTOGRAM,
+          options: {
+            boundaries: [1, 10, 100],
+            recordMinMax: true,
+          },
+        }
+      );
+    });
+
     it('should fall back to the default aggregation for instrument kinds not listed in aggregationPreference', async () => {
       exporter = new PrometheusExporter({
         aggregationPreference: {


### PR DESCRIPTION
## Which problem is this PR solving?

The `PrometheusExporter` currently hard-codes the default aggregation (`AggregationType.DEFAULT`) for every instrument kind, so users have no way to override how instruments are aggregated when exporting to Prometheus. This PR adds an optional `aggregationSelector` to the exporter configuration so users can configure the default aggregation as a function of instrument kind, consistent with the SDK's `MetricReader` API.

Part of #6605

## Short description of the changes

- Add an optional `aggregationSelector?: AggregationSelector` field to `ExporterConfig` (`src/export/types.ts`).
- Wire the configured `aggregationSelector` through to the underlying `MetricReader` in `PrometheusExporter`, falling back to the previous behavior  (`AggregationType.DEFAULT` for all instruments) when it is not provided.
- Add a CHANGELOG entry.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Added a unit test in `PrometheusExporter.test.ts` verifying that a  configured `aggregationSelector` is respected: with a `SUM` aggregation  selector, a histogram instrument is exported as a single summed counter  instead of histogram buckets.
- [x] Ran the exporter-prometheus package test suite locally.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
