### PR TITLE
ci: install libatomic for benchmark jobs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,9 +23,10 @@ jobs:
     steps:
       # Apt packages:
       # - git: Needed for 'npm run submodule'
+      # - libatomic1: Needed by Node.js 26
       - name: Setup container environment
         run: |
-          apt-get update && apt-get install --fix-missing -y git
+          apt-get update && apt-get install --fix-missing -y git libatomic1
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #6915.

The benchmark workflow runs in an Ubuntu 24.04 container, where Node.js 26 setup fails before the benchmarks start because `libatomic.so.1` is unavailable.

## Short description of the changes

Install Ubuntu's `libatomic1` package alongside `git` during container setup, before `actions/setup-node` runs.

## How was this tested?

- Parsed `.github/workflows/benchmark.yml` with Ruby's YAML parser.
- Verified `libatomic1` is available for Ubuntu 24.04 (`noble`) on amd64 in the official Ubuntu package index.
- Ran `git diff --check`.