### PR TITLE
docs(sdk-logs): mark logger configuration experimental

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -20,6 +20,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :books: Documentation
 
+* docs(sdk-logs): mark logger configuration as experimental [#6996](https://github.com/open-telemetry/opentelemetry-js/pull/6996) @LarryHu0217
 * docs(configuration): document the `ConfigModel` suffix naming convention for exported types [#6612](https://github.com/open-telemetry/opentelemetry-js/issues/6612) @vedantchalke36
 
 ### :house: Internal

--- a/experimental/packages/sdk-logs/README.md
+++ b/experimental/packages/sdk-logs/README.md
@@ -66,6 +66,11 @@ configuration as specified in [config.ts](./src/config.ts)
 
 ## Logger Configuration
 
+**Experimental:** `LoggerConfigurator` and the filtering options described in
+this section are experimental and opt-in. They do not alter log processing
+unless a `loggerConfigurator` is explicitly configured, and their APIs may
+change in future releases.
+
 The SDK supports advanced logger configuration through the `LoggerConfigurator` API, which allows you to:
 
 - **Filter logs by minimum severity level** - Drop logs below a configured severity threshold


### PR DESCRIPTION
## Which problem is this PR solving?

The sdk-logs README documents `LoggerConfigurator` without explicitly identifying the feature itself as experimental. This can make the API appear more stable than its current specification status.

Fixes #6677

## Short description of the changes

- Mark `LoggerConfigurator` and its filtering options as experimental and opt-in.
- Clarify that logging behavior is unchanged unless `loggerConfigurator` is explicitly configured.
- Note that the APIs may change in future releases.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `npx --yes markdownlint-cli2@0.19.1 experimental/packages/sdk-logs/README.md`
- [x] `git diff --check`

## Checklist

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added (not applicable; documentation-only change)
- [x] Documentation has been updated