### PR TITLE
feat(instrumentation-http): set `error.type` to status code in metrics for error requests

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,6 +16,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :rocket: Features
 
 * feat(sdk-node): emit a deprecation warning when the `JaegerPropagator` is selected via `OTEL_PROPAGATORS` or declarative config; use `tracecontext` instead. @pichlermarc
+* feat(instrumentation-http): set `error.type` to status code in metrics for error requests. [#6919](https://github.com/open-telemetry/opentelemetry-js/pull/6919) @raphael-theriault-swi
 
 ### :bug: Bug Fixes
 

--- a/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/utils.ts
@@ -465,9 +465,16 @@ export const getOutgoingStableRequestMetricAttributesOnResponse = (
       spanAttributes[ATTR_NETWORK_PROTOCOL_VERSION];
   }
 
-  if (spanAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE]) {
-    metricAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE] =
-      spanAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE];
+  const statusCode = spanAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE];
+  if (statusCode) {
+    metricAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE] = statusCode;
+    if (
+      typeof statusCode === 'number' &&
+      statusCode >= 400 &&
+      statusCode < 600
+    ) {
+      metricAttributes[ATTR_ERROR_TYPE] ??= String(statusCode);
+    }
   }
   return metricAttributes;
 };
@@ -779,10 +786,18 @@ export const getIncomingStableRequestMetricAttributesOnResponse = (
   }
 
   // required if and only if one was sent, same as span requirement
-  if (spanAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE]) {
-    metricAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE] =
-      spanAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE];
+  const statusCode = spanAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE];
+  if (statusCode) {
+    metricAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE] = statusCode;
+    if (
+      typeof statusCode === 'number' &&
+      statusCode >= 500 &&
+      statusCode < 600
+    ) {
+      metricAttributes[ATTR_ERROR_TYPE] ??= String(statusCode);
+    }
   }
+
   return metricAttributes;
 };
 

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-metrics.test.ts
@@ -68,6 +68,11 @@ describe('metrics', () => {
       assert.strictEqual(rpcData.type, RPCType.HTTP);
       assert.strictEqual(rpcData.route, undefined);
       rpcData.route = 'TheRoute';
+      if (request.url?.endsWith('/error/client')) {
+        response.statusCode = 400;
+      } else if (request.url?.endsWith('/error/server')) {
+        response.statusCode = 500;
+      }
       response.end('Test Server Response');
     });
     server.listen(serverPort);
@@ -173,6 +178,81 @@ describe('metrics', () => {
         [ATTR_SERVER_ADDRESS]: 'localhost',
         [ATTR_SERVER_PORT]: 22346,
         [ATTR_ERROR_TYPE]: 'TypeError',
+      });
+    });
+
+    it('should set error type attribute on metrics for client/server errors', async () => {
+      await httpRequest.get(
+        `${protocol}://${hostname}:${serverPort}${pathname}/error/client`
+      );
+      await httpRequest.get(
+        `${protocol}://${hostname}:${serverPort}${pathname}/error/server`
+      );
+
+      await metricReader.collectAndExport();
+      const resourceMetrics = metricsMemoryExporter.getMetrics();
+      const scopeMetrics = resourceMetrics[0].scopeMetrics;
+      assert.strictEqual(scopeMetrics.length, 1, 'scopeMetrics count');
+      const metrics = scopeMetrics[0].metrics;
+      assert.strictEqual(metrics.length, 2, 'metrics count');
+
+      assert.strictEqual(metrics[0].dataPointType, DataPointType.HISTOGRAM);
+      assert.strictEqual(
+        metrics[0].descriptor.description,
+        'Duration of HTTP server requests.'
+      );
+      assert.strictEqual(
+        metrics[0].descriptor.name,
+        'http.server.request.duration'
+      );
+      assert.strictEqual(metrics[0].descriptor.unit, 's');
+      assert.strictEqual(metrics[0].dataPoints.length, 2);
+      assert.strictEqual((metrics[0].dataPoints[0].value as any).count, 1);
+      assert.strictEqual((metrics[0].dataPoints[1].value as any).count, 1);
+      assert.deepStrictEqual(metrics[0].dataPoints[0].attributes, {
+        [ATTR_HTTP_REQUEST_METHOD]: 'GET',
+        [ATTR_URL_SCHEME]: 'http',
+        [ATTR_HTTP_RESPONSE_STATUS_CODE]: 400,
+        [ATTR_NETWORK_PROTOCOL_VERSION]: '1.1',
+        [ATTR_HTTP_ROUTE]: 'TheRoute',
+      });
+      assert.deepStrictEqual(metrics[0].dataPoints[1].attributes, {
+        [ATTR_HTTP_REQUEST_METHOD]: 'GET',
+        [ATTR_URL_SCHEME]: 'http',
+        [ATTR_HTTP_RESPONSE_STATUS_CODE]: 500,
+        [ATTR_ERROR_TYPE]: '500',
+        [ATTR_NETWORK_PROTOCOL_VERSION]: '1.1',
+        [ATTR_HTTP_ROUTE]: 'TheRoute',
+      });
+
+      assert.strictEqual(metrics[1].dataPointType, DataPointType.HISTOGRAM);
+      assert.strictEqual(
+        metrics[1].descriptor.description,
+        'Duration of HTTP client requests.'
+      );
+      assert.strictEqual(
+        metrics[1].descriptor.name,
+        'http.client.request.duration'
+      );
+      assert.strictEqual(metrics[1].descriptor.unit, 's');
+      assert.strictEqual(metrics[1].dataPoints.length, 2);
+      assert.strictEqual((metrics[1].dataPoints[0].value as any).count, 1);
+      assert.strictEqual((metrics[1].dataPoints[1].value as any).count, 1);
+      assert.deepStrictEqual(metrics[1].dataPoints[0].attributes, {
+        [ATTR_HTTP_REQUEST_METHOD]: 'GET',
+        [ATTR_SERVER_ADDRESS]: 'localhost',
+        [ATTR_SERVER_PORT]: 22346,
+        [ATTR_NETWORK_PROTOCOL_VERSION]: '1.1',
+        [ATTR_HTTP_RESPONSE_STATUS_CODE]: 400,
+        [ATTR_ERROR_TYPE]: '400',
+      });
+      assert.deepStrictEqual(metrics[1].dataPoints[1].attributes, {
+        [ATTR_HTTP_REQUEST_METHOD]: 'GET',
+        [ATTR_SERVER_ADDRESS]: 'localhost',
+        [ATTR_SERVER_PORT]: 22346,
+        [ATTR_NETWORK_PROTOCOL_VERSION]: '1.1',
+        [ATTR_HTTP_RESPONSE_STATUS_CODE]: 500,
+        [ATTR_ERROR_TYPE]: '500',
       });
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

I added the `error.type` attribute to HTTP metrics in #5647, which is currently set when an exception bubbles all the way to the `http` handler, a.k.a. almost never. The semantic conventions actually also [recommend](https://github.com/open-telemetry/semantic-conventions/blob/v1.43.0/docs/http/http-metrics.md?plain=1#L121-L122) setting it to the status code as a string when it represents an error state, which is what this PR does.

## Short description of the changes

The instrumentation now sets the `error.type` attribute to the stringified status code when said status code is set and represents an error state. 4xx and 5xx codes are considered errors for the client instrumentation, and 5xx are for the server instrumentation.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Unit testing

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
