### PR TITLE
feat(sdk-logs): allow modifying ReadWriteLogRecord properties

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -15,6 +15,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :rocket: Features
 
+* feat(sdk-logs): allow modifying ReadWriteLogRecord properties (including hrTime, hrTimeObserved, and spanContext) in accordance with the OpenTelemetry Logs specification [#6923](https://github.com/open-telemetry/opentelemetry-js/pull/6923) @Babul422
 * feat(sdk-node): emit a deprecation warning when the `JaegerPropagator` is selected via `OTEL_PROPAGATORS` or declarative config; use `tracecontext` instead. @pichlermarc
 
 ### :bug: Bug Fixes

--- a/experimental/packages/sdk-logs/src/LogRecordImpl.ts
+++ b/experimental/packages/sdk-logs/src/LogRecordImpl.ts
@@ -25,15 +25,15 @@ import type { LoggerProviderSharedState } from './internal/LoggerProviderSharedS
 import { addAttribute, AddAttributeDecision } from './utils/validation';
 
 export class LogRecordImpl implements ReadableLogRecord {
-  hrTime: api.HrTime;
-  hrTimeObserved: api.HrTime;
-  spanContext?: api.SpanContext;
   readonly resource: Resource;
   readonly instrumentationScope: InstrumentationScope & {
     attributes?: LogAttributes;
     droppedAttributesCount?: number;
   };
   readonly attributes: LogAttributes = {};
+  private _hrTime: api.HrTime;
+  private _hrTimeObserved: api.HrTime;
+  private _spanContext?: api.SpanContext;
   private _severityText?: string;
   private _severityNumber?: SeverityNumber;
   private _body?: LogBody;
@@ -43,6 +43,36 @@ export class LogRecordImpl implements ReadableLogRecord {
 
   private _isReadonly: boolean = false;
   private readonly _logRecordLimits: Required<LogRecordLimits>;
+
+  get hrTime(): api.HrTime {
+    return this._hrTime;
+  }
+  set hrTime(hrTime: api.HrTime) {
+    if (this._isLogRecordReadonly()) {
+      return;
+    }
+    this._hrTime = hrTime;
+  }
+
+  get hrTimeObserved(): api.HrTime {
+    return this._hrTimeObserved;
+  }
+  set hrTimeObserved(hrTimeObserved: api.HrTime) {
+    if (this._isLogRecordReadonly()) {
+      return;
+    }
+    this._hrTimeObserved = hrTimeObserved;
+  }
+
+  get spanContext(): api.SpanContext | undefined {
+    return this._spanContext;
+  }
+  set spanContext(spanContext: api.SpanContext | undefined) {
+    if (this._isLogRecordReadonly()) {
+      return;
+    }
+    this._spanContext = spanContext;
+  }
 
   set severityText(severityText: string | undefined) {
     if (this._isLogRecordReadonly()) {
@@ -106,13 +136,13 @@ export class LogRecordImpl implements ReadableLogRecord {
     } = logRecord;
 
     const now = Date.now();
-    this.hrTime = timeInputToHrTime(timestamp ?? now);
-    this.hrTimeObserved = timeInputToHrTime(observedTimestamp ?? now);
+    this._hrTime = timeInputToHrTime(timestamp ?? now);
+    this._hrTimeObserved = timeInputToHrTime(observedTimestamp ?? now);
 
     if (context) {
       const spanContext = api.trace.getSpanContext(context);
       if (spanContext && api.isSpanContextValid(spanContext)) {
-        this.spanContext = spanContext;
+        this._spanContext = spanContext;
       }
     }
     this.severityNumber = severityNumber;

--- a/experimental/packages/sdk-logs/src/LogRecordImpl.ts
+++ b/experimental/packages/sdk-logs/src/LogRecordImpl.ts
@@ -25,9 +25,9 @@ import type { LoggerProviderSharedState } from './internal/LoggerProviderSharedS
 import { addAttribute, AddAttributeDecision } from './utils/validation';
 
 export class LogRecordImpl implements ReadableLogRecord {
-  readonly hrTime: api.HrTime;
-  readonly hrTimeObserved: api.HrTime;
-  readonly spanContext?: api.SpanContext;
+  hrTime: api.HrTime;
+  hrTimeObserved: api.HrTime;
+  spanContext?: api.SpanContext;
   readonly resource: Resource;
   readonly instrumentationScope: InstrumentationScope & {
     attributes?: LogAttributes;

--- a/experimental/packages/sdk-logs/src/export/SdkLogRecord.ts
+++ b/experimental/packages/sdk-logs/src/export/SdkLogRecord.ts
@@ -23,9 +23,9 @@ import type { Resource } from '@opentelemetry/resources';
  * SdkLogRecord instances are created and managed by the SDK.
  */
 export interface SdkLogRecord {
-  readonly hrTime: HrTime;
-  readonly hrTimeObserved: HrTime;
-  readonly spanContext?: SpanContext;
+  hrTime: HrTime;
+  hrTimeObserved: HrTime;
+  spanContext?: SpanContext;
   readonly resource: Resource;
   /**
    * The instrumentation scope associated with the log record.

--- a/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
@@ -804,4 +804,26 @@ describe('LogRecord', () => {
       assert.ok(emitted);
     });
   });
+
+  describe('ReadWriteLogRecord mutability', () => {
+    it('should allow modifying hrTime, hrTimeObserved, and spanContext', () => {
+      const { logRecord } = setup();
+
+      const newHrTime: HrTime = [123, 456];
+      const newHrTimeObserved: HrTime = [789, 101112];
+      const newSpanContext = {
+        traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+        spanId: '6e0c63257de34c92',
+        traceFlags: TraceFlags.SAMPLED,
+      };
+
+      logRecord.hrTime = newHrTime;
+      logRecord.hrTimeObserved = newHrTimeObserved;
+      logRecord.spanContext = newSpanContext;
+
+      assert.deepStrictEqual(logRecord.hrTime, newHrTime);
+      assert.deepStrictEqual(logRecord.hrTimeObserved, newHrTimeObserved);
+      assert.deepStrictEqual(logRecord.spanContext, newSpanContext);
+    });
+  });
 });

--- a/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
@@ -825,5 +825,39 @@ describe('LogRecord', () => {
       assert.deepStrictEqual(logRecord.hrTimeObserved, newHrTimeObserved);
       assert.deepStrictEqual(logRecord.spanContext, newSpanContext);
     });
+
+    it('should not allow modifying hrTime, hrTimeObserved, and spanContext after makeReadonly has been called', () => {
+      const warnStub = sinon.spy(diag, 'warn');
+      const { logRecord } = setup();
+
+      const initialHrTime = logRecord.hrTime;
+      const initialHrTimeObserved = logRecord.hrTimeObserved;
+      const initialSpanContext = logRecord.spanContext;
+
+      logRecord._makeReadonly();
+
+      const newHrTime: HrTime = [123, 456];
+      const newHrTimeObserved: HrTime = [789, 101112];
+      const newSpanContext = {
+        traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+        spanId: '6e0c63257de34c92',
+        traceFlags: TraceFlags.SAMPLED,
+      };
+
+      logRecord.hrTime = newHrTime;
+      logRecord.hrTimeObserved = newHrTimeObserved;
+      logRecord.spanContext = newSpanContext;
+
+      assert.deepStrictEqual(logRecord.hrTime, initialHrTime);
+      assert.deepStrictEqual(logRecord.hrTimeObserved, initialHrTimeObserved);
+      assert.deepStrictEqual(logRecord.spanContext, initialSpanContext);
+
+      sinon.assert.callCount(warnStub, 3);
+      sinon.assert.alwaysCalledWith(
+        warnStub,
+        'Can not execute the operation on emitted log record'
+      );
+      warnStub.restore();
+    });
   });
 });

--- a/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
@@ -835,6 +835,4 @@ describe('LogRecord', () => {
       assert.ok(emitted);
     });
   });
-
-
 });

--- a/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
@@ -395,7 +395,7 @@ describe('LogRecord', () => {
     });
   });
 
-  describe('should rewrite body/severityNumber/severityText', () => {
+  describe('should rewrite body/severityNumber/severityText/eventName/hrTime/hrTimeObserved/spanContext', () => {
     const currentTime = new Date().getTime();
     const logRecordData: logsAPI.LogRecord = {
       timestamp: currentTime,
@@ -411,6 +411,13 @@ describe('LogRecord', () => {
     const newSeverityNumber = logsAPI.SeverityNumber.INFO;
     const newSeverityText = 'INFO';
     const newName = 'new name';
+    const newHrTime: HrTime = [123, 456];
+    const newHrTimeObserved: HrTime = [789, 101112];
+    const newSpanContext = {
+      traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+      spanId: '6e0c63257de34c92',
+      traceFlags: TraceFlags.SAMPLED,
+    };
 
     it('should rewrite directly through the property method', () => {
       const { logRecord } = setup(undefined, logRecordData);
@@ -419,11 +426,17 @@ describe('LogRecord', () => {
       logRecord.severityNumber = newSeverityNumber;
       logRecord.severityText = newSeverityText;
       logRecord.eventName = newName;
+      logRecord.hrTime = newHrTime;
+      logRecord.hrTimeObserved = newHrTimeObserved;
+      logRecord.spanContext = newSpanContext;
 
       assert.deepStrictEqual(logRecord.body, newBody);
       assert.deepStrictEqual(logRecord.severityNumber, newSeverityNumber);
       assert.deepStrictEqual(logRecord.severityText, newSeverityText);
       assert.deepStrictEqual(logRecord.eventName, newName);
+      assert.deepStrictEqual(logRecord.hrTime, newHrTime);
+      assert.deepStrictEqual(logRecord.hrTimeObserved, newHrTimeObserved);
+      assert.deepStrictEqual(logRecord.spanContext, newSpanContext);
     });
 
     it('should rewrite using the set method', () => {
@@ -441,7 +454,7 @@ describe('LogRecord', () => {
     });
   });
 
-  describe('should be read-only(body/severityNumber/severityText/eventName) if makeReadonly has been called', () => {
+  describe('should be read-only(body/severityNumber/severityText/eventName/hrTime/hrTimeObserved/spanContext) if makeReadonly has been called', () => {
     const currentTime = new Date().getTime();
     const logRecordData: logsAPI.LogRecord = {
       timestamp: currentTime,
@@ -457,16 +470,30 @@ describe('LogRecord', () => {
     const newSeverityNumber = logsAPI.SeverityNumber.INFO;
     const newSeverityText = 'INFO';
     const newName = 'new name';
+    const newHrTime: HrTime = [123, 456];
+    const newHrTimeObserved: HrTime = [789, 101112];
+    const newSpanContext = {
+      traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+      spanId: '6e0c63257de34c92',
+      traceFlags: TraceFlags.SAMPLED,
+    };
 
     it('should not rewrite directly through the property method', () => {
       const warnStub = sinon.spy(diag, 'warn');
       const { logRecord } = setup(undefined, logRecordData);
+      const initialHrTime = logRecord.hrTime;
+      const initialHrTimeObserved = logRecord.hrTimeObserved;
+      const initialSpanContext = logRecord.spanContext;
+
       logRecord._makeReadonly();
 
       logRecord.body = newBody;
       logRecord.severityNumber = newSeverityNumber;
       logRecord.severityText = newSeverityText;
       logRecord.eventName = newName;
+      logRecord.hrTime = newHrTime;
+      logRecord.hrTimeObserved = newHrTimeObserved;
+      logRecord.spanContext = newSpanContext;
 
       assert.deepStrictEqual(logRecord.body, logRecordData.body);
       assert.deepStrictEqual(logRecord.eventName, logRecordData.eventName);
@@ -478,7 +505,11 @@ describe('LogRecord', () => {
         logRecord.severityText,
         logRecordData.severityText
       );
-      sinon.assert.callCount(warnStub, 4);
+      assert.deepStrictEqual(logRecord.hrTime, initialHrTime);
+      assert.deepStrictEqual(logRecord.hrTimeObserved, initialHrTimeObserved);
+      assert.deepStrictEqual(logRecord.spanContext, initialSpanContext);
+
+      sinon.assert.callCount(warnStub, 7);
       sinon.assert.alwaysCalledWith(
         warnStub,
         'Can not execute the operation on emitted log record'
@@ -805,59 +836,5 @@ describe('LogRecord', () => {
     });
   });
 
-  describe('ReadWriteLogRecord mutability', () => {
-    it('should allow modifying hrTime, hrTimeObserved, and spanContext', () => {
-      const { logRecord } = setup();
 
-      const newHrTime: HrTime = [123, 456];
-      const newHrTimeObserved: HrTime = [789, 101112];
-      const newSpanContext = {
-        traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-        spanId: '6e0c63257de34c92',
-        traceFlags: TraceFlags.SAMPLED,
-      };
-
-      logRecord.hrTime = newHrTime;
-      logRecord.hrTimeObserved = newHrTimeObserved;
-      logRecord.spanContext = newSpanContext;
-
-      assert.deepStrictEqual(logRecord.hrTime, newHrTime);
-      assert.deepStrictEqual(logRecord.hrTimeObserved, newHrTimeObserved);
-      assert.deepStrictEqual(logRecord.spanContext, newSpanContext);
-    });
-
-    it('should not allow modifying hrTime, hrTimeObserved, and spanContext after makeReadonly has been called', () => {
-      const warnStub = sinon.spy(diag, 'warn');
-      const { logRecord } = setup();
-
-      const initialHrTime = logRecord.hrTime;
-      const initialHrTimeObserved = logRecord.hrTimeObserved;
-      const initialSpanContext = logRecord.spanContext;
-
-      logRecord._makeReadonly();
-
-      const newHrTime: HrTime = [123, 456];
-      const newHrTimeObserved: HrTime = [789, 101112];
-      const newSpanContext = {
-        traceId: 'd4cda95b652f4a1592b449d5929fda1b',
-        spanId: '6e0c63257de34c92',
-        traceFlags: TraceFlags.SAMPLED,
-      };
-
-      logRecord.hrTime = newHrTime;
-      logRecord.hrTimeObserved = newHrTimeObserved;
-      logRecord.spanContext = newSpanContext;
-
-      assert.deepStrictEqual(logRecord.hrTime, initialHrTime);
-      assert.deepStrictEqual(logRecord.hrTimeObserved, initialHrTimeObserved);
-      assert.deepStrictEqual(logRecord.spanContext, initialSpanContext);
-
-      sinon.assert.callCount(warnStub, 3);
-      sinon.assert.alwaysCalledWith(
-        warnStub,
-        'Can not execute the operation on emitted log record'
-      );
-      warnStub.restore();
-    });
-  });
 });


### PR DESCRIPTION
## Summary

This PR updates the SDK logs implementation to allow modifying the properties required by the OpenTelemetry Logs specification.

### Changes

- Remove `readonly` from:
  - `hrTime`
  - `hrTimeObserved`
  - `spanContext`
- Add a unit test verifying these properties can be modified.

### Testing

- ✅ npm run lint
- ✅ npm run compile
- ✅ nx test @opentelemetry/sdk-logs

Fixes #6822