### PR TITLE
docs(configuration): document ConfigModel suffix naming convention

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -18,6 +18,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :books: Documentation
 
+* docs(configuration): document the `ConfigModel` suffix naming convention for exported types [#6612](https://github.com/open-telemetry/opentelemetry-js/issues/6612) @vedantchalke36
+
 ### :house: Internal
 
 * refactor(sampler-jaeger-remote): remove `axios` dependency and use `fetch` to get the sampler configuration from Jaeger API [#6963](https://github.com/open-telemetry/opentelemetry-js/pull/6963) @david-luna

--- a/experimental/packages/configuration/README.md
+++ b/experimental/packages/configuration/README.md
@@ -139,6 +139,12 @@ When no config file is set, the factory reads from the standard OpenTelemetry SD
 
 See [`src/EnvironmentConfigFactory.ts`](src/EnvironmentConfigFactory.ts) for the exact parsing logic.
 
+## Exported types
+
+Types exported from this package that model configuration data use a `ConfigModel` suffix (e.g. `SamplerConfigModel`, `SpanExporterConfigModel`) rather than their schema name (e.g. `Sampler`, `SpanExporter`). This keeps them from colliding with the SDK runtime types of the same name. The root type is `ConfigurationModel`.
+
+Internally the package uses the schema names from `src/generated/types.ts`; the renaming happens at export time in `src/index.ts`. Follow this convention when adding new exports.
+
 ## Development
 
 ### Generated files

--- a/experimental/packages/configuration/src/index.ts
+++ b/experimental/packages/configuration/src/index.ts
@@ -3,6 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Naming convention for types exported from this package: configuration
+// types use the `ConfigModel` suffix (e.g. `SamplerConfigModel`) rather than
+// their schema name (e.g. `Sampler`) so that they don't collide with the SDK
+// runtime types of the same name. Internally the package uses the schema
+// names from `./generated/types`; the renaming happens at export time here.
+// Follow this convention when adding new exports.
+
 export type { ConfigFactory } from './IConfigFactory';
 export type {
   ConfigurationModel,


### PR DESCRIPTION
## Summary

Part of the type-naming discussion in #6612. The maintainers agreed in the issue comments to:

1. Keep the rename-on-export pattern (`Sampler` -> `SamplerConfigModel`), which is already in place.
2. Add a comment in `src/index.ts` explaining the convention so future contributors follow it.
3. Document the convention in the configuration package README.

This PR implements points 2 and 3, closing out the issue.

## Changes

- `experimental/packages/configuration/src/index.ts`: added a comment at the top of the file explaining the `ConfigModel` suffix naming convention (schema names internally, `ConfigModel`-suffixed names at export time to avoid collisions with SDK runtime types).
- `experimental/packages/configuration/README.md`: added an "Exported types" section documenting the convention.
- `experimental/CHANGELOG.md`: added a documentation entry under Unreleased.

## Checklist

- [x] Followed the project's contributing guidelines
- [x] Added a changelog entry