### PR TITLE
feat(sdk-logs)!: configure force flush timeout per call

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -8,6 +8,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :boom: Breaking Changes
 
+* feat(sdk-logs)!: configure the force flush timeout per call #6927 @LarryHu0217
+  * (user-facing): `LoggerProviderOptions.forceFlushTimeoutMillis` has been removed; pass `timeoutMillis` to `LoggerProvider.forceFlush()` instead.
 * feat(instrumentation-http)!: emit only stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable no longer changes HTTP attribute or metric emission — old (v1.7.0) and duplicate (`http`/`http/dup`) semconv outputs have been removed. [#6819](https://github.com/open-telemetry/opentelemetry-js/pull/6819) @maryliag
 * feat(instrumentation-fetch)!: emit only stable HTTP semantic conventions. The `semconvStabilityOptIn` instrumentation config option has been removed; old (v1.7.0) and duplicate semconv outputs are no longer emitted. [#6819](https://github.com/open-telemetry/opentelemetry-js/pull/6819) @maryliag
 * feat(instrumentation-xml-http-request)!: emit only stable HTTP semantic conventions. The `semconvStabilityOptIn` instrumentation config option has been removed; old (v1.7.0) and duplicate semconv outputs are no longer emitted. [#6819](https://github.com/open-telemetry/opentelemetry-js/pull/6819) @maryliag

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -8,7 +8,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :boom: Breaking Changes
 
-* feat(sdk-logs)!: configure the force flush timeout per call #6927 @LarryHu0217
+* feat(sdk-logs)!: configure the force flush timeout per call [#6931](https://github.com/open-telemetry/opentelemetry-js/pull/6931) @LarryHu0217
   * (user-facing): `LoggerProviderOptions.forceFlushTimeoutMillis` has been removed; pass `timeoutMillis` to `LoggerProvider.forceFlush()` instead.
 * feat(instrumentation-http)!: emit only stable HTTP semantic conventions. The `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable no longer changes HTTP attribute or metric emission — old (v1.7.0) and duplicate (`http`/`http/dup`) semconv outputs have been removed. [#6819](https://github.com/open-telemetry/opentelemetry-js/pull/6819) @maryliag
 * feat(instrumentation-fetch)!: emit only stable HTTP semantic conventions. The `semconvStabilityOptIn` instrumentation config option has been removed; old (v1.7.0) and duplicate semconv outputs are no longer emitted. [#6819](https://github.com/open-telemetry/opentelemetry-js/pull/6819) @maryliag

--- a/experimental/packages/sdk-logs/src/LogRecordProcessor.ts
+++ b/experimental/packages/sdk-logs/src/LogRecordProcessor.ts
@@ -7,12 +7,13 @@ import type { Context } from '@opentelemetry/api';
 import type { InstrumentationScope } from '@opentelemetry/core';
 import type { SdkLogRecord } from './export/SdkLogRecord';
 import type { SeverityNumber } from '@opentelemetry/api-logs';
+import type { ForceFlushOptions } from './types';
 
 export interface LogRecordProcessor {
   /**
    * Forces to export all finished log records
    */
-  forceFlush(): Promise<void>;
+  forceFlush(options?: ForceFlushOptions): Promise<void>;
 
   /**
    * Called when a {@link LogRecord} is emit

--- a/experimental/packages/sdk-logs/src/LoggerProvider.ts
+++ b/experimental/packages/sdk-logs/src/LoggerProvider.ts
@@ -12,7 +12,7 @@ import { createNoopLogger } from '@opentelemetry/api-logs';
 import { defaultResource } from '@opentelemetry/resources';
 import { BindOnceFuture } from '@opentelemetry/core';
 
-import type { LoggerProviderOptions } from './types';
+import type { ForceFlushOptions, LoggerProviderOptions } from './types';
 import { Logger } from './Logger';
 import {
   DEFAULT_LOGGER_CONFIGURATOR,
@@ -33,7 +33,6 @@ export class LoggerProvider implements ILoggerProvider {
   constructor(config: LoggerProviderOptions = {}) {
     const mergedConfig = {
       resource: config.resource ?? defaultResource(),
-      forceFlushTimeoutMillis: config.forceFlushTimeoutMillis ?? 30000,
       logRecordLimits: {
         attributeCountLimit: config.logRecordLimits?.attributeCountLimit ?? 128,
         attributeValueLengthLimit:
@@ -46,7 +45,6 @@ export class LoggerProvider implements ILoggerProvider {
     };
     this._sharedState = new LoggerProviderSharedState(
       mergedConfig.resource,
-      mergedConfig.forceFlushTimeoutMillis,
       mergedConfig.logRecordLimits,
       mergedConfig.processors,
       mergedConfig.loggerConfigurator,
@@ -97,13 +95,13 @@ export class LoggerProvider implements ILoggerProvider {
    *
    * Returns a promise which is resolved when all flushes are complete.
    */
-  public forceFlush(): Promise<void> {
+  public forceFlush(options?: ForceFlushOptions): Promise<void> {
     // do not flush after shutdown
     if (this._shutdownOnce.isCalled) {
       diag.warn('invalid attempt to force flush after LoggerProvider shutdown');
       return this._shutdownOnce.promise;
     }
-    return this._sharedState.activeProcessor.forceFlush();
+    return this._sharedState.activeProcessor.forceFlush(options);
   }
 
   /**

--- a/experimental/packages/sdk-logs/src/MultiLogRecordProcessor.ts
+++ b/experimental/packages/sdk-logs/src/MultiLogRecordProcessor.ts
@@ -9,6 +9,7 @@ import type { Context } from '@opentelemetry/api';
 import type { LogRecordProcessor } from './LogRecordProcessor';
 import type { SdkLogRecord } from './export/SdkLogRecord';
 import type { SeverityNumber } from '@opentelemetry/api-logs';
+import type { ForceFlushOptions } from './types';
 
 /**
  * Implementation of the {@link LogRecordProcessor} that simply forwards all
@@ -16,17 +17,12 @@ import type { SeverityNumber } from '@opentelemetry/api-logs';
  */
 export class MultiLogRecordProcessor implements LogRecordProcessor {
   public readonly processors: LogRecordProcessor[];
-  public readonly forceFlushTimeoutMillis: number;
-  constructor(
-    processors: LogRecordProcessor[],
-    forceFlushTimeoutMillis: number
-  ) {
+  constructor(processors: LogRecordProcessor[]) {
     this.processors = processors;
-    this.forceFlushTimeoutMillis = forceFlushTimeoutMillis;
   }
 
-  public async forceFlush(): Promise<void> {
-    const timeout = this.forceFlushTimeoutMillis;
+  public async forceFlush(options?: ForceFlushOptions): Promise<void> {
+    const timeout = options?.timeoutMillis ?? 30000;
     await Promise.all(
       this.processors.map(processor =>
         callWithTimeout(processor.forceFlush(), timeout)

--- a/experimental/packages/sdk-logs/src/index.ts
+++ b/experimental/packages/sdk-logs/src/index.ts
@@ -4,6 +4,7 @@
  */
 
 export type {
+  ForceFlushOptions,
   LoggerProviderConfig,
   LoggerProviderOptions,
   LoggerConfig,

--- a/experimental/packages/sdk-logs/src/internal/LoggerProviderSharedState.ts
+++ b/experimental/packages/sdk-logs/src/internal/LoggerProviderSharedState.ts
@@ -38,7 +38,6 @@ export class LoggerProviderSharedState {
   activeProcessor: LogRecordProcessor;
   readonly registeredLogRecordProcessors: LogRecordProcessor[] = [];
   readonly resource: Resource;
-  readonly forceFlushTimeoutMillis: number;
   readonly logRecordLimits: Required<LogRecordLimits>;
   readonly processors: LogRecordProcessor[];
   readonly loggerMetrics: LoggerMetrics;
@@ -48,21 +47,18 @@ export class LoggerProviderSharedState {
 
   constructor(
     resource: Resource,
-    forceFlushTimeoutMillis: number,
     logRecordLimits: Required<LogRecordLimits>,
     processors: LogRecordProcessor[],
     loggerConfigurator?: LoggerConfigurator,
     meterProvider?: MeterProvider
   ) {
     this.resource = resource;
-    this.forceFlushTimeoutMillis = forceFlushTimeoutMillis;
     this.logRecordLimits = logRecordLimits;
     this.processors = processors;
     if (processors.length > 0) {
       this.registeredLogRecordProcessors = processors;
       this.activeProcessor = new MultiLogRecordProcessor(
-        this.registeredLogRecordProcessors,
-        this.forceFlushTimeoutMillis
+        this.registeredLogRecordProcessors
       );
     } else {
       this.activeProcessor = new NoopLogRecordProcessor();

--- a/experimental/packages/sdk-logs/src/types.ts
+++ b/experimental/packages/sdk-logs/src/types.ts
@@ -62,15 +62,17 @@ export type LoggerConfigurator = (
   loggerScope: InstrumentationScope
 ) => Required<LoggerConfig>;
 
+export interface ForceFlushOptions {
+  /**
+   * How long the force flush can run before it is cancelled.
+   * The default value is 30000ms.
+   */
+  timeoutMillis?: number;
+}
+
 export interface LoggerProviderOptions {
   /** Resource associated with trace telemetry  */
   resource?: Resource;
-
-  /**
-   * How long the forceFlush can run before it is cancelled.
-   * The default value is 30000ms
-   */
-  forceFlushTimeoutMillis?: number;
 
   /** Log Record Limits*/
   logRecordLimits?: LogRecordLimits;

--- a/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LogRecord.test.ts
@@ -34,7 +34,6 @@ const setup = (limits?: LogRecordLimits, data?: logsAPI.LogRecord) => {
   const resource = defaultResource();
   const sharedState = new LoggerProviderSharedState(
     resource,
-    Infinity,
     {
       attributeCountLimit: limits?.attributeCountLimit ?? 128,
       attributeValueLengthLimit: limits?.attributeValueLengthLimit ?? Infinity,

--- a/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
+++ b/experimental/packages/sdk-logs/test/common/LoggerProvider.test.ts
@@ -78,12 +78,6 @@ describe('LoggerProvider', () => {
         const { resource } = provider['_sharedState'];
         assert.deepStrictEqual(resource, passedInResource);
       });
-
-      it('should have default forceFlushTimeoutMillis if not pass', () => {
-        const provider = new LoggerProvider();
-        const sharedState = provider['_sharedState'];
-        assert.ok(sharedState.forceFlushTimeoutMillis === 30_000);
-      });
     });
 
     describe('logRecordLimits', () => {
@@ -486,6 +480,22 @@ describe('LoggerProvider', () => {
           sinon.assert.calledTwice(forceFlushStub);
           done();
         });
+    });
+
+    it('should use the timeout passed to forceFlush', async () => {
+      const clock = sinon.useFakeTimers();
+      const processor = new NoopLogRecordProcessor();
+      sinon.stub(processor, 'forceFlush').returns(new Promise(() => {}));
+      const provider = new LoggerProvider({ processors: [processor] });
+
+      const flush = provider
+        .forceFlush({ timeoutMillis: 10 })
+        .catch(error => error);
+      await clock.tickAsync(10);
+
+      const rejection: unknown = await flush;
+      assert.ok(rejection instanceof Error);
+      assert.match(rejection.message, /Operation timed out/);
     });
   });
 

--- a/experimental/packages/sdk-logs/test/common/MultiLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/MultiLogRecordProcessor.test.ts
@@ -38,10 +38,7 @@ class TestProcessor implements LogRecordProcessor {
 
 const setup = (processors: LogRecordProcessor[] = []) => {
   const forceFlushTimeoutMillis = 30_000;
-  const multiProcessor = new MultiLogRecordProcessor(
-    processors,
-    forceFlushTimeoutMillis
-  );
+  const multiProcessor = new MultiLogRecordProcessor(processors);
   return { multiProcessor, forceFlushTimeoutMillis };
 };
 

--- a/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/BatchLogRecordProcessor.test.ts
@@ -40,7 +40,6 @@ const createLogRecord = (
 ): SdkLogRecord => {
   const sharedState = new LoggerProviderSharedState(
     resource || defaultResource(),
-    Infinity,
     {
       attributeCountLimit: limits?.attributeCountLimit ?? 128,
       attributeValueLengthLimit: limits?.attributeValueLengthLimit ?? Infinity,

--- a/experimental/packages/sdk-logs/test/common/export/SimpleLogRecordProcessor.test.ts
+++ b/experimental/packages/sdk-logs/test/common/export/SimpleLogRecordProcessor.test.ts
@@ -31,7 +31,6 @@ import { TestMetricReader } from '../utils';
 const setup = (exporter: LogRecordExporter, resource?: Resource) => {
   const sharedState = new LoggerProviderSharedState(
     resource || defaultResource(),
-    Infinity,
     {
       attributeCountLimit: 128,
       attributeValueLengthLimit: Infinity,


### PR DESCRIPTION
## Which problem is this PR solving?

`LoggerProviderOptions.forceFlushTimeoutMillis` cannot be supplied through declarative configuration because it controls a later `forceFlush()` call rather than provider construction.

Fixes #6927

## Short description of the changes

- remove `forceFlushTimeoutMillis` from `LoggerProviderOptions`
- add an exported `ForceFlushOptions` object with `timeoutMillis`
- pass the per-call timeout through `LoggerProvider` to `MultiLogRecordProcessor`
- preserve the existing 30-second default when no timeout is supplied
- update unit-test fixtures and the experimental changelog

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `npx --no-install nx run @opentelemetry/sdk-logs:compile --skip-nx-cache`
- [x] `npx --no-install nx run @opentelemetry/sdk-logs:test --skip-nx-cache` (202 passing, 9 pending browser-only tests)
- [x] `npx --no-install nx run @opentelemetry/sdk-logs:lint --skip-nx-cache`
- [x] Prettier check for all touched TypeScript files
- [x] Markdown lint for `experimental/CHANGELOG.md`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
