### PR TITLE
chore: Only need to approve major/minor updates & split updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -41,12 +41,13 @@
     },
     {
       "matchPackageNames": ["typescript", "lerna"],
-      "matchUpdateTypes": ["major"],
+      "matchUpdateTypes": ["major", "minor"],
       "dependencyDashboardApproval": true
     },
     {
       "matchPackageNames": ["typescript", "lerna"],
-      "separateMultipleMajor": true
+      "separateMultipleMajor": true,
+      "separateMultipleMinor": true
     }
   ],
   "lockFileMaintenance": {

--- a/renovate.json5
+++ b/renovate.json5
@@ -41,7 +41,12 @@
     },
     {
       "matchPackageNames": ["typescript", "lerna"],
+      "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true
+    },
+    {
+      "matchPackageNames": ["typescript", "lerna"],
+      "separateMultipleMajor": true
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
## Which problem is this PR solving?

Currently the renovate dashboard in offering the ability to update typescript to 5.96 or 7, there is no 6. Also 5.9.6 is minor which shouldn’t need approval.

## Short description of the changes

- scope dashboard approval to only apply to major for typescript/lerna
- Add additional rule for typescript/lerna to split multiple majors