### PR TITLE
fix(sdk-node): support headers_list for declarative exporters

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -18,6 +18,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(sdk-node): support `headers_list` when creating OTLP exporters from declarative configuration [#6953](https://github.com/open-telemetry/opentelemetry-js/issues/6953) @JacksonWeber
+
 ### :books: Documentation
 
 * docs(configuration): document the `ConfigModel` suffix naming convention for exported types [#6612](https://github.com/open-telemetry/opentelemetry-js/issues/6612) @vedantchalke36

--- a/experimental/packages/configuration/src/FileConfigFactory.ts
+++ b/experimental/packages/configuration/src/FileConfigFactory.ts
@@ -4,7 +4,7 @@
  */
 
 import { diag } from '@opentelemetry/api';
-import { getStringFromEnv } from '@opentelemetry/core';
+import { getStringFromEnv, parseKeyPairsIntoRecord } from '@opentelemetry/core';
 import * as fs from 'fs';
 import * as yaml from 'yaml';
 import type { ConfigFactory } from './IConfigFactory';
@@ -12,6 +12,7 @@ import { substituteEnvVars } from './utils';
 import type {
   AttributeNameValue,
   ConfigurationModel,
+  NameStringValuePair,
   TextMapPropagator,
 } from './generated/types';
 // Pre-compiled ajv validator — eliminates runtime schema compilation on cold start.
@@ -170,6 +171,27 @@ export function mergeResourceAttributesConfig(
   }
 
   return mergedAttrs;
+}
+
+/**
+ * Merge headers from `headers` and `headers_list` (comma-separated key=value
+ * pairs) into a record. Entries in `headers` take precedence.
+ */
+export function mergeHeadersConfig(
+  headers?: NameStringValuePair[],
+  headers_list?: string | null
+): Record<string, string> | undefined {
+  if (!headers && !headers_list) {
+    return undefined;
+  }
+
+  const mergedHeaders = parseKeyPairsIntoRecord(headers_list ?? undefined);
+  headers?.forEach(header => {
+    if (header.value !== null) {
+      mergedHeaders[header.name] = header.value;
+    }
+  });
+  return mergedHeaders;
 }
 
 /**

--- a/experimental/packages/configuration/src/index.ts
+++ b/experimental/packages/configuration/src/index.ts
@@ -59,6 +59,7 @@ export type {
 } from './generated/types';
 export { createConfigFactory } from './ConfigFactory';
 export {
+  mergeHeadersConfig,
   mergeResourceAttributesConfig,
   mergePropagatorCompositeConfig,
 } from './FileConfigFactory';

--- a/experimental/packages/configuration/test/FileConfigFactory.test.ts
+++ b/experimental/packages/configuration/test/FileConfigFactory.test.ts
@@ -10,6 +10,7 @@ import { diag } from '@opentelemetry/api';
 import type { ConfigurationModel } from '../src';
 import { createConfigFactory } from '../src/ConfigFactory';
 import {
+  mergeHeadersConfig,
   mergeResourceAttributesConfig,
   mergePropagatorCompositeConfig,
   parseConfigFile,
@@ -1270,6 +1271,36 @@ describe('mergeResourceAttributesConfig', function () {
       warnStub.restore();
     });
   }
+});
+
+describe('mergeHeadersConfig', function () {
+  it('returns undefined when headers are not set', function () {
+    assert.strictEqual(mergeHeadersConfig(undefined, undefined), undefined);
+  });
+
+  it('returns headers when headers are set', function () {
+    assert.deepStrictEqual(
+      mergeHeadersConfig([{ name: 'x-test-header', value: 'test-value' }]),
+      { 'x-test-header': 'test-value' }
+    );
+  });
+
+  it('parses headers_list and lets headers take precedence', function () {
+    assert.deepStrictEqual(
+      mergeHeadersConfig(
+        [
+          { name: 'shared', value: 'from-headers' },
+          { name: 'ignored', value: null },
+        ],
+        'shared=from-list,list-only=hello%20world,ignored=from-list'
+      ),
+      {
+        shared: 'from-headers',
+        'list-only': 'hello world',
+        ignored: 'from-list',
+      }
+    );
+  });
 });
 
 describe('mergePropagatorCompositeConfig', function () {

--- a/experimental/packages/opentelemetry-sdk-node/src/create-from-config.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/create-from-config.ts
@@ -48,6 +48,7 @@ import { OTLPTraceExporter as OTLPHttpTraceExporter } from '@opentelemetry/expor
 import { OTLPTraceExporter as OTLPGrpcTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { CompressionAlgorithm } from '@opentelemetry/otlp-exporter-base';
 import {
+  createEmptyMetadata,
   createInsecureCredentials,
   createSslCredentials,
 } from '@opentelemetry/otlp-grpc-exporter-base';
@@ -73,6 +74,7 @@ import type {
   MeterProviderConfigModel,
   MetricProducerConfigModel,
   MetricReaderConfigModel,
+  NameStringValuePairConfigModel,
   OtlpGrpcExporterConfigModel,
   OtlpGrpcMetricExporterConfigModel,
   OtlpHttpExporterConfigModel,
@@ -93,7 +95,10 @@ import type {
   TracerProviderConfigModel,
   ViewConfigModel,
 } from '@opentelemetry/configuration';
-import { mergePropagatorCompositeConfig } from '@opentelemetry/configuration';
+import {
+  mergeHeadersConfig,
+  mergePropagatorCompositeConfig,
+} from '@opentelemetry/configuration';
 import type {
   LogRecordExporter,
   LogRecordProcessor,
@@ -132,12 +137,22 @@ import {
 } from '@opentelemetry/sdk-metrics';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 
-import {
-  getGrpcMetadataFromHeaders,
-  getHeadersFromConfiguration,
-} from './utils';
-
 // ---- internal utilities
+
+function getGrpcMetadataFromHeaders(
+  headers: NameStringValuePairConfigModel[] | undefined,
+  headersList?: string | null
+) {
+  const headerValues = mergeHeadersConfig(headers, headersList);
+  if (!headerValues || Object.keys(headerValues).length === 0) {
+    return undefined;
+  }
+  const metadata = createEmptyMetadata();
+  for (const [name, value] of Object.entries(headerValues)) {
+    metadata.set(name, value);
+  }
+  return metadata;
+}
 
 /**
  * Warn if some props from a declarative config object have not been handled.
@@ -444,10 +459,7 @@ export function createLogRecordExporterFromConfig(
             ? CompressionAlgorithm.GZIP
             : CompressionAlgorithm.NONE,
         url: props?.endpoint ?? undefined,
-        headers: getHeadersFromConfiguration(
-          props?.headers,
-          props?.headers_list
-        ),
+        headers: mergeHeadersConfig(props?.headers, props?.headers_list),
         timeoutMillis: validateExportTimeoutConfig(
           props?.timeout,
           'OtlpHttpExporter.timeout'
@@ -680,10 +692,7 @@ export function createPushMetricExporterFromConfig(
             ? CompressionAlgorithm.GZIP
             : CompressionAlgorithm.NONE,
         url: props?.endpoint ?? undefined,
-        headers: getHeadersFromConfiguration(
-          props?.headers,
-          props?.headers_list
-        ),
+        headers: mergeHeadersConfig(props?.headers, props?.headers_list),
         timeoutMillis: validateExportTimeoutConfig(
           props?.timeout,
           'PushMetricExporter.timeout'
@@ -1132,10 +1141,7 @@ function createSpanExporterFromConfig(
             ? CompressionAlgorithm.GZIP
             : CompressionAlgorithm.NONE,
         url: props?.endpoint ?? undefined,
-        headers: getHeadersFromConfiguration(
-          props?.headers,
-          props?.headers_list
-        ),
+        headers: mergeHeadersConfig(props?.headers, props?.headers_list),
         timeoutMillis: validateExportTimeoutConfig(
           props?.timeout,
           'OtlpHttpExporter.timeout'

--- a/experimental/packages/opentelemetry-sdk-node/src/create-from-config.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/create-from-config.ts
@@ -428,11 +428,11 @@ export function createLogRecordExporterFromConfig(
 
   switch (name) {
     case 'otlp_http': {
-      // TODO(6953): headers_list
       checkConfigUse('OtlpHttpExporter', properties!, [
         'compression',
         'endpoint',
         'headers',
+        'headers_list',
         'timeout',
         'tls',
         'encoding',
@@ -444,7 +444,10 @@ export function createLogRecordExporterFromConfig(
             ? CompressionAlgorithm.GZIP
             : CompressionAlgorithm.NONE,
         url: props?.endpoint ?? undefined,
-        headers: getHeadersFromConfiguration(props?.headers),
+        headers: getHeadersFromConfiguration(
+          props?.headers,
+          props?.headers_list
+        ),
         timeoutMillis: validateExportTimeoutConfig(
           props?.timeout,
           'OtlpHttpExporter.timeout'
@@ -465,13 +468,13 @@ export function createLogRecordExporterFromConfig(
     }
 
     case 'otlp_grpc': {
-      // TODO(6953): headers_list
       checkConfigUse('OtlpGrpcExporter', properties!, [
         'compression',
         'endpoint',
         'timeout',
         'tls',
         'headers',
+        'headers_list',
       ]);
       const props = properties as OtlpGrpcExporterConfigModel;
       return new OTLPGrpcLogExporter({
@@ -485,7 +488,10 @@ export function createLogRecordExporterFromConfig(
           'OtlpGrpcExporter.timeout'
         ),
         credentials: grpcCredentialsFromConfig(props?.tls),
-        metadata: getGrpcMetadataFromHeaders(props?.headers),
+        metadata: getGrpcMetadataFromHeaders(
+          props?.headers,
+          props?.headers_list
+        ),
       });
     }
 
@@ -656,11 +662,11 @@ export function createPushMetricExporterFromConfig(
 
   switch (name) {
     case 'otlp_http': {
-      // TODO(6953): headers_list
       checkConfigUse('PushMetricExporter', properties!, [
         'compression',
         'endpoint',
         'headers',
+        'headers_list',
         'timeout',
         'tls',
         'temporality_preference',
@@ -674,7 +680,10 @@ export function createPushMetricExporterFromConfig(
             ? CompressionAlgorithm.GZIP
             : CompressionAlgorithm.NONE,
         url: props?.endpoint ?? undefined,
-        headers: getHeadersFromConfiguration(props?.headers),
+        headers: getHeadersFromConfiguration(
+          props?.headers,
+          props?.headers_list
+        ),
         timeoutMillis: validateExportTimeoutConfig(
           props?.timeout,
           'PushMetricExporter.timeout'
@@ -701,13 +710,13 @@ export function createPushMetricExporterFromConfig(
     }
 
     case 'otlp_grpc': {
-      // TODO(6953): headers_list
       checkConfigUse('PushMetricExporter', properties!, [
         'compression',
         'endpoint',
         'timeout',
         'tls',
         'headers',
+        'headers_list',
         'temporality_preference',
         'default_histogram_aggregation',
       ]);
@@ -723,7 +732,10 @@ export function createPushMetricExporterFromConfig(
           'PushMetricExporter.timeout'
         ),
         credentials: grpcCredentialsFromConfig(props?.tls),
-        metadata: getGrpcMetadataFromHeaders(props?.headers),
+        metadata: getGrpcMetadataFromHeaders(
+          props?.headers,
+          props?.headers_list
+        ),
         temporalityPreference: aggregationTemporalityPreferenceFromConfig(
           props?.temporality_preference
         ),
@@ -1104,11 +1116,11 @@ function createSpanExporterFromConfig(
 
   switch (name) {
     case 'otlp_http': {
-      // TODO(6953): headers_list
       checkConfigUse('OtlpHttpExporter', properties!, [
         'compression',
         'endpoint',
         'headers',
+        'headers_list',
         'timeout',
         'tls',
         'encoding',
@@ -1120,7 +1132,10 @@ function createSpanExporterFromConfig(
             ? CompressionAlgorithm.GZIP
             : CompressionAlgorithm.NONE,
         url: props?.endpoint ?? undefined,
-        headers: getHeadersFromConfiguration(props?.headers),
+        headers: getHeadersFromConfiguration(
+          props?.headers,
+          props?.headers_list
+        ),
         timeoutMillis: validateExportTimeoutConfig(
           props?.timeout,
           'OtlpHttpExporter.timeout'
@@ -1141,13 +1156,13 @@ function createSpanExporterFromConfig(
     }
 
     case 'otlp_grpc': {
-      // TODO(6953): headers_list
       checkConfigUse('OtlpGrpcExporter', properties!, [
         'compression',
         'endpoint',
         'timeout',
         'tls',
         'headers',
+        'headers_list',
       ]);
       const props = properties as OtlpGrpcExporterConfigModel;
       return new OTLPGrpcTraceExporter({
@@ -1161,7 +1176,10 @@ function createSpanExporterFromConfig(
           'OtlpGrpcExporter.timeout'
         ),
         credentials: grpcCredentialsFromConfig(props?.tls),
-        metadata: getGrpcMetadataFromHeaders(props?.headers),
+        metadata: getGrpcMetadataFromHeaders(
+          props?.headers,
+          props?.headers_list
+        ),
       });
     }
 

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -14,6 +14,7 @@ import {
   getNumberFromEnv,
   getStringFromEnv,
   getStringListFromEnv,
+  parseKeyPairsIntoRecord,
   W3CBaggagePropagator,
   W3CTraceContextPropagator,
 } from '@opentelemetry/core';
@@ -495,13 +496,14 @@ export function getBatchLogRecordProcessorFromEnv(
 }
 
 export function getHeadersFromConfiguration(
-  headers: NameStringValuePairConfigModel[] | undefined
+  headers: NameStringValuePairConfigModel[] | undefined,
+  headersList?: string | null
 ): Record<string, string> | undefined {
-  if (!headers) {
+  if (!headers && !headersList) {
     return undefined;
   }
-  const result: Record<string, string> = {};
-  headers.forEach(header => {
+  const result = parseKeyPairsIntoRecord(headersList ?? undefined);
+  headers?.forEach(header => {
     if (header.value !== null) {
       result[header.name] = header.value;
     }
@@ -510,16 +512,16 @@ export function getHeadersFromConfiguration(
 }
 
 export function getGrpcMetadataFromHeaders(
-  headers: NameStringValuePairConfigModel[] | undefined
+  headers: NameStringValuePairConfigModel[] | undefined,
+  headersList?: string | null
 ) {
-  if (!headers || headers.length === 0) {
+  const headerValues = getHeadersFromConfiguration(headers, headersList);
+  if (!headerValues || Object.keys(headerValues).length === 0) {
     return undefined;
   }
   const metadata = createEmptyMetadata();
-  for (const header of headers) {
-    if (header.value !== null) {
-      metadata.set(header.name, header.value);
-    }
+  for (const [name, value] of Object.entries(headerValues)) {
+    metadata.set(name, value);
   }
   return metadata;
 }

--- a/experimental/packages/opentelemetry-sdk-node/src/utils.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/utils.ts
@@ -14,7 +14,6 @@ import {
   getNumberFromEnv,
   getStringFromEnv,
   getStringListFromEnv,
-  parseKeyPairsIntoRecord,
   W3CBaggagePropagator,
   W3CTraceContextPropagator,
 } from '@opentelemetry/core';
@@ -43,11 +42,7 @@ import {
 import { B3InjectEncoding, B3Propagator } from '@opentelemetry/propagator-b3';
 import { JaegerPropagator } from '@opentelemetry/propagator-jaeger';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
-import { createEmptyMetadata } from '@opentelemetry/otlp-grpc-exporter-base';
-import type {
-  ConfigurationModel,
-  NameStringValuePairConfigModel,
-} from '@opentelemetry/configuration';
+import type { ConfigurationModel } from '@opentelemetry/configuration';
 import { mergeResourceAttributesConfig } from '@opentelemetry/configuration';
 import type {
   IMetricReader,
@@ -493,37 +488,6 @@ export function getBatchLogRecordProcessorFromEnv(
     selfObsMeterProvider,
     ...getBatchLogRecordProcessorConfigFromEnv(),
   });
-}
-
-export function getHeadersFromConfiguration(
-  headers: NameStringValuePairConfigModel[] | undefined,
-  headersList?: string | null
-): Record<string, string> | undefined {
-  if (!headers && !headersList) {
-    return undefined;
-  }
-  const result = parseKeyPairsIntoRecord(headersList ?? undefined);
-  headers?.forEach(header => {
-    if (header.value !== null) {
-      result[header.name] = header.value;
-    }
-  });
-  return result;
-}
-
-export function getGrpcMetadataFromHeaders(
-  headers: NameStringValuePairConfigModel[] | undefined,
-  headersList?: string | null
-) {
-  const headerValues = getHeadersFromConfiguration(headers, headersList);
-  if (!headerValues || Object.keys(headerValues).length === 0) {
-    return undefined;
-  }
-  const metadata = createEmptyMetadata();
-  for (const [name, value] of Object.entries(headerValues)) {
-    metadata.set(name, value);
-  }
-  return metadata;
 }
 
 export function getInstanceID(config: ConfigurationModel): string | undefined {

--- a/experimental/packages/opentelemetry-sdk-node/test/create-from-config.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/create-from-config.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert';
 import * as path from 'path';
+import * as sinon from 'sinon';
 
 import type {
   ConfigurationModel,
@@ -13,14 +14,16 @@ import type {
   MeterProviderConfigModel,
   PushMetricExporterConfigModel,
   SamplerConfigModel,
+  SpanExporterConfigModel,
   TracerProviderConfigModel,
 } from '@opentelemetry/configuration';
-import type { SpanLimits } from '@opentelemetry/sdk-trace';
+import type { SpanExporter, SpanLimits } from '@opentelemetry/sdk-trace';
 import {
   BatchSpanProcessor,
   RandomIdGenerator,
   TracerProvider,
 } from '@opentelemetry/sdk-trace';
+import { diag } from '@opentelemetry/api';
 import type { LogRecordLimits } from '@opentelemetry/sdk-logs';
 import {
   BatchLogRecordProcessor,
@@ -62,6 +65,125 @@ import {
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 
 describe('create-from-config', () => {
+  describe('headers_list exporter wiring', function () {
+    const headers = [{ name: 'shared', value: 'from-headers' }];
+    const headers_list = 'shared=from-list,list-only=hello%20world';
+    const resource = resourceFromAttributes({});
+
+    function createTraceExporter(
+      exporter: SpanExporterConfigModel
+    ): SpanExporter {
+      const provider = createTracerProviderFromConfig(resource, {
+        processors: [{ simple: { exporter } }],
+      });
+      return (provider as any)._activeSpanProcessor._spanProcessors[0]
+        ._exporter;
+    }
+
+    const corpus: {
+      testName: string;
+      protocol: 'http' | 'grpc';
+      createExporter: () => unknown;
+    }[] = [
+      {
+        testName: 'log OTLP HTTP/protobuf',
+        protocol: 'http',
+        createExporter: () =>
+          createLogRecordExporterFromConfig({
+            otlp_http: { headers, headers_list },
+          }),
+      },
+      {
+        testName: 'log OTLP HTTP/JSON',
+        protocol: 'http',
+        createExporter: () =>
+          createLogRecordExporterFromConfig({
+            otlp_http: { headers, headers_list, encoding: 'json' },
+          }),
+      },
+      {
+        testName: 'log OTLP gRPC',
+        protocol: 'grpc',
+        createExporter: () =>
+          createLogRecordExporterFromConfig({
+            otlp_grpc: { headers, headers_list },
+          }),
+      },
+      {
+        testName: 'metric OTLP HTTP/protobuf',
+        protocol: 'http',
+        createExporter: () =>
+          createPushMetricExporterFromConfig({
+            otlp_http: { headers, headers_list },
+          }),
+      },
+      {
+        testName: 'metric OTLP HTTP/JSON',
+        protocol: 'http',
+        createExporter: () =>
+          createPushMetricExporterFromConfig({
+            otlp_http: { headers, headers_list, encoding: 'json' },
+          }),
+      },
+      {
+        testName: 'metric OTLP gRPC',
+        protocol: 'grpc',
+        createExporter: () =>
+          createPushMetricExporterFromConfig({
+            otlp_grpc: { headers, headers_list },
+          }),
+      },
+      {
+        testName: 'trace OTLP HTTP/protobuf',
+        protocol: 'http',
+        createExporter: () =>
+          createTraceExporter({
+            otlp_http: { headers, headers_list },
+          }),
+      },
+      {
+        testName: 'trace OTLP HTTP/JSON',
+        protocol: 'http',
+        createExporter: () =>
+          createTraceExporter({
+            otlp_http: { headers, headers_list, encoding: 'json' },
+          }),
+      },
+      {
+        testName: 'trace OTLP gRPC',
+        protocol: 'grpc',
+        createExporter: () =>
+          createTraceExporter({
+            otlp_grpc: { headers, headers_list },
+          }),
+      },
+    ];
+
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    for (const item of corpus) {
+      it(item.testName, async function () {
+        const warnStub = sinon.stub(diag, 'warn');
+        const exporter = item.createExporter() as any;
+
+        if (item.protocol === 'http') {
+          const resolvedHeaders =
+            await exporter._delegate._transport._transport._parameters.headers();
+          assert.equal(resolvedHeaders.shared, 'from-headers');
+          assert.equal(resolvedHeaders['list-only'], 'hello world');
+        } else {
+          const metadata = exporter._delegate._transport._parameters.metadata();
+          assert.deepStrictEqual(metadata.get('shared'), ['from-headers']);
+          assert.deepStrictEqual(metadata.get('list-only'), ['hello world']);
+        }
+
+        sinon.assert.notCalled(warnStub);
+      });
+    }
+  });
+
   describe('createPropagatorFromConfig', function () {
     it('single propagator still uses CompositePropagator', function () {
       const propagator = createPropagatorFromConfig({

--- a/experimental/packages/opentelemetry-sdk-node/test/utils.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/utils.test.ts
@@ -9,6 +9,7 @@ import {
   getLoggerProviderConfigFromEnv,
   getBatchLogRecordProcessorConfigFromEnv,
   getResourceDetectorsFromConfiguration,
+  getGrpcMetadataFromHeaders,
   getHeadersFromConfiguration,
 } from '../src/utils';
 import * as assert from 'assert';
@@ -444,5 +445,34 @@ describe('getHeadersFromConfiguration', function () {
       ),
       { 'x-test-header': 'test-value' }
     );
+  });
+
+  it('parses headers_list and lets headers take precedence', function () {
+    assert.deepStrictEqual(
+      getHeadersFromConfiguration(
+        [
+          { name: 'shared', value: 'from-headers' },
+          { name: 'ignored', value: null },
+        ],
+        'shared=from-list,list-only=hello%20world,ignored=from-list'
+      ),
+      {
+        shared: 'from-headers',
+        'list-only': 'hello world',
+        ignored: 'from-list',
+      }
+    );
+  });
+});
+
+describe('getGrpcMetadataFromHeaders', function () {
+  it('merges headers_list into metadata with headers taking precedence', function () {
+    const metadata = getGrpcMetadataFromHeaders(
+      [{ name: 'shared', value: 'from-headers' }],
+      'shared=from-list,list-only=value'
+    );
+
+    assert.deepStrictEqual(metadata?.get('shared'), ['from-headers']);
+    assert.deepStrictEqual(metadata?.get('list-only'), ['value']);
   });
 });

--- a/experimental/packages/opentelemetry-sdk-node/test/utils.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/utils.test.ts
@@ -9,8 +9,6 @@ import {
   getLoggerProviderConfigFromEnv,
   getBatchLogRecordProcessorConfigFromEnv,
   getResourceDetectorsFromConfiguration,
-  getGrpcMetadataFromHeaders,
-  getHeadersFromConfiguration,
 } from '../src/utils';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
@@ -407,72 +405,5 @@ describe('getResourceDetectorsFromConfiguration', function () {
       processDetector,
       serviceInstanceIdDetector,
     ]);
-  });
-});
-
-describe('getHeadersFromConfiguration', function () {
-  it('returns empty object when headers are not set', function () {
-    const config: ConfigurationModel = {};
-    assert.deepStrictEqual(
-      getHeadersFromConfiguration(
-        config.tracer_provider?.processors?.[0]?.simple?.exporter?.otlp_http
-          ?.headers
-      ),
-      undefined
-    );
-  });
-
-  it('returns headers object when headers are set', function () {
-    const config: ConfigurationModel = {
-      tracer_provider: {
-        processors: [
-          {
-            simple: {
-              exporter: {
-                otlp_http: {
-                  headers: [{ name: 'x-test-header', value: 'test-value' }],
-                },
-              },
-            },
-          },
-        ],
-      },
-    };
-    assert.deepStrictEqual(
-      getHeadersFromConfiguration(
-        config.tracer_provider?.processors?.[0]?.simple?.exporter?.otlp_http
-          ?.headers
-      ),
-      { 'x-test-header': 'test-value' }
-    );
-  });
-
-  it('parses headers_list and lets headers take precedence', function () {
-    assert.deepStrictEqual(
-      getHeadersFromConfiguration(
-        [
-          { name: 'shared', value: 'from-headers' },
-          { name: 'ignored', value: null },
-        ],
-        'shared=from-list,list-only=hello%20world,ignored=from-list'
-      ),
-      {
-        shared: 'from-headers',
-        'list-only': 'hello world',
-        ignored: 'from-list',
-      }
-    );
-  });
-});
-
-describe('getGrpcMetadataFromHeaders', function () {
-  it('merges headers_list into metadata with headers taking precedence', function () {
-    const metadata = getGrpcMetadataFromHeaders(
-      [{ name: 'shared', value: 'from-headers' }],
-      'shared=from-list,list-only=value'
-    );
-
-    assert.deepStrictEqual(metadata?.get('shared'), ['from-headers']);
-    assert.deepStrictEqual(metadata?.get('list-only'), ['value']);
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

Declarative OTLP exporter configuration supports `headers_list`, but `startNodeSDK()` ignored it when creating log, metric, and trace exporters. This could omit authentication or routing headers and emitted an unhandled-property warning for valid configuration.

Fixes #6953

## Short description of the changes

- Parse `headers_list` with the existing `parseKeyPairsIntoRecord` behavior, including percent decoding.
- Merge structured `headers` over `headers_list`, matching the configuration schema's precedence rules.
- Apply the merged values to HTTP headers and gRPC metadata for log, metric, and trace exporters.
- Mark `headers_list` as handled for every current OTLP exporter creation path.
- Add parameterized coverage for logs, metrics, and traces across HTTP/protobuf, HTTP/JSON, and gRPC.
- Add an experimental changelog entry.

This incorporates and extends the log-exporter work from #6955 by @LarryHu0217 to cover all exporter paths currently present on `main`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

From `experimental/packages/opentelemetry-sdk-node`:

- [x] `npm run compile`
- [x] `npm test -- --grep "headers_list exporter wiring|getHeadersFromConfiguration|getGrpcMetadataFromHeaders"`
- [x] `npm run lint -- --quiet`

The tests verify all nine exporter variants, structured-header precedence, percent decoding, gRPC metadata conversion, and absence of unhandled-config warnings.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated via the experimental changelog

AI disclosure: GitHub Copilot was used to assist with implementation and test development; the resulting changes were reviewed before submission.