### PR TITLE
feat(sdk-trace-web): deprecate instrumentation utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :rocket: Features
 
 * feat(sdk-trace): allow configuring the force flush timeout per call #6929 @LarryHu0217
+* feat(sdk-trace-web): deprecate instrumentation utilities [#5869](https://github.com/open-telemetry/opentelemetry-js/issues/5869) @keshav-019
 
 ### :bug: Bug Fixes
 

--- a/packages/opentelemetry-sdk-trace-web/src/enums/PerformanceTimingNames.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/enums/PerformanceTimingNames.ts
@@ -3,6 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @deprecated This enum supports instrumentation utilities. Instrumentation
+ * packages should copy this definition into their own package. This export
+ * will be removed in a future major release.
+ */
 export enum PerformanceTimingNames {
   CONNECT_END = 'connectEnd',
   CONNECT_START = 'connectStart',

--- a/packages/opentelemetry-sdk-trace-web/src/types.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/types.ts
@@ -4,6 +4,11 @@
  */
 import type { PerformanceTimingNames } from './enums/PerformanceTimingNames';
 
+/**
+ * @deprecated This type supports instrumentation utilities. Instrumentation
+ * packages should copy this definition into their own package. This export
+ * will be removed in a future major release.
+ */
 export type PerformanceEntries = {
   [PerformanceTimingNames.CONNECT_END]?: number;
   [PerformanceTimingNames.CONNECT_START]?: number;
@@ -32,6 +37,10 @@ export type PerformanceEntries = {
 /**
  * This interface defines a fallback to read performance metrics,
  * this happens for example on Safari Mac
+ *
+ * @deprecated This type supports instrumentation utilities. Instrumentation
+ * packages should copy this definition into their own package. This export
+ * will be removed in a future major release.
  */
 export interface PerformanceLegacy {
   timing?: PerformanceEntries;
@@ -40,6 +49,10 @@ export interface PerformanceLegacy {
 /**
  * This interface is used in {@link getResource} function to return
  *     main request and it's corresponding PreFlight request
+ *
+ * @deprecated This type supports instrumentation utilities. Instrumentation
+ * packages should copy this definition into their own package. This export
+ * will be removed in a future major release.
  */
 export interface PerformanceResourceTimingInfo {
   corsPreFlightRequest?: PerformanceResourceTiming;
@@ -50,6 +63,10 @@ type PropagateTraceHeaderCorsUrl = string | RegExp;
 
 /**
  * urls which should include trace headers when origin doesn't match
+ *
+ * @deprecated This type supports instrumentation utilities. Instrumentation
+ * packages should copy this definition into their own package. This export
+ * will be removed in a future major release.
  */
 export type PropagateTraceHeaderCorsUrls =
   | PropagateTraceHeaderCorsUrl

--- a/packages/opentelemetry-sdk-trace-web/src/utils.ts
+++ b/packages/opentelemetry-sdk-trace-web/src/utils.ts
@@ -34,6 +34,10 @@ function getUrlNormalizingAnchor(): HTMLAnchorElement {
  * Helper function to be able to use enum as typed key in type and in interface when using forEach
  * @param obj
  * @param key
+ *
+ * @deprecated This is an instrumentation utility. Instrumentation packages
+ * should copy this implementation into their own package. This export will be
+ * removed in a future major release.
  */
 export function hasKey<O extends object>(
   obj: O,
@@ -48,6 +52,10 @@ export function hasKey<O extends object>(
  * @param performanceName name of performance entry for time start
  * @param entries
  * @param ignoreZeros
+ *
+ * @deprecated This is an instrumentation utility. Instrumentation packages
+ * should copy this implementation into their own package. This export will be
+ * removed in a future major release.
  */
 export function addSpanNetworkEvent(
   span: api.Span,
@@ -68,6 +76,10 @@ export function addSpanNetworkEvent(
 
 /**
  * Helper function for adding network events and content length attributes.
+ *
+ * @deprecated This is an instrumentation utility. Instrumentation packages
+ * should copy this implementation into their own package. This export will be
+ * removed in a future major release.
  */
 export function addSpanNetworkEvents(
   span: api.Span,
@@ -119,6 +131,10 @@ export function addSpanNetworkEvents(
 /**
  * sort resources by startTime
  * @param filteredResources
+ *
+ * @deprecated This is an instrumentation utility. Instrumentation packages
+ * should copy this implementation into their own package. This export will be
+ * removed in a future major release.
  */
 export function sortResources(
   filteredResources: PerformanceResourceTiming[]
@@ -149,6 +165,10 @@ function getOrigin(): string | undefined {
  * @param resources
  * @param ignoredResources
  * @param initiatorType
+ *
+ * @deprecated This is an instrumentation utility. Instrumentation packages
+ * should copy this implementation into their own package. This export will be
+ * removed in a future major release.
  */
 export function getResource(
   spanUrl: string,
@@ -298,6 +318,10 @@ function filterResourcesForSpan(
 
 /**
  * The URLLike interface represents an URL and HTMLAnchorElement compatible fields.
+ *
+ * @deprecated This type supports instrumentation utilities. Instrumentation
+ * packages should copy this definition into their own package. This export
+ * will be removed in a future major release.
  */
 export interface URLLike {
   hash: string;
@@ -316,6 +340,10 @@ export interface URLLike {
 /**
  * Parses url using URL constructor or fallback to anchor element.
  * @param url
+ *
+ * @deprecated This is an instrumentation utility. Instrumentation packages
+ * should copy this implementation into their own package. This export will be
+ * removed in a future major release.
  */
 export function parseUrl(url: string): URLLike {
   if (typeof URL === 'function') {
@@ -340,6 +368,10 @@ export function parseUrl(url: string): URLLike {
  * Performs the steps described in https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url
  *
  * @param url
+ *
+ * @deprecated This is an instrumentation utility. Instrumentation packages
+ * should copy this implementation into their own package. This export will be
+ * removed in a future major release.
  */
 export function normalizeUrl(url: string): string {
   const urlLike = parseUrl(url);
@@ -351,6 +383,10 @@ export function normalizeUrl(url: string): string {
  * @param target - target element
  * @param optimised - when id attribute of element is present the xpath can be
  * simplified to contain id
+ *
+ * @deprecated This is an instrumentation utility. Instrumentation packages
+ * should copy this implementation into their own package. This export will be
+ * removed in a future major release.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getElementXPath(target: any, optimised?: boolean): string {
@@ -433,6 +469,10 @@ function getNodeValue(target: HTMLElement, optimised?: boolean): string {
  * Checks if trace headers should be propagated
  * @param spanUrl
  * @private
+ *
+ * @deprecated This is an instrumentation utility. Instrumentation packages
+ * should copy this implementation into their own package. This export will be
+ * removed in a future major release.
  */
 export function shouldPropagateTraceHeaders(
   spanUrl: string,


### PR DESCRIPTION
## Which problem is this PR solving?

`@opentelemetry/sdk-trace-web` currently exports instrumentation-specific utilities and supporting types. These utilities should be owned by the instrumentation packages that consume them so they can eventually be removed from the SDK.

Fixes #5869

## Short description of the changes

- Mark all 15 instrumentation utility exports listed in #5869 as deprecated.
- Direct instrumentation packages to copy the required implementations or definitions locally.
- Document that the exports will be removed in a future major release.
- Add an Unreleased changelog entry.
- Preserve existing runtime behavior.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `npm.cmd run lint --workspace=@opentelemetry/sdk-trace-web`
- [x] `npm.cmd run compile --workspace=@opentelemetry/sdk-trace-web`
- [x] `npm.cmd run compile --ignore-scripts`
- [x] Browser suite: 60/60 tests passed using Headless Chrome with GPU disabled for the local sandbox
- [x] Web Worker suite: 50/50 tests passed using Headless Chrome with GPU disabled for the local sandbox
- [x] Generated declaration audit confirmed all 15 exports retain `@deprecated` metadata

## Checklist:

- [x] Followed the style guidelines of this project
- [ ] Unit tests have been added (not applicable: documentation-only deprecations with no runtime changes)
- [x] Documentation has been updated