### PR TITLE
feat(otlp-exporter-base): add env-free createOtlp*Exporter factory functions

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -13,6 +13,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :rocket: Features
 
 * feat(sdk-logs): deprecate `SdkLogRecord` in favor of `ReadWriteLogRecord` [#6939](https://github.com/open-telemetry/opentelemetry-js/pull/6939) @pichlermarc
+* feat(otlp-exporter-base): add `createOtlp*Exporter()` factory functions to the OTLP trace, metric and log exporter packages (`-otlp-http`, `-otlp-proto`, `-otlp-grpc`); unlike the exporter classes, they do not read `OTEL_EXPORTER_OTLP_*` environment variables, which makes them suitable for use with declarative configuration [#6959](https://github.com/open-telemetry/opentelemetry-js/issues/6959) @pacocartones
 
 ### :bug: Bug Fixes
 

--- a/experimental/packages/exporter-logs-otlp-grpc/README.md
+++ b/experimental/packages/exporter-logs-otlp-grpc/README.md
@@ -107,6 +107,18 @@ const loggerProvider = new LoggerProvider({
 
 > Settings configured programmatically take precedence over environment variables. Per-signal environment variables take precedence over non-per-signal environment variables.
 
+### Creating an exporter without environment variable configuration
+
+The `OTLPLogExporter` class reads the environment variables described above. When that is not desirable — for example, when the exporter is configured from a configuration file — use `createOtlpGrpcLogExporter` instead. It accepts the same options, but does not read `OTEL_EXPORTER_OTLP_*` environment variables; options that are not provided fall back to the defaults defined by the OTLP exporter specification.
+
+```js
+const { createOtlpGrpcLogExporter } = require('@opentelemetry/exporter-logs-otlp-grpc');
+
+const exporter = createOtlpGrpcLogExporter({
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is localhost:4317
+});
+```
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/experimental/packages/exporter-logs-otlp-grpc/src/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/src/OTLPLogExporter.ts
@@ -10,6 +10,7 @@ import type {
 import type { OTLPGRPCExporterConfigNode } from '@opentelemetry/otlp-grpc-exporter-base';
 import {
   convertLegacyOtlpGrpcOptions,
+  convertLegacyOtlpGrpcOptionsWithoutEnv,
   createOtlpGrpcExportDelegate,
 } from '@opentelemetry/otlp-grpc-exporter-base';
 import {
@@ -39,4 +40,29 @@ export class OTLPLogExporter
       )
     );
   }
+}
+
+/**
+ * Creates a log record exporter that sends data over OTLP/gRPC.
+ *
+ * Unlike the {@link OTLPLogExporter} class, the created exporter does not use
+ * `OTEL_EXPORTER_OTLP_*` environment variables for configuration: options that
+ * are not provided in `config` fall back to the defaults defined by the OTLP
+ * exporter specification. Reading configuration from the environment is the
+ * caller's responsibility.
+ */
+export function createOtlpGrpcLogExporter(
+  config: OTLPGRPCExporterConfigNode = {}
+): LogRecordExporter {
+  return new OTLPExporterBase(
+    createOtlpGrpcExportDelegate(
+      convertLegacyOtlpGrpcOptionsWithoutEnv(config),
+      ProtobufLogsSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_GRPC_LOG_EXPORTER,
+      LogsExporterMetricsHelper,
+      config.selfObsMeterProvider,
+      'LogsExportService',
+      '/opentelemetry.proto.collector.logs.v1.LogsService/Export'
+    )
+  );
 }

--- a/experimental/packages/exporter-logs-otlp-grpc/src/index.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/src/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPLogExporter } from './OTLPLogExporter';
+export { createOtlpGrpcLogExporter, OTLPLogExporter } from './OTLPLogExporter';

--- a/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-grpc/test/OTLPLogExporter.test.ts
@@ -8,7 +8,7 @@ import {
   SimpleLogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
-import { OTLPLogExporter } from '../src';
+import { OTLPLogExporter, createOtlpGrpcLogExporter } from '../src';
 import type { ServerTestContext } from './utils';
 import { startServer, TestMetricReader } from './utils';
 import * as assert from 'assert';
@@ -99,5 +99,29 @@ describe('OTLPLogExporter', function () {
     );
     assert.ok(scopeMetrics);
     await meterProvider.shutdown();
+  });
+
+  describe('createOtlpGrpcLogExporter', function () {
+    it('successfully exports data', async () => {
+      // arrange
+      const loggerProvider = new LoggerProvider({
+        processors: [
+          new SimpleLogRecordProcessor({
+            exporter: createOtlpGrpcLogExporter({
+              url: 'http://localhost:1503',
+            }),
+          }),
+        ],
+      });
+
+      // act
+      loggerProvider.getLogger('test-logger').emit({
+        body: 'test-body',
+      });
+      await loggerProvider.shutdown();
+
+      // assert
+      assert.strictEqual(serverTestContext.requests.length, 1);
+    });
   });
 });

--- a/experimental/packages/exporter-logs-otlp-http/README.md
+++ b/experimental/packages/exporter-logs-otlp-http/README.md
@@ -93,6 +93,18 @@ In addition to settings passed to the constructor, the exporter also supports co
 
 > Settings configured programmatically take precedence over environment variables. Per-signal environment variables take precedence over non-per-signal environment variables.
 
+### Creating an exporter without environment variable configuration
+
+The `OTLPLogExporter` class reads the environment variables described above. When that is not desirable — for example, when the exporter is configured from a configuration file — use `createOtlpHttpLogExporter` instead. It accepts the same options, but does not read `OTEL_EXPORTER_OTLP_*` environment variables; options that are not provided fall back to the defaults defined by the OTLP exporter specification.
+
+```js
+const { createOtlpHttpLogExporter } = require('@opentelemetry/exporter-logs-otlp-http');
+
+const exporter = createOtlpHttpLogExporter({
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:4318/v1/logs
+});
+```
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/experimental/packages/exporter-logs-otlp-http/src/index.ts
+++ b/experimental/packages/exporter-logs-otlp-http/src/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPLogExporter } from './platform';
+export { createOtlpHttpLogExporter, OTLPLogExporter } from './platform';

--- a/experimental/packages/exporter-logs-otlp-http/src/platform/browser/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-http/src/platform/browser/OTLPLogExporter.ts
@@ -38,3 +38,28 @@ export class OTLPLogExporter
     );
   }
 }
+
+/**
+ * Creates a log record exporter that sends data over OTLP/HTTP with JSON
+ * encoding.
+ *
+ * The created exporter does not use `OTEL_EXPORTER_OTLP_*` environment
+ * variables for configuration: options that are not provided in `config` fall
+ * back to the defaults defined by the OTLP exporter specification. Reading
+ * configuration from the environment is the caller's responsibility.
+ */
+export function createOtlpHttpLogExporter(
+  config: OTLPExporterConfigBase = {}
+): LogRecordExporter {
+  return new OTLPExporterBase(
+    createLegacyOtlpBrowserExportDelegate(
+      config,
+      JsonLogsSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_LOG_EXPORTER,
+      LogsExporterMetricsHelper,
+      config.selfObsMeterProvider,
+      'v1/logs',
+      { 'Content-Type': 'application/json' }
+    )
+  );
+}

--- a/experimental/packages/exporter-logs-otlp-http/src/platform/browser/index.ts
+++ b/experimental/packages/exporter-logs-otlp-http/src/platform/browser/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPLogExporter } from './OTLPLogExporter';
+export { createOtlpHttpLogExporter, OTLPLogExporter } from './OTLPLogExporter';

--- a/experimental/packages/exporter-logs-otlp-http/src/platform/index.ts
+++ b/experimental/packages/exporter-logs-otlp-http/src/platform/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPLogExporter } from './node';
+export { createOtlpHttpLogExporter, OTLPLogExporter } from './node';

--- a/experimental/packages/exporter-logs-otlp-http/src/platform/node/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-http/src/platform/node/OTLPLogExporter.ts
@@ -15,6 +15,7 @@ import {
 } from '@opentelemetry/otlp-transformer';
 import {
   convertLegacyHttpOptions,
+  convertLegacyHttpOptionsWithoutEnv,
   createOtlpHttpExportDelegate,
 } from '@opentelemetry/otlp-exporter-base/node-http';
 
@@ -40,4 +41,30 @@ export class OTLPLogExporter
       )
     );
   }
+}
+
+/**
+ * Creates a log record exporter that sends data over OTLP/HTTP with JSON
+ * encoding.
+ *
+ * Unlike the {@link OTLPLogExporter} class, the created exporter does not use
+ * `OTEL_EXPORTER_OTLP_*` environment variables for configuration: options that
+ * are not provided in `config` fall back to the defaults defined by the OTLP
+ * exporter specification. Reading configuration from the environment is the
+ * caller's responsibility.
+ */
+export function createOtlpHttpLogExporter(
+  config: OTLPExporterNodeConfigBase = {}
+): LogRecordExporter {
+  return new OTLPExporterBase(
+    createOtlpHttpExportDelegate(
+      convertLegacyHttpOptionsWithoutEnv(config, 'v1/logs', {
+        'Content-Type': 'application/json',
+      }),
+      JsonLogsSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_LOG_EXPORTER,
+      LogsExporterMetricsHelper,
+      config.selfObsMeterProvider
+    )
+  );
 }

--- a/experimental/packages/exporter-logs-otlp-http/src/platform/node/index.ts
+++ b/experimental/packages/exporter-logs-otlp-http/src/platform/node/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPLogExporter } from './OTLPLogExporter';
+export { createOtlpHttpLogExporter, OTLPLogExporter } from './OTLPLogExporter';

--- a/experimental/packages/exporter-logs-otlp-http/test/browser/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-http/test/browser/OTLPLogExporter.test.ts
@@ -5,7 +5,10 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 
-import { OTLPLogExporter } from '../../src/platform/browser';
+import {
+  createOtlpHttpLogExporter,
+  OTLPLogExporter,
+} from '../../src/platform/browser';
 import {
   LoggerProvider,
   SimpleLogRecordProcessor,
@@ -64,5 +67,33 @@ describe('OTLPLogExporter', function () {
       assert.ok(scopeMetrics);
       await meterProvider.shutdown();
     });
+  });
+});
+
+describe('createOtlpHttpLogExporter', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should send data to the default endpoint', async function () {
+    // arrange
+    const stubFetch = sinon
+      .stub(window, 'fetch')
+      .resolves(new Response('', { status: 200 }));
+    const loggerProvider = new LoggerProvider({
+      processors: [
+        new SimpleLogRecordProcessor({ exporter: createOtlpHttpLogExporter() }),
+      ],
+    });
+
+    // act
+    loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
+    await loggerProvider.shutdown();
+
+    // assert
+    assert.strictEqual(
+      stubFetch.firstCall.args[0],
+      'http://localhost:4318/v1/logs'
+    );
   });
 });

--- a/experimental/packages/exporter-logs-otlp-http/test/node/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-http/test/node/OTLPLogExporter.test.ts
@@ -17,6 +17,7 @@ import {
 } from '@opentelemetry/sdk-logs';
 import { type Attributes } from '@opentelemetry/api';
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
+import { syncBuiltinESMExports } from 'module';
 import { Stream } from 'stream';
 import { TestMetricReader } from '../utils';
 
@@ -27,10 +28,38 @@ import { TestMetricReader } from '../utils';
  * - `@opentelemetry/otlp-transformer`: Everything regarding serialization and transforming internal representations to OTLP
  */
 
