### PR TITLE
fix(sdk-trace, sdk-logs): invoke all lifecycle processors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-trace): invoke all lifecycle processors during flush and shutdown #6980 @teamleaderleo
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,6 +16,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-logs): invoke all lifecycle processors during flush and shutdown [#6980](https://github.com/open-telemetry/opentelemetry-js/pull/6980) @teamleaderleo
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/experimental/packages/sdk-logs/src/MultiLogRecordProcessor.ts
+++ b/experimental/packages/sdk-logs/src/MultiLogRecordProcessor.ts
@@ -22,10 +22,11 @@ export class MultiLogRecordProcessor implements LogRecordProcessor {
   }
 
   public async forceFlush(options?: ForceFlushOptions): Promise<void> {
+    const processors = this.processors.slice();
     const timeout = options?.timeoutMillis ?? 30000;
     await Promise.all(
-      this.processors.map(processor =>
-        callWithTimeout(processor.forceFlush(), timeout)
+      processors.map(processor =>
+        callLifecycle(() => callWithTimeout(processor.forceFlush(), timeout))
       )
     );
   }
@@ -37,7 +38,10 @@ export class MultiLogRecordProcessor implements LogRecordProcessor {
   }
 
   public async shutdown(): Promise<void> {
-    await Promise.all(this.processors.map(processor => processor.shutdown()));
+    const processors = this.processors.slice();
+    await Promise.all(
+      processors.map(processor => callLifecycle(() => processor.shutdown()))
+    );
   }
 
   public enabled(options: {
@@ -52,5 +56,13 @@ export class MultiLogRecordProcessor implements LogRecordProcessor {
       }
     }
     return false;
+  }
+}
+
+function callLifecycle(callback: () => Promise<void>): Promise<void> {
+  try {
+    return callback();
+  } catch (error) {
+    return Promise.reject(error);
   }
 }

--- a/experimental/packages/sdk-logs/test/common/MultiLogRecordProcessor.attempt-all.test.ts
+++ b/experimental/packages/sdk-logs/test/common/MultiLogRecordProcessor.attempt-all.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import type { LogRecordProcessor } from '../../src';
+import { MultiLogRecordProcessor } from '../../src/MultiLogRecordProcessor';
+
+describe('MultiLogRecordProcessor attempt-all lifecycle', () => {
+  it('rejects shutdown after attempting every processor', async () => {
+    const error = new Error('logs shutdown failure');
+    let firstCalls = 0;
+    let secondCalls = 0;
+    const first: LogRecordProcessor = {
+      onEmit() {},
+      forceFlush: () => Promise.resolve(),
+      shutdown: () => {
+        firstCalls += 1;
+        throw error;
+      },
+    };
+    const second: LogRecordProcessor = {
+      onEmit() {},
+      forceFlush: () => Promise.resolve(),
+      shutdown: () => {
+        secondCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    const processor = new MultiLogRecordProcessor([first, second]);
+
+    await assert.rejects(
+      processor.shutdown(),
+      candidate => candidate === error
+    );
+    assert.strictEqual(firstCalls, 1);
+    assert.strictEqual(secondCalls, 1);
+  });
+
+  it('uses the opening processor snapshot during shutdown', async () => {
+    const processors: LogRecordProcessor[] = [];
+    let secondCalls = 0;
+    const first: LogRecordProcessor = {
+      onEmit() {},
+      forceFlush: () => Promise.resolve(),
+      shutdown: () => {
+        processors.splice(1, 1);
+        return Promise.resolve();
+      },
+    };
+    const second: LogRecordProcessor = {
+      onEmit() {},
+      forceFlush: () => Promise.resolve(),
+      shutdown: () => {
+        secondCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    processors.push(first, second);
+
+    await new MultiLogRecordProcessor(processors).shutdown();
+
+    assert.strictEqual(secondCalls, 1);
+    assert.deepStrictEqual(processors, [first]);
+  });
+
+  it('rejects forceFlush after attempting every processor', async () => {
+    const error = new Error('logs forceFlush failure');
+    let firstCalls = 0;
+    let secondCalls = 0;
+    const first: LogRecordProcessor = {
+      onEmit() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => {
+        firstCalls += 1;
+        throw error;
+      },
+    };
+    const second: LogRecordProcessor = {
+      onEmit() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => {
+        secondCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    const processor = new MultiLogRecordProcessor([first, second]);
+
+    await assert.rejects(
+      processor.forceFlush(),
+      candidate => candidate === error
+    );
+    assert.strictEqual(firstCalls, 1);
+    assert.strictEqual(secondCalls, 1);
+  });
+
+  it('uses the opening processor snapshot during forceFlush', async () => {
+    const processors: LogRecordProcessor[] = [];
+    let secondCalls = 0;
+    const first: LogRecordProcessor = {
+      onEmit() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => {
+        processors.splice(1, 1);
+        return Promise.resolve();
+      },
+    };
+    const second: LogRecordProcessor = {
+      onEmit() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => {
+        secondCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    processors.push(first, second);
+
+    await new MultiLogRecordProcessor(processors).forceFlush();
+
+    assert.strictEqual(secondCalls, 1);
+    assert.deepStrictEqual(processors, [first]);
+  });
+});

--- a/packages/sdk-trace/src/MultiSpanProcessor.ts
+++ b/packages/sdk-trace/src/MultiSpanProcessor.ts
@@ -20,10 +20,11 @@ export class MultiSpanProcessor implements SpanProcessor {
   }
 
   forceFlush(): Promise<void> {
+    const spanProcessors = this._spanProcessors.slice();
     const promises: Promise<void>[] = [];
 
-    for (const spanProcessor of this._spanProcessors) {
-      promises.push(spanProcessor.forceFlush());
+    for (const spanProcessor of spanProcessors) {
+      promises.push(callLifecycle(() => spanProcessor.forceFlush()));
     }
     return new Promise(resolve => {
       Promise.all(promises)
@@ -60,15 +61,24 @@ export class MultiSpanProcessor implements SpanProcessor {
   }
 
   shutdown(): Promise<void> {
+    const spanProcessors = this._spanProcessors.slice();
     const promises: Promise<void>[] = [];
 
-    for (const spanProcessor of this._spanProcessors) {
-      promises.push(spanProcessor.shutdown());
+    for (const spanProcessor of spanProcessors) {
+      promises.push(callLifecycle(() => spanProcessor.shutdown()));
     }
     return new Promise((resolve, reject) => {
       Promise.all(promises).then(() => {
         resolve();
       }, reject);
     });
+  }
+}
+
+function callLifecycle(callback: () => Promise<void>): Promise<void> {
+  try {
+    return callback();
+  } catch (error) {
+    return Promise.reject(error);
   }
 }

--- a/packages/sdk-trace/src/TracerProvider.ts
+++ b/packages/sdk-trace/src/TracerProvider.ts
@@ -100,36 +100,34 @@ export class TracerProvider implements ApiTracerProvider {
 
   forceFlush(options?: ForceFlushOptions): Promise<void> {
     const timeout = options?.timeoutMillis ?? this._forceFlushTimeoutMillis;
-    const promises = this._activeSpanProcessor['_spanProcessors'].map(
-      (spanProcessor: SpanProcessor) => {
-        return new Promise(resolve => {
-          let state: ForceFlushState;
-          const timeoutInterval = setTimeout(() => {
-            resolve(
-              new Error(
-                `Span processor did not completed within timeout period of ${timeout} ms`
-              )
-            );
-            state = ForceFlushState.timeout;
-          }, timeout);
+    const spanProcessors = this._activeSpanProcessor['_spanProcessors'].slice();
+    const promises = spanProcessors.map((spanProcessor: SpanProcessor) => {
+      return new Promise(resolve => {
+        let state: ForceFlushState;
+        const timeoutInterval = setTimeout(() => {
+          resolve(
+            new Error(
+              `Span processor did not completed within timeout period of ${timeout} ms`
+            )
+          );
+          state = ForceFlushState.timeout;
+        }, timeout);
 
-          spanProcessor
-            .forceFlush()
-            .then(() => {
-              clearTimeout(timeoutInterval);
-              if (state !== ForceFlushState.timeout) {
-                state = ForceFlushState.resolved;
-                resolve(state);
-              }
-            })
-            .catch(error => {
-              clearTimeout(timeoutInterval);
-              state = ForceFlushState.error;
-              resolve(error);
-            });
-        });
-      }
-    );
+        callLifecycle(() => spanProcessor.forceFlush())
+          .then(() => {
+            clearTimeout(timeoutInterval);
+            if (state !== ForceFlushState.timeout) {
+              state = ForceFlushState.resolved;
+              resolve(state);
+            }
+          })
+          .catch(error => {
+            clearTimeout(timeoutInterval);
+            state = ForceFlushState.error;
+            resolve(error);
+          });
+      });
+    });
 
     return new Promise<void>((resolve, reject) => {
       Promise.all(promises)
@@ -167,5 +165,13 @@ export class TracerProvider implements ApiTracerProvider {
       ),
     };
     return formatInspect('TracerProvider', payload, depth, options, inspect);
+  }
+}
+
+function callLifecycle(callback: () => Promise<void>): Promise<void> {
+  try {
+    return callback();
+  } catch (error) {
+    return Promise.reject(error);
   }
 }

--- a/packages/sdk-trace/test/common/MultiSpanProcessor.attempt-all.test.ts
+++ b/packages/sdk-trace/test/common/MultiSpanProcessor.attempt-all.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import {
+  loggingErrorHandler,
+  setGlobalErrorHandler,
+} from '@opentelemetry/core';
+import type { SpanProcessor } from '../../src';
+import { MultiSpanProcessor } from '../../src/MultiSpanProcessor';
+
+describe('MultiSpanProcessor attempt-all lifecycle', () => {
+  afterEach(() => {
+    setGlobalErrorHandler(loggingErrorHandler());
+  });
+
+  it('rejects shutdown after attempting every processor', async () => {
+    const error = new Error('trace shutdown failure');
+    let firstCalls = 0;
+    let secondCalls = 0;
+    const first: SpanProcessor = {
+      onStart() {},
+      onEnd() {},
+      forceFlush: () => Promise.resolve(),
+      shutdown: () => {
+        firstCalls += 1;
+        throw error;
+      },
+    };
+    const second: SpanProcessor = {
+      onStart() {},
+      onEnd() {},
+      forceFlush: () => Promise.resolve(),
+      shutdown: () => {
+        secondCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    const processor = new MultiSpanProcessor([first, second]);
+
+    await assert.rejects(
+      processor.shutdown(),
+      candidate => candidate === error
+    );
+    assert.strictEqual(firstCalls, 1);
+    assert.strictEqual(secondCalls, 1);
+  });
+
+  it('uses the opening processor snapshot during shutdown', async () => {
+    const processors: SpanProcessor[] = [];
+    let secondCalls = 0;
+    const first: SpanProcessor = {
+      onStart() {},
+      onEnd() {},
+      forceFlush: () => Promise.resolve(),
+      shutdown: () => {
+        processors.splice(1, 1);
+        return Promise.resolve();
+      },
+    };
+    const second: SpanProcessor = {
+      onStart() {},
+      onEnd() {},
+      forceFlush: () => Promise.resolve(),
+      shutdown: () => {
+        secondCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    processors.push(first, second);
+
+    await new MultiSpanProcessor(processors).shutdown();
+
+    assert.strictEqual(secondCalls, 1);
+    assert.deepStrictEqual(processors, [first]);
+  });
+
+  it('reports forceFlush failure after attempting every processor', async () => {
+    const error = new Error('trace forceFlush failure');
+    let firstCalls = 0;
+    let secondCalls = 0;
+    let handledError: unknown;
+    setGlobalErrorHandler(candidate => {
+      handledError = candidate;
+    });
+    const first: SpanProcessor = {
+      onStart() {},
+      onEnd() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => {
+        firstCalls += 1;
+        throw error;
+      },
+    };
+    const second: SpanProcessor = {
+      onStart() {},
+      onEnd() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => {
+        secondCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    const processor = new MultiSpanProcessor([first, second]);
+
+    await processor.forceFlush();
+    assert.strictEqual(firstCalls, 1);
+    assert.strictEqual(secondCalls, 1);
+    assert.strictEqual(handledError, error);
+  });
+
+  it('uses the opening processor snapshot during forceFlush', async () => {
+    const processors: SpanProcessor[] = [];
+    let secondCalls = 0;
+    const first: SpanProcessor = {
+      onStart() {},
+      onEnd() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => {
+        processors.splice(1, 1);
+        return Promise.resolve();
+      },
+    };
+    const second: SpanProcessor = {
+      onStart() {},
+      onEnd() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => {
+        secondCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    processors.push(first, second);
+
+    await new MultiSpanProcessor(processors).forceFlush();
+
+    assert.strictEqual(secondCalls, 1);
+    assert.deepStrictEqual(processors, [first]);
+  });
+});

--- a/packages/sdk-trace/test/common/TracerProvider.attempt-all.test.ts
+++ b/packages/sdk-trace/test/common/TracerProvider.attempt-all.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import type { SpanProcessor } from '../../src';
+import { TracerProvider } from '../../src';
+
+describe('TracerProvider attempt-all lifecycle', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('rejects after a synchronous throw without leaving its timeout armed', async () => {
+    const clock = sinon.useFakeTimers();
+    const error = new Error('trace provider forceFlush failure');
+    let firstCalls = 0;
+    let secondCalls = 0;
+    const first: SpanProcessor = {
+      onStart() {},
+      onEnd() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => {
+        firstCalls += 1;
+        throw error;
+      },
+    };
+    const second: SpanProcessor = {
+      onStart() {},
+      onEnd() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => {
+        secondCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    const provider = new TracerProvider({
+      spanProcessors: [first, second],
+    });
+
+    await assert.rejects(
+      provider.forceFlush({ timeoutMillis: 1000 }),
+      candidate =>
+        Array.isArray(candidate) &&
+        candidate.length === 1 &&
+        candidate[0] === error
+    );
+
+    assert.strictEqual(firstCalls, 1);
+    assert.strictEqual(secondCalls, 1);
+    assert.strictEqual(clock.countTimers(), 0);
+
+    await provider.shutdown();
+  });
+
+  it('uses the opening processor snapshot during forceFlush', async () => {
+    const processors: SpanProcessor[] = [];
+    let secondCalls = 0;
+    const first: SpanProcessor = {
+      onStart() {},
+      onEnd() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => {
+        processors.splice(1, 1);
+        return Promise.resolve();
+      },
+    };
+    const second: SpanProcessor = {
+      onStart() {},
+      onEnd() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => {
+        secondCalls += 1;
+        return Promise.resolve();
+      },
+    };
+    processors.push(first, second);
+
+    const provider = new TracerProvider({ spanProcessors: processors });
+    await provider.forceFlush();
+
+    assert.strictEqual(secondCalls, 1);
+    assert.deepStrictEqual(processors, [first]);
+
+    processors.push(second);
+    await provider.shutdown();
+  });
+
+  it('preserves timeout rejection for a processor that does not settle', async () => {
+    const clock = sinon.useFakeTimers();
+    const processor: SpanProcessor = {
+      onStart() {},
+      onEnd() {},
+      shutdown: () => Promise.resolve(),
+      forceFlush: () => new Promise<void>(() => {}),
+    };
+    const provider = new TracerProvider({
+      spanProcessors: [processor],
+    });
+
+    const result = provider.forceFlush({ timeoutMillis: 1000 });
+    await clock.tickAsync(1000);
+
+    await assert.rejects(
+      result,
+      candidate =>
+        Array.isArray(candidate) &&
+        candidate.length === 1 &&
+        candidate[0] instanceof Error
+    );
+    assert.strictEqual(clock.countTimers(), 0);
+
+    await provider.shutdown();
+  });
+});


### PR DESCRIPTION
## Which problem is this PR solving?

Trace and log processor fanout can skip processors that were present when `shutdown()` or `forceFlush()` began.

A processor that throws synchronously can stop construction of later promise inputs. A processor can also mutate the retained processor array during fanout and remove another processor from the current operation. In `TracerProvider.forceFlush()`, a synchronous throw can bypass the normal rejection path and leave that processor's timeout armed until expiry.

This change keeps the existing result and error policies while ensuring every processor in the opening set receives its lifecycle call. It adds no dependencies and makes no public API or configuration changes.

Fixes #6977

## Short description of the changes

- Snapshot trace and log processor lists before lifecycle fanout begins.
- Convert direct synchronous lifecycle throws into rejected promises.
- Preserve the existing trace, logs, and provider settlement policies.
- Clear `TracerProvider.forceFlush()` timers through the existing failure path.
- Add regression tests for synchronous throws, opening-set mutation, timer cleanup, error shape, and genuine timeout behavior.

Metrics remains out of scope because its collector list is internally constructed and its lifecycle methods already cross an asynchronous boundary.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Eleven regression tests cover:

- `MultiSpanProcessor.forceFlush()` and `shutdown()`;
- `MultiLogRecordProcessor.forceFlush()` and `shutdown()`;
- direct synchronous throws without skipping later processors;
- mutation of the caller-retained processor array;
- provider error-array preservation and timeout cleanup;
- a genuinely non-settling processor still timing out.

The candidate tree has passed the repository's Unit Tests, Lint, E2E, Bundler, W3C Trace Context, CodeQL, API peer-dependency, and security-analysis workflows.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation is not required because this change does not alter public APIs or configuration

Changelog entries are included for the stable trace SDK and experimental logs SDK.