### PR TITLE
perf(api): add getGlobal fast-path

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 
 ### :house: Internal
 
+* perf(api): add getGlobal fast-path [#6956](https://github.com/open-telemetry/opentelemetry-js/pull/6956) @legendecas
+
 ## 1.9.1
 
 ### :bug: (Bug Fix)

--- a/api/package.json
+++ b/api/package.json
@@ -28,6 +28,7 @@
     "lint": "eslint . && npm run cycle-check",
     "test:browser": "karma start --single-run",
     "test": "nyc mocha 'test/**/*.test.ts'",
+    "test:bench": "node test/performance/benchmark/internal-benchmarks.js && node test/performance/benchmark/public-benchmarks.js | tee .benchmark-results.txt",
     "test:node8-compat": "node test/backcompat/node8-compat.js",
     "test:webworker": "karma start karma.worker.js --single-run",
     "cycle-check": "dpdm --exit-code circular:1 src/index.ts",

--- a/api/src/internal/global-utils.ts
+++ b/api/src/internal/global-utils.ts
@@ -32,17 +32,26 @@ const _global = (
           : {}
 ) as OTelGlobal;
 
+function _makeGlobalApi(): OTelGlobalAPI {
+  // The version property is sealed (non-writable, non-configurable) so it stays
+  // constant for the api object's lifetime. getGlobal caches its compatibility
+  // check per api-object identity and relies on that invariant.
+  return Object.defineProperty({} as OTelGlobalAPI, 'version', {
+    value: VERSION,
+    enumerable: true,
+    writable: false,
+    configurable: false,
+  });
+}
+
 export function registerGlobal<Type extends keyof OTelGlobalAPI>(
   type: Type,
   instance: OTelGlobalAPI[Type],
   diag: DiagLogger,
   allowOverride = false
 ): boolean {
-  const api = (_global[GLOBAL_OPENTELEMETRY_API_KEY] = _global[
-    GLOBAL_OPENTELEMETRY_API_KEY
-  ] ?? {
-    version: VERSION,
-  });
+  const api = (_global[GLOBAL_OPENTELEMETRY_API_KEY] =
+    _global[GLOBAL_OPENTELEMETRY_API_KEY] ?? _makeGlobalApi());
 
   if (!allowOverride && api[type]) {
     // already registered an API of this type
@@ -70,14 +79,27 @@ export function registerGlobal<Type extends keyof OTelGlobalAPI>(
   return true;
 }
 
+// The api object whose compatibility has already been verified. Its version is
+// sealed at registerGlobal, so a full compatibility check is only needed when
+// the object identity changes, letting the steady-state hot path skip it.
+let _compatibleGlobalApi: OTelGlobalAPI | undefined;
+
 export function getGlobal<Type extends keyof OTelGlobalAPI>(
   type: Type
 ): OTelGlobalAPI[Type] | undefined {
-  const globalVersion = _global[GLOBAL_OPENTELEMETRY_API_KEY]?.version;
-  if (!globalVersion || !isCompatible(globalVersion)) {
+  const api = _global[GLOBAL_OPENTELEMETRY_API_KEY];
+  if (api == null) {
     return;
   }
-  return _global[GLOBAL_OPENTELEMETRY_API_KEY]?.[type];
+  if (api !== _compatibleGlobalApi) {
+    // A new api object has been registered since the last time we checked, so
+    // verify its compatibility again.
+    if (!api.version || !isCompatible(api.version)) {
+      return;
+    }
+    _compatibleGlobalApi = api;
+  }
+  return api[type];
 }
 
 export function unregisterGlobal(type: keyof OTelGlobalAPI, diag: DiagLogger) {

--- a/api/test/common/internal/global.test.ts
+++ b/api/test/common/internal/global.test.ts
@@ -79,8 +79,10 @@ describe('Global Utils', function () {
     api1.diag.setLogger(logger1);
     const globalInstance = getGlobal('diag');
     assert.ok(globalInstance);
+    // The registered version property is sealed, so simulate a version mismatch
+    // by swapping in a global api object with a different version.
     // @ts-expect-error we are modifying internals for testing purposes here
-    globalThis[Symbol.for(GLOBAL_API_SYMBOL_KEY)].version = '0.0.1';
+    globalThis[Symbol.for(GLOBAL_API_SYMBOL_KEY)] = { version: '0.0.1' };
 
     assert.equal(false, api1.diag.setLogger(logger2)); // won't happen
 
@@ -88,6 +90,12 @@ describe('Global Utils', function () {
     sinon.assert.notCalled(logger2.error);
     sinon.assert.notCalled(logger2.info);
     sinon.assert.notCalled(logger2.warn);
+  });
+
+  it('should return undefined when the global api object is null', function () {
+    // @ts-expect-error we are modifying internals for testing purposes here
+    globalThis[Symbol.for(GLOBAL_API_SYMBOL_KEY)] = null;
+    assert.strictEqual(getGlobal('context'), undefined);
   });
 
   it('should debug log registrations', function () {

--- a/api/test/performance/benchmark/api-accessors.js
+++ b/api/test/performance/benchmark/api-accessors.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Public benchmark: the hot API accessors as end users call them. Each one
+// bottoms out in a getGlobal lookup against the global registry.
+
+const Benchmark = require('benchmark');
+const { context, trace } = require('../../../build/src');
+
+const ROOT_CONTEXT = {
+  getValue() {},
+  setValue() {
+    return ROOT_CONTEXT;
+  },
+  deleteValue() {
+    return ROOT_CONTEXT;
+  },
+};
+context.setGlobalContextManager({
+  active() {
+    return ROOT_CONTEXT;
+  },
+  with(_c, fn, thisArg, ...args) {
+    return fn.apply(thisArg, args);
+  },
+  bind(_c, target) {
+    return target;
+  },
+  enable() {
+    return this;
+  },
+  disable() {
+    return this;
+  },
+});
+const tracer = { startSpan() {}, startActiveSpan() {} };
+trace.setGlobalTracerProvider({
+  getTracer() {
+    return tracer;
+  },
+});
+
+const BATCH = 100;
+let sink = 0;
+
+const suite = new Benchmark.Suite();
+
+suite.on('cycle', event => {
+  console.log(String(event.target));
+});
+
+suite.add(`context.active() x${BATCH}`, () => {
+  let n = 0;
+  for (let i = 0; i < BATCH; i++) {
+    if (context.active() !== undefined) n++;
+  }
+  sink += n;
+});
+
+suite.add(`trace.getTracerProvider() x${BATCH}`, () => {
+  let n = 0;
+  for (let i = 0; i < BATCH; i++) {
+    if (trace.getTracerProvider() !== undefined) n++;
+  }
+  sink += n;
+});
+
+suite.run();
+
+if (sink < 0) {
+  throw new Error(`unreachable ${sink}`);
+}

--- a/api/test/performance/benchmark/get-global.js
+++ b/api/test/performance/benchmark/get-global.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Internal benchmark: isolates the global registry lookup that backs every
+// public API accessor (context.active, trace.getTracerProvider, etc.).
+//
+// Each case batches the nanosecond-level calls and makes the result observable.
+
+const Benchmark = require('benchmark');
+const { getGlobal } = require('../../../build/src/internal/global-utils');
+const { isCompatible } = require('../../../build/src/internal/semver');
+const { VERSION } = require('../../../build/src/version');
+const { context, trace } = require('../../../build/src');
+
+// Register globals so getGlobal takes its steady-state path (the realistic
+// "SDK installed" case): version read + compatibility check + type read.
+const ROOT_CONTEXT = {
+  getValue() {},
+  setValue() {
+    return ROOT_CONTEXT;
+  },
+  deleteValue() {
+    return ROOT_CONTEXT;
+  },
+};
+context.setGlobalContextManager({
+  active() {
+    return ROOT_CONTEXT;
+  },
+  with(_c, fn, thisArg, ...args) {
+    return fn.apply(thisArg, args);
+  },
+  bind(_c, target) {
+    return target;
+  },
+  enable() {
+    return this;
+  },
+  disable() {
+    return this;
+  },
+});
+const tracer = { startSpan() {}, startActiveSpan() {} };
+trace.setGlobalTracerProvider({
+  getTracer() {
+    return tracer;
+  },
+});
+
+const BATCH = 100;
+// Observed after the suite runs so V8 cannot treat the reads as dead code.
+let sink = 0;
+
+const suite = new Benchmark.Suite();
+
+suite.on('cycle', event => {
+  console.log(String(event.target));
+});
+
+suite.add(`getGlobal (registered) x${BATCH}`, () => {
+  let n = 0;
+  for (let i = 0; i < BATCH; i++) {
+    if (getGlobal('context') !== undefined) n++;
+  }
+  sink += n;
+});
+
+suite.add(`getGlobal (unregistered type) x${BATCH}`, () => {
+  let n = 0;
+  for (let i = 0; i < BATCH; i++) {
+    if (getGlobal('metrics') !== undefined) n++;
+  }
+  sink += n;
+});
+
+suite.add(`isCompatible (accepted version) x${BATCH}`, () => {
+  let n = 0;
+  for (let i = 0; i < BATCH; i++) {
+    if (isCompatible(VERSION)) n++;
+  }
+  sink += n;
+});
+
+suite.run();
+
+if (sink < 0) {
+  throw new Error(`unreachable ${sink}`);
+}

--- a/api/test/performance/benchmark/internal-benchmarks.js
+++ b/api/test/performance/benchmark/internal-benchmarks.js
@@ -1,0 +1,6 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+require('./get-global');

--- a/api/test/performance/benchmark/public-benchmarks.js
+++ b/api/test/performance/benchmark/public-benchmarks.js
@@ -1,0 +1,6 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+require('./api-accessors');


### PR DESCRIPTION
## Which problem is this PR solving?

In examples, documents and instrumentations, we use patterns like `api.context.active()` and `api.trace.setSpan(...)` a lot. However, the `isCompatible` check could be expensive even if it caches the version with a `Set.has` if the call count accumulates.

This adds a fast-path where the global api is rarely modified, as API registration happens way less frequent than `getGlobal()`. API registration usually only happens at startup time once.

One caveat is that this assumes that no one tries to modify the `global[GLOBAL_OPENTELEMETRY_API_KEY].version` on the same object `global[GLOBAL_OPENTELEMETRY_API_KEY]`. The `@opentelemetry/api` package itself does not do this, so the fast-path is compatible with existing `@opentelemetry/api` versions. This also seals the `global[GLOBAL_OPENTELEMETRY_API_KEY].version` to be non-writable and non-configurable to make sure that fast-path is always correct.


```
┌───────────────────────────┬───────────┬────────────┬─────────────┐
│         Benchmark         │ Main      │   New      │ Improvement │
├───────────────────────────┼───────────┼────────────┼─────────────┤
│ getGlobal (registered)    │ 3,372,280 │ 16,076,095 │ +377%       │
├───────────────────────────┼───────────┼────────────┼─────────────┤
│ getGlobal (unregistered)  │ 3,725,912 │ 21,017,474 │ +464%       │
├───────────────────────────┼───────────┼────────────┼─────────────┤
│ context.active()          │ 3,423,831 │ 10,616,871 │ +210%       │
├───────────────────────────┼───────────┼────────────┼─────────────┤
│ trace.getTracerProvider() │ 3,324,899 │ 12,627,415 │ +280%       │
└───────────────────────────┴───────────┴────────────┴─────────────┘
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] All existing tests should pass
- [x] Verify that if someone installs `null` to the `global[GLOBAL_OPENTELEMETRY_API_KEY]`.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
