### PR TITLE
refactor(sdk-node): move all existing create<SdkThing>FromConfig() to create-from-config.ts

### DIFF
--- a/experimental/packages/opentelemetry-sdk-node/src/create-from-config.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/create-from-config.ts
@@ -6,13 +6,269 @@
 /**
  * Create SDK components from parsed declarative config.
  * https://opentelemetry.io/docs/specs/otel/configuration/sdk/#create
+ *
+ * Dev Notes:
+ * This file exports `create<SDK Thing>FromConfig(...)` functions intended to
+ * be used by the "create" step of `startNodeSDK()`.
  */
 
+import { diag } from '@opentelemetry/api';
+import type { SpanLimits } from '@opentelemetry/sdk-trace';
+import type { Resource } from '@opentelemetry/resources';
+import { OTLPLogExporter as OTLPHttpLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
+import { OTLPLogExporter as OTLPGrpcLogExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
+import { OTLPLogExporter as OTLPProtoLogExporter } from '@opentelemetry/exporter-logs-otlp-proto';
+import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base';
 import type {
   AttributeLimitsConfigModel,
+  BatchLogRecordProcessorConfigModel,
+  LoggerProviderConfigModel,
+  LogRecordExporterConfigModel,
+  LogRecordLimitsConfigModel,
+  LogRecordProcessorConfigModel,
+  OtlpGrpcExporterConfigModel,
+  OtlpHttpExporterConfigModel,
+  SimpleLogRecordProcessorConfigModel,
   SpanLimitsConfigModel,
 } from '@opentelemetry/configuration';
-import type { SpanLimits } from '@opentelemetry/sdk-trace';
+import type {
+  LogRecordExporter,
+  LogRecordProcessor,
+  LogRecordLimits,
+} from '@opentelemetry/sdk-logs';
+import {
+  BatchLogRecordProcessor,
+  ConsoleLogRecordExporter,
+  SimpleLogRecordProcessor,
+  LoggerProvider,
+} from '@opentelemetry/sdk-logs';
+
+import {
+  getGrpcCredentialsFromTls,
+  getGrpcMetadataFromHeaders,
+  getHeadersFromConfiguration,
+  getHttpAgentOptionsFromTls,
+  validateExporterTimeout,
+} from './utils';
+
+// ---- internal utilities
+
+/**
+ * Warn if some props from a declarative config object have not been handled.
+ *
+ * This is intended to be used by `create*FromConfig()` functions. It is a low
+ * tech mechanism to add awareness when a given valid config is not being
+ * completely handled. This could help when properties are added to the
+ * configuration schema. (A higher tech mechanism that wraps the parsed
+ * configuration during `create()` and watches for untouched properties
+ * might be nice.)
+ */
+function checkConfigUse(
+  name: string,
+  props: object | undefined,
+  handledProps: string[]
+) {
+  if (!props) return;
+  // Dev note: I'd use Set#difference, but that requires Node.js v22.
+  const unhandledProps = Object.keys(props).filter(
+    k => !handledProps.includes(k)
+  );
+
+  if (unhandledProps.length > 0) {
+    diag.warn(
+      `Config warning: some specified ${name} configuration properties were not handled by SDK setup: ${JSON.stringify(unhandledProps)}`
+    );
+  }
+}
+
+/**
+ * Return the single non-undefined entry in the given config object, or throw.
+ *
+ * It is common for Declarative Configuration to have config objects with
+ * a single entry, e.g.
+ *
+ *    "LogRecordProcessor": {
+ *      "type": "object",
+ *      "additionalProperties": {
+ *        "type": [
+ *          "object",
+ *          "null"
+ *        ]
+ *      },
+ *      "minProperties": 1,
+ *      "maxProperties": 1,
+ *
+ * The TypeScript types cannot express the minProperties/maxProperties from the
+ * JSON schema. We guard against that here.
+ */
+function mustSingleEntry(
+  configObj: Record<string, unknown>,
+  configTypeName: string
+): [string, unknown] {
+  const entries = Object.entries(configObj).filter(
+    ([_name, properties]) => properties !== undefined
+  );
+
+  if (entries.length !== 1) {
+    const entryNames = entries.map(e => e[0]);
+    throw Error(
+      `invalid ${configTypeName} in configuration: must have exactly one entry: entries=${JSON.stringify(entryNames)}`
+    );
+  }
+
+  return entries[0];
+}
+
+// ---- create<SDKThing>FromConfig functions
+
+export function createLogRecordLimitsFromConfig(
+  limits?: LogRecordLimitsConfigModel,
+  attribute_limits?: AttributeLimitsConfigModel
+): LogRecordLimits | undefined {
+  if (!limits && !attribute_limits) {
+    return undefined;
+  }
+  return {
+    attributeValueLengthLimit:
+      limits?.attribute_value_length_limit ??
+      attribute_limits?.attribute_value_length_limit ??
+      undefined,
+    attributeCountLimit:
+      limits?.attribute_count_limit ??
+      attribute_limits?.attribute_count_limit ??
+      undefined,
+  };
+}
+
+export function createLogRecordExporterFromConfig(
+  exporter: LogRecordExporterConfigModel
+): LogRecordExporter {
+  const [name, properties] = mustSingleEntry(exporter, 'LogRecordExporter');
+
+  switch (name) {
+    case 'otlp_http': {
+      checkConfigUse('LogRecordExporter', properties!, [
+        'compression',
+        'endpoint',
+        'headers',
+        'timeout',
+        'tls',
+        'encoding',
+      ]);
+      const props = properties as OtlpHttpExporterConfigModel;
+      const commonOpts = {
+        compression:
+          props?.compression === 'gzip'
+            ? CompressionAlgorithm.GZIP
+            : CompressionAlgorithm.NONE,
+        url: props?.endpoint ?? undefined,
+        headers: getHeadersFromConfiguration(props?.headers),
+        timeoutMillis: validateExporterTimeout(props?.timeout),
+        httpAgentOptions: getHttpAgentOptionsFromTls(props?.tls),
+      };
+      const encoding = props?.encoding ?? 'protobuf';
+      switch (encoding) {
+        case 'json':
+          return new OTLPHttpLogExporter(commonOpts);
+        case 'protobuf':
+          return new OTLPProtoLogExporter(commonOpts);
+        default:
+          throw new Error(
+            `unknown OtlpHttpExporter encoding in configuration: "${encoding}"`
+          );
+      }
+    }
+
+    case 'otlp_grpc': {
+      checkConfigUse('LogRecordExporter', properties!, [
+        'compression',
+        'endpoint',
+        'timeout',
+        'tls',
+        'headers',
+      ]);
+      const props = properties as OtlpGrpcExporterConfigModel;
+      return new OTLPGrpcLogExporter({
+        compression:
+          props?.compression === 'gzip'
+            ? CompressionAlgorithm.GZIP
+            : CompressionAlgorithm.NONE,
+        url: props?.endpoint ?? undefined,
+        timeoutMillis: validateExporterTimeout(props?.timeout),
+        credentials: getGrpcCredentialsFromTls(props?.tls),
+        metadata: getGrpcMetadataFromHeaders(props?.headers),
+      });
+    }
+
+    case 'console':
+      return new ConsoleLogRecordExporter();
+
+    default:
+      throw new Error(
+        `unknown LogRecordExporter name in configuration: "${name}"`
+      );
+  }
+}
+
+export function createLogRecordProcessorFromConfig(
+  processor: LogRecordProcessorConfigModel
+): LogRecordProcessor {
+  const [name, properties] = mustSingleEntry(processor, 'LogRecordProcessor');
+
+  switch (name) {
+    case 'batch': {
+      checkConfigUse('BatchLogRecordProcessor', properties!, [
+        'exporter',
+        'max_queue_size',
+        'max_export_batch_size',
+        'schedule_delay',
+        'export_timeout',
+      ]);
+      const props = properties as BatchLogRecordProcessorConfigModel;
+      const exporter = createLogRecordExporterFromConfig(props.exporter);
+      return new BatchLogRecordProcessor({
+        exporter,
+        maxQueueSize: props.max_queue_size ?? undefined,
+        maxExportBatchSize: props.max_export_batch_size ?? undefined,
+        scheduledDelayMillis: props.schedule_delay ?? undefined,
+        exportTimeoutMillis: props.export_timeout ?? undefined,
+      });
+    }
+
+    case 'simple': {
+      const props = properties as SimpleLogRecordProcessorConfigModel;
+      const exporter = createLogRecordExporterFromConfig(props.exporter);
+      return new SimpleLogRecordProcessor({ exporter });
+    }
+
+    default:
+      throw new Error(`unknown LogRecordProcessor name: "${name}"`);
+  }
+}
+
+export function createLoggerProviderFromConfig(
+  resource: Resource,
+  logger_provider: LoggerProviderConfigModel,
+  attribute_limits?: AttributeLimitsConfigModel
+): LoggerProvider {
+  const processors = logger_provider.processors.map(p =>
+    createLogRecordProcessorFromConfig(p)
+  );
+  const logRecordLimits = createLogRecordLimitsFromConfig(
+    logger_provider.limits,
+    attribute_limits
+  );
+  checkConfigUse('LoggerProvider', logger_provider, ['processors', 'limits']);
+
+  return new LoggerProvider({
+    resource,
+    processors,
+    logRecordLimits,
+    // TODO: loggerConfigurator
+    // TODO: meterProvider
+    // Note: forceFlushTimeoutMillis not configurable via decl conf.
+  });
+}
 
 export function createSpanLimitsFromConfig(
   limits?: SpanLimitsConfigModel,

--- a/experimental/packages/opentelemetry-sdk-node/src/start.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/start.ts
@@ -19,7 +19,6 @@ import {
   getIdGeneratorFromConfiguration,
   getSamplerFromConfiguration,
   getInstanceID,
-  createLoggerProviderFromConfig,
   getMeterReadersFromConfiguration,
   getMeterViewsFromConfiguration,
   getPropagatorFromConfiguration,
@@ -45,7 +44,10 @@ import {
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { ATTR_SERVICE_INSTANCE_ID } from './semconv';
 import { diagLogLevelFromSeverityNumberConfig } from './diag';
-import { createSpanLimitsFromConfig } from './create-from-config';
+import {
+  createLoggerProviderFromConfig,
+  createSpanLimitsFromConfig,
+} from './create-from-config';
 
 // Exported for testing.
 export const NOOP_SDK = {

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -53,9 +53,6 @@ import {
 import { B3InjectEncoding, B3Propagator } from '@opentelemetry/propagator-b3';
 import { JaegerPropagator } from '@opentelemetry/propagator-jaeger';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
-import { OTLPLogExporter as OTLPHttpLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
-import { OTLPLogExporter as OTLPGrpcLogExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
-import { OTLPLogExporter as OTLPProtoLogExporter } from '@opentelemetry/exporter-logs-otlp-proto';
 import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base';
 import {
   createEmptyMetadata,
@@ -64,7 +61,6 @@ import {
 } from '@opentelemetry/otlp-grpc-exporter-base';
 import type {
   ConfigurationModel,
-  LogRecordExporterConfigModel,
   InstrumentTypeConfigModel,
   AggregationConfigModel,
   MetricProducerConfigModel,
@@ -78,14 +74,6 @@ import type {
   HttpTlsConfigModel,
   GrpcTlsConfigModel,
   TextMapPropagatorConfigModel,
-  AttributeLimitsConfigModel,
-  BatchLogRecordProcessorConfigModel,
-  LoggerProviderConfigModel,
-  LogRecordProcessorConfigModel,
-  OtlpGrpcExporterConfigModel,
-  OtlpHttpExporterConfigModel,
-  SimpleLogRecordProcessorConfigModel,
-  LogRecordLimitsConfigModel,
 } from '@opentelemetry/configuration';
 import {
   mergePropagatorCompositeConfig,
@@ -115,16 +103,9 @@ import type {
   BatchLogRecordProcessorOptions,
   LogRecordExporter,
   LoggerProviderOptions,
-  LogRecordProcessor,
-  LogRecordLimits,
 } from '@opentelemetry/sdk-logs';
 import type { MetricProducer } from '@opentelemetry/sdk-metrics';
-import {
-  BatchLogRecordProcessor,
-  ConsoleLogRecordExporter,
-  SimpleLogRecordProcessor,
-  LoggerProvider,
-} from '@opentelemetry/sdk-logs';
+import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
 import * as fs from 'fs';
 import { inspect } from 'util';
 import { createBatchSpanProcessorFromEnv } from './create-from-env';
@@ -822,130 +803,6 @@ export function getBatchLogRecordProcessorFromEnv(
   });
 }
 
-function createLogRecordLimitsFromConfig(
-  limits?: LogRecordLimitsConfigModel,
-  attribute_limits?: AttributeLimitsConfigModel
-): LogRecordLimits {
-  return {
-    attributeValueLengthLimit:
-      limits?.attribute_value_length_limit ??
-      attribute_limits?.attribute_value_length_limit ??
-      undefined,
-    attributeCountLimit:
-      limits?.attribute_count_limit ??
-      attribute_limits?.attribute_count_limit ??
-      undefined,
-  };
-}
-
-export function createLoggerProviderFromConfig(
-  resource: Resource,
-  logger_provider: LoggerProviderConfigModel,
-  attribute_limits?: AttributeLimitsConfigModel
-): LoggerProvider {
-  const processors = logger_provider.processors.map(p =>
-    createLogRecordProcessorFromConfig(p)
-  );
-  const logRecordLimits = createLogRecordLimitsFromConfig(
-    logger_provider.limits,
-    attribute_limits
-  );
-  checkConfigUse('LoggerProvider', logger_provider, ['processors', 'limits']);
-
-  return new LoggerProvider({
-    resource,
-    processors,
-    logRecordLimits,
-    // TODO: loggerConfigurator
-    // TODO: meterProvider
-    // Note: forceFlushTimeoutMillis not configurable via decl conf.
-  });
-}
-
-export function createLogRecordExporterFromConfig(
-  exporter: LogRecordExporterConfigModel
-): LogRecordExporter {
-  const [name, properties] = mustSingleEntry(exporter, 'LogRecordExporter');
-
-  switch (name) {
-    case 'otlp_http': {
-      const props = properties as OtlpHttpExporterConfigModel;
-      const commonOpts = {
-        compression:
-          props?.compression === 'gzip'
-            ? CompressionAlgorithm.GZIP
-            : CompressionAlgorithm.NONE,
-        url: props?.endpoint ?? undefined,
-        headers: getHeadersFromConfiguration(props?.headers),
-        timeoutMillis: validateExporterTimeout(props?.timeout),
-        httpAgentOptions: getHttpAgentOptionsFromTls(props?.tls),
-      };
-      const encoding = props?.encoding ?? 'protobuf';
-      switch (encoding) {
-        case 'json':
-          return new OTLPHttpLogExporter(commonOpts);
-        case 'protobuf':
-          return new OTLPProtoLogExporter(commonOpts);
-        default:
-          throw new Error(
-            `unknown OtlpHttpExporter encoding in configuration: "${encoding}"`
-          );
-      }
-    }
-
-    case 'otlp_grpc': {
-      const props = properties as OtlpGrpcExporterConfigModel;
-      return new OTLPGrpcLogExporter({
-        compression:
-          props?.compression === 'gzip'
-            ? CompressionAlgorithm.GZIP
-            : CompressionAlgorithm.NONE,
-        url: props?.endpoint ?? undefined,
-        timeoutMillis: validateExporterTimeout(props?.timeout),
-        credentials: getGrpcCredentialsFromTls(props?.tls),
-        metadata: getGrpcMetadataFromHeaders(props?.headers),
-      });
-    }
-
-    case 'console':
-      return new ConsoleLogRecordExporter();
-
-    default:
-      throw new Error(
-        `unknown LogRecordExporter name in configuration: "${name}"`
-      );
-  }
-}
-
-export function createLogRecordProcessorFromConfig(
-  processor: LogRecordProcessorConfigModel
-): LogRecordProcessor {
-  const [name, properties] = mustSingleEntry(processor, 'LogRecordProcessor');
-
-  switch (name) {
-    case 'batch': {
-      const props = properties as BatchLogRecordProcessorConfigModel;
-      const exporter = createLogRecordExporterFromConfig(props.exporter);
-      return new BatchLogRecordProcessor({
-        exporter,
-        maxQueueSize: props.max_queue_size ?? undefined,
-        maxExportBatchSize: props.max_export_batch_size ?? undefined,
-        scheduledDelayMillis: props.schedule_delay ?? undefined,
-        exportTimeoutMillis: props.export_timeout ?? undefined,
-      });
-    }
-
-    case 'simple': {
-      const props = properties as SimpleLogRecordProcessorConfigModel;
-      const exporter = createLogRecordExporterFromConfig(props.exporter);
-      return new SimpleLogRecordProcessor({ exporter });
-    }
-
-    default:
-      throw new Error(`unknown LogRecordProcessor name: "${name}"`);
-  }
-}
-
 export function getHeadersFromConfiguration(
   headers: NameStringValuePairConfigModel[] | undefined
 ): Record<string, string> | undefined {
@@ -966,7 +823,7 @@ export function getHeadersFromConfiguration(
  * (infinity)" but the JS exporters don't support that yet (see #6617).
  * Warn and return undefined so the exporter falls back to its default.
  */
-function validateExporterTimeout(
+export function validateExporterTimeout(
   timeout: number | null | undefined
 ): number | undefined {
   if (timeout === null) {
@@ -993,7 +850,7 @@ export function getHttpAgentOptionsFromTls(
   return undefined;
 }
 
-function getGrpcCredentialsFromTls(tls?: GrpcTlsConfigModel) {
+export function getGrpcCredentialsFromTls(tls?: GrpcTlsConfigModel) {
   if (tls?.insecure) {
     return createInsecureCredentials();
   }
@@ -1011,7 +868,7 @@ function getGrpcCredentialsFromTls(tls?: GrpcTlsConfigModel) {
   return undefined;
 }
 
-function getGrpcMetadataFromHeaders(
+export function getGrpcMetadataFromHeaders(
   headers: NameStringValuePairConfigModel[] | undefined
 ) {
   if (!headers || headers.length === 0) {
@@ -1386,70 +1243,4 @@ export function buildSamplerFromConfig(
   }
   diag.warn('Unknown sampler config, defaulting to ParentBased(AlwaysOn).');
   return new ParentBasedSampler({ root: new AlwaysOnSampler() });
-}
-
-/**
- * Warn if some props from a declarative config object have not been handled.
- *
- * This is intended to be used by `create*FromConfig()` functions. It is a low
- * tech mechanism to add awareness when a given valid config is not being
- * completely handled. This could help when properties are added to the
- * configuration schema. (A higher tech mechanism that wraps the parsed
- * configuration during `create()` and watches for untouched properties
- * might be nice.)
- */
-function checkConfigUse(
-  name: string,
-  props: object | undefined,
-  handledProps: string[]
-) {
-  if (!props) return;
-  // Dev note: I'd use Set#difference, but that requires Node.js v22.
-  const unhandledProps = Object.keys(props).filter(
-    k => !handledProps.includes(k)
-  );
-
-  if (unhandledProps.length > 0) {
-    diag.warn(
-      `Config warning: some specified ${name} configuration properties were not handled by SDK setup: ${JSON.stringify(unhandledProps)}`
-    );
-  }
-}
-
-/**
- * Return the single non-undefined entry in the given config object, or throw.
- *
- * It is common for Declarative Configuration to have config objects with
- * a single entry, e.g.
- *
- *    "LogRecordProcessor": {
- *      "type": "object",
- *      "additionalProperties": {
- *        "type": [
- *          "object",
- *          "null"
- *        ]
- *      },
- *      "minProperties": 1,
- *      "maxProperties": 1,
- *
- * The TypeScript types cannot express the minProperties/maxProperties from the
- * JSON schema. We guard against that here.
- */
-function mustSingleEntry(
-  configObj: Record<string, unknown>,
-  configTypeName: string
-): [string, unknown] {
-  const entries = Object.entries(configObj).filter(
-    ([_name, properties]) => properties !== undefined
-  );
-
-  if (entries.length !== 1) {
-    const entryNames = entries.map(e => e[0]);
-    throw Error(
-      `invalid ${configTypeName} in configuration: must have exactly one entry: entries=${JSON.stringify(entryNames)}`
-    );
-  }
-
-  return entries[0];
 }

--- a/experimental/packages/opentelemetry-sdk-node/test/create-from-config.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/create-from-config.test.ts
@@ -4,11 +4,337 @@
  */
 
 import * as assert from 'assert';
-import type { ConfigurationModel } from '@opentelemetry/configuration';
+
+import type {
+  ConfigurationModel,
+  LogRecordExporterConfigModel,
+  LogRecordProcessorConfigModel,
+} from '@opentelemetry/configuration';
 import type { SpanLimits } from '@opentelemetry/sdk-trace';
-import { createSpanLimitsFromConfig } from '../src/create-from-config';
+import type { LogRecordLimits } from '@opentelemetry/sdk-logs';
+import {
+  BatchLogRecordProcessor,
+  ConsoleLogRecordExporter,
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+} from '@opentelemetry/sdk-logs';
+import { OTLPLogExporter as OTLPProtoLogExporter } from '@opentelemetry/exporter-logs-otlp-proto';
+import { OTLPLogExporter as OTLPHttpLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
+import { OTLPLogExporter as OTLPGrpcLogExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
+import type { Resource } from '@opentelemetry/resources';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+
+import {
+  createLoggerProviderFromConfig,
+  createLogRecordExporterFromConfig,
+  createLogRecordLimitsFromConfig,
+  createLogRecordProcessorFromConfig,
+  createSpanLimitsFromConfig,
+} from '../src/create-from-config';
 
 describe('create-from-config', () => {
+  describe('createLogRecordExporterFromConfig', () => {
+    const corpus: {
+      testName: string;
+      exporterConfig: LogRecordExporterConfigModel;
+      exporterInstanceOf?: any;
+      throws?: boolean;
+      only?: boolean;
+    }[] = [
+      {
+        testName: 'empty exporter config throws',
+        exporterConfig: {},
+        throws: true,
+      },
+      // Test each LogRecordExporterConfigModel property
+      {
+        testName: 'console',
+        exporterConfig: {
+          console: null,
+        },
+        exporterInstanceOf: ConsoleLogRecordExporter,
+      },
+      {
+        testName: 'otlp_http',
+        exporterConfig: {
+          otlp_http: null,
+        },
+        exporterInstanceOf: OTLPProtoLogExporter,
+      },
+      {
+        testName: 'otlp_http (encoding=json)',
+        exporterConfig: {
+          otlp_http: { encoding: 'json' },
+        },
+        exporterInstanceOf: OTLPHttpLogExporter,
+      },
+      {
+        testName: 'otlp_grpc',
+        exporterConfig: {
+          otlp_grpc: null,
+        },
+        exporterInstanceOf: OTLPGrpcLogExporter,
+      },
+      {
+        testName: 'otlp_file/development is not supported, should throw',
+        exporterConfig: {
+          'otlp_file/development': null,
+        },
+        throws: true,
+      },
+      // Test various attributes on each of the exporter types.
+      {
+        testName: 'otlp_http (specifying every property)',
+        exporterConfig: {
+          otlp_http: {
+            endpoint: 'https://coll.example.com/v1/logs',
+            tls: {
+              ca_file: './fixtures/ca.pem',
+              key_file: './fixtures/ca-key.pem',
+              cert_file: './fixtures/cert.pem',
+            },
+            headers: [{ name: 'foo', value: 'bar' }],
+            headers_list: 'foo=baz,a=b',
+            compression: 'gzip',
+            timeout: 1234,
+            encoding: 'json',
+          },
+        },
+        exporterInstanceOf: OTLPHttpLogExporter,
+      },
+      {
+        testName: 'otlp_grpc (specifying every property)',
+        exporterConfig: {
+          otlp_grpc: {
+            endpoint: 'https://coll.example.com:4317/v1/logs',
+            tls: {
+              ca_file: './fixtures/ca.pem',
+              key_file: './fixtures/ca-key.pem',
+              cert_file: './fixtures/cert.pem',
+              insecure: false,
+            },
+            headers: [{ name: 'foo', value: 'bar' }],
+            headers_list: 'foo=baz,a=b',
+            compression: 'gzip',
+            timeout: 1234,
+          },
+        },
+        exporterInstanceOf: OTLPGrpcLogExporter,
+      },
+    ];
+
+    for (const item of corpus) {
+      (item.only ? it.only : it)(item.testName, function () {
+        if (item.throws) {
+          assert.throws(() => {
+            createLogRecordExporterFromConfig(item.exporterConfig);
+          });
+        } else {
+          const exporter = createLogRecordExporterFromConfig(
+            item.exporterConfig
+          );
+          assert.ok(
+            exporter instanceof item.exporterInstanceOf,
+            `exporter should be an instance of ${item.exporterInstanceOf.name} (actual ${exporter.constructor.name})`
+          );
+        }
+      });
+    }
+  });
+
+  describe('createLogRecordLimitsFromConfig', () => {
+    const corpus: {
+      testName: string;
+      config: ConfigurationModel;
+      logRecordLimits: LogRecordLimits | undefined;
+      only?: boolean;
+    }[] = [
+      {
+        testName: 'empty',
+        config: {},
+        logRecordLimits: undefined,
+      },
+      {
+        testName: 'just general limits',
+        config: {
+          attribute_limits: {
+            attribute_count_limit: 1,
+            attribute_value_length_limit: 2,
+          },
+        },
+        logRecordLimits: {
+          attributeCountLimit: 1,
+          attributeValueLengthLimit: 2,
+        },
+      },
+      {
+        testName: 'just log record limits limits',
+        config: {
+          logger_provider: {
+            processors: [{ simple: { exporter: { console: null } } }],
+            limits: {
+              attribute_count_limit: 10,
+              attribute_value_length_limit: 11,
+            },
+          },
+        },
+        logRecordLimits: {
+          attributeCountLimit: 10,
+          attributeValueLengthLimit: 11,
+        },
+      },
+      {
+        testName: 'log record limits beat general limits',
+        config: {
+          attribute_limits: {
+            attribute_count_limit: 1,
+            attribute_value_length_limit: 2,
+          },
+          logger_provider: {
+            processors: [{ simple: { exporter: { console: null } } }],
+            limits: {
+              attribute_count_limit: 10,
+            },
+          },
+        },
+        logRecordLimits: {
+          attributeCountLimit: 10,
+          attributeValueLengthLimit: 2,
+        },
+      },
+    ];
+
+    for (const item of corpus) {
+      (item.only ? it.only : it)(item.testName, function () {
+        const logRecordLimits = createLogRecordLimitsFromConfig(
+          item.config.logger_provider?.limits,
+          item.config.attribute_limits
+        );
+        assert.deepStrictEqual(logRecordLimits, item.logRecordLimits);
+      });
+    }
+  });
+
+  describe('createLogRecordProcessorFromConfig', () => {
+    const corpus: {
+      testName: string;
+      processorConfig: LogRecordProcessorConfigModel;
+      processorInstanceOf?: any;
+      throws?: boolean;
+      only?: boolean;
+    }[] = [
+      {
+        testName: 'empty config throws',
+        processorConfig: {},
+        throws: true,
+      },
+      {
+        testName: 'simple',
+        processorConfig: {
+          simple: { exporter: { console: null } },
+        },
+        processorInstanceOf: SimpleLogRecordProcessor,
+      },
+      {
+        testName: 'batch',
+        processorConfig: {
+          batch: { exporter: { console: null } },
+        },
+        processorInstanceOf: BatchLogRecordProcessor,
+      },
+      {
+        testName: 'event_to_span_event_bridge/development is not supported',
+        processorConfig: {
+          'event_to_span_event_bridge/development': null,
+        },
+        throws: true,
+      },
+      {
+        testName: 'batch (specify all properties)',
+        processorConfig: {
+          batch: {
+            schedule_delay: 123,
+            export_timeout: 12345,
+            max_queue_size: 1234,
+            max_export_batch_size: 123,
+            exporter: { console: null },
+          },
+        },
+        processorInstanceOf: BatchLogRecordProcessor,
+      },
+    ];
+
+    for (const item of corpus) {
+      (item.only ? it.only : it)(item.testName, function () {
+        if (item.throws) {
+          assert.throws(() => {
+            createLogRecordProcessorFromConfig(item.processorConfig);
+          });
+        } else {
+          const processor = createLogRecordProcessorFromConfig(
+            item.processorConfig
+          );
+          assert.ok(
+            processor instanceof item.processorInstanceOf,
+            `processor should be an instance of ${item.processorInstanceOf.name} (actual ${processor.constructor.name})`
+          );
+        }
+      });
+    }
+  });
+
+  describe('createLoggerProviderFromConfig', () => {
+    const resource = resourceFromAttributes({ foo: 'bar' });
+    const corpus: {
+      testName: string;
+      resource: Resource;
+      config: ConfigurationModel;
+      throws?: boolean;
+      only?: boolean;
+    }[] = [
+      {
+        testName: 'basic',
+        resource,
+        config: {
+          logger_provider: {
+            processors: [{ simple: { exporter: { console: null } } }],
+          },
+        },
+      },
+      {
+        testName: 'logger_configurator/development is not yet supported',
+        resource,
+        config: {
+          logger_provider: {
+            processors: [{ simple: { exporter: { console: null } } }],
+            'logger_configurator/development': {},
+          },
+        },
+      },
+    ];
+
+    for (const item of corpus) {
+      (item.only ? it.only : it)(item.testName, function () {
+        if (item.throws) {
+          assert.throws(() => {
+            createLoggerProviderFromConfig(
+              item.resource,
+              item.config.logger_provider!,
+              item.config.attribute_limits
+            );
+          });
+        } else {
+          const provider = createLoggerProviderFromConfig(
+            item.resource,
+            item.config.logger_provider!,
+            item.config.attribute_limits
+          );
+          assert.ok(provider instanceof LoggerProvider);
+        }
+      });
+    }
+  });
+
   describe('createSpanLimitsFromConfig', () => {
     const corpus: {
       testName: string;

--- a/experimental/packages/opentelemetry-sdk-node/test/start.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/start.test.ts
@@ -34,10 +34,7 @@ import {
   ConsoleLogRecordExporter,
   BatchLogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
-import type {
-  ConfigFactory,
-  LogRecordExporterConfigModel,
-} from '@opentelemetry/configuration';
+import type { ConfigFactory } from '@opentelemetry/configuration';
 import { createConfigFactory } from '@opentelemetry/configuration';
 import { OTLPLogExporter as OTLPProtoLogExporter } from '@opentelemetry/exporter-logs-otlp-proto';
 import { OTLPLogExporter as OTLPHttpLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
@@ -56,7 +53,6 @@ import {
 } from '../src/semconv';
 import { ATTR_OS_TYPE } from '@opentelemetry/resources/src/semconv';
 import {
-  createLogRecordExporterFromConfig,
   getPeriodicMetricReaderFromConfiguration,
   getSpanExporter,
   setupContextManager,
@@ -961,13 +957,6 @@ describe('startNodeSDK', function () {
   });
 
   describe('tests to increase code coverage', function () {
-    it('should throw for invalid log record exporter model', async () => {
-      assert.throws(() => {
-        const exporter: LogRecordExporterConfigModel = {};
-        createLogRecordExporterFromConfig(exporter);
-      });
-    });
-
     it('should warn for unsupported metric producer', async () => {
       const warnSpy = Sinon.spy(diag, 'warn');
       const reader = getPeriodicMetricReaderFromConfiguration({


### PR DESCRIPTION
Also add tests for each of them, adding some tests to what was
there before.
The functions were *moved* from utils.ts to create-from-config.ts
The only change was adding a few 'checkConfigUse()' internal calls.

---

This continues on work from https://github.com/open-telemetry/opentelemetry-js/pull/6785
In that PR I added these methods to "utils.ts" because at the same time I'd had a PR starting "create-from-config.ts".

This is a refactor, mostly just moving existing functionality, before I continue work on "fail fast" semantics mentioned at https://github.com/open-telemetry/opentelemetry-js/pull/6785
See this comment from that PR: https://github.com/open-telemetry/opentelemetry-js/pull/6785#discussion_r3375851567