### PR TITLE
fix(otlp-exporter-base): suppress tracing around the browser fetch transport request

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -14,6 +14,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(otlp-exporter-base): suppress tracing around the browser fetch transport's own request so a `fetch` instrumentation cannot create an export → span → export loop
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -14,7 +14,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
-* fix(otlp-exporter-base): suppress tracing around the browser fetch transport's own request so a `fetch` instrumentation cannot create an export → span → export loop
+* fix(otlp-exporter-base): suppress tracing around the browser fetch transport's own request so a `fetch` instrumentation cannot create an export → span → export loop [#6948](https://github.com/open-telemetry/opentelemetry-js/pull/6948) @YangJonghun
 
 ### :books: Documentation
 

--- a/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
@@ -5,7 +5,8 @@
 
 import type { IExporterTransport } from '../exporter-transport';
 import type { ExportResponse } from '../export-response';
-import { diag } from '@opentelemetry/api';
+import { context, diag } from '@opentelemetry/api';
+import { suppressTracing } from '@opentelemetry/core';
 import {
   isExportHTTPErrorRetryable,
   parseRetryAfterToMills,
@@ -56,11 +57,10 @@ class FetchTransport implements IExporterTransport {
     const abortController = new AbortController();
     const timeout = setTimeout(() => abortController.abort(), timeoutMillis);
     // Fetch API may be wrapped by an instrumentation like `@opentelemetry/instrumentation-fetch`.
-    // In that case the instrumentation would create a new Span for this request
-    // because the context manager cannot keep the context after `await` calls.
-    // This creates an indirect endless loop Export -> Span -> Export
-    // By using the `__original` function the instrumentation can't intercept the call
-    // and no Span will be created breaking the vicious cycle
+    // In that case the instrumentation would create a new Span for this request,
+    // creating an indirect endless loop Export -> Span -> Export.
+    // `__original` lets the call bypass one wrapper; the suppressed context
+    // below covers a `fetch` that was wrapped more than once.
     let fetchApi = globalThis.fetch;
     // @ts-expect-error -- fetch could be wrapped
     if (typeof fetchApi.__original === 'function') {
@@ -87,20 +87,29 @@ class FetchTransport implements IExporterTransport {
       );
     }
 
+    // Captured before the first `await`, which a synchronous context manager
+    // would not survive.
+    const suppressedContext = suppressTracing(context.active());
+
     try {
       const url = new URL(this._parameters.url);
-      const response = await fetchApi(url.href, {
-        method: 'POST',
-        headers: await this._parameters.headers(),
-        body: data,
-        signal: abortController.signal,
-        keepalive: useKeepalive,
-        mode: globalThis.location
-          ? globalThis.location.origin === url.origin
-            ? 'same-origin'
-            : 'cors'
-          : 'no-cors',
-      });
+      // Unsuppressed on purpose: propagators skip injection under suppression,
+      // and `headers()` may inject propagation headers.
+      const headers = await this._parameters.headers();
+      const response = await context.with(suppressedContext, () =>
+        fetchApi(url.href, {
+          method: 'POST',
+          headers,
+          body: data,
+          signal: abortController.signal,
+          keepalive: useKeepalive,
+          mode: globalThis.location
+            ? globalThis.location.origin === url.origin
+              ? 'same-origin'
+              : 'cors'
+            : 'no-cors',
+        })
+      );
 
       if (response.status >= 200 && response.status <= 299) {
         diag.debug(`export response success (status: ${response.status})`);

--- a/experimental/packages/otlp-exporter-base/test/browser/TestStackContextManager.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/TestStackContextManager.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ContextManager, Context } from '@opentelemetry/api';
+import { ROOT_CONTEXT } from '@opentelemetry/api';
+
+/**
+ * A test-only ContextManager that uses an in-memory stack to keep track of
+ * the active context.
+ *
+ * This is not intended for advanced or asynchronous use cases.
+ */
+export class TestStackContextManager implements ContextManager {
+  private _contextStack: Context[] = [];
+
+  active(): Context {
+    return this._contextStack[this._contextStack.length - 1] ?? ROOT_CONTEXT;
+  }
+
+  with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
+    context: Context,
+    fn: F,
+    thisArg?: ThisParameterType<F>,
+    ...args: A
+  ): ReturnType<F> {
+    this._contextStack.push(context);
+    try {
+      return fn.call(thisArg, ...args);
+    } finally {
+      this._contextStack.pop();
+    }
+  }
+
+  bind<T>(context: Context, target: T): T {
+    throw new Error('Method not implemented.');
+  }
+
+  enable(): this {
+    return this;
+  }
+
+  disable(): this {
+    return this;
+  }
+}

--- a/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
@@ -5,6 +5,9 @@
 
 import * as sinon from 'sinon';
 import * as assert from 'assert';
+import { context, propagation } from '@opentelemetry/api';
+import { isTracingSuppressed, suppressTracing } from '@opentelemetry/core';
+import { TestStackContextManager } from './TestStackContextManager';
 import { createFetchTransport } from '../../src/transport/fetch-transport';
 import { createRetryingTransport } from '../../src/retrying-transport';
 import { registerMockDiagLogger } from '../common/test-utils';
@@ -228,6 +231,133 @@ describe('FetchTransport', function () {
         (result as ExportResponseFailure).error.message,
         'Fetch request errored'
       );
+    });
+  });
+
+  describe('suppressTracing context', function () {
+    afterEach(function () {
+      context.disable();
+    });
+
+    it('suppresses tracing for the fetch call when the caller already did so', function (done) {
+      context.setGlobalContextManager(new TestStackContextManager());
+
+      let suppressedDuringFetch: boolean | undefined;
+      sinon.stub(globalThis, 'fetch').callsFake(() => {
+        suppressedDuringFetch = isTracingSuppressed(context.active());
+        return Promise.resolve(new Response('', { status: 200 }));
+      });
+
+      const transport = createFetchTransport(testTransportParameters);
+
+      context.with(suppressTracing(context.active()), () => {
+        transport.send(testPayload, requestTimeout).then(response => {
+          try {
+            assert.strictEqual(response.status, 'success');
+            assert.strictEqual(
+              suppressedDuringFetch,
+              true,
+              'fetch must run with suppressTracing still active to avoid an export -> span -> export loop'
+            );
+          } catch (e) {
+            return done(e);
+          }
+          done();
+        }, done /* catch any rejections */);
+      });
+    });
+
+    it('carries the caller context into the fetch call', function (done) {
+      context.setGlobalContextManager(new TestStackContextManager());
+
+      let baggageDuringFetch: string | undefined;
+      sinon.stub(globalThis, 'fetch').callsFake(() => {
+        baggageDuringFetch = propagation
+          .getBaggage(context.active())
+          ?.getEntry('tenant')?.value;
+        return Promise.resolve(new Response('', { status: 200 }));
+      });
+
+      const transport = createFetchTransport(testTransportParameters);
+      const callerContext = propagation.setBaggage(
+        context.active(),
+        propagation.createBaggage({ tenant: { value: 'acme' } })
+      );
+
+      context.with(callerContext, () => {
+        transport.send(testPayload, requestTimeout).then(() => {
+          try {
+            assert.strictEqual(
+              baggageDuringFetch,
+              'acme',
+              'the caller context must still be active for the fetch call'
+            );
+          } catch (e) {
+            return done(e);
+          }
+          done();
+        }, done /* catch any rejections */);
+      });
+    });
+
+    it('suppresses tracing for the fetch call even when the caller did not', function (done) {
+      context.setGlobalContextManager(new TestStackContextManager());
+
+      let suppressedDuringFetch: boolean | undefined;
+      sinon.stub(globalThis, 'fetch').callsFake(() => {
+        suppressedDuringFetch = isTracingSuppressed(context.active());
+        return Promise.resolve(new Response('', { status: 200 }));
+      });
+
+      const transport = createFetchTransport(testTransportParameters);
+
+      assert.strictEqual(isTracingSuppressed(context.active()), false);
+      transport.send(testPayload, requestTimeout).then(response => {
+        try {
+          assert.strictEqual(response.status, 'success');
+          assert.strictEqual(
+            suppressedDuringFetch,
+            true,
+            'the transport must suppress tracing for its own request'
+          );
+        } catch (e) {
+          return done(e);
+        }
+        done();
+      }, done /* catch any rejections */);
+    });
+
+    it('suppresses tracing on retries, which run from a timer', function (done) {
+      context.setGlobalContextManager(new TestStackContextManager());
+
+      const suppressedPerAttempt: boolean[] = [];
+      let attempt = 0;
+      sinon.stub(globalThis, 'fetch').callsFake(() => {
+        suppressedPerAttempt.push(isTracingSuppressed(context.active()));
+        return Promise.resolve(
+          attempt++ === 0
+            ? new Response('', { status: 503, headers: { 'Retry-After': '0' } })
+            : new Response('', { status: 200 })
+        );
+      });
+
+      const transport = createRetryingTransport({
+        transport: createFetchTransport(testTransportParameters),
+      });
+
+      transport.send(testPayload, requestTimeout).then(response => {
+        try {
+          assert.strictEqual(response.status, 'success');
+          assert.deepStrictEqual(
+            suppressedPerAttempt,
+            [true, true],
+            'every attempt must run suppressed'
+          );
+        } catch (e) {
+          return done(e);
+        }
+        done();
+      }, done /* catch any rejections */);
     });
   });
 

--- a/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
@@ -267,6 +267,47 @@ describe('FetchTransport', function () {
       });
     });
 
+    it('keeps tracing suppressed when a third-party wrapper hides an instrumented fetch', async function () {
+      context.setGlobalContextManager(new TestStackContextManager());
+
+      const nativeFetch = sinon
+        .stub()
+        .resolves(new Response('', { status: 200 }));
+      let suppressedDuringInstrumentedFetch: boolean | undefined;
+      const instrumentedFetch = sinon
+        .stub()
+        .callsFake(
+          (...args: Parameters<typeof fetch>): ReturnType<typeof fetch> => {
+            suppressedDuringInstrumentedFetch = isTracingSuppressed(
+              context.active()
+            );
+            return nativeFetch(...args);
+          }
+        );
+      (
+        instrumentedFetch as unknown as { __original: typeof fetch }
+      ).__original = nativeFetch as unknown as typeof fetch;
+
+      // Simulate a third-party wrapper installed after the instrumentation.
+      // It calls the instrumented fetch but does not expose `__original`.
+      sinon.stub(globalThis, 'fetch').callsFake((...args) => {
+        return instrumentedFetch(...args);
+      });
+
+      const transport = createFetchTransport(testTransportParameters);
+      const response = await context.with(
+        suppressTracing(context.active()),
+        () => transport.send(testPayload, requestTimeout)
+      );
+
+      assert.strictEqual(response.status, 'success');
+      assert.strictEqual(
+        suppressedDuringInstrumentedFetch,
+        true,
+        'the hidden instrumentation wrapper must observe suppressed tracing'
+      );
+    });
+
     it('carries the caller context into the fetch call', function (done) {
       context.setGlobalContextManager(new TestStackContextManager());
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

When `globalThis.fetch` is wrapped by an instrumentation, every OTLP export request gets a span of its own, and every span triggers the next export, resulting in an unbounded export → span → export loop. The existing `__original` escape hatch only bypasses one wrapper, so a `fetch` wrapped multiple times can still loop.

The suppression that the span processor applies around `doExport()` does not help either. Since #5994, the transport has awaited the synchronous `headers()` factory before calling `fetch`, causing the browser's synchronous `StackContextManager` to lose the suppressed context at that `await`.

## Short description of the changes

- Capture the caller's context before the transport's first `await`, then call `fetch` within that context with tracing suppressed.
- Keep `headers()` unsuppressed so that a factory that injects propagation headers continues to work.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

New browser tests using a synchronous context manager assert that tracing is suppressed during the `fetch` call, both with and without a suppressed caller frame, including retries scheduled from a timer. They also assert that the caller's baggage remains available during the fetch call.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
