### PR TITLE
fix(sdk-node): keep propagation enabled when SDK is disabled

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -16,6 +16,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-node): keep propagation enabled when the SDK is disabled [#6983](https://github.com/open-telemetry/opentelemetry-js/pull/6983) @vincentkoc
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -230,7 +230,7 @@ export class NodeSDK {
       diag.warn(
         "The 'metricReader' option is deprecated. Please use 'metricReaders' instead."
       );
-    } else {
+    } else if (!this._disabled) {
       this._meterProviderConfig = {
         readers: getMetricReadersFromEnv(),
         views: configuration.views,
@@ -244,6 +244,13 @@ export class NodeSDK {
    * Call this method to construct SDK components and register them with the OpenTelemetry API.
    */
   public start(): void {
+    setupContextManager(this._configuration?.contextManager);
+    setupPropagator(
+      this._configuration?.textMapPropagator === null
+        ? null // null means don't set, so we cannot fall back to env config.
+        : (this._configuration?.textMapPropagator ?? getPropagatorFromEnv())
+    );
+
     if (this._disabled) {
       return;
     }
@@ -251,13 +258,6 @@ export class NodeSDK {
     registerInstrumentations({
       instrumentations: this._instrumentations,
     });
-
-    setupContextManager(this._configuration?.contextManager);
-    setupPropagator(
-      this._configuration?.textMapPropagator === null
-        ? null // null means don't set, so we cannot fall back to env config.
-        : (this._configuration?.textMapPropagator ?? getPropagatorFromEnv())
-    );
 
     if (this._autoDetectResources) {
       const internalConfig: ResourceDetectionConfig = {

--- a/experimental/packages/opentelemetry-sdk-node/src/start.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/start.ts
@@ -75,12 +75,27 @@ export function startNodeSDK(sdkOptions?: SDKOptions): {
     return NOOP_SDK;
   }
 
-  if (config.disabled) {
-    return NOOP_SDK;
-  }
-
   const logLevel = diagLogLevelFromSeverityNumberConfig(config.log_level);
   diag.setLogger(new DiagConsoleLogger(), { logLevel });
+
+  if (config.disabled) {
+    const components: SDKComponents = {};
+    try {
+      components.contextManager = new AsyncLocalStorageContextManager();
+      components.contextManager.enable();
+      components.propagator = getPropagator(config, sdkOptions);
+    } catch (createErr) {
+      diag.error(`Could not create OpenTelemetry SDK: ${createErr.message}`);
+      return NOOP_SDK;
+    }
+    if (components.contextManager) {
+      context.setGlobalContextManager(components.contextManager);
+    }
+    if (components.propagator) {
+      propagation.setGlobalPropagator(components.propagator);
+    }
+    return NOOP_SDK;
+  }
 
   registerInstrumentations({
     instrumentations: sdkOptions?.instrumentations?.flat() ?? [],
@@ -140,13 +155,7 @@ function create(
 
     const resource = setupResource(config, sdkOptions);
 
-    if (sdkOptions?.textMapPropagator !== undefined) {
-      if (sdkOptions.textMapPropagator !== null) {
-        components.propagator = sdkOptions.textMapPropagator;
-      }
-    } else if (config.propagator) {
-      components.propagator = createPropagatorFromConfig(config.propagator);
-    }
+    components.propagator = getPropagator(config, sdkOptions);
 
     if (config.logger_provider) {
       components.loggerProvider = createLoggerProviderFromConfig(
@@ -200,6 +209,18 @@ function create(
 
     throw createErr;
   }
+}
+
+function getPropagator(
+  config: ConfigurationModel,
+  sdkOptions?: SDKOptions
+): SDKComponents['propagator'] {
+  if (sdkOptions?.textMapPropagator !== undefined) {
+    return sdkOptions.textMapPropagator ?? undefined;
+  }
+  return config.propagator
+    ? createPropagatorFromConfig(config.propagator)
+    : undefined;
 }
 
 export function setupResource(

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -67,10 +67,17 @@ import { OTLPLogExporter as OTLPGrpcLogExporter } from '@opentelemetry/exporter-
 import { OTLPTraceExporter as OTLPProtoTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import { OTLPTraceExporter as OTLPGrpcTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { ZipkinExporter } from '@opentelemetry/exporter-zipkin';
+import { InstrumentationBase } from '@opentelemetry/instrumentation';
 
 import { NOOP_COUNTER_METRIC } from '../../../../api/src/metrics/NoopMeter';
 import { ATTR_HOST_NAME, ATTR_PROCESS_PID } from '../src/semconv';
 import { NOOP_HISTOGRAM_METRIC } from '../../../../api/src/metrics/NoopMeter';
+
+class TestInstrumentation extends InstrumentationBase {
+  init() {
+    return [];
+  }
+}
 
 function assertDefaultContextManagerRegistered() {
   assert.ok(
@@ -87,6 +94,24 @@ function assertDefaultPropagatorRegistered() {
   ]);
 }
 
+function assertTraceContextAndBaggagePropagation() {
+  assertDefaultPropagatorRegistered();
+
+  const extracted = propagation.extract(context.active(), {
+    traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+    baggage: 'test=value',
+  });
+
+  assert.strictEqual(
+    trace.getSpanContext(extracted)?.traceId,
+    '4bf92f3577b34da6a3ce929d0e0e4736'
+  );
+  assert.strictEqual(
+    propagation.getBaggage(extracted)?.getEntry('test')?.value,
+    'value'
+  );
+}
+
 function clearOTelEnv() {
   for (const key of Object.keys(process.env)) {
     if (key.startsWith('OTEL_')) {
@@ -98,6 +123,7 @@ function clearOTelEnv() {
 describe('NodeSDK', () => {
   let setGlobalTracerProviderSpy: Sinon.SinonSpy;
   let setGlobalLoggerProviderSpy: Sinon.SinonSpy;
+  let setGlobalMeterProviderSpy: Sinon.SinonSpy;
 
   beforeEach(() => {
     diag.disable();
@@ -109,6 +135,7 @@ describe('NodeSDK', () => {
 
     setGlobalTracerProviderSpy = Sinon.spy(trace, 'setGlobalTracerProvider');
     setGlobalLoggerProviderSpy = Sinon.spy(logs, 'setGlobalLoggerProvider');
+    setGlobalMeterProviderSpy = Sinon.spy(metrics, 'setGlobalMeterProvider');
 
     // need to set these to none, since the default value is 'otlp'. Tests either
     // provide exporters programatically or reset to an appropriate value.
@@ -1166,21 +1193,62 @@ describe('NodeSDK', () => {
 
   describe('A disabled SDK should be no-op', () => {
     beforeEach(() => {
-      process.env.OTEL_SDK_DISABLED = 'true';
+      process.env.OTEL_SDK_DISABLED = 'TrUe';
     });
 
     afterEach(() => {
       delete process.env.OTEL_SDK_DISABLED;
+      delete process.env.OTEL_PROPAGATORS;
     });
 
-    it('should not register a trace provider', async () => {
-      const sdk = new NodeSDK({});
+    it('should configure context and propagation without starting signal components', async () => {
+      process.env.OTEL_PROPAGATORS = 'tracecontext,baggage';
+      const detect = Sinon.spy(() => ({
+        attributes: { detected: true },
+      }));
+      const instrumentation = new TestInstrumentation('test', '1.0.0', {
+        enabled: false,
+      });
+      const enableInstrumentation = Sinon.spy(instrumentation, 'enable');
+      const sdk = new NodeSDK({
+        instrumentations: [instrumentation],
+        resourceDetectors: [{ detect }],
+      });
+
       sdk.start();
 
-      assert.ok(
-        setGlobalTracerProviderSpy.called === false,
-        'sdk.start() should not change the global tracer provider'
-      );
+      assertDefaultContextManagerRegistered();
+      assertTraceContextAndBaggagePropagation();
+      assert.ok(setGlobalTracerProviderSpy.notCalled);
+      assert.ok(setGlobalMeterProviderSpy.notCalled);
+      assert.ok(setGlobalLoggerProviderSpy.notCalled);
+      assert.ok(enableInstrumentation.notCalled);
+      assert.ok(detect.notCalled);
+      assert.strictEqual(sdk['_tracerProvider'], undefined);
+      assert.strictEqual(sdk['_meterProvider'], undefined);
+      assert.strictEqual(sdk['_loggerProvider'], undefined);
+
+      await sdk.shutdown();
+    });
+
+    it('should not create env metric exporters', async () => {
+      process.env.OTEL_METRICS_EXPORTER = 'console';
+      const sdk = new NodeSDK({});
+
+      assert.strictEqual(sdk['_meterProviderConfig'], undefined);
+
+      sdk.start();
+      await sdk.shutdown();
+    });
+
+    it('should honor OTEL_PROPAGATORS=none', async () => {
+      process.env.OTEL_PROPAGATORS = 'none';
+      const sdk = new NodeSDK({});
+
+      sdk.start();
+
+      assertDefaultContextManagerRegistered();
+      assert.deepStrictEqual(propagation.fields(), []);
 
       await sdk.shutdown();
     });

--- a/experimental/packages/opentelemetry-sdk-node/test/start.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/start.test.ts
@@ -70,6 +70,13 @@ import {
   SimpleSpanProcessor,
   TracerProvider,
 } from '@opentelemetry/sdk-trace';
+import { InstrumentationBase } from '@opentelemetry/instrumentation';
+
+class TestInstrumentation extends InstrumentationBase {
+  init() {
+    return [];
+  }
+}
 
 describe('startNodeSDK', function () {
   let setGlobalLoggerProviderSpy: Sinon.SinonSpy;
@@ -107,11 +114,61 @@ describe('startNodeSDK', function () {
   });
 
   describe('Basic Registration', function () {
-    it('should return NOOP_SDK when disabled is true', async () => {
+    it('should configure context and propagation without starting signal components when disabled', async () => {
+      process.env.OTEL_SDK_DISABLED = 'TrUe';
+      process.env.OTEL_PROPAGATORS = 'tracecontext,baggage';
+      process.env.OTEL_TRACES_EXPORTER = 'console';
+      process.env.OTEL_LOGS_EXPORTER = 'console';
+      process.env.OTEL_METRICS_EXPORTER = 'console';
+      const detect = Sinon.spy(() => ({
+        attributes: { detected: true },
+      }));
+      const instrumentation = new TestInstrumentation('test', '1.0.0', {
+        enabled: false,
+      });
+      const enableInstrumentation = Sinon.spy(instrumentation, 'enable');
+      const sdk = startNodeSDK({
+        instrumentations: [instrumentation],
+        resourceDetectors: [{ detect }],
+      });
+
+      assert.strictEqual(sdk, NOOP_SDK);
+      assertDefaultContextManagerRegistered();
+      assert.deepStrictEqual(propagation.fields(), [
+        'traceparent',
+        'tracestate',
+        'baggage',
+      ]);
+
+      const extracted = propagation.extract(context.active(), {
+        traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+        baggage: 'test=value',
+      });
+      assert.strictEqual(
+        trace.getSpanContext(extracted)?.traceId,
+        '4bf92f3577b34da6a3ce929d0e0e4736'
+      );
+      assert.strictEqual(
+        propagation.getBaggage(extracted)?.getEntry('test')?.value,
+        'value'
+      );
+      assert.ok(setGlobalLoggerProviderSpy.notCalled);
+      assert.ok(setGlobalMeterProviderSpy.notCalled);
+      assert.ok(setGlobalTracerProviderSpy.notCalled);
+      assert.ok(enableInstrumentation.notCalled);
+      assert.ok(detect.notCalled);
+
+      await sdk.shutdown();
+    });
+
+    it('should honor OTEL_PROPAGATORS=none when disabled', async () => {
       process.env.OTEL_SDK_DISABLED = 'true';
+      process.env.OTEL_PROPAGATORS = 'none';
       const sdk = startNodeSDK();
 
       assert.strictEqual(sdk, NOOP_SDK);
+      assertDefaultContextManagerRegistered();
+      assert.deepStrictEqual(propagation.fields(), []);
 
       await sdk.shutdown();
     });


### PR DESCRIPTION
## Which problem is this PR solving?

`OTEL_SDK_DISABLED=true` currently returns from both `NodeSDK.start()` and
experimental `startNodeSDK()` before the configured context manager and
propagator are installed. The
[SDK environment variable specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)
says disabling the SDK has no effect on propagators configured through
`OTEL_PROPAGATORS`.

This addresses the remaining disabled-SDK case of #4480.

Downstream context:
https://github.com/openclaw/openclaw/issues/119927

## Short description of the changes

- Install configured context management and propagation before the disabled
  early return in both Node SDK entry points.
- Keep instrumentation registration, resource detection, providers, exporters,
  and other signal setup behind the disabled guard.
- Avoid constructing environment-configured metric exporters in the stable
  `NodeSDK` constructor when the SDK is disabled.
- Cover mixed-case `true`, `tracecontext,baggage`, `none`, operational context
  extraction, and the absence of signal providers/exporters.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `npm run compile`
- [x] `npm run lint:fix`
- [x] `npm run lint -- --no-cache`
- [x] `env -u OTEL_SDK_DISABLED -u OTEL_TRACES_EXPORTER -u OTEL_METRICS_EXPORTER -u OTEL_LOGS_EXPORTER npm test -- --grep disabled`
- [x] `env -u OTEL_SDK_DISABLED -u OTEL_TRACES_EXPORTER -u OTEL_METRICS_EXPORTER -u OTEL_LOGS_EXPORTER npm test`
- [x] Runtime reproduction for both entry points with all signal exporters set
  to `console`: context is `AsyncLocalStorageContextManager`, propagation fields
  are `traceparent,tracestate,baggage`, and all signal providers remain no-op.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
