### PR TITLE
chore(sampler-jaeger-remote): remove axios dependency

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -20,6 +20,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
+*refactor(sampler-jaeger-remote): remove `axios` dependency and use `fetch` to get the sampler configuration from Jaeger API [#6963](https://github.com/open-telemetry/opentelemetry-js/pull/6963) @david-luna
+
 ## 0.221.0
 
 ### :boom: Breaking Changes

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -20,7 +20,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :house: Internal
 
-*refactor(sampler-jaeger-remote): remove `axios` dependency and use `fetch` to get the sampler configuration from Jaeger API [#6963](https://github.com/open-telemetry/opentelemetry-js/pull/6963) @david-luna
+* refactor(sampler-jaeger-remote): remove `axios` dependency and use `fetch` to get the sampler configuration from Jaeger API [#6963](https://github.com/open-telemetry/opentelemetry-js/pull/6963) @david-luna
 
 ## 0.221.0
 

--- a/experimental/packages/sampler-jaeger-remote/package.json
+++ b/experimental/packages/sampler-jaeger-remote/package.json
@@ -41,8 +41,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/sdk-trace": "2.10.0",
-    "axios": "^1.15.0"
+    "@opentelemetry/sdk-trace": "2.10.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/experimental/packages/sampler-jaeger-remote/src/JaegerRemoteSampler.ts
+++ b/experimental/packages/sampler-jaeger-remote/src/JaegerRemoteSampler.ts
@@ -124,12 +124,12 @@ export class JaegerRemoteSampler implements Sampler {
     // the response is a protobuf mapped to JSON so `response.json()` will get the data parsed.
     const samplingUrl = `${this._endpoint}/sampling?service=${serviceName ?? ''}`;
     return fetch(samplingUrl)
-      .then(r => {
-        if (r.status < 200 || r.status >= 400) {
-          throw new Error(`Fetch sampling error(${r.status}): ${r.statusText}`);
+      .then(resp => {
+        if (resp.ok) {
+          return resp;
         }
-        return r;
+        throw new Error(`Fetch sampling error(${resp.status}): ${resp.statusText}`);
       })
-      .then(r => r.json()) as Promise<SamplingStrategyResponse>;
+      .then(resp => resp.json()) as Promise<SamplingStrategyResponse>;
   }
 }

--- a/experimental/packages/sampler-jaeger-remote/src/JaegerRemoteSampler.ts
+++ b/experimental/packages/sampler-jaeger-remote/src/JaegerRemoteSampler.ts
@@ -128,7 +128,9 @@ export class JaegerRemoteSampler implements Sampler {
         if (resp.ok) {
           return resp;
         }
-        throw new Error(`Fetch sampling error(${resp.status}): ${resp.statusText}`);
+        throw new Error(
+          `Fetch sampling error(${resp.status}): ${resp.statusText}`
+        );
       })
       .then(resp => resp.json()) as Promise<SamplingStrategyResponse>;
   }

--- a/experimental/packages/sampler-jaeger-remote/src/JaegerRemoteSampler.ts
+++ b/experimental/packages/sampler-jaeger-remote/src/JaegerRemoteSampler.ts
@@ -123,6 +123,13 @@ export class JaegerRemoteSampler implements Sampler {
     // As described in https://www.jaegertracing.io/docs/2.20/architecture/apis/#remote-sampling-apis
     // the response is a protobuf mapped to JSON so `response.json()` will get the data parsed.
     const samplingUrl = `${this._endpoint}/sampling?service=${serviceName ?? ''}`;
-    return fetch(samplingUrl).then(r => r.json()) as Promise<SamplingStrategyResponse>;
+    return fetch(samplingUrl)
+      .then(r => {
+        if (r.status < 200 || r.status >= 400) {
+          throw new Error(`Fetch sampling error(${r.status}): ${r.statusText}`);
+        }
+        return r;
+      })
+      .then(r => r.json()) as Promise<SamplingStrategyResponse>;
   }
 }

--- a/experimental/packages/sampler-jaeger-remote/src/JaegerRemoteSampler.ts
+++ b/experimental/packages/sampler-jaeger-remote/src/JaegerRemoteSampler.ts
@@ -10,7 +10,6 @@ import {
   ParentBasedSampler,
   TraceIdRatioBasedSampler,
 } from '@opentelemetry/sdk-trace';
-import * as axios from 'axios';
 import { PerOperationSampler } from './PerOperationSampler';
 import type { SamplingStrategyResponse } from './types';
 import { StrategyType } from './types';
@@ -121,9 +120,9 @@ export class JaegerRemoteSampler implements Sampler {
   private async getSamplerConfig(
     serviceName?: string
   ): Promise<SamplingStrategyResponse> {
-    const response = await axios.get<SamplingStrategyResponse>(
-      `${this._endpoint}/sampling?service=${serviceName ?? ''}`
-    );
-    return response.data;
+    // As described in https://www.jaegertracing.io/docs/2.20/architecture/apis/#remote-sampling-apis
+    // the response is a protobuf mapped to JSON so `response.json()` will get the data parsed.
+    const samplingUrl = `${this._endpoint}/sampling?service=${serviceName ?? ''}`;
+    return fetch(samplingUrl).then(r => r.json()) as Promise<SamplingStrategyResponse>;
   }
 }

--- a/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
+++ b/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
@@ -515,7 +515,7 @@ describe('JaegerRemoteSampler', () => {
       );
     });
 
-    it('Should keep inital sampler if endpoint fails.', async () => {
+    it('Should keep initial sampler if endpoint fails.', async () => {
       const jaegerRemoteSampler = new JaegerRemoteSampler({
         endpoint,
         serviceName: 'failingService',

--- a/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
+++ b/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
@@ -498,6 +498,33 @@ describe('JaegerRemoteSampler', () => {
       );
     });
 
+    it('Should keep inital sampler if endpoint fails.', async () => {
+      fetchStub.returns(new Response(
+        '',
+        {
+          status: 500,
+          statusText: 'Internal Server Error'
+        }
+      ));
+      const jaegerRemoteSampler = new JaegerRemoteSampler({
+        endpoint,
+        serviceName,
+        poolingInterval,
+        initialSampler: alwaysOnSampler,
+      });
+      await clock.tickAsync(poolingInterval);
+      sinon.assert.calledOnceWithExactly(
+        fetchStub,
+        `${endpoint}/sampling?service=${serviceName}`
+      );
+      // @ts-expect-error -- accessing internal property
+      const jaegerCurrentSampler = jaegerRemoteSampler._sampler;
+      assert.equal(
+        jaegerCurrentSampler,
+        alwaysOnSampler,
+      );
+    });
+
     it('Should pass endpoint and blank service name if nothing is provided.', async () => {
       new JaegerRemoteSampler({
         endpoint,

--- a/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
+++ b/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
@@ -477,7 +477,24 @@ describe('JaegerRemoteSampler', () => {
     let fetchStub: sinon.SinonStub;
 
     beforeEach(() => {
-      fetchStub = sinon.stub(globalThis, 'fetch');
+      fetchStub = sinon.stub(globalThis, 'fetch').callsFake((input) => {
+        const url = new URL(input);
+        let response;
+
+        if (url.searchParams.get('service') === 'failingService') {
+          response = new Response('', { status: 500 });
+        } else {
+          const payload = {
+            strategyType: 'PROBABILISTIC',
+            probabilisticSampling: { samplingRate: 1 },
+          };
+          response = new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return Promise.resolve(response);
+      });
     });
 
     afterEach(() => {
@@ -499,30 +516,20 @@ describe('JaegerRemoteSampler', () => {
     });
 
     it('Should keep inital sampler if endpoint fails.', async () => {
-      fetchStub.returns(new Response(
-        '',
-        {
-          status: 500,
-          statusText: 'Internal Server Error'
-        }
-      ));
       const jaegerRemoteSampler = new JaegerRemoteSampler({
         endpoint,
-        serviceName,
+        serviceName: 'failingService',
         poolingInterval,
         initialSampler: alwaysOnSampler,
       });
       await clock.tickAsync(poolingInterval);
       sinon.assert.calledOnceWithExactly(
         fetchStub,
-        `${endpoint}/sampling?service=${serviceName}`
+        `${endpoint}/sampling?service=failingService`
       );
       // @ts-expect-error -- accessing internal property
       const jaegerCurrentSampler = jaegerRemoteSampler._sampler;
-      assert.equal(
-        jaegerCurrentSampler,
-        alwaysOnSampler,
-      );
+      assert.equal(jaegerCurrentSampler, alwaysOnSampler);
     });
 
     it('Should pass endpoint and blank service name if nothing is provided.', async () => {

--- a/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
+++ b/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
@@ -477,7 +477,7 @@ describe('JaegerRemoteSampler', () => {
     let fetchStub: sinon.SinonStub;
 
     beforeEach(() => {
-      fetchStub = sinon.stub(globalThis, 'fetch').callsFake((input) => {
+      fetchStub = sinon.stub(globalThis, 'fetch').callsFake(input => {
         const url = new URL(input);
         let response;
 

--- a/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
+++ b/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
@@ -19,7 +19,6 @@ import type { SamplingStrategyResponse } from '../src/types';
 import { StrategyType } from '../src/types';
 import { PerOperationSampler } from '../src/PerOperationSampler';
 import { randomSamplingProability } from './utils';
-import * as axios from 'axios';
 
 describe('JaegerRemoteSampler', () => {
   const endpoint = 'http://localhost:5778';
@@ -478,7 +477,7 @@ describe('JaegerRemoteSampler', () => {
     let axiosGetStub: sinon.SinonStub;
 
     beforeEach(() => {
-      axiosGetStub = sinon.stub(axios, 'get');
+      axiosGetStub = sinon.stub(globalThis, 'fetch');
     });
 
     afterEach(() => {

--- a/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
+++ b/experimental/packages/sampler-jaeger-remote/test/JaegerRemoteSampler.test.ts
@@ -474,14 +474,14 @@ describe('JaegerRemoteSampler', () => {
   });
 
   describe('getSamplerConfig', () => {
-    let axiosGetStub: sinon.SinonStub;
+    let fetchStub: sinon.SinonStub;
 
     beforeEach(() => {
-      axiosGetStub = sinon.stub(globalThis, 'fetch');
+      fetchStub = sinon.stub(globalThis, 'fetch');
     });
 
     afterEach(() => {
-      axiosGetStub.restore();
+      fetchStub.restore();
     });
 
     it('Should pass endpoint and service name.', async () => {
@@ -493,7 +493,7 @@ describe('JaegerRemoteSampler', () => {
       });
       await clock.tickAsync(poolingInterval);
       sinon.assert.calledOnceWithExactly(
-        axiosGetStub,
+        fetchStub,
         `${endpoint}/sampling?service=${serviceName}`
       );
     });
@@ -507,7 +507,7 @@ describe('JaegerRemoteSampler', () => {
       });
       await clock.tickAsync(poolingInterval);
       sinon.assert.calledOnceWithExactly(
-        axiosGetStub,
+        fetchStub,
         `${endpoint}/sampling?service=`
       );
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2057,8 +2057,7 @@
       "version": "0.221.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-trace": "2.10.0",
-        "axios": "^1.15.0"
+        "@opentelemetry/sdk-trace": "2.10.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "1.9.1",


### PR DESCRIPTION
## Which problem is this PR solving?

Removes dependency from `axios` in `@opentelemetry/sampler-jaeger-remote` since it's only used to make a get request to the sampler API endpoint ([ref](https://www.jaegertracing.io/docs/2.20/architecture/apis/#remote-sampling-apis)).

## Short description of the changes

- remove `axios` from dependencies
- refactor code to use the `fetch` nodejs API

## Type of change

Please delete options that are not relevant.

- [X] Refactor (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [X] Unit tests
- [ ] Test package with a real Jaeger backend

## Checklist:

- [X] Followed the style guidelines of this project
- [X] Unit tests have been updated
