### PR TITLE
chore: start using min-release-age in .npmrc, disable minimumReleaseAge for renovate lockfile updates

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 lockfile-version=3
 prefer-dedupe=true
+min-release-age=3

--- a/doc/contributing/dependencies.md
+++ b/doc/contributing/dependencies.md
@@ -11,7 +11,7 @@ This section refers to `"dependencies"` and `"devDependencies"` entries in `pack
 **Example:** `^1.2.3` might inadvertently lead to version `1.2.6` which includes unintended breaking changes).
 
 > [!NOTE]
-> As this approach might leave our project with outdated tooling, we adopt `renovate-bot`. This automated dependency update tool proactively opens pull requests upon the release of new patch/minor/major versions. The complete configuration for renovate-bot can be found in [renovate.json](../../renovate.json) file.
+> As this approach might leave our project with outdated tooling, we adopt `renovate-bot`. This automated dependency update tool proactively opens pull requests upon the release of new patch/minor/major versions. The complete configuration for renovate-bot can be found in [renovate.json5](../../renovate.json5) file.
 
 ## @opentelemetry/* dependencies
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -46,7 +46,10 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 3am on Monday"]
+    "schedule": ["before 3am on Monday"],
+    // disable minimumReleaseAge for this rule only as this is not supported for
+    // lockfile updates; the config from .npmrc will be applied instead.
+    "minimumReleaseAge": "0"
   },
   "rebaseWhen": "conflicted",
   "ignoreDeps": [
@@ -55,7 +58,7 @@
     "@types/node"
   ],
   "constraints": {
-    "npm": ">=11.6.3"
+    "npm": ">=11.18.0"
   },
   "assignees": ["@dyladan", "@legendecas", "@pichlermarc", "@trentm"],
   "labels": ["dependencies"],


### PR DESCRIPTION
## Which problem is this PR solving?

Renovate lockfile updates never get green checks because the `minimumReleaseAge` config does not work for lockfiles. As such, it also reduces some of the benefit we get from using `minimumReleaseAge`: the packages are still being pulled in on that branch and workflows run on it.

This PR attempts to fix that by:
- introducing `min-release-age` in `.npmrc`
- disabling the ineffective `minimumReleaseAge` setting (`min-release-age` will ensure that this constraint is satisfied)
- setting >=11.18.0 as the constraint for npm in `renovate.json5`

It also has the nice side-effect that if you're using `npm` to install deps locally `min-release-age` will be applied to your installs (as long as you have a `npm` version that supports it)

Note: I also renamed `renovate.json` -> `renovate.json5`, so that we can add comments to the rules since most of the time it's not obvious why they're the way they are.