+function stubSuccessfulHttpRequest(): void {
+  (sinon.stub(http, 'request') as sinon.SinonStub).callsFake(
+    (...args: unknown[]) => {
+      const responseCallback =
+        typeof args[args.length - 1] === 'function'
+          ? (args[args.length - 1] as (res: unknown) => void)
+          : null;
+      const fakeRequest = new Stream.PassThrough();
+      Object.defineProperty(fakeRequest, 'setTimeout', {
+        value: function (_timeout: number) {},
+      });
+      fakeRequest.on('finish', () => {
+        if (responseCallback) {
+          const fakeResponse = new Stream.PassThrough() as any;
+          fakeResponse.statusCode = 200;
+          fakeResponse.statusMessage = 'OK';
+          fakeResponse.headers = {};
+          responseCallback(fakeResponse);
+          fakeResponse.end();
+        }
+      });
+      return fakeRequest as any;
+    }
+  );
+  syncBuiltinESMExports();
+}
+
 describe('OTLPLogExporter', () => {
   describe('export', () => {
     afterEach(() => {
       sinon.restore();
+      syncBuiltinESMExports();
     });
 
     it('successfully exports data', done => {
@@ -45,6 +74,7 @@ describe('OTLPLogExporter', () => {
       });
 
       sinon.stub(http, 'request').returns(fakeRequest as any);
+      syncBuiltinESMExports();
       let buff = Buffer.from('');
       fakeRequest.on('finish', async () => {
         try {
@@ -86,8 +116,14 @@ describe('OTLPLogExporter', () => {
 });
 
 describe('createOtlpHttpLogExporter', () => {
+  beforeEach(() => {
+    stubSuccessfulHttpRequest();
+  });
+
   afterEach(() => {
     delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
+    sinon.restore();
+    syncBuiltinESMExports();
   });
 
   async function collectServerAttributes(
@@ -121,10 +157,8 @@ describe('createOtlpHttpLogExporter', () => {
       ],
     });
 
-    // The exporter records the endpoint it targets in its own metrics,
-    // synchronously when the export starts, so no request needs to complete
-    // for this assertion (and there is nothing to shut down for it).
     loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
+    await loggerProvider.shutdown();
 
     const serverAttributes = await collectServerAttributes(metricReader);
     assert.ok(
@@ -158,6 +192,7 @@ describe('createOtlpHttpLogExporter', () => {
     });
 
     loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
+    await loggerProvider.shutdown();
 
     const serverAttributes = await collectServerAttributes(metricReader);
     assert.ok(

--- a/experimental/packages/exporter-logs-otlp-http/test/node/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-http/test/node/OTLPLogExporter.test.ts
@@ -7,11 +7,15 @@ import * as assert from 'assert';
 import * as http from 'http';
 import * as sinon from 'sinon';
 
-import { OTLPLogExporter } from '../../src/platform/node';
+import {
+  createOtlpHttpLogExporter,
+  OTLPLogExporter,
+} from '../../src/platform/node';
 import {
   LoggerProvider,
   SimpleLogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
+import { type Attributes } from '@opentelemetry/api';
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
 import { Stream } from 'stream';
 import { TestMetricReader } from '../utils';
@@ -78,5 +82,93 @@ describe('OTLPLogExporter', () => {
       loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
       loggerProvider.shutdown();
     });
+  });
+});
+
+describe('createOtlpHttpLogExporter', () => {
+  afterEach(() => {
+    delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
+  });
+
+  async function collectServerAttributes(
+    metricReader: TestMetricReader
+  ): Promise<Attributes[]> {
+    const { resourceMetrics } = await metricReader.collect();
+    const scopeMetrics = resourceMetrics.scopeMetrics.find(
+      sm => sm.scope.name === '@opentelemetry/otlp-exporter'
+    );
+    return (
+      scopeMetrics?.metrics.flatMap(metric =>
+        metric.dataPoints.map(dataPoint => dataPoint.attributes)
+      ) ?? []
+    );
+  }
+
+  it('returns an exporter that does not use configuration from the environment', async () => {
+    process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = 'http://127.0.0.1:9/v1/logs';
+
+    const metricReader = new TestMetricReader();
+    const meterProvider = new MeterProvider({
+      readers: [metricReader],
+    });
+    const loggerProvider = new LoggerProvider({
+      processors: [
+        new SimpleLogRecordProcessor({
+          exporter: createOtlpHttpLogExporter({
+            selfObsMeterProvider: meterProvider,
+          }),
+        }),
+      ],
+    });
+
+    // The exporter records the endpoint it targets in its own metrics,
+    // synchronously when the export starts, so no request needs to complete
+    // for this assertion (and there is nothing to shut down for it).
+    loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
+
+    const serverAttributes = await collectServerAttributes(metricReader);
+    assert.ok(
+      serverAttributes.some(
+        attrs =>
+          attrs['server.address'] === 'localhost' &&
+          attrs['server.port'] === 4318
+      ),
+      `expected exporter metrics to target the default endpoint, got ${JSON.stringify(
+        serverAttributes
+      )}`
+    );
+    await meterProvider.shutdown();
+  });
+
+  it('control: the class-based exporter keeps using the environment', async () => {
+    process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = 'http://127.0.0.1:9/v1/logs';
+
+    const metricReader = new TestMetricReader();
+    const meterProvider = new MeterProvider({
+      readers: [metricReader],
+    });
+    const loggerProvider = new LoggerProvider({
+      processors: [
+        new SimpleLogRecordProcessor({
+          exporter: new OTLPLogExporter({
+            selfObsMeterProvider: meterProvider,
+          }),
+        }),
+      ],
+    });
+
+    loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
+
+    const serverAttributes = await collectServerAttributes(metricReader);
+    assert.ok(
+      serverAttributes.some(
+        attrs =>
+          attrs['server.address'] === '127.0.0.1' && attrs['server.port'] === 9
+      ),
+      `expected exporter metrics to target the env-provided endpoint, got ${JSON.stringify(
+        serverAttributes
+      )}`
+    );
+    await meterProvider.shutdown();
   });
 });

--- a/experimental/packages/exporter-logs-otlp-proto/README.md
+++ b/experimental/packages/exporter-logs-otlp-proto/README.md
@@ -44,6 +44,18 @@ logger.emit({
 })
 ```
 
+## Creating an exporter without environment variable configuration
+
+The `OTLPLogExporter` class reads `OTEL_EXPORTER_OTLP_*` environment variables for configuration. When that is not desirable — for example, when the exporter is configured from a configuration file — use `createOtlpProtoLogExporter` instead. It accepts the same options, but does not read environment variables; options that are not provided fall back to the defaults defined by the OTLP exporter specification.
+
+```js
+const { createOtlpProtoLogExporter } = require('@opentelemetry/exporter-logs-otlp-proto');
+
+const exporter = createOtlpProtoLogExporter({
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:4318/v1/logs
+});
+```
+
 ## Exporter Timeout Configuration
 
 The OTLPLogExporter has a timeout configuration option which is the maximum time, in milliseconds, the OTLP exporter will wait for each batch export. The default value is 10000ms.

--- a/experimental/packages/exporter-logs-otlp-proto/src/index.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/index.ts
@@ -2,4 +2,4 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-export { OTLPLogExporter } from './platform';
+export { createOtlpProtoLogExporter, OTLPLogExporter } from './platform';

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/OTLPLogExporter.ts
@@ -39,3 +39,28 @@ export class OTLPLogExporter
     );
   }
 }
+
+/**
+ * Creates a log record exporter that sends data over OTLP/HTTP with protobuf
+ * encoding.
+ *
+ * The created exporter does not use `OTEL_EXPORTER_OTLP_*` environment
+ * variables for configuration: options that are not provided in `config` fall
+ * back to the defaults defined by the OTLP exporter specification. Reading
+ * configuration from the environment is the caller's responsibility.
+ */
+export function createOtlpProtoLogExporter(
+  config: OTLPExporterConfigBase = {}
+): LogRecordExporter {
+  return new OTLPExporterBase(
+    createLegacyOtlpBrowserExportDelegate(
+      config,
+      ProtobufLogsSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_LOG_EXPORTER,
+      LogsExporterMetricsHelper,
+      config.selfObsMeterProvider,
+      'v1/logs',
+      { 'Content-Type': 'application/x-protobuf' }
+    )
+  );
+}

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/index.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/browser/index.ts
@@ -2,4 +2,4 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-export { OTLPLogExporter } from './OTLPLogExporter';
+export { createOtlpProtoLogExporter, OTLPLogExporter } from './OTLPLogExporter';

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/index.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/index.ts
@@ -2,4 +2,4 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-export { OTLPLogExporter } from './node';
+export { createOtlpProtoLogExporter, OTLPLogExporter } from './node';

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/node/OTLPLogExporter.ts
@@ -11,6 +11,7 @@ import {
 } from '@opentelemetry/otlp-transformer';
 import {
   convertLegacyHttpOptions,
+  convertLegacyHttpOptionsWithoutEnv,
   createOtlpHttpExportDelegate,
 } from '@opentelemetry/otlp-exporter-base/node-http';
 import type {
@@ -40,4 +41,30 @@ export class OTLPLogExporter
       )
     );
   }
+}
+
+/**
+ * Creates a log record exporter that sends data over OTLP/HTTP with protobuf
+ * encoding.
+ *
+ * Unlike the {@link OTLPLogExporter} class, the created exporter does not use
+ * `OTEL_EXPORTER_OTLP_*` environment variables for configuration: options that
+ * are not provided in `config` fall back to the defaults defined by the OTLP
+ * exporter specification. Reading configuration from the environment is the
+ * caller's responsibility.
+ */
+export function createOtlpProtoLogExporter(
+  config: OTLPExporterNodeConfigBase = {}
+): LogRecordExporter {
+  return new OTLPExporterBase(
+    createOtlpHttpExportDelegate(
+      convertLegacyHttpOptionsWithoutEnv(config, 'v1/logs', {
+        'Content-Type': 'application/x-protobuf',
+      }),
+      ProtobufLogsSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_LOG_EXPORTER,
+      LogsExporterMetricsHelper,
+      config.selfObsMeterProvider
+    )
+  );
 }

--- a/experimental/packages/exporter-logs-otlp-proto/src/platform/node/index.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/src/platform/node/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPLogExporter } from './OTLPLogExporter';
+export { createOtlpProtoLogExporter, OTLPLogExporter } from './OTLPLogExporter';

--- a/experimental/packages/exporter-logs-otlp-proto/test/browser/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/test/browser/OTLPLogExporter.test.ts
@@ -5,7 +5,10 @@
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 
-import { OTLPLogExporter } from '../../src/platform/browser';
+import {
+  createOtlpProtoLogExporter,
+  OTLPLogExporter,
+} from '../../src/platform/browser';
 import {
   LoggerProvider,
   SimpleLogRecordProcessor,
@@ -64,5 +67,35 @@ describe('OTLPLogExporter', function () {
       assert.ok(scopeMetrics);
       await meterProvider.shutdown();
     });
+  });
+});
+
+describe('createOtlpProtoLogExporter', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should send data to the default endpoint', async function () {
+    // arrange
+    const stubFetch = sinon
+      .stub(window, 'fetch')
+      .resolves(new Response('', { status: 200 }));
+    const loggerProvider = new LoggerProvider({
+      processors: [
+        new SimpleLogRecordProcessor({
+          exporter: createOtlpProtoLogExporter(),
+        }),
+      ],
+    });
+
+    // act
+    loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
+    await loggerProvider.shutdown();
+
+    // assert
+    assert.strictEqual(
+      stubFetch.firstCall.args[0],
+      'http://localhost:4318/v1/logs'
+    );
   });
 });

--- a/experimental/packages/exporter-logs-otlp-proto/test/node/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/test/node/OTLPLogExporter.test.ts
@@ -17,6 +17,7 @@ import {
 } from '@opentelemetry/sdk-logs';
 import { type Attributes } from '@opentelemetry/api';
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
+import { syncBuiltinESMExports } from 'module';
 import { Stream } from 'stream';
 import { TestMetricReader } from '../utils';
 
@@ -27,10 +28,38 @@ import { TestMetricReader } from '../utils';
  * - `@opentelemetry/otlp-transformer`: Everything regarding serialization and transforming internal representations to OTLP
  */
 
+function stubSuccessfulHttpRequest(): void {
+  (sinon.stub(http, 'request') as sinon.SinonStub).callsFake(
+    (...args: unknown[]) => {
+      const responseCallback =
+        typeof args[args.length - 1] === 'function'
+          ? (args[args.length - 1] as (res: unknown) => void)
+          : null;
+      const fakeRequest = new Stream.PassThrough();
+      Object.defineProperty(fakeRequest, 'setTimeout', {
+        value: function (_timeout: number) {},
+      });
+      fakeRequest.on('finish', () => {
+        if (responseCallback) {
+          const fakeResponse = new Stream.PassThrough() as any;
+          fakeResponse.statusCode = 200;
+          fakeResponse.statusMessage = 'OK';
+          fakeResponse.headers = {};
+          responseCallback(fakeResponse);
+          fakeResponse.end();
+        }
+      });
+      return fakeRequest as any;
+    }
+  );
+  syncBuiltinESMExports();
+}
+
 describe('OTLPLogExporter', () => {
   describe('export', () => {
     afterEach(() => {
       sinon.restore();
+      syncBuiltinESMExports();
     });
 
     it('successfully exports data', done => {
@@ -45,6 +74,7 @@ describe('OTLPLogExporter', () => {
       });
 
       sinon.stub(http, 'request').returns(fakeRequest as any);
+      syncBuiltinESMExports();
       let buff = Buffer.from('');
       fakeRequest.on('finish', async () => {
         try {
@@ -86,8 +116,14 @@ describe('OTLPLogExporter', () => {
 });
 
 describe('createOtlpProtoLogExporter', () => {
+  beforeEach(() => {
+    stubSuccessfulHttpRequest();
+  });
+
   afterEach(() => {
     delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
+    sinon.restore();
+    syncBuiltinESMExports();
   });
 
   async function collectServerAttributes(
@@ -121,10 +157,8 @@ describe('createOtlpProtoLogExporter', () => {
       ],
     });
 
-    // The exporter records the endpoint it targets in its own metrics,
-    // synchronously when the export starts, so no request needs to complete
-    // for this assertion (and there is nothing to shut down for it).
     loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
+    await loggerProvider.shutdown();
 
     const serverAttributes = await collectServerAttributes(metricReader);
     assert.ok(
@@ -158,6 +192,7 @@ describe('createOtlpProtoLogExporter', () => {
     });
 
     loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
+    await loggerProvider.shutdown();
 
     const serverAttributes = await collectServerAttributes(metricReader);
     assert.ok(

--- a/experimental/packages/exporter-logs-otlp-proto/test/node/OTLPLogExporter.test.ts
+++ b/experimental/packages/exporter-logs-otlp-proto/test/node/OTLPLogExporter.test.ts
@@ -7,11 +7,15 @@ import * as assert from 'assert';
 import * as http from 'http';
 import * as sinon from 'sinon';
 
-import { OTLPLogExporter } from '../../src/platform/node';
+import {
+  createOtlpProtoLogExporter,
+  OTLPLogExporter,
+} from '../../src/platform/node';
 import {
   LoggerProvider,
   SimpleLogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
+import { type Attributes } from '@opentelemetry/api';
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
 import { Stream } from 'stream';
 import { TestMetricReader } from '../utils';
@@ -78,5 +82,93 @@ describe('OTLPLogExporter', () => {
       loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
       loggerProvider.shutdown();
     });
+  });
+});
+
+describe('createOtlpProtoLogExporter', () => {
+  afterEach(() => {
+    delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
+  });
+
+  async function collectServerAttributes(
+    metricReader: TestMetricReader
+  ): Promise<Attributes[]> {
+    const { resourceMetrics } = await metricReader.collect();
+    const scopeMetrics = resourceMetrics.scopeMetrics.find(
+      sm => sm.scope.name === '@opentelemetry/otlp-exporter'
+    );
+    return (
+      scopeMetrics?.metrics.flatMap(metric =>
+        metric.dataPoints.map(dataPoint => dataPoint.attributes)
+      ) ?? []
+    );
+  }
+
+  it('returns an exporter that does not use configuration from the environment', async () => {
+    process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = 'http://127.0.0.1:9/v1/logs';
+
+    const metricReader = new TestMetricReader();
+    const meterProvider = new MeterProvider({
+      readers: [metricReader],
+    });
+    const loggerProvider = new LoggerProvider({
+      processors: [
+        new SimpleLogRecordProcessor({
+          exporter: createOtlpProtoLogExporter({
+            selfObsMeterProvider: meterProvider,
+          }),
+        }),
+      ],
+    });
+
+    // The exporter records the endpoint it targets in its own metrics,
+    // synchronously when the export starts, so no request needs to complete
+    // for this assertion (and there is nothing to shut down for it).
+    loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
+
+    const serverAttributes = await collectServerAttributes(metricReader);
+    assert.ok(
+      serverAttributes.some(
+        attrs =>
+          attrs['server.address'] === 'localhost' &&
+          attrs['server.port'] === 4318
+      ),
+      `expected exporter metrics to target the default endpoint, got ${JSON.stringify(
+        serverAttributes
+      )}`
+    );
+    await meterProvider.shutdown();
+  });
+
+  it('control: the class-based exporter keeps using the environment', async () => {
+    process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = 'http://127.0.0.1:9/v1/logs';
+
+    const metricReader = new TestMetricReader();
+    const meterProvider = new MeterProvider({
+      readers: [metricReader],
+    });
+    const loggerProvider = new LoggerProvider({
+      processors: [
+        new SimpleLogRecordProcessor({
+          exporter: new OTLPLogExporter({
+            selfObsMeterProvider: meterProvider,
+          }),
+        }),
+      ],
+    });
+
+    loggerProvider.getLogger('test-logger').emit({ body: 'test-body' });
+
+    const serverAttributes = await collectServerAttributes(metricReader);
+    assert.ok(
+      serverAttributes.some(
+        attrs =>
+          attrs['server.address'] === '127.0.0.1' && attrs['server.port'] === 9
+      ),
+      `expected exporter metrics to target the env-provided endpoint, got ${JSON.stringify(
+        serverAttributes
+      )}`
+    );
+    await meterProvider.shutdown();
   });
 });

--- a/experimental/packages/exporter-trace-otlp-grpc/README.md
+++ b/experimental/packages/exporter-trace-otlp-grpc/README.md
@@ -165,6 +165,18 @@ const exporter = new OTLPTraceExporter(collectorOptions);
 
  > Settings configured programmatically take precedence over environment variables. Per-signal environment variables take precedence over non-per-signal environment variables.
 
+### Creating an exporter without environment variable configuration
+
+The `OTLPTraceExporter` class reads the environment variables described above. When that is not desirable — for example, when the exporter is configured from a configuration file — use `createOtlpGrpcSpanExporter` instead. It accepts the same options, but does not read `OTEL_EXPORTER_OTLP_*` environment variables; options that are not provided fall back to the defaults defined by the OTLP exporter specification.
+
+```js
+const { createOtlpGrpcSpanExporter } = require('@opentelemetry/exporter-trace-otlp-grpc');
+
+const exporter = createOtlpGrpcSpanExporter({
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is localhost:4317
+});
+```
+
 ## Running opentelemetry-collector locally to see the traces
 
 1. Go to `examples/otlp-exporter-node`

--- a/experimental/packages/exporter-trace-otlp-grpc/src/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-grpc/src/OTLPTraceExporter.ts
@@ -7,6 +7,7 @@ import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace';
 import type { OTLPGRPCExporterConfigNode } from '@opentelemetry/otlp-grpc-exporter-base';
 import {
   convertLegacyOtlpGrpcOptions,
+  convertLegacyOtlpGrpcOptionsWithoutEnv,
   createOtlpGrpcExportDelegate,
 } from '@opentelemetry/otlp-grpc-exporter-base';
 import {
@@ -37,4 +38,29 @@ export class OTLPTraceExporter
       )
     );
   }
+}
+
+/**
+ * Creates a span exporter that sends data over OTLP/gRPC.
+ *
+ * Unlike the {@link OTLPTraceExporter} class, the created exporter does not
+ * use `OTEL_EXPORTER_OTLP_*` environment variables for configuration: options
+ * that are not provided in `config` fall back to the defaults defined by the
+ * OTLP exporter specification. Reading configuration from the environment is
+ * the caller's responsibility.
+ */
+export function createOtlpGrpcSpanExporter(
+  config: OTLPGRPCExporterConfigNode = {}
+): SpanExporter {
+  return new OTLPExporterBase(
+    createOtlpGrpcExportDelegate(
+      convertLegacyOtlpGrpcOptionsWithoutEnv(config),
+      ProtobufTraceSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_GRPC_SPAN_EXPORTER,
+      TraceExporterMetricsHelper,
+      config.selfObsMeterProvider,
+      'TraceExportService',
+      '/opentelemetry.proto.collector.trace.v1.TraceService/Export'
+    )
+  );
 }

--- a/experimental/packages/exporter-trace-otlp-grpc/src/index.ts
+++ b/experimental/packages/exporter-trace-otlp-grpc/src/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPTraceExporter } from './OTLPTraceExporter';
+export { createOtlpGrpcSpanExporter, OTLPTraceExporter } from './OTLPTraceExporter';

--- a/experimental/packages/exporter-trace-otlp-grpc/test/OTLPTraceExporter.test.ts
+++ b/experimental/packages/exporter-trace-otlp-grpc/test/OTLPTraceExporter.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OTLPTraceExporter } from '../src';
+import { OTLPTraceExporter, createOtlpGrpcSpanExporter } from '../src';
 import type { ServerTestContext } from './utils';
 import { startServer, TestMetricReader } from './utils';
 import * as assert from 'assert';
@@ -94,5 +94,27 @@ describe('OTLPTraceExporter', function () {
     );
     assert.ok(scopeMetrics);
     await meterProvider.shutdown();
+  });
+
+  describe('createOtlpGrpcSpanExporter', function () {
+    it('successfully exports data', async () => {
+      // arrange
+      const tracerProvider = new TracerProvider({
+        spanProcessors: [
+          new SimpleSpanProcessor({
+            exporter: createOtlpGrpcSpanExporter({
+              url: 'http://localhost:1501',
+            }),
+          }),
+        ],
+      });
+
+      // act
+      tracerProvider.getTracer('test-tracer').startSpan('test-span').end();
+      await tracerProvider.shutdown();
+
+      // assert
+      assert.strictEqual(serverTestContext.requests.length, 1);
+    });
   });
 });

--- a/experimental/packages/exporter-trace-otlp-http/README.md
+++ b/experimental/packages/exporter-trace-otlp-http/README.md
@@ -116,6 +116,18 @@ OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://metric-service:4318/v1/metrics
 
 For more details, see [OpenTelemetry Specification on Protocol Exporter][opentelemetry-spec-protocol-exporter].
 
+### Creating an exporter without environment variable configuration
+
+The `OTLPTraceExporter` class reads the environment variables described above. When that is not desirable — for example, when the exporter is configured from a configuration file — use `createOtlpHttpSpanExporter` instead. It accepts the same options, but does not read `OTEL_EXPORTER_OTLP_*` environment variables; options that are not provided fall back to the defaults defined by the OTLP exporter specification.
+
+```js
+const { createOtlpHttpSpanExporter } = require('@opentelemetry/exporter-trace-otlp-http');
+
+const exporter = createOtlpHttpSpanExporter({
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:4318/v1/traces
+});
+```
+
 ## Exporter Timeout Configuration
 
 The OTLPTraceExporter has a timeout configuration option which is the maximum time, in milliseconds, the OTLP exporter will wait for each batch export. The default value is 10000ms.

--- a/experimental/packages/exporter-trace-otlp-http/src/index.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPTraceExporter } from './platform';
+export { createOtlpHttpSpanExporter, OTLPTraceExporter } from './platform';

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/browser/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/browser/OTLPTraceExporter.ts
@@ -35,3 +35,27 @@ export class OTLPTraceExporter
     );
   }
 }
+
+/**
+ * Creates a span exporter that sends data over OTLP/HTTP with JSON encoding.
+ *
+ * The created exporter does not use `OTEL_EXPORTER_OTLP_*` environment
+ * variables for configuration: options that are not provided in `config` fall
+ * back to the defaults defined by the OTLP exporter specification. Reading
+ * configuration from the environment is the caller's responsibility.
+ */
+export function createOtlpHttpSpanExporter(
+  config: OTLPExporterConfigBase = {}
+): SpanExporter {
+  return new OTLPExporterBase(
+    createLegacyOtlpBrowserExportDelegate(
+      config,
+      JsonTraceSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_SPAN_EXPORTER,
+      TraceExporterMetricsHelper,
+      config.selfObsMeterProvider,
+      'v1/traces',
+      { 'Content-Type': 'application/json' }
+    )
+  );
+}

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/browser/index.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/browser/index.ts
@@ -3,4 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPTraceExporter } from './OTLPTraceExporter';
+export {
+  createOtlpHttpSpanExporter,
+  OTLPTraceExporter,
+} from './OTLPTraceExporter';

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/index.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPTraceExporter } from './node';
+export { createOtlpHttpSpanExporter, OTLPTraceExporter } from './node';

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/node/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/node/OTLPTraceExporter.ts
@@ -12,6 +12,7 @@ import {
 } from '@opentelemetry/otlp-transformer';
 import {
   convertLegacyHttpOptions,
+  convertLegacyHttpOptionsWithoutEnv,
   createOtlpHttpExportDelegate,
 } from '@opentelemetry/otlp-exporter-base/node-http';
 import { OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_SPAN_EXPORTER } from '../../semconv';
@@ -36,4 +37,29 @@ export class OTLPTraceExporter
       )
     );
   }
+}
+
+/**
+ * Creates a span exporter that sends data over OTLP/HTTP with JSON encoding.
+ *
+ * Unlike the {@link OTLPTraceExporter} class, the created exporter does not
+ * use `OTEL_EXPORTER_OTLP_*` environment variables for configuration: options
+ * that are not provided in `config` fall back to the defaults defined by the
+ * OTLP exporter specification. Reading configuration from the environment is
+ * the caller's responsibility.
+ */
+export function createOtlpHttpSpanExporter(
+  config: OTLPExporterNodeConfigBase = {}
+): SpanExporter {
+  return new OTLPExporterBase(
+    createOtlpHttpExportDelegate(
+      convertLegacyHttpOptionsWithoutEnv(config, 'v1/traces', {
+        'Content-Type': 'application/json',
+      }),
+      JsonTraceSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_SPAN_EXPORTER,
+      TraceExporterMetricsHelper,
+      config.selfObsMeterProvider
+    )
+  );
 }

--- a/experimental/packages/exporter-trace-otlp-http/src/platform/node/index.ts
+++ b/experimental/packages/exporter-trace-otlp-http/src/platform/node/index.ts
@@ -3,4 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPTraceExporter } from './OTLPTraceExporter';
+export {
+  createOtlpHttpSpanExporter,
+  OTLPTraceExporter,
+} from './OTLPTraceExporter';

--- a/experimental/packages/exporter-trace-otlp-http/test/browser/OTLPTraceExporter.test.ts
+++ b/experimental/packages/exporter-trace-otlp-http/test/browser/OTLPTraceExporter.test.ts
@@ -7,7 +7,10 @@ import { MeterProvider } from '@opentelemetry/sdk-metrics';
 import { TracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { OTLPTraceExporter } from '../../src/platform/browser/index';
+import {
+  createOtlpHttpSpanExporter,
+  OTLPTraceExporter,
+} from '../../src/platform/browser/index';
 import { TestMetricReader } from '../utils';
 
 /*
@@ -62,5 +65,33 @@ describe('OTLPTraceExporter', () => {
       assert.ok(scopeMetrics);
       await meterProvider.shutdown();
     });
+  });
+});
+
+describe('createOtlpHttpSpanExporter', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should send data to the default endpoint', async function () {
+    // arrange
+    const stubFetch = sinon
+      .stub(window, 'fetch')
+      .resolves(new Response('', { status: 200 }));
+    const tracerProvider = new TracerProvider({
+      spanProcessors: [
+        new SimpleSpanProcessor({ exporter: createOtlpHttpSpanExporter() }),
+      ],
+    });
+
+    // act
+    tracerProvider.getTracer('test-tracer').startSpan('test-span').end();
+    await tracerProvider.shutdown();
+
+    // assert
+    assert.strictEqual(
+      stubFetch.firstCall.args[0],
+      'http://localhost:4318/v1/traces'
+    );
   });
 });

--- a/experimental/packages/exporter-trace-otlp-http/test/node/OTLPTraceExporter.test.ts
+++ b/experimental/packages/exporter-trace-otlp-http/test/node/OTLPTraceExporter.test.ts
@@ -8,9 +8,13 @@ import * as http from 'http';
 import * as sinon from 'sinon';
 import { Stream } from 'stream';
 
+import { type Attributes } from '@opentelemetry/api';
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
 import { TracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace';
-import { OTLPTraceExporter } from '../../src/platform/node';
+import {
+  createOtlpHttpSpanExporter,
+  OTLPTraceExporter,
+} from '../../src/platform/node';
 import { TestMetricReader } from '../utils';
 
 /*
@@ -74,5 +78,95 @@ describe('OTLPTraceExporter', () => {
 
       tracerProvider.getTracer('test-tracer').startSpan('test-span').end();
     });
+  });
+});
+
+describe('createOtlpHttpSpanExporter', () => {
+  afterEach(() => {
+    delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+  });
+
+  async function collectServerAttributes(
+    metricReader: TestMetricReader
+  ): Promise<Attributes[]> {
+    const { resourceMetrics } = await metricReader.collect();
+    const scopeMetrics = resourceMetrics.scopeMetrics.find(
+      sm => sm.scope.name === '@opentelemetry/otlp-exporter'
+    );
+    return (
+      scopeMetrics?.metrics.flatMap(metric =>
+        metric.dataPoints.map(dataPoint => dataPoint.attributes)
+      ) ?? []
+    );
+  }
+
+  it('returns an exporter that does not use configuration from the environment', async () => {
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT =
+      'http://127.0.0.1:9/v1/traces';
+
+    const metricReader = new TestMetricReader();
+    const meterProvider = new MeterProvider({
+      readers: [metricReader],
+    });
+    const tracerProvider = new TracerProvider({
+      spanProcessors: [
+        new SimpleSpanProcessor({
+          exporter: createOtlpHttpSpanExporter({
+            selfObsMeterProvider: meterProvider,
+          }),
+        }),
+      ],
+    });
+
+    // The exporter records the endpoint it targets in its own metrics,
+    // synchronously when the export starts, so no request needs to complete
+    // for this assertion (and there is nothing to shut down for it).
+    tracerProvider.getTracer('test-tracer').startSpan('test-span').end();
+
+    const serverAttributes = await collectServerAttributes(metricReader);
+    assert.ok(
+      serverAttributes.some(
+        attrs =>
+          attrs['server.address'] === 'localhost' &&
+          attrs['server.port'] === 4318
+      ),
+      `expected exporter metrics to target the default endpoint, got ${JSON.stringify(
+        serverAttributes
+      )}`
+    );
+    await meterProvider.shutdown();
+  });
+
+  it('control: the class-based exporter keeps using the environment', async () => {
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT =
+      'http://127.0.0.1:9/v1/traces';
+
+    const metricReader = new TestMetricReader();
+    const meterProvider = new MeterProvider({
+      readers: [metricReader],
+    });
+    const tracerProvider = new TracerProvider({
+      spanProcessors: [
+        new SimpleSpanProcessor({
+          exporter: new OTLPTraceExporter({
+            selfObsMeterProvider: meterProvider,
+          }),
+        }),
+      ],
+    });
+
+    tracerProvider.getTracer('test-tracer').startSpan('test-span').end();
+
+    const serverAttributes = await collectServerAttributes(metricReader);
+    assert.ok(
+      serverAttributes.some(
+        attrs =>
+          attrs['server.address'] === '127.0.0.1' && attrs['server.port'] === 9
+      ),
+      `expected exporter metrics to target the env-provided endpoint, got ${JSON.stringify(
+        serverAttributes
+      )}`
+    );
+    await meterProvider.shutdown();
   });
 });

--- a/experimental/packages/exporter-trace-otlp-http/test/node/OTLPTraceExporter.test.ts
+++ b/experimental/packages/exporter-trace-otlp-http/test/node/OTLPTraceExporter.test.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert';
 import * as http from 'http';
 import * as sinon from 'sinon';
+import { syncBuiltinESMExports } from 'module';
 import { Stream } from 'stream';
 
 import { type Attributes } from '@opentelemetry/api';
@@ -24,10 +25,38 @@ import { TestMetricReader } from '../utils';
  * - `@opentelemetry/otlp-transformer`: Everything regarding serialization and transforming internal representations to OTLP
  */
 
+function stubSuccessfulHttpRequest(): void {
+  (sinon.stub(http, 'request') as sinon.SinonStub).callsFake(
+    (...args: unknown[]) => {
+      const responseCallback =
+        typeof args[args.length - 1] === 'function'
+          ? (args[args.length - 1] as (res: unknown) => void)
+          : null;
+      const fakeRequest = new Stream.PassThrough();
+      Object.defineProperty(fakeRequest, 'setTimeout', {
+        value: function (_timeout: number) {},
+      });
+      fakeRequest.on('finish', () => {
+        if (responseCallback) {
+          const fakeResponse = new Stream.PassThrough() as any;
+          fakeResponse.statusCode = 200;
+          fakeResponse.statusMessage = 'OK';
+          fakeResponse.headers = {};
+          responseCallback(fakeResponse);
+          fakeResponse.end();
+        }
+      });
+      return fakeRequest as any;
+    }
+  );
+  syncBuiltinESMExports();
+}
+
 describe('OTLPTraceExporter', () => {
   describe('export', () => {
     afterEach(() => {
       sinon.restore();
+      syncBuiltinESMExports();
     });
 
     it('successfully exports data', done => {
@@ -42,6 +71,7 @@ describe('OTLPTraceExporter', () => {
       });
 
       sinon.stub(http, 'request').returns(fakeRequest as any);
+      syncBuiltinESMExports();
       let buff = Buffer.from('');
       fakeRequest.on('finish', async () => {
         try {
@@ -82,8 +112,14 @@ describe('OTLPTraceExporter', () => {
 });
 
 describe('createOtlpHttpSpanExporter', () => {
+  beforeEach(() => {
+    stubSuccessfulHttpRequest();
+  });
+
   afterEach(() => {
     delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    sinon.restore();
+    syncBuiltinESMExports();
   });
 
   async function collectServerAttributes(
@@ -118,10 +154,8 @@ describe('createOtlpHttpSpanExporter', () => {
       ],
     });
 
-    // The exporter records the endpoint it targets in its own metrics,
-    // synchronously when the export starts, so no request needs to complete
-    // for this assertion (and there is nothing to shut down for it).
     tracerProvider.getTracer('test-tracer').startSpan('test-span').end();
+    await tracerProvider.shutdown();
 
     const serverAttributes = await collectServerAttributes(metricReader);
     assert.ok(
@@ -156,6 +190,7 @@ describe('createOtlpHttpSpanExporter', () => {
     });
 
     tracerProvider.getTracer('test-tracer').startSpan('test-span').end();
+    await tracerProvider.shutdown();
 
     const serverAttributes = await collectServerAttributes(metricReader);
     assert.ok(

--- a/experimental/packages/exporter-trace-otlp-proto/README.md
+++ b/experimental/packages/exporter-trace-otlp-proto/README.md
@@ -40,6 +40,18 @@ const tracerProvider = new TracerProvider({
 trace.setGlobalTracerProvider(tracerProvider);
 ```
 
+## Creating an exporter without environment variable configuration
+
+The `OTLPTraceExporter` class reads `OTEL_EXPORTER_OTLP_*` environment variables for configuration. When that is not desirable — for example, when the exporter is configured from a configuration file — use `createOtlpProtoSpanExporter` instead. It accepts the same options, but does not read environment variables; options that are not provided fall back to the defaults defined by the OTLP exporter specification.
+
+```js
+const { createOtlpProtoSpanExporter } = require('@opentelemetry/exporter-trace-otlp-proto');
+
+const exporter = createOtlpProtoSpanExporter({
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:4318/v1/traces
+});
+```
+
 ## Exporter Timeout Configuration
 
 The OTLPTraceExporter has a timeout configuration option which is the maximum time, in milliseconds, the OTLP exporter will wait for each batch export. The default value is 10000ms.

--- a/experimental/packages/exporter-trace-otlp-proto/src/index.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/src/index.ts
@@ -2,4 +2,4 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-export { OTLPTraceExporter } from './platform';
+export { createOtlpProtoSpanExporter, OTLPTraceExporter } from './platform';

--- a/experimental/packages/exporter-trace-otlp-proto/src/platform/browser/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/src/platform/browser/OTLPTraceExporter.ts
@@ -36,3 +36,28 @@ export class OTLPTraceExporter
     );
   }
 }
+
+/**
+ * Creates a span exporter that sends data over OTLP/HTTP with protobuf
+ * encoding.
+ *
+ * The created exporter does not use `OTEL_EXPORTER_OTLP_*` environment
+ * variables for configuration: options that are not provided in `config` fall
+ * back to the defaults defined by the OTLP exporter specification. Reading
+ * configuration from the environment is the caller's responsibility.
+ */
+export function createOtlpProtoSpanExporter(
+  config: OTLPExporterConfigBase = {}
+): SpanExporter {
+  return new OTLPExporterBase(
+    createLegacyOtlpBrowserExportDelegate(
+      config,
+      ProtobufTraceSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_SPAN_EXPORTER,
+      TraceExporterMetricsHelper,
+      config.selfObsMeterProvider,
+      DEFAULT_COLLECTOR_RESOURCE_PATH,
+      { 'Content-Type': 'application/x-protobuf' }
+    )
+  );
+}

--- a/experimental/packages/exporter-trace-otlp-proto/src/platform/browser/index.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/src/platform/browser/index.ts
@@ -2,4 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-export { OTLPTraceExporter } from './OTLPTraceExporter';
+export {
+  createOtlpProtoSpanExporter,
+  OTLPTraceExporter,
+} from './OTLPTraceExporter';

--- a/experimental/packages/exporter-trace-otlp-proto/src/platform/index.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/src/platform/index.ts
@@ -2,4 +2,4 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-export { OTLPTraceExporter } from './node';
+export { createOtlpProtoSpanExporter, OTLPTraceExporter } from './node';

--- a/experimental/packages/exporter-trace-otlp-proto/src/platform/node/OTLPTraceExporter.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/src/platform/node/OTLPTraceExporter.ts
@@ -13,6 +13,7 @@ import {
 import {
   createOtlpHttpExportDelegate,
   convertLegacyHttpOptions,
+  convertLegacyHttpOptionsWithoutEnv,
 } from '@opentelemetry/otlp-exporter-base/node-http';
 import { OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_SPAN_EXPORTER } from '../../semconv';
 
@@ -36,4 +37,30 @@ export class OTLPTraceExporter
       )
     );
   }
+}
+
+/**
+ * Creates a span exporter that sends data over OTLP/HTTP with protobuf
+ * encoding.
+ *
+ * Unlike the {@link OTLPTraceExporter} class, the created exporter does not
+ * use `OTEL_EXPORTER_OTLP_*` environment variables for configuration: options
+ * that are not provided in `config` fall back to the defaults defined by the
+ * OTLP exporter specification. Reading configuration from the environment is
+ * the caller's responsibility.
+ */
+export function createOtlpProtoSpanExporter(
+  config: OTLPExporterNodeConfigBase = {}
+): SpanExporter {
+  return new OTLPExporterBase(
+    createOtlpHttpExportDelegate(
+      convertLegacyHttpOptionsWithoutEnv(config, 'v1/traces', {
+        'Content-Type': 'application/x-protobuf',
+      }),
+      ProtobufTraceSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_SPAN_EXPORTER,
+      TraceExporterMetricsHelper,
+      config.selfObsMeterProvider
+    )
+  );
 }

--- a/experimental/packages/exporter-trace-otlp-proto/src/platform/node/index.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/src/platform/node/index.ts
@@ -3,4 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPTraceExporter } from './OTLPTraceExporter';
+export {
+  createOtlpProtoSpanExporter,
+  OTLPTraceExporter,
+} from './OTLPTraceExporter';

--- a/experimental/packages/exporter-trace-otlp-proto/test/browser/OTLPTraceExporter.test.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/test/browser/OTLPTraceExporter.test.ts
@@ -7,7 +7,10 @@ import { MeterProvider } from '@opentelemetry/sdk-metrics';
 import { TracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { OTLPTraceExporter } from '../../src/platform/browser/index';
+import {
+  createOtlpProtoSpanExporter,
+  OTLPTraceExporter,
+} from '../../src/platform/browser/index';
 import { TestMetricReader } from '../utils';
 
 /*
@@ -62,5 +65,33 @@ describe('OTLPTraceExporter', () => {
       assert.ok(scopeMetrics);
       await meterProvider.shutdown();
     });
+  });
+});
+
+describe('createOtlpProtoSpanExporter', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should send data to the default endpoint', async function () {
+    // arrange
+    const stubFetch = sinon
+      .stub(window, 'fetch')
+      .resolves(new Response('', { status: 200 }));
+    const tracerProvider = new TracerProvider({
+      spanProcessors: [
+        new SimpleSpanProcessor({ exporter: createOtlpProtoSpanExporter() }),
+      ],
+    });
+
+    // act
+    tracerProvider.getTracer('test-tracer').startSpan('test-span').end();
+    await tracerProvider.shutdown();
+
+    // assert
+    assert.strictEqual(
+      stubFetch.firstCall.args[0],
+      'http://localhost:4318/v1/traces'
+    );
   });
 });

--- a/experimental/packages/exporter-trace-otlp-proto/test/node/OTLPTraceExporter.test.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/test/node/OTLPTraceExporter.test.ts
@@ -6,6 +6,7 @@
 import * as assert from 'assert';
 import * as http from 'http';
 import * as sinon from 'sinon';
+import { syncBuiltinESMExports } from 'module';
 import { Stream } from 'stream';
 
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
@@ -24,10 +25,38 @@ import { TestMetricReader } from '../utils';
  * - `@opentelemetry/otlp-transformer`: Everything regarding serialization and transforming internal representations to OTLP
  */
 
+function stubSuccessfulHttpRequest(): void {
+  (sinon.stub(http, 'request') as sinon.SinonStub).callsFake(
+    (...args: unknown[]) => {
+      const responseCallback =
+        typeof args[args.length - 1] === 'function'
+          ? (args[args.length - 1] as (res: unknown) => void)
+          : null;
+      const fakeRequest = new Stream.PassThrough();
+      Object.defineProperty(fakeRequest, 'setTimeout', {
+        value: function (_timeout: number) {},
+      });
+      fakeRequest.on('finish', () => {
+        if (responseCallback) {
+          const fakeResponse = new Stream.PassThrough() as any;
+          fakeResponse.statusCode = 200;
+          fakeResponse.statusMessage = 'OK';
+          fakeResponse.headers = {};
+          responseCallback(fakeResponse);
+          fakeResponse.end();
+        }
+      });
+      return fakeRequest as any;
+    }
+  );
+  syncBuiltinESMExports();
+}
+
 describe('OTLPTraceExporter', () => {
   describe('export', () => {
     afterEach(() => {
       sinon.restore();
+      syncBuiltinESMExports();
     });
 
     it('successfully exports data', done => {
@@ -42,6 +71,7 @@ describe('OTLPTraceExporter', () => {
       });
 
       sinon.stub(http, 'request').returns(fakeRequest as any);
+      syncBuiltinESMExports();
       let buff = Buffer.from('');
       fakeRequest.on('finish', async () => {
         try {
@@ -82,8 +112,14 @@ describe('OTLPTraceExporter', () => {
 });
 
 describe('createOtlpProtoSpanExporter', () => {
+  beforeEach(() => {
+    stubSuccessfulHttpRequest();
+  });
+
   afterEach(() => {
     delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    sinon.restore();
+    syncBuiltinESMExports();
   });
 
   async function collectServerAttributes(
@@ -118,10 +154,8 @@ describe('createOtlpProtoSpanExporter', () => {
       ],
     });
 
-    // The exporter records the endpoint it targets in its own metrics,
-    // synchronously when the export starts, so no request needs to complete
-    // for this assertion (and there is nothing to shut down for it).
     tracerProvider.getTracer('test-tracer').startSpan('test-span').end();
+    await tracerProvider.shutdown();
 
     const serverAttributes = await collectServerAttributes(metricReader);
     assert.ok(
@@ -156,6 +190,7 @@ describe('createOtlpProtoSpanExporter', () => {
     });
 
     tracerProvider.getTracer('test-tracer').startSpan('test-span').end();
+    await tracerProvider.shutdown();
 
     const serverAttributes = await collectServerAttributes(metricReader);
     assert.ok(

--- a/experimental/packages/exporter-trace-otlp-proto/test/node/OTLPTraceExporter.test.ts
+++ b/experimental/packages/exporter-trace-otlp-proto/test/node/OTLPTraceExporter.test.ts
@@ -9,8 +9,12 @@ import * as sinon from 'sinon';
 import { Stream } from 'stream';
 
 import { MeterProvider } from '@opentelemetry/sdk-metrics';
+import { type Attributes } from '@opentelemetry/api';
 import { TracerProvider, SimpleSpanProcessor } from '@opentelemetry/sdk-trace';
-import { OTLPTraceExporter } from '../../src/platform/node';
+import {
+  createOtlpProtoSpanExporter,
+  OTLPTraceExporter,
+} from '../../src/platform/node';
 import { TestMetricReader } from '../utils';
 
 /*
@@ -74,5 +78,95 @@ describe('OTLPTraceExporter', () => {
 
       tracerProvider.getTracer('test-tracer').startSpan('test-span').end();
     });
+  });
+});
+
+describe('createOtlpProtoSpanExporter', () => {
+  afterEach(() => {
+    delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+  });
+
+  async function collectServerAttributes(
+    metricReader: TestMetricReader
+  ): Promise<Attributes[]> {
+    const { resourceMetrics } = await metricReader.collect();
+    const scopeMetrics = resourceMetrics.scopeMetrics.find(
+      sm => sm.scope.name === '@opentelemetry/otlp-exporter'
+    );
+    return (
+      scopeMetrics?.metrics.flatMap(metric =>
+        metric.dataPoints.map(dataPoint => dataPoint.attributes)
+      ) ?? []
+    );
+  }
+
+  it('returns an exporter that does not use configuration from the environment', async () => {
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT =
+      'http://127.0.0.1:9/v1/traces';
+
+    const metricReader = new TestMetricReader();
+    const meterProvider = new MeterProvider({
+      readers: [metricReader],
+    });
+    const tracerProvider = new TracerProvider({
+      spanProcessors: [
+        new SimpleSpanProcessor({
+          exporter: createOtlpProtoSpanExporter({
+            selfObsMeterProvider: meterProvider,
+          }),
+        }),
+      ],
+    });
+
+    // The exporter records the endpoint it targets in its own metrics,
+    // synchronously when the export starts, so no request needs to complete
+    // for this assertion (and there is nothing to shut down for it).
+    tracerProvider.getTracer('test-tracer').startSpan('test-span').end();
+
+    const serverAttributes = await collectServerAttributes(metricReader);
+    assert.ok(
+      serverAttributes.some(
+        attrs =>
+          attrs['server.address'] === 'localhost' &&
+          attrs['server.port'] === 4318
+      ),
+      `expected exporter metrics to target the default endpoint, got ${JSON.stringify(
+        serverAttributes
+      )}`
+    );
+    await meterProvider.shutdown();
+  });
+
+  it('control: the class-based exporter keeps using the environment', async () => {
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT =
+      'http://127.0.0.1:9/v1/traces';
+
+    const metricReader = new TestMetricReader();
+    const meterProvider = new MeterProvider({
+      readers: [metricReader],
+    });
+    const tracerProvider = new TracerProvider({
+      spanProcessors: [
+        new SimpleSpanProcessor({
+          exporter: new OTLPTraceExporter({
+            selfObsMeterProvider: meterProvider,
+          }),
+        }),
+      ],
+    });
+
+    tracerProvider.getTracer('test-tracer').startSpan('test-span').end();
+
+    const serverAttributes = await collectServerAttributes(metricReader);
+    assert.ok(
+      serverAttributes.some(
+        attrs =>
+          attrs['server.address'] === '127.0.0.1' && attrs['server.port'] === 9
+      ),
+      `expected exporter metrics to target the env-provided endpoint, got ${JSON.stringify(
+        serverAttributes
+      )}`
+    );
+    await meterProvider.shutdown();
   });
 });

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/README.md
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/README.md
@@ -120,6 +120,18 @@ In addition to settings passed to the constructor, the exporter also supports co
 
 > Settings configured programmatically take precedence over environment variables. Per-signal environment variables take precedence over non-per-signal environment variables.
 
+### Creating an exporter without environment variable configuration
+
+The `OTLPMetricExporter` class reads the environment variables described above. When that is not desirable — for example, when the exporter is configured from a configuration file — use `createOtlpGrpcMetricExporter` instead. It accepts the same options, but does not read `OTEL_EXPORTER_OTLP_*` environment variables; options that are not provided fall back to the defaults defined by the OTLP exporter specification (in particular, cumulative aggregation temporality is used when `temporalityPreference` is not set).
+
+```js
+const { createOtlpGrpcMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-grpc');
+
+const exporter = createOtlpGrpcMetricExporter({
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is localhost:4317
+});
+```
+
 ## Running opentelemetry-collector locally to see the metrics
 
 1. Go to `examples/otlp-exporter-node`

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/package.json
@@ -49,7 +49,6 @@
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
     "@opentelemetry/api": "1.9.1",
-    "@opentelemetry/sdk-metrics": "2.10.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.19.130",
     "@types/sinon": "17.0.4",
@@ -65,7 +64,8 @@
   "dependencies": {
     "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
     "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
-    "@opentelemetry/otlp-transformer": "0.221.0"
+    "@opentelemetry/otlp-transformer": "0.221.0",
+    "@opentelemetry/sdk-metrics": "2.10.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/OTLPMetricExporter.ts
@@ -4,10 +4,15 @@
  */
 
 import type { OTLPMetricExporterOptions } from '@opentelemetry/exporter-metrics-otlp-http';
-import { OTLPMetricExporterBase } from '@opentelemetry/exporter-metrics-otlp-http';
+import {
+  AggregationTemporalityPreference,
+  OTLPMetricExporterBase,
+} from '@opentelemetry/exporter-metrics-otlp-http';
+import type { PushMetricExporter } from '@opentelemetry/sdk-metrics';
 import type { OTLPGRPCExporterConfigNode } from '@opentelemetry/otlp-grpc-exporter-base';
 import {
   convertLegacyOtlpGrpcOptions,
+  convertLegacyOtlpGrpcOptionsWithoutEnv,
   createOtlpGrpcExportDelegate,
   createOtlpGrpcExporterMetrics,
 } from '@opentelemetry/otlp-grpc-exporter-base';
@@ -53,4 +58,38 @@ export class OTLPMetricExporter extends OTLPMetricExporterBase {
       )
     );
   }
+}
+
+/**
+ * Creates a metric exporter that sends data over OTLP/gRPC.
+ *
+ * Unlike the {@link OTLPMetricExporter} class, the created exporter does not
+ * use `OTEL_EXPORTER_OTLP_*` environment variables for configuration: options
+ * that are not provided in `config` fall back to the defaults defined by the
+ * OTLP exporter specification (in particular, cumulative aggregation
+ * temporality is used when `temporalityPreference` is not set, instead of the
+ * `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable).
+ * Reading configuration from the environment is the caller's responsibility.
+ */
+export function createOtlpGrpcMetricExporter(
+  config?: OTLPGRPCExporterConfigNode & OTLPMetricExporterOptions
+): PushMetricExporter {
+  return new OTLPMetricExporterBase(
+    createOtlpGrpcExportDelegate(
+      convertLegacyOtlpGrpcOptionsWithoutEnv(config ?? {}),
+      ProtobufMetricsSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_GRPC_METRIC_EXPORTER,
+      MetricsExporterMetricsHelper,
+      config?.selfObsMeterProvider,
+      'MetricsExportService',
+      '/opentelemetry.proto.collector.metrics.v1.MetricsService/Export'
+    ),
+    {
+      ...config,
+      // default from the specification instead of reading the environment
+      temporalityPreference:
+        config?.temporalityPreference ??
+        AggregationTemporalityPreference.CUMULATIVE,
+    }
+  );
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/src/index.ts
@@ -3,4 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPMetricExporter } from './OTLPMetricExporter';
+export {
+  createOtlpGrpcMetricExporter,
+  OTLPMetricExporter,
+} from './OTLPMetricExporter';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/test/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-grpc/test/OTLPMetricExporter.test.ts
@@ -3,11 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OTLPMetricExporter } from '../src';
+import { OTLPMetricExporter, createOtlpGrpcMetricExporter } from '../src';
 import type { ServerTestContext } from './utils';
 import { startServer, TestMetricReader } from './utils';
 import * as assert from 'assert';
+import { AggregationTemporalityPreference } from '@opentelemetry/exporter-metrics-otlp-http';
 import {
+  AggregationTemporality,
+  InstrumentType,
   MeterProvider,
   PeriodicExportingMetricReader,
 } from '@opentelemetry/sdk-metrics';
@@ -93,5 +96,61 @@ describe('OTLPMetricsExporter', function () {
     );
     assert.ok(scopeMetrics);
     await meterProvider.shutdown();
+  });
+
+  describe('createOtlpGrpcMetricExporter', function () {
+    afterEach(function () {
+      delete process.env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE;
+    });
+
+    it('does not read OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE from the environment', function () {
+      process.env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = 'delta';
+
+      // control: the class-based exporter keeps using the environment
+      assert.equal(
+        new OTLPMetricExporter().selectAggregationTemporality(
+          InstrumentType.COUNTER
+        ),
+        AggregationTemporality.DELTA
+      );
+
+      // the factory-created exporter uses the specification default instead
+      assert.equal(
+        createOtlpGrpcMetricExporter().selectAggregationTemporality!(
+          InstrumentType.COUNTER
+        ),
+        AggregationTemporality.CUMULATIVE
+      );
+    });
+
+    it('honors an explicit temporalityPreference over the specification default', function () {
+      process.env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE =
+        'cumulative';
+
+      assert.equal(
+        createOtlpGrpcMetricExporter({
+          temporalityPreference: AggregationTemporalityPreference.DELTA,
+        }).selectAggregationTemporality!(InstrumentType.COUNTER),
+        AggregationTemporality.DELTA
+      );
+    });
+
+    it('successfully exports data', async () => {
+      // arrange
+      const exporter = createOtlpGrpcMetricExporter({
+        url: 'http://localhost:1502',
+      });
+      const meterProvider = new MeterProvider({
+        readers: [new PeriodicExportingMetricReader({ exporter })],
+      });
+
+      // act
+      meterProvider.getMeter('test-meter').createCounter('test-counter').add(1);
+      await meterProvider.forceFlush();
+
+      // assert
+      assert.strictEqual(serverTestContext.requests.length, 1);
+      await meterProvider.shutdown();
+    });
   });
 });

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/README.md
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/README.md
@@ -89,6 +89,18 @@ In addition to settings passed to the constructor, the exporter also supports co
 > Settings configured programmatically take precedence over environment variables. Per-signal environment variables take
 > precedence over non-per-signal environment variables.
 
+### Creating an exporter without environment variable configuration
+
+The `OTLPMetricExporter` class reads the environment variables described above. When that is not desirable — for example, when the exporter is configured from a configuration file — use `createOtlpHttpMetricExporter` instead. It accepts the same options, but does not read `OTEL_EXPORTER_OTLP_*` environment variables; options that are not provided fall back to the defaults defined by the OTLP exporter specification (in particular, cumulative aggregation temporality is used when `temporalityPreference` is not set).
+
+```js
+const { createOtlpHttpMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-http');
+
+const exporter = createOtlpHttpMetricExporter({
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:4318/v1/metrics
+});
+```
+
 ## Running opentelemetry-collector locally to see the metrics
 
 1. Go to `examples/otlp-exporter-node`

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/index.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPMetricExporter } from './platform';
+export { createOtlpHttpMetricExporter, OTLPMetricExporter } from './platform';
 export { AggregationTemporalityPreference } from './OTLPMetricExporterOptions';
 export type { OTLPMetricExporterOptions } from './OTLPMetricExporterOptions';
 export {

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/browser/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/browser/OTLPMetricExporter.ts
@@ -4,7 +4,9 @@
  */
 
 import { type MeterProvider } from '@opentelemetry/api';
+import type { PushMetricExporter } from '@opentelemetry/sdk-metrics';
 import type { OTLPMetricExporterOptions } from '../../OTLPMetricExporterOptions';
+import { AggregationTemporalityPreference } from '../../OTLPMetricExporterOptions';
 import { OTLPMetricExporterBase } from '../../OTLPMetricExporterBase';
 import type { OTLPExporterConfigBase } from '@opentelemetry/otlp-exporter-base';
 import {
@@ -53,4 +55,37 @@ export class OTLPMetricExporter extends OTLPMetricExporterBase {
       )
     );
   }
+}
+
+/**
+ * Creates a metric exporter that sends data over OTLP/HTTP with JSON encoding.
+ *
+ * The created exporter does not use `OTEL_EXPORTER_OTLP_*` environment
+ * variables for configuration: options that are not provided in `config` fall
+ * back to the defaults defined by the OTLP exporter specification (in
+ * particular, cumulative aggregation temporality is used when
+ * `temporalityPreference` is not set). Reading configuration from the
+ * environment is the caller's responsibility.
+ */
+export function createOtlpHttpMetricExporter(
+  config?: OTLPExporterConfigBase & OTLPMetricExporterOptions
+): PushMetricExporter {
+  return new OTLPMetricExporterBase(
+    createLegacyOtlpBrowserExportDelegate(
+      config ?? {},
+      JsonMetricsSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_METRIC_EXPORTER,
+      MetricsExporterMetricsHelper,
+      config?.selfObsMeterProvider,
+      'v1/metrics',
+      { 'Content-Type': 'application/json' }
+    ),
+    {
+      ...config,
+      // default from the specification instead of reading the environment
+      temporalityPreference:
+        config?.temporalityPreference ??
+        AggregationTemporalityPreference.CUMULATIVE,
+    }
+  );
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/browser/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/browser/index.ts
@@ -3,4 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPMetricExporter } from './OTLPMetricExporter';
+export {
+  createOtlpHttpMetricExporter,
+  OTLPMetricExporter,
+} from './OTLPMetricExporter';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPMetricExporter } from './node';
+export { createOtlpHttpMetricExporter, OTLPMetricExporter } from './node';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/OTLPMetricExporter.ts
@@ -4,7 +4,9 @@
  */
 
 import { type MeterProvider } from '@opentelemetry/api';
+import type { PushMetricExporter } from '@opentelemetry/sdk-metrics';
 import type { OTLPMetricExporterOptions } from '../../OTLPMetricExporterOptions';
+import { AggregationTemporalityPreference } from '../../OTLPMetricExporterOptions';
 import { OTLPMetricExporterBase } from '../../OTLPMetricExporterBase';
 import type { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
 import {
@@ -13,6 +15,7 @@ import {
 } from '@opentelemetry/otlp-transformer';
 import {
   convertLegacyHttpOptions,
+  convertLegacyHttpOptionsWithoutEnv,
   createOtlpHttpExportDelegate,
   createOtlpHttpExporterMetrics,
 } from '@opentelemetry/otlp-exporter-base/node-http';
@@ -54,4 +57,38 @@ export class OTLPMetricExporter extends OTLPMetricExporterBase {
       )
     );
   }
+}
+
+/**
+ * Creates a metric exporter that sends data over OTLP/HTTP with JSON encoding.
+ *
+ * Unlike the {@link OTLPMetricExporter} class, the created exporter does not
+ * use `OTEL_EXPORTER_OTLP_*` environment variables for configuration: options
+ * that are not provided in `config` fall back to the defaults defined by the
+ * OTLP exporter specification (in particular, cumulative aggregation
+ * temporality is used when `temporalityPreference` is not set, instead of the
+ * `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable).
+ * Reading configuration from the environment is the caller's responsibility.
+ */
+export function createOtlpHttpMetricExporter(
+  config?: OTLPExporterNodeConfigBase & OTLPMetricExporterOptions
+): PushMetricExporter {
+  return new OTLPMetricExporterBase(
+    createOtlpHttpExportDelegate(
+      convertLegacyHttpOptionsWithoutEnv(config ?? {}, 'v1/metrics', {
+        'Content-Type': 'application/json',
+      }),
+      JsonMetricsSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_METRIC_EXPORTER,
+      MetricsExporterMetricsHelper,
+      config?.selfObsMeterProvider
+    ),
+    {
+      ...config,
+      // default from the specification instead of reading the environment
+      temporalityPreference:
+        config?.temporalityPreference ??
+        AggregationTemporalityPreference.CUMULATIVE,
+    }
+  );
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/src/platform/node/index.ts
@@ -3,4 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPMetricExporter } from './OTLPMetricExporter';
+export {
+  createOtlpHttpMetricExporter,
+  OTLPMetricExporter,
+} from './OTLPMetricExporter';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/browser/OTLPMetricExporter.test.ts
@@ -14,7 +14,10 @@ import {
 } from '@opentelemetry/sdk-metrics';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { OTLPMetricExporter } from '../../src/platform/browser';
+import {
+  createOtlpHttpMetricExporter,
+  OTLPMetricExporter,
+} from '../../src/platform/browser';
 import { TestMetricReader } from '../utils';
 
 /*
@@ -208,5 +211,16 @@ describe('OTLPMetricExporter', function () {
         }
       );
     });
+  });
+});
+
+describe('createOtlpHttpMetricExporter', () => {
+  it('uses the specification default temporality without reading the environment', function () {
+    assert.strictEqual(
+      createOtlpHttpMetricExporter().selectAggregationTemporality!(
+        InstrumentType.COUNTER
+      ),
+      AggregationTemporality.CUMULATIVE
+    );
   });
 });

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-http/test/node/OTLPMetricExporter.test.ts
@@ -8,7 +8,10 @@ import * as http from 'http';
 import * as sinon from 'sinon';
 
 import { AggregationTemporalityPreference } from '../../src';
-import { OTLPMetricExporter } from '../../src/platform/node';
+import {
+  createOtlpHttpMetricExporter,
+  OTLPMetricExporter,
+} from '../../src/platform/node';
 import type { AggregationOption } from '@opentelemetry/sdk-metrics';
 import {
   AggregationTemporality,
@@ -246,5 +249,43 @@ describe('OTLPMetricExporter', () => {
       // act
       meterProvider.forceFlush();
     });
+  });
+});
+
+describe('createOtlpHttpMetricExporter', () => {
+  afterEach(() => {
+    delete process.env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE;
+  });
+
+  it('does not read OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE from the environment', () => {
+    process.env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = 'delta';
+
+    // control: the class-based exporter keeps using the environment
+    assert.equal(
+      new OTLPMetricExporter().selectAggregationTemporality(
+        InstrumentType.COUNTER
+      ),
+      AggregationTemporality.DELTA
+    );
+
+    // the factory-created exporter uses the specification default instead
+    assert.equal(
+      createOtlpHttpMetricExporter().selectAggregationTemporality!(
+        InstrumentType.COUNTER
+      ),
+      AggregationTemporality.CUMULATIVE
+    );
+  });
+
+  it('honors an explicit temporalityPreference over the specification default', () => {
+    process.env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE =
+      'cumulative';
+
+    assert.equal(
+      createOtlpHttpMetricExporter({
+        temporalityPreference: AggregationTemporalityPreference.DELTA,
+      }).selectAggregationTemporality!(InstrumentType.COUNTER),
+      AggregationTemporality.DELTA
+    );
   });
 });

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/README.md
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/README.md
@@ -57,6 +57,18 @@ In addition to settings passed to the constructor, the exporter also supports co
 > Settings configured programmatically take precedence over environment variables. Per-signal environment variables take
 > precedence over non-per-signal environment variables.
 
+### Creating an exporter without environment variable configuration
+
+The `OTLPMetricExporter` class reads the environment variables described above. When that is not desirable — for example, when the exporter is configured from a configuration file — use `createOtlpProtoMetricExporter` instead. It accepts the same options, but does not read `OTEL_EXPORTER_OTLP_*` environment variables; options that are not provided fall back to the defaults defined by the OTLP exporter specification (in particular, cumulative aggregation temporality is used when `temporalityPreference` is not set).
+
+```js
+const { createOtlpProtoMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-proto');
+
+const exporter = createOtlpProtoMetricExporter({
+  url: '<opentelemetry-collector-url>', // url is optional and can be omitted - default is http://localhost:4318/v1/metrics
+});
+```
+
 ## Running opentelemetry-collector locally to see the metrics
 
 1. Go to `examples/otlp-exporter-node`

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/package.json
@@ -64,7 +64,6 @@
     "@babel/core": "7.29.7",
     "@babel/preset-env": "7.29.7",
     "@opentelemetry/api": "1.9.1",
-    "@opentelemetry/sdk-metrics": "2.10.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.19.130",
     "@types/sinon": "17.0.4",
@@ -91,7 +90,8 @@
   "dependencies": {
     "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
     "@opentelemetry/otlp-exporter-base": "0.221.0",
-    "@opentelemetry/otlp-transformer": "0.221.0"
+    "@opentelemetry/otlp-transformer": "0.221.0",
+    "@opentelemetry/sdk-metrics": "2.10.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-exporter-metrics-otlp-proto",
   "sideEffects": false

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPMetricExporter } from './platform';
+export { createOtlpProtoMetricExporter, OTLPMetricExporter } from './platform';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/browser/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/browser/OTLPMetricExporter.ts
@@ -4,8 +4,12 @@
  */
 
 import { type MeterProvider } from '@opentelemetry/api';
+import type { PushMetricExporter } from '@opentelemetry/sdk-metrics';
 import type { OTLPMetricExporterOptions } from '@opentelemetry/exporter-metrics-otlp-http';
-import { OTLPMetricExporterBase } from '@opentelemetry/exporter-metrics-otlp-http';
+import {
+  AggregationTemporalityPreference,
+  OTLPMetricExporterBase,
+} from '@opentelemetry/exporter-metrics-otlp-http';
 import type { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
 import {
   MetricsExporterMetricsHelper,
@@ -52,4 +56,38 @@ export class OTLPMetricExporter extends OTLPMetricExporterBase {
       )
     );
   }
+}
+
+/**
+ * Creates a metric exporter that sends data over OTLP/HTTP with protobuf
+ * encoding.
+ *
+ * The created exporter does not use `OTEL_EXPORTER_OTLP_*` environment
+ * variables for configuration: options that are not provided in `config` fall
+ * back to the defaults defined by the OTLP exporter specification (in
+ * particular, cumulative aggregation temporality is used when
+ * `temporalityPreference` is not set). Reading configuration from the
+ * environment is the caller's responsibility.
+ */
+export function createOtlpProtoMetricExporter(
+  config: OTLPExporterNodeConfigBase & OTLPMetricExporterOptions = {}
+): PushMetricExporter {
+  return new OTLPMetricExporterBase(
+    createLegacyOtlpBrowserExportDelegate(
+      config,
+      ProtobufMetricsSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_METRIC_EXPORTER,
+      MetricsExporterMetricsHelper,
+      config?.selfObsMeterProvider,
+      'v1/metrics',
+      { 'Content-Type': 'application/x-protobuf' }
+    ),
+    {
+      ...config,
+      // default from the specification instead of reading the environment
+      temporalityPreference:
+        config?.temporalityPreference ??
+        AggregationTemporalityPreference.CUMULATIVE,
+    }
+  );
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/browser/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/browser/index.ts
@@ -3,4 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPMetricExporter } from './OTLPMetricExporter';
+export {
+  createOtlpProtoMetricExporter,
+  OTLPMetricExporter,
+} from './OTLPMetricExporter';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPMetricExporter } from './node';
+export { createOtlpProtoMetricExporter, OTLPMetricExporter } from './node';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/node/OTLPMetricExporter.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/node/OTLPMetricExporter.ts
@@ -4,8 +4,12 @@
  */
 
 import { type MeterProvider } from '@opentelemetry/api';
+import type { PushMetricExporter } from '@opentelemetry/sdk-metrics';
 import type { OTLPMetricExporterOptions } from '@opentelemetry/exporter-metrics-otlp-http';
-import { OTLPMetricExporterBase } from '@opentelemetry/exporter-metrics-otlp-http';
+import {
+  AggregationTemporalityPreference,
+  OTLPMetricExporterBase,
+} from '@opentelemetry/exporter-metrics-otlp-http';
 import type { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
 import {
   MetricsExporterMetricsHelper,
@@ -13,6 +17,7 @@ import {
 } from '@opentelemetry/otlp-transformer';
 import {
   convertLegacyHttpOptions,
+  convertLegacyHttpOptionsWithoutEnv,
   createOtlpHttpExportDelegate,
   createOtlpHttpExporterMetrics,
 } from '@opentelemetry/otlp-exporter-base/node-http';
@@ -51,4 +56,39 @@ export class OTLPMetricExporter extends OTLPMetricExporterBase {
       )
     );
   }
+}
+
+/**
+ * Creates a metric exporter that sends data over OTLP/HTTP with protobuf
+ * encoding.
+ *
+ * Unlike the {@link OTLPMetricExporter} class, the created exporter does not
+ * use `OTEL_EXPORTER_OTLP_*` environment variables for configuration: options
+ * that are not provided in `config` fall back to the defaults defined by the
+ * OTLP exporter specification (in particular, cumulative aggregation
+ * temporality is used when `temporalityPreference` is not set, instead of the
+ * `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable).
+ * Reading configuration from the environment is the caller's responsibility.
+ */
+export function createOtlpProtoMetricExporter(
+  config?: OTLPExporterNodeConfigBase & OTLPMetricExporterOptions
+): PushMetricExporter {
+  return new OTLPMetricExporterBase(
+    createOtlpHttpExportDelegate(
+      convertLegacyHttpOptionsWithoutEnv(config ?? {}, 'v1/metrics', {
+        'Content-Type': 'application/x-protobuf',
+      }),
+      ProtobufMetricsSerializer,
+      OTEL_COMPONENT_TYPE_VALUE_OTLP_HTTP_METRIC_EXPORTER,
+      MetricsExporterMetricsHelper,
+      config?.selfObsMeterProvider
+    ),
+    {
+      ...config,
+      // default from the specification instead of reading the environment
+      temporalityPreference:
+        config?.temporalityPreference ??
+        AggregationTemporalityPreference.CUMULATIVE,
+    }
+  );
 }

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/node/index.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/src/platform/node/index.ts
@@ -3,4 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { OTLPMetricExporter } from './OTLPMetricExporter';
+export {
+  createOtlpProtoMetricExporter,
+  OTLPMetricExporter,
+} from './OTLPMetricExporter';

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/browser/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/browser/OTLPMetricExporter.test.ts
@@ -4,12 +4,17 @@
  */
 
 import {
+  AggregationTemporality,
+  InstrumentType,
   MeterProvider,
   PeriodicExportingMetricReader,
 } from '@opentelemetry/sdk-metrics';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { OTLPMetricExporter } from '../../src/platform/browser';
+import {
+  createOtlpProtoMetricExporter,
+  OTLPMetricExporter,
+} from '../../src/platform/browser';
 import { TestMetricReader } from '../utils';
 
 /*
@@ -63,5 +68,16 @@ describe('OTLPMetricExporter', () => {
       assert.ok(scopeMetrics);
       await meterProvider.shutdown();
     });
+  });
+});
+
+describe('createOtlpProtoMetricExporter', () => {
+  it('uses the specification default temporality without reading the environment', function () {
+    assert.strictEqual(
+      createOtlpProtoMetricExporter().selectAggregationTemporality!(
+        InstrumentType.COUNTER
+      ),
+      AggregationTemporality.CUMULATIVE
+    );
   });
 });

--- a/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/node/OTLPMetricExporter.test.ts
+++ b/experimental/packages/opentelemetry-exporter-metrics-otlp-proto/test/node/OTLPMetricExporter.test.ts
@@ -8,7 +8,11 @@ import * as http from 'http';
 import * as sinon from 'sinon';
 
 import { OTLPMetricExporter } from '../../src/platform/node';
+import { createOtlpProtoMetricExporter } from '../../src/platform/node';
+import { AggregationTemporalityPreference } from '@opentelemetry/exporter-metrics-otlp-http';
 import {
+  AggregationTemporality,
+  InstrumentType,
   MeterProvider,
   PeriodicExportingMetricReader,
 } from '@opentelemetry/sdk-metrics';
@@ -99,5 +103,43 @@ describe('OTLPMetricExporter', () => {
       // act
       meterProvider.forceFlush();
     });
+  });
+});
+
+describe('createOtlpProtoMetricExporter', () => {
+  afterEach(() => {
+    delete process.env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE;
+  });
+
+  it('does not read OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE from the environment', () => {
+    process.env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = 'delta';
+
+    // control: the class-based exporter keeps using the environment
+    assert.equal(
+      new OTLPMetricExporter().selectAggregationTemporality(
+        InstrumentType.COUNTER
+      ),
+      AggregationTemporality.DELTA
+    );
+
+    // the factory-created exporter uses the specification default instead
+    assert.equal(
+      createOtlpProtoMetricExporter().selectAggregationTemporality!(
+        InstrumentType.COUNTER
+      ),
+      AggregationTemporality.CUMULATIVE
+    );
+  });
+
+  it('honors an explicit temporalityPreference over the specification default', () => {
+    process.env.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE =
+      'cumulative';
+
+    assert.equal(
+      createOtlpProtoMetricExporter({
+        temporalityPreference: AggregationTemporalityPreference.DELTA,
+      }).selectAggregationTemporality!(InstrumentType.COUNTER),
+      AggregationTemporality.DELTA
+    );
   });
 });

--- a/experimental/packages/otlp-exporter-base/src/configuration/convert-legacy-node-http-options.ts
+++ b/experimental/packages/otlp-exporter-base/src/configuration/convert-legacy-node-http-options.ts
@@ -35,6 +35,25 @@ function convertLegacyAgentOptions(
   }
 }
 
+function getUserProvidedConfiguration(
+  config: OTLPExporterNodeConfigBase
+): Partial<OtlpNodeHttpConfiguration> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((config as any).metadata) {
+    diag.warn('Metadata cannot be set when using http');
+  }
+
+  return {
+    url: config.url,
+    headers: convertLegacyHeaders(config),
+    concurrencyLimit: config.concurrencyLimit,
+    timeoutMillis: config.timeoutMillis,
+    compression: config.compression,
+    agentFactory: convertLegacyAgentOptions(config),
+    userAgent: config.userAgent,
+  };
+}
+
 /**
  * @deprecated this will be removed in 2.0
  * @param config
@@ -48,25 +67,35 @@ export function convertLegacyHttpOptions(
   signalResourcePath: string,
   requiredHeaders: Record<string, string>
 ): OtlpNodeHttpConfiguration {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ((config as any).metadata) {
-    diag.warn('Metadata cannot be set when using http');
-  }
-
   return mergeOtlpNodeHttpConfigurationWithDefaults(
-    {
-      url: config.url,
-      headers: convertLegacyHeaders(config),
-      concurrencyLimit: config.concurrencyLimit,
-      timeoutMillis: config.timeoutMillis,
-      compression: config.compression,
-      agentFactory: convertLegacyAgentOptions(config),
-      userAgent: config.userAgent,
-    },
+    getUserProvidedConfiguration(config),
     getNodeHttpConfigurationFromEnvironment(
       signalIdentifier,
       signalResourcePath
     ),
+    getNodeHttpConfigurationDefaults(requiredHeaders, signalResourcePath)
+  );
+}
+
+/**
+ * Converts the legacy configuration options into the configuration model used
+ * by the OTLP HTTP exporters, without reading configuration from the
+ * environment. Options that are not provided in `config` fall back to the
+ * defaults defined by the OTLP exporter specification; reading configuration
+ * from the environment is the caller's responsibility.
+ *
+ * @param config user-provided configuration options
+ * @param signalResourcePath signal resource path to append to the default URL (e.g.: v1/metrics, v1/traces, v1/logs)
+ * @param requiredHeaders headers that are always set, taking precedence over user-provided ones (e.g.: Content-Type)
+ */
+export function convertLegacyHttpOptionsWithoutEnv(
+  config: OTLPExporterNodeConfigBase,
+  signalResourcePath: string,
+  requiredHeaders: Record<string, string>
+): OtlpNodeHttpConfiguration {
+  return mergeOtlpNodeHttpConfigurationWithDefaults(
+    getUserProvidedConfiguration(config),
+    {}, // no fallback from the environment
     getNodeHttpConfigurationDefaults(requiredHeaders, signalResourcePath)
   );
 }

--- a/experimental/packages/otlp-exporter-base/src/index-node-http.ts
+++ b/experimental/packages/otlp-exporter-base/src/index-node-http.ts
@@ -9,4 +9,7 @@ export {
   createOtlpHttpExporterMetrics,
 } from './otlp-http-export-delegate';
 export { getSharedConfigurationFromEnvironment } from './configuration/shared-env-configuration';
-export { convertLegacyHttpOptions } from './configuration/convert-legacy-node-http-options';
+export {
+  convertLegacyHttpOptions,
+  convertLegacyHttpOptionsWithoutEnv,
+} from './configuration/convert-legacy-node-http-options';

--- a/experimental/packages/otlp-exporter-base/test/node/configuration/convert-legacy-node-otlp-http-options.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/node/configuration/convert-legacy-node-otlp-http-options.test.ts
@@ -6,7 +6,10 @@
 import * as sinon from 'sinon';
 import * as assert from 'assert';
 import type * as https from 'https';
-import { convertLegacyHttpOptions } from '../../../src/configuration/convert-legacy-node-http-options';
+import {
+  convertLegacyHttpOptions,
+  convertLegacyHttpOptionsWithoutEnv,
+} from '../../../src/configuration/convert-legacy-node-http-options';
 import { registerMockDiagLogger } from '../../common/test-utils';
 
 describe('convertLegacyHttpOptions', function () {
@@ -100,5 +103,94 @@ describe('convertLegacyHttpOptions', function () {
     // assert
     assert.deepStrictEqual(initialHeaders, { foo: 'bar' });
     assert.deepStrictEqual(laterHeaders, { foo: 'baz' });
+  });
+});
+
+describe('convertLegacyHttpOptionsWithoutEnv', function () {
+  afterEach(function () {
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    delete process.env.OTEL_EXPORTER_OTLP_HEADERS;
+    delete process.env.OTEL_EXPORTER_OTLP_TIMEOUT;
+    delete process.env.OTEL_EXPORTER_OTLP_COMPRESSION;
+    sinon.restore();
+  });
+
+  it('should warn when used with metadata', function () {
+    const { warn } = registerMockDiagLogger();
+
+    convertLegacyHttpOptionsWithoutEnv(
+      { metadata: { foo: 'bar' } } as any,
+      'v1/signal',
+      {}
+    );
+
+    sinon.assert.calledOnceWithExactly(
+      warn,
+      'Metadata cannot be set when using http'
+    );
+  });
+
+  it('should not use the endpoint from the environment', function () {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://env.example:4318';
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT =
+      'http://traces.env.example:4318';
+
+    // control: the environment-aware conversion does use the environment
+    assert.strictEqual(
+      convertLegacyHttpOptions({}, 'TRACES', 'v1/traces', {}).url,
+      'http://traces.env.example:4318/'
+    );
+
+    const options = convertLegacyHttpOptionsWithoutEnv({}, 'v1/traces', {});
+    assert.strictEqual(options.url, 'http://localhost:4318/v1/traces');
+  });
+
+  it('should not use timeout or compression from the environment', function () {
+    process.env.OTEL_EXPORTER_OTLP_TIMEOUT = '15000';
+    process.env.OTEL_EXPORTER_OTLP_COMPRESSION = 'gzip';
+
+    // control: the environment-aware conversion does use the environment
+    const fromEnv = convertLegacyHttpOptions({}, 'TRACES', 'v1/traces', {});
+    assert.strictEqual(fromEnv.timeoutMillis, 15000);
+    assert.strictEqual(fromEnv.compression, 'gzip');
+
+    const options = convertLegacyHttpOptionsWithoutEnv({}, 'v1/traces', {});
+    assert.strictEqual(options.timeoutMillis, 10000);
+    assert.strictEqual(options.compression, 'none');
+  });
+
+  it('should not use headers from the environment', async function () {
+    process.env.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar';
+
+    // control: the environment-aware conversion does use the environment
+    const fromEnv = convertLegacyHttpOptions({}, 'TRACES', 'v1/traces', {});
+    assert.deepStrictEqual(await fromEnv.headers(), { foo: 'bar' });
+
+    const options = convertLegacyHttpOptionsWithoutEnv({}, 'v1/traces', {
+      'Content-Type': 'application/json',
+    });
+    assert.deepStrictEqual(await options.headers(), {
+      'Content-Type': 'application/json',
+    });
+  });
+
+  it('should use user-provided configuration even when the environment is set', async function () {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://env.example:4318';
+    process.env.OTEL_EXPORTER_OTLP_TIMEOUT = '15000';
+
+    const options = convertLegacyHttpOptionsWithoutEnv(
+      {
+        url: 'http://user.example:4318/v1/traces',
+        timeoutMillis: 1234,
+        headers: { foo: 'user' },
+      },
+      'v1/traces',
+      {}
+    );
+
+    assert.strictEqual(options.url, 'http://user.example:4318/v1/traces');
+    assert.strictEqual(options.timeoutMillis, 1234);
+    assert.deepStrictEqual(await options.headers(), { foo: 'user' });
   });
 });

--- a/experimental/packages/otlp-grpc-exporter-base/src/configuration/convert-legacy-otlp-grpc-options.ts
+++ b/experimental/packages/otlp-grpc-exporter-base/src/configuration/convert-legacy-otlp-grpc-options.ts
@@ -11,6 +11,28 @@ import {
 import { createEmptyMetadata } from '../grpc-exporter-transport';
 import { getOtlpGrpcConfigurationFromEnv } from './otlp-grpc-env-configuration';
 
+function getUserProvidedGrpcConfiguration(
+  config: OTLPGRPCExporterConfigNode
+): Partial<OtlpGrpcConfiguration> {
+  // keep credentials locally in case user updates the reference on the config object
+  const userProvidedCredentials = config.credentials;
+  return {
+    url: config.url,
+    metadata: () => {
+      // metadata resolution strategy is merge, so we can return empty here, and it will not override the rest of the settings.
+      return config.metadata ?? createEmptyMetadata();
+    },
+    compression: config.compression,
+    timeoutMillis: config.timeoutMillis,
+    concurrencyLimit: config.concurrencyLimit,
+    credentials:
+      userProvidedCredentials != null
+        ? () => userProvidedCredentials
+        : undefined,
+    userAgent: config.userAgent,
+  };
+}
+
 /**
  * @deprecated
  * @param config
@@ -20,25 +42,28 @@ export function convertLegacyOtlpGrpcOptions(
   config: OTLPGRPCExporterConfigNode,
   signalIdentifier: string
 ): OtlpGrpcConfiguration {
-  // keep credentials locally in case user updates the reference on the config object
-  const userProvidedCredentials = config.credentials;
   return mergeOtlpGrpcConfigurationWithDefaults(
-    {
-      url: config.url,
-      metadata: () => {
-        // metadata resolution strategy is merge, so we can return empty here, and it will not override the rest of the settings.
-        return config.metadata ?? createEmptyMetadata();
-      },
-      compression: config.compression,
-      timeoutMillis: config.timeoutMillis,
-      concurrencyLimit: config.concurrencyLimit,
-      credentials:
-        userProvidedCredentials != null
-          ? () => userProvidedCredentials
-          : undefined,
-      userAgent: config.userAgent,
-    },
+    getUserProvidedGrpcConfiguration(config),
     getOtlpGrpcConfigurationFromEnv(signalIdentifier),
+    getOtlpGrpcDefaultConfiguration()
+  );
+}
+
+/**
+ * Converts the legacy configuration options into the configuration model used
+ * by the OTLP gRPC exporters, without reading configuration from the
+ * environment. Options that are not provided in `config` fall back to the
+ * defaults defined by the OTLP exporter specification; reading configuration
+ * from the environment is the caller's responsibility.
+ *
+ * @param config user-provided configuration options
+ */
+export function convertLegacyOtlpGrpcOptionsWithoutEnv(
+  config: OTLPGRPCExporterConfigNode
+): OtlpGrpcConfiguration {
+  return mergeOtlpGrpcConfigurationWithDefaults(
+    getUserProvidedGrpcConfiguration(config),
+    {}, // no fallback from the environment
     getOtlpGrpcDefaultConfiguration()
   );
 }

--- a/experimental/packages/otlp-grpc-exporter-base/src/index.ts
+++ b/experimental/packages/otlp-grpc-exporter-base/src/index.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { convertLegacyOtlpGrpcOptions } from './configuration/convert-legacy-otlp-grpc-options';
+export {
+  convertLegacyOtlpGrpcOptions,
+  convertLegacyOtlpGrpcOptionsWithoutEnv,
+} from './configuration/convert-legacy-otlp-grpc-options';
 export {
   createOtlpGrpcExportDelegate,
   createOtlpGrpcExporterMetrics,

--- a/experimental/packages/otlp-grpc-exporter-base/test/configuration/convert-legacy-otlp-grpc-options.test.ts
+++ b/experimental/packages/otlp-grpc-exporter-base/test/configuration/convert-legacy-otlp-grpc-options.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+
+import {
+  convertLegacyOtlpGrpcOptions,
+  convertLegacyOtlpGrpcOptionsWithoutEnv,
+} from '../../src/configuration/convert-legacy-otlp-grpc-options';
+import {
+  createInsecureCredentials,
+  createSslCredentials,
+} from '../../src/grpc-exporter-transport';
+
+describe('convertLegacyOtlpGrpcOptionsWithoutEnv', function () {
+  afterEach(function () {
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    delete process.env.OTEL_EXPORTER_OTLP_HEADERS;
+    delete process.env.OTEL_EXPORTER_OTLP_TIMEOUT;
+    delete process.env.OTEL_EXPORTER_OTLP_INSECURE;
+  });
+
+  it('should not use the endpoint from the environment', function () {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://env.example:4317';
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT =
+      'http://traces.env.example:4317';
+
+    // control: the environment-aware conversion does use the environment
+    assert.strictEqual(
+      convertLegacyOtlpGrpcOptions({}, 'TRACES').url,
+      'traces.env.example:4317'
+    );
+
+    const options = convertLegacyOtlpGrpcOptionsWithoutEnv({});
+    assert.strictEqual(options.url, 'localhost:4317');
+  });
+
+  it('should not use timeout from the environment', function () {
+    process.env.OTEL_EXPORTER_OTLP_TIMEOUT = '15000';
+
+    // control: the environment-aware conversion does use the environment
+    assert.strictEqual(
+      convertLegacyOtlpGrpcOptions({}, 'TRACES').timeoutMillis,
+      15000
+    );
+
+    const options = convertLegacyOtlpGrpcOptionsWithoutEnv({});
+    assert.strictEqual(options.timeoutMillis, 10000);
+  });
+
+  it('should not use headers from the environment as metadata', function () {
+    process.env.OTEL_EXPORTER_OTLP_HEADERS = 'foo=bar';
+
+    // control: the environment-aware conversion does use the environment
+    assert.deepStrictEqual(
+      convertLegacyOtlpGrpcOptions({}, 'TRACES').metadata().getMap(),
+      { foo: 'bar' }
+    );
+
+    const options = convertLegacyOtlpGrpcOptionsWithoutEnv({});
+    assert.deepStrictEqual(options.metadata().getMap(), {});
+  });
+
+  it('should not use credential settings from the environment', function () {
+    process.env.OTEL_EXPORTER_OTLP_INSECURE = 'true';
+
+    // control: the environment-aware conversion does use the environment
+    assert.deepStrictEqual(
+      convertLegacyOtlpGrpcOptions(
+        { url: 'example.test:4317' },
+        'TRACES'
+      ).credentials(),
+      createInsecureCredentials()
+    );
+
+    // without the environment, a scheme-less URL uses secure credentials
+    const options = convertLegacyOtlpGrpcOptionsWithoutEnv({
+      url: 'example.test:4317',
+    });
+    assert.deepStrictEqual(options.credentials(), createSslCredentials());
+  });
+
+  it('should use user-provided configuration even when the environment is set', function () {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://env.example:4317';
+    process.env.OTEL_EXPORTER_OTLP_TIMEOUT = '15000';
+
+    const options = convertLegacyOtlpGrpcOptionsWithoutEnv({
+      url: 'http://user.example:4317',
+      timeoutMillis: 1234,
+    });
+
+    assert.strictEqual(options.url, 'user.example:4317');
+    assert.strictEqual(options.timeoutMillis, 1234);
+    assert.deepStrictEqual(options.credentials(), createInsecureCredentials());
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1059,13 +1059,13 @@
       "dependencies": {
         "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
         "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
-        "@opentelemetry/otlp-transformer": "0.221.0"
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-metrics": "2.10.0"
       },
       "devDependencies": {
         "@grpc/grpc-js": "^1.14.3",
         "@grpc/proto-loader": "^0.8.0",
         "@opentelemetry/api": "1.9.1",
-        "@opentelemetry/sdk-metrics": "2.10.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.19.130",
         "@types/sinon": "17.0.4",
@@ -1208,13 +1208,13 @@
       "dependencies": {
         "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
         "@opentelemetry/otlp-exporter-base": "0.221.0",
-        "@opentelemetry/otlp-transformer": "0.221.0"
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-metrics": "2.10.0"
       },
       "devDependencies": {
         "@babel/core": "7.29.7",
         "@babel/preset-env": "7.29.7",
         "@opentelemetry/api": "1.9.1",
-        "@opentelemetry/sdk-metrics": "2.10.0",
         "@types/mocha": "10.0.10",
         "@types/node": "18.19.130",
         "@types/sinon": "17.0.4",


### PR DESCRIPTION
﻿## Which problem is this PR solving?

Closes #6959.

The Declarative Config file handling in `sdk-node` needs to create OTLP exporters while passing `undefined` for options and **without** the exporter packages reading `process.env` (declarative config rule: the usual `OTEL_` SDK env vars must not be used). Today every OTLP exporter class merges configuration from the environment as a fallback between the user-provided options and the specification defaults, so there is no way to construct an exporter that ignores the environment.

## Short description of the changes

Following the approach sketched in the issue, this PR adds `create...Exporter()` factory functions that never touch the environment, and leaves the exporter classes fully compatible (they still read the env; they are *not* deprecated yet — that can be a follow-up):

- `@opentelemetry/otlp-exporter-base/node-http`: new exported `convertLegacyHttpOptionsWithoutEnv(config, signalResourcePath, requiredHeaders)` — same legacy-options conversion as `convertLegacyHttpOptions`, but with an **empty environment fallback**, so unset options land on the OTLP specification defaults.
- `@opentelemetry/otlp-grpc-exporter-base`: same, `convertLegacyOtlpGrpcOptionsWithoutEnv(config)`.
- New factory functions, one per OTLP exporter package (also on the browser entry points of the isomorphic packages, for API parity — the browser path never read env anyway):

| Package | Factory |
|---|---|
| `@opentelemetry/exporter-trace-otlp-http` | `createOtlpHttpSpanExporter(config?)` |
| `@opentelemetry/exporter-trace-otlp-proto` | `createOtlpProtoSpanExporter(config?)` |
| `@opentelemetry/exporter-trace-otlp-grpc` | `createOtlpGrpcSpanExporter(config?)` |
| `@opentelemetry/exporter-metrics-otlp-http` | `createOtlpHttpMetricExporter(config?)` |
| `@opentelemetry/exporter-metrics-otlp-proto` | `createOtlpProtoMetricExporter(config?)` |
| `@opentelemetry/exporter-metrics-otlp-grpc` | `createOtlpGrpcMetricExporter(config?)` |
| `@opentelemetry/exporter-logs-otlp-http` | `createOtlpHttpLogExporter(config?)` |
| `@opentelemetry/exporter-logs-otlp-proto` | `createOtlpProtoLogExporter(config?)` |
| `@opentelemetry/exporter-logs-otlp-grpc` | `createOtlpGrpcLogExporter(config?)` |

Each factory accepts the same (fully optional) options bag as the matching class and returns the SDK interface (`SpanExporter` / `PushMetricExporter` / `LogRecordExporter`). For metric exporters, an unset `temporalityPreference` resolves to the specification default (cumulative) instead of reading `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`.

- READMEs of the nine packages document the new factory next to the env-var configuration section.
- CHANGELOG entry in `experimental/CHANGELOG.md`.

Notes on the issue's "files to update" list:

- `OTLPMetricExporterBase.ts` ended up **not** needing changes: the metric factories pass an explicit `temporalityPreference` (caller value or the spec default), so the env-reading branch in the base class is never reached from the factory path. Happy to restructure if you'd rather have an explicit env-free mode in the base class.
- The `*-env-configuration.ts` modules are also unchanged on purpose: they keep serving the class constructors; the factory path simply doesn't call them.
- `sdk-node` is not switched over in this PR — the factories are the enabler; wiring `create-from-config.ts` to them is a clean follow-up.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

New tests per package, co-located with the existing ones. The key assertion: with `OTEL_EXPORTER_OTLP_*` variables set, a factory-created exporter resolves the **specification defaults** (asserted via the exporter's own `server.address`/`server.port` self-observability metrics for the HTTP packages, and via the resolved config object in the base packages), while a **control** in the same file proves the class-based exporter still picks up the same env vars. Metric packages assert `selectAggregationTemporality(COUNTER)` is `CUMULATIVE` with `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta` set (control: the class returns `DELTA`).

Red first (tests added on top of `main`, before the implementation):

- `npm run compile` → `error TS2724: '"../../../src/configuration/convert-legacy-node-http-options"' has no exported member named 'convertLegacyHttpOptionsWithoutEnv'. Did you mean 'convertLegacyHttpOptions'?`
- After implementing only the base packages, the package-level tests failed as expected, e.g. `exporter-trace-otlp-http`: `1 passing, 2 failing — TypeError: (0 , node_1.createOtlpHttpSpanExporter) is not a function` (same shape for the metric and gRPC packages).

Green (after the full change), all run locally on Windows with Node v24.14.1:

```text
# cd ~/repos/otel-js && npm run compile        (tsc -b, also type-checks the tests)
FINAL_COMPILE_EXIT=0

# per package: TS_NODE_TRANSPILE_ONLY=1 npx mocha --require ts-node/register 'test/**/*.test.ts' --exclude 'test/browser/**/*.ts'
# (npm test also works; on Windows I invoked mocha directly because npm's cmd.exe
#  passes the quoted glob to mocha literally)
otlp-exporter-base                     156 passing
otlp-grpc-exporter-base                 79 passing (1 pre-existing pending)
exporter-trace-otlp-http                 3 passing
exporter-trace-otlp-proto                3 passing
exporter-trace-otlp-grpc                 2 passing   (spins up a real in-process gRPC server)
exporter-metrics-otlp-http               8 passing
exporter-metrics-otlp-proto              3 passing
exporter-metrics-otlp-grpc               4 passing   (idem)
exporter-logs-otlp-http                  3 passing
exporter-logs-otlp-proto                 3 passing
exporter-logs-otlp-grpc                  2 passing   (idem)

# per isomorphic package: npx karma start --single-run  (Chrome Headless 151)
exporter-trace-otlp-http       2/2 SUCCESS
exporter-trace-otlp-proto      2/2 SUCCESS
exporter-metrics-otlp-http     7/7 SUCCESS
exporter-metrics-otlp-proto    2/2 SUCCESS
exporter-logs-otlp-http        2/2 SUCCESS
exporter-logs-otlp-proto       2/2 SUCCESS

# lint
npm run lint            # per touched package: 11/11 clean (one pre-existing no-shadow
                        # warning in an untouched file of otlp-exporter-base)
npm run lint:markdown   # clean
```

Not verified locally (CI covers these): the Node 18–26 test matrix and the Windows job, `test:webworker`, `bundler-tests`, e2e/w3c integration tests, and `npm run docs` / `docs:test` (typedoc + linkinator, part of the CI lint job). None of the touched packages require external services; the gRPC tests start an in-process server.

## Checklist:

- [x] Followed the style guidelines of this project (`eslint` + `prettier` clean, `lint:fix` applied)
- [x] Unit tests have been added (and fail without the change — see above)
- [x] Documentation has been updated (READMEs of all nine packages + `experimental/CHANGELOG.md`)

## Review follow-up (2026-08-11)

The two points from the initial maintainer review are addressed in `20b64b5`:

- `@opentelemetry/sdk-metrics` `2.10.0` is now a runtime dependency of the gRPC and proto metric exporter packages, with the workspace lockfile updated consistently.
- The four new Node HTTP/proto log and trace suites stub `node:http.request`, restore the built-in binding between tests, and await `LoggerProvider.shutdown()` / `TracerProvider.shutdown()` before assertions, so they do not leave real requests or providers running.

Fresh focused verification on the published commit: the four Node suites pass `12/12`; the gRPC/HTTP/proto dependency classification probe passes `3/3`; ESLint and Prettier pass on all seven follow-up files.
---

_AI-assisted: this change was drafted with AI assistance. I reviewed the complete diff, ran the red→green and the gates shown above on my own machine, and I own the change — happy to walk through every line and adjust naming/scope as you prefer._

