### PR TITLE
feat(otlp-exporter-base): support timeoutMillis=0

### DIFF
--- a/experimental/packages/otlp-exporter-base/src/configuration/shared-configuration.ts
+++ b/experimental/packages/otlp-exporter-base/src/configuration/shared-configuration.ts
@@ -20,11 +20,11 @@ export interface OtlpSharedConfiguration {
 }
 
 export function validateTimeoutMillis(timeoutMillis: number) {
-  if (Number.isFinite(timeoutMillis) && timeoutMillis > 0) {
+  if (Number.isFinite(timeoutMillis) && timeoutMillis >= 0) {
     return timeoutMillis;
   }
   throw new Error(
-    `Configuration: timeoutMillis is invalid, expected number greater than 0 (actual: '${timeoutMillis}')`
+    `Configuration: timeoutMillis is invalid, expected number greater than or equal to 0 (actual: '${timeoutMillis}')`
   );
 }
 

--- a/experimental/packages/otlp-exporter-base/src/retrying-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/retrying-transport.ts
@@ -58,18 +58,22 @@ class RetryingTransport implements IExporterTransport {
       const retryInMillis = result.retryInMillis ?? backoff;
 
       // return when expected retry time is after the export deadline.
-      const remainingTimeoutMillis = deadline - Date.now();
-      if (retryInMillis > remainingTimeoutMillis) {
-        diag.info(
-          `Export retry time ${Math.round(retryInMillis)}ms exceeds remaining timeout ${Math.round(
-            remainingTimeoutMillis
-          )}ms, not retrying further.`
-        );
-        return result;
+      let nextTimeoutMillis = 0;
+      if (timeoutMillis > 0) {
+        const remainingTimeoutMillis = deadline - Date.now();
+        if (retryInMillis > remainingTimeoutMillis) {
+          diag.info(
+            `Export retry time ${Math.round(retryInMillis)}ms exceeds remaining timeout ${Math.round(
+              remainingTimeoutMillis
+            )}ms, not retrying further.`
+          );
+          return result;
+        }
+        nextTimeoutMillis = remainingTimeoutMillis;
       }
 
       diag.verbose(`Scheduling export retry in ${Math.round(retryInMillis)}ms`);
-      result = await this.retry(data, remainingTimeoutMillis, retryInMillis);
+      result = await this.retry(data, nextTimeoutMillis, retryInMillis);
     }
 
     if (result.status === 'success') {

--- a/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
@@ -92,9 +92,17 @@ class FetchTransport implements IExporterTransport {
 
     try {
       const url = new URL(this._parameters.url);
+      const headers = await this._parameters.headers();
+
+      if (abortController.signal.aborted) {
+        const abortError = new Error('The operation was aborted.');
+        abortError.name = 'AbortError';
+        throw abortError;
+      }
+
       const response = await fetchApi(url.href, {
         method: 'POST',
-        headers: await this._parameters.headers(),
+        headers,
         body: data,
         signal: abortController.signal,
         keepalive: useKeepalive,

--- a/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
@@ -54,7 +54,10 @@ class FetchTransport implements IExporterTransport {
 
   async send(data: Uint8Array, timeoutMillis: number): Promise<ExportResponse> {
     const abortController = new AbortController();
-    const timeout = timeoutMillis > 0 ? setTimeout(() => abortController.abort(), timeoutMillis) : undefined;
+    const timeout =
+      timeoutMillis > 0
+        ? setTimeout(() => abortController.abort(), timeoutMillis)
+        : undefined;
     // Fetch API may be wrapped by an instrumentation like `@opentelemetry/instrumentation-fetch`.
     // In that case the instrumentation would create a new Span for this request
     // because the context manager cannot keep the context after `await` calls.

--- a/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
@@ -54,7 +54,7 @@ class FetchTransport implements IExporterTransport {
 
   async send(data: Uint8Array, timeoutMillis: number): Promise<ExportResponse> {
     const abortController = new AbortController();
-    const timeout = setTimeout(() => abortController.abort(), timeoutMillis);
+    const timeout = timeoutMillis > 0 ? setTimeout(() => abortController.abort(), timeoutMillis) : undefined;
     // Fetch API may be wrapped by an instrumentation like `@opentelemetry/instrumentation-fetch`.
     // In that case the instrumentation would create a new Span for this request
     // because the context manager cannot keep the context after `await` calls.
@@ -134,7 +134,9 @@ class FetchTransport implements IExporterTransport {
         error: new Error('Fetch request errored', { cause: error }),
       };
     } finally {
-      clearTimeout(timeout);
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
       if (useKeepalive) {
         pendingBodySize -= requestSize;
         pendingKeepaliveCount--;

--- a/experimental/packages/otlp-exporter-base/src/transport/http-transport-utils.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/http-transport-utils.ts
@@ -135,13 +135,15 @@ export function sendWithHttp(
       });
     });
 
-    req.setTimeout(timeoutMillis, () => {
-      req.destroy();
-      resolve({
-        status: 'retryable',
-        error: new Error('Request timed out'),
+    if (timeoutMillis > 0) {
+      req.setTimeout(timeoutMillis, () => {
+        req.destroy();
+        resolve({
+          status: 'retryable',
+          error: new Error('Request timed out'),
+        });
       });
-    });
+    }
 
     req.on('error', (error: Error) => {
       if (isHttpTransportNetworkErrorRetryable(error)) {

--- a/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
@@ -167,6 +167,41 @@ describe('FetchTransport', function () {
       clock.tick(requestTimeout + 100);
     });
 
+    it('returns failure when aborted during headers resolution', function (done) {
+      // arrange
+      const clock = sinon.useFakeTimers();
+      const headersPromise = new Promise<Record<string, string>>(resolve => {
+        setTimeout(() => {
+          resolve({ 'Content-Type': 'application/json' });
+        }, 200);
+      });
+      const transport = createFetchTransport({
+        url: 'http://example.test',
+        headers: () => headersPromise,
+      });
+
+      //act
+      transport.send(testPayload, 100).then(response => {
+        // assert
+        try {
+          assert.strictEqual(response.status, 'failure');
+          assert.strictEqual(
+            (response as ExportResponseFailure).error.message,
+            'Fetch request errored'
+          );
+          assert.strictEqual(
+            ((response as ExportResponseFailure).error.cause as Error).name,
+            'AbortError'
+          );
+        } catch (e) {
+          done(e);
+        }
+        done();
+      }, done /* catch any rejections */);
+      clock.tick(150);
+      clock.tick(100);
+    });
+
     it('returns failure when fetch throws non-network error', function (done) {
       // arrange
       sinon.stub(globalThis, 'fetch').throws(new Error('fetch failed'));

--- a/experimental/packages/otlp-exporter-base/test/common/configuration/shared-configuration.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/common/configuration/shared-configuration.test.ts
@@ -125,12 +125,16 @@ describe('mergeOtlpSharedConfigurationWithDefaults', function () {
 
 describe('validateTimeoutMillis', function () {
   it('throws if timeout is not a positive number', () => {
-    const values = [null, '1', true, NaN, Infinity, -Infinity, -1, 0];
+    const values = [null, '1', true, NaN, Infinity, -Infinity, -1];
 
     for (let i = 0; i < values.length; ++i) {
       assert.throws(() => {
         validateTimeoutMillis(values[i] as any);
       }, /Configuration: timeoutMillis is invalid/);
     }
+  });
+
+  it('does not throw if timeout is 0', () => {
+    assert.strictEqual(validateTimeoutMillis(0), 0);
   });
 });

--- a/experimental/packages/otlp-exporter-base/test/common/retrying-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/common/retrying-transport.test.ts
@@ -10,8 +10,13 @@ import { createRetryingTransport } from '../../src/retrying-transport';
 import type { ExportResponse } from '../../src';
 
 const timeoutMillis = 1000000;
+const originalMathRandom = Math.random;
 
 describe('RetryingTransport', function () {
+  afterEach(function () {
+    Math.random = originalMathRandom;
+  });
+
   describe('send', function () {
     it('does not retry when underlying transport succeeds', async function () {
       // arrange
@@ -230,6 +235,36 @@ describe('RetryingTransport', function () {
         timeoutMillis
       );
       assert.strictEqual(result, retryResponse);
+    });
+
+    it('retries when timeoutMillis is 0 (infinite timeout)', async function () {
+      // arrange
+      const retryResponse: ExportResponse = {
+        status: 'retryable',
+      };
+      const successResponse: ExportResponse = {
+        status: 'success',
+      };
+      const mockData = Uint8Array.from([1, 2, 3]);
+
+      const transportStubs = {
+        send: sinon
+          .stub()
+          .onFirstCall()
+          .returns(Promise.resolve(retryResponse))
+          .onSecondCall()
+          .returns(Promise.resolve(successResponse)),
+        shutdown: sinon.stub(),
+      };
+      const mockTransport = <IExporterTransport>transportStubs;
+      const transport = createRetryingTransport({ transport: mockTransport });
+
+      // act
+      const actualResponse = await transport.send(mockData, 0);
+
+      // assert
+      sinon.assert.calledTwice(transportStubs.send);
+      assert.deepEqual(actualResponse, successResponse);
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6195,9 +6195,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6212,9 +6209,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6229,9 +6223,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6246,9 +6237,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Description

This PR updates the OTLP exporter to support `timeoutMillis = 0`, in accordance with the OpenTelemetry specification, where a value of `0` indicates that no timeout should be applied.

### Changes

- Allow `timeoutMillis = 0` during configuration validation.
- Skip transport-level timeout registration when no timeout is configured.
- Preserve retry behavior when timeout is disabled.
- Add unit tests covering the new behavior.
### Testing

- Verified configuration validation accepts `timeoutMillis = 0`.
- Verified browser transport no longer aborts immediately when `timeoutMillis = 0`.
- Verified Node.js transport behaves correctly when `timeoutMillis = 0`.
- Verified retry behavior is preserved when timeout is disabled.
- All affected unit tests pass successfully.
Fixes #6617