### PR TITLE
fix(otlp-exporter-base): handle abort before fetch starts

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,6 +16,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(otlp-exporter-base): handle abort before fetch starts — check `abortController.signal.aborted` after resolving headers so that timed-out exports are not passed to `fetch()` [#6921](https://github.com/open-telemetry/opentelemetry-js/pull/6921) @Babul422
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
@@ -89,9 +89,17 @@ class FetchTransport implements IExporterTransport {
 
     try {
       const url = new URL(this._parameters.url);
+      const headers = await this._parameters.headers();
+
+      if (abortController.signal.aborted) {
+        const abortError = new Error('The operation was aborted.');
+        abortError.name = 'AbortError';
+        throw abortError;
+      }
+
       const response = await fetchApi(url.href, {
         method: 'POST',
-        headers: await this._parameters.headers(),
+        headers,
         body: data,
         signal: abortController.signal,
         keepalive: useKeepalive,

--- a/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
@@ -167,6 +167,41 @@ describe('FetchTransport', function () {
       clock.tick(requestTimeout + 100);
     });
 
+    it('returns failure when aborted during headers resolution', function (done) {
+      // arrange
+      const clock = sinon.useFakeTimers();
+      const headersPromise = new Promise<Record<string, string>>(resolve => {
+        setTimeout(() => {
+          resolve({ 'Content-Type': 'application/json' });
+        }, 200);
+      });
+      const transport = createFetchTransport({
+        url: 'http://example.test',
+        headers: () => headersPromise,
+      });
+
+      //act
+      transport.send(testPayload, 100).then(response => {
+        // assert
+        try {
+          assert.strictEqual(response.status, 'failure');
+          assert.strictEqual(
+            (response as ExportResponseFailure).error.message,
+            'Fetch request errored'
+          );
+          assert.strictEqual(
+            ((response as ExportResponseFailure).error.cause as Error).name,
+            'AbortError'
+          );
+        } catch (e) {
+          done(e);
+        }
+        done();
+      }, done /* catch any rejections */);
+      clock.tick(150);
+      clock.tick(100);
+    });
+
     it('returns failure when fetch throws non-network error', function (done) {
       // arrange
       sinon.stub(globalThis, 'fetch').throws(new Error('fetch failed'));

--- a/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
@@ -169,6 +169,12 @@ describe('FetchTransport', function () {
 
     it('returns failure when aborted during headers resolution', function (done) {
       // arrange
+      // Stub globalThis.fetch so we can assert it is never called.
+      // Without this stub the test would pass even on the pre-fix behavior
+      // because calling fetch() with an already-aborted signal also rejects
+      // with AbortError, making the outcome indistinguishable.
+      const fetchStub = sinon.stub(globalThis, 'fetch');
+
       const clock = sinon.useFakeTimers();
       const headersPromise = new Promise<Record<string, string>>(resolve => {
         setTimeout(() => {
@@ -182,7 +188,7 @@ describe('FetchTransport', function () {
 
       //act
       transport.send(testPayload, 100).then(response => {
-        // assert
+        // assert - transport must fail with an AbortError-caused failure
         try {
           assert.strictEqual(response.status, 'failure');
           assert.strictEqual(
@@ -193,8 +199,14 @@ describe('FetchTransport', function () {
             ((response as ExportResponseFailure).error.cause as Error).name,
             'AbortError'
           );
+          // Critical regression guard: fetch must NOT be called when the
+          // timeout fires before headers resolve. The transport must bail
+          // out after detecting the aborted signal, never reaching the
+          // fetch() call. This assertion fails on the pre-fix behavior.
+          sinon.assert.notCalled(fetchStub);
         } catch (e) {
           done(e);
+          return;
         }
         done();
       }, done /* catch any rejections */);


### PR DESCRIPTION
## Summary

This fixes a race condition in FetchTransport where the request timeout can abort the AbortController while asynchronous headers are still being resolved.

Previously, if headers() took longer than timeoutMillis, fetch() could later be invoked with an already-aborted signal.

This change resolves headers before initiating the request and checks whether the request has already been aborted before calling fetch.

## Changes

- Resolve headers before starting the request.
- Return an AbortError before calling fetch if the request has already timed out.
- Add a browser regression test covering aborts during header resolution.

## Testing

- Added browser regression test.
- Browser test suite passes.