### PR TITLE
fix(otlp-exporter-base): drain the fetch response body so that browsers release the keepalive quota

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -19,6 +19,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :bug: Bug Fixes
 
 * fix(sdk-node): support `headers_list` when creating OTLP exporters from declarative configuration [#6953](https://github.com/open-telemetry/opentelemetry-js/issues/6953) @JacksonWeber
+* fix(otlp-exporter-base): drain the fetch response body so that browsers release the keepalive quota [#7002](https://github.com/open-telemetry/opentelemetry-js/pull/7002) @anneheartrecord
 
 ### :books: Documentation
 

--- a/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
@@ -102,6 +102,8 @@ class FetchTransport implements IExporterTransport {
           : 'no-cors',
       });
 
+      await drainResponseBody(response);
+
       if (response.status >= 200 && response.status <= 299) {
         diag.debug(`export response success (status: ${response.status})`);
         return { status: 'success' };
@@ -159,4 +161,39 @@ export function createFetchTransport(
 
 function isFetchNetworkErrorRetryable(error: unknown): boolean {
   return error instanceof TypeError && !error.cause;
+}
+
+/**
+ * Reads the response body to its end and discards it.
+ *
+ * Chromium gives the request's share of the keepalive quota back only once the
+ * response body has been read to the end, and it skips the buffering consumer
+ * that would otherwise drain the body on its own when the response carries a
+ * `Cache-Control: no-store` header, which collectors commonly send. Leaving the
+ * body unread then leaks the quota until the document goes away and every
+ * following keepalive export stays pending forever.
+ *
+ * @see https://fetch.spec.whatwg.org/#fetch-processresponseendofbody
+ */
+async function drainResponseBody(response: Response): Promise<void> {
+  // Empty and opaque responses have no body to read.
+  const body = response.body;
+  if (body == null) {
+    return;
+  }
+
+  const reader = body.getReader();
+  try {
+    // Chunks are dropped as they arrive: the payload is not used, and buffering
+    // it - with `response.arrayBuffer()` for instance - would keep a response
+    // of arbitrary size in memory.
+    let chunk = await reader.read();
+    while (!chunk.done) {
+      chunk = await reader.read();
+    }
+  } catch (error) {
+    // The export outcome is decided by the response status, a body that cannot
+    // be read must not change it.
+    diag.debug(`error reading export response body: ${error}`);
+  }
 }

--- a/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
@@ -176,20 +176,29 @@ function isFetchNetworkErrorRetryable(error: unknown): boolean {
  * @see https://fetch.spec.whatwg.org/#fetch-processresponseendofbody
  */
 async function drainResponseBody(response: Response): Promise<void> {
-  // Empty and opaque responses have no body to read.
-  const body = response.body;
-  if (body == null) {
-    return;
-  }
-
-  const reader = body.getReader();
   try {
-    // Chunks are dropped as they arrive: the payload is not used, and buffering
-    // it - with `response.arrayBuffer()` for instance - would keep a response
-    // of arbitrary size in memory.
-    let chunk = await reader.read();
-    while (!chunk.done) {
-      chunk = await reader.read();
+    // Empty and opaque responses have no body to read.
+    const body = response.body;
+    if (body == null) {
+      return;
+    }
+
+    // Throws when the body is already locked to another reader, which happens
+    // when the same response is handed to more than one export.
+    const reader = body.getReader();
+    try {
+      // Chunks are dropped as they arrive: the payload is not used, and
+      // buffering it - with `response.arrayBuffer()` for instance - would keep
+      // a response of arbitrary size in memory.
+      let chunk = await reader.read();
+      while (!chunk.done) {
+        chunk = await reader.read();
+      }
+    } finally {
+      // The reader keeps the body locked until it is released, which would
+      // make a later export handed the same response fail to acquire a reader
+      // and skip the drain.
+      reader.releaseLock();
     }
   } catch (error) {
     // The export outcome is decided by the response status, a body that cannot

--- a/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
+++ b/experimental/packages/otlp-exporter-base/src/transport/fetch-transport.ts
@@ -171,7 +171,9 @@ function isFetchNetworkErrorRetryable(error: unknown): boolean {
  * that would otherwise drain the body on its own when the response carries a
  * `Cache-Control: no-store` header, which collectors commonly send. Leaving the
  * body unread then leaks the quota until the document goes away and every
- * following keepalive export stays pending forever.
+ * following keepalive export stays pending forever. Cancelling the body is the
+ * client-abort path and releases the quota far more slowly than reading it to
+ * the end, so the body is read rather than cancelled.
  *
  * @see https://fetch.spec.whatwg.org/#fetch-processresponseendofbody
  */

--- a/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
@@ -231,6 +231,72 @@ describe('FetchTransport', function () {
     });
   });
 
+  describe('response body handling', function () {
+    it('reads the response body of a successful export', async function () {
+      // arrange
+      let cancelled = false;
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(Uint8Array.from([1, 2, 3]));
+          controller.close();
+        },
+        cancel() {
+          cancelled = true;
+        },
+      });
+      const response = new Response(body, { status: 200 });
+      sinon.stub(globalThis, 'fetch').resolves(response);
+      const transport = createFetchTransport(testTransportParameters);
+
+      // act
+      const result = await transport.send(testPayload, requestTimeout);
+
+      // assert - the body has to be read to its end, cancelling it does not
+      // release the keepalive quota the request holds
+      assert.strictEqual(result.status, 'success');
+      assert.strictEqual(response.bodyUsed, true);
+      assert.strictEqual(cancelled, false);
+    });
+
+    it('reads the response body of a retryable export', async function () {
+      // arrange
+      const response = new Response('test response', {
+        status: 503,
+        headers: { 'Retry-After': '5' },
+      });
+      sinon.stub(globalThis, 'fetch').resolves(response);
+      const transport = createFetchTransport(testTransportParameters);
+
+      // act
+      const result = await transport.send(testPayload, requestTimeout);
+
+      // assert
+      assert.strictEqual(result.status, 'retryable');
+      assert.strictEqual(response.bodyUsed, true);
+    });
+
+    it('returns success when the response body cannot be read', async function () {
+      // arrange
+      const erroringBody = new ReadableStream({
+        start(controller) {
+          controller.error(new Error('body read failed'));
+        },
+      });
+      sinon
+        .stub(globalThis, 'fetch')
+        .resolves(new Response(erroringBody, { status: 200 }));
+      const { debug } = registerMockDiagLogger();
+      const transport = createFetchTransport(testTransportParameters);
+
+      // act
+      const result = await transport.send(testPayload, requestTimeout);
+
+      // assert - the export already reached the collector, the read is best effort
+      assert.strictEqual(result.status, 'success');
+      sinon.assert.calledWithMatch(debug, /error reading export response body/);
+    });
+  });
+
   describe('keepalive queue tracking', function () {
     it('enables keepalive for small requests under limits', async function () {
       // arrange

--- a/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
@@ -275,6 +275,42 @@ describe('FetchTransport', function () {
       assert.strictEqual(response.bodyUsed, true);
     });
 
+    it('releases the reader lock after draining the body', async function () {
+      // arrange - a held reader would keep the body locked, and a later export
+      // handed the same response could then not drain it
+      const response = new Response('test response', { status: 200 });
+      sinon.stub(globalThis, 'fetch').resolves(response);
+      const transport = createFetchTransport(testTransportParameters);
+
+      // act
+      const first = await transport.send(testPayload, requestTimeout);
+      const second = await transport.send(testPayload, requestTimeout);
+
+      // assert
+      assert.strictEqual(first.status, 'success');
+      assert.strictEqual(second.status, 'success');
+      assert.strictEqual(response.bodyUsed, true);
+      assert.strictEqual(response.body?.locked, false);
+    });
+
+    it('returns success when the response body is locked by another reader', async function () {
+      // arrange - a fetch wrapper may hold the body's reader. The export
+      // already reached the collector, so a body that cannot be drained must
+      // not turn into a network error and have the export retried.
+      const response = new Response('test response', { status: 200 });
+      response.body?.getReader();
+      sinon.stub(globalThis, 'fetch').resolves(response);
+      const { debug } = registerMockDiagLogger();
+      const transport = createFetchTransport(testTransportParameters);
+
+      // act
+      const result = await transport.send(testPayload, requestTimeout);
+
+      // assert
+      assert.strictEqual(result.status, 'success');
+      sinon.assert.calledWithMatch(debug, /error reading export response body/);
+    });
+
     it('returns success when the response body cannot be read', async function () {
       // arrange
       const erroringBody = new ReadableStream({

--- a/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
@@ -7,7 +7,7 @@ import * as sinon from 'sinon';
 import * as assert from 'assert';
 import { createFetchTransport } from '../../src/transport/fetch-transport';
 import { createRetryingTransport } from '../../src/retrying-transport';
-import { registerMockDiagLogger } from '../common/test-utils';
+import { registerMockDiagLogger, withResolvers } from '../common/test-utils';
 import type {
   ExportResponseRetryable,
   ExportResponseFailure,
@@ -41,11 +41,17 @@ function neverEndingBodyAbortedBy(
   return new ReadableStream({
     start(controller) {
       controller.enqueue(Uint8Array.from([1, 2, 3]));
-      signal?.addEventListener('abort', () =>
+      const abort = () =>
         controller.error(
           new DOMException('The user aborted a request.', 'AbortError')
-        )
-      );
+        );
+      // An abort that already happened fires no event, and the body would
+      // then stay open until the test times out instead of failing.
+      if (signal?.aborted) {
+        abort();
+        return;
+      }
+      signal?.addEventListener('abort', abort);
     },
   });
 }
@@ -275,6 +281,43 @@ describe('FetchTransport', function () {
       assert.strictEqual(result.status, 'success');
       assert.strictEqual(response.bodyUsed, true);
       assert.strictEqual(cancelled, false);
+    });
+
+    it('does not settle the export until the response body reaches its end', async function () {
+      // arrange - a body that stays open until this test closes it. Chromium
+      // returns the request's keepalive quota only once the body has been read
+      // to the end, so send() must not resolve before then. `bodyUsed` is no
+      // help here: it flips on the first read, not on completion, so it holds
+      // even if the drain is never awaited.
+      const bodyClosed = withResolvers<void>();
+      const body = new ReadableStream({
+        start(controller) {
+          controller.enqueue(Uint8Array.from([1, 2, 3]));
+          void bodyClosed.promise.then(() => controller.close());
+        },
+      });
+      sinon
+        .stub(globalThis, 'fetch')
+        .resolves(new Response(body, { status: 200 }));
+      const transport = createFetchTransport(testTransportParameters);
+
+      // act
+      let settled = false;
+      const sent = transport
+        .send(testPayload, requestTimeout)
+        .then(result => ((settled = true), result));
+      // a macrotask boundary drains every microtask the export could still
+      // have queued, so the drain is parked on the open body by now
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      // assert
+      assert.strictEqual(
+        settled,
+        false,
+        'export settled while the response body was still open'
+      );
+      bodyClosed.resolve();
+      assert.strictEqual((await sent).status, 'success');
     });
 
     it('reads the response body of a retryable export', async function () {

--- a/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
@@ -31,6 +31,25 @@ const MAX_KEEPALIVE_BODY_SIZE = 60 * 1024;
 // 9 is the max concurrent keepalive requests
 const MAX_KEEPALIVE_REQUESTS = 9;
 
+/**
+ * A response body that delivers one chunk and then stays open until the
+ * request is aborted, at which point it fails the way a real fetch body does.
+ */
+function neverEndingBodyAbortedBy(
+  signal: AbortSignal | null | undefined
+): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(Uint8Array.from([1, 2, 3]));
+      signal?.addEventListener('abort', () =>
+        controller.error(
+          new DOMException('The user aborted a request.', 'AbortError')
+        )
+      );
+    },
+  });
+}
+
 describe('FetchTransport', function () {
   afterEach(function () {
     sinon.restore();
@@ -331,6 +350,38 @@ describe('FetchTransport', function () {
       assert.strictEqual(result.status, 'success');
       sinon.assert.calledWithMatch(debug, /error reading export response body/);
     });
+
+    // The timeout keeps running while the body is drained, so a collector that
+    // holds the response open long enough gets the request aborted in the
+    // middle of the read. The headers are in by then, so the status the
+    // collector sent still decides the export outcome.
+    for (const { status, expected } of [
+      { status: 200, expected: 'success' },
+      { status: 503, expected: 'retryable' },
+    ]) {
+      it(`returns ${expected} when the timeout aborts the export while its ${status} response body is being read`, async function () {
+        // arrange - a body that stays open until the request is aborted, which
+        // is what the reader sees when the timeout fires mid-drain
+        sinon
+          .stub(globalThis, 'fetch')
+          .callsFake(
+            async (_input, init) =>
+              new Response(neverEndingBodyAbortedBy(init?.signal), { status })
+          );
+        const { debug } = registerMockDiagLogger();
+        const transport = createFetchTransport(testTransportParameters);
+
+        // act
+        const result = await transport.send(testPayload, 1);
+
+        // assert
+        assert.strictEqual(result.status, expected);
+        sinon.assert.calledWithMatch(
+          debug,
+          /error reading export response body/
+        );
+      });
+    }
   });
 
   describe('keepalive queue tracking', function () {

--- a/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/browser/fetch-transport.test.ts
@@ -276,8 +276,9 @@ describe('FetchTransport', function () {
       // act
       const result = await transport.send(testPayload, requestTimeout);
 
-      // assert - the body has to be read to its end, cancelling it does not
-      // release the keepalive quota the request holds
+      // assert - the body has to be read to its end. Cancelling it takes the
+      // client-abort path instead, which releases the keepalive quota far
+      // more slowly (measured at about 1s against about 5ms for a full read)
       assert.strictEqual(result.status, 'success');
       assert.strictEqual(response.bodyUsed, true);
       assert.strictEqual(cancelled, false);


### PR DESCRIPTION
## Which problem is this PR solving?

Addresses the keepalive quota leak reported in #7001 (deliberately not a closing reference — the issue covers more than this fix, see discussion below)

The fetch transport never reads the response body. In Chromium that means the request's share of the 64KiB cumulative `keepalive` quota is never given back: `HandleLoaderFinish` — which decrements `inflight_keepalive_bytes_` — is only reachable once the body has been read to its end. Blink normally hides this by draining the body itself through a `BufferingBytesConsumer`, but it explicitly skips that consumer when the response carries `Cache-Control: no-store`, which is a common header for a collector to return ([fetch_manager.cc](https://github.com/chromium/chromium/blob/1af7c3cde84323e827f77d8066ca23da811203b8/third_party/blink/renderer/core/fetch/fetch_manager.cc#L818-L836)).

The result, reproduced in the issue, is that successful exports leak the quota until it is exhausted, after which every export stays `(pending)` in devtools forever and telemetry is silently lost. The transport's own accounting (`pendingBodySize` / `pendingKeepaliveCount`) meanwhile releases at response headers, so it keeps sending requests with `keepalive: true` that the browser can no longer accept.

## Short description of the changes

* Read the response body to its end and discard it before evaluating the status. The reader loop drops chunks as they arrive rather than calling `response.arrayBuffer()`, so a large response is not buffered in memory.
* Read errors are logged at debug level and do not change the export outcome — the status already tells us what happened to the export.
* Because the drain is awaited before the `finally` block, the transport now holds its in-flight counters for the lifetime of the body as well. That is intentional: it makes the internal accounting line up with when the browser actually releases the quota, instead of releasing ahead of it.

Cancelling the body instead of reading it is Blink's client-abort path. It does release the quota eventually, but far more slowly than reading to the end (measured in #7070 at roughly 1 s against roughly 5 ms), so the body is read rather than cancelled.

The body is still discarded rather than returned as `ExportResponseSuccess.data`, so partial-success responses remain unhandled in the browser (`otlp-export-delegate` handles `data` when the node transport sets it). That is a separate gap and I kept it out of this fix, happy to follow up if you'd like it in the same PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `npm run test:browser` in `experimental/packages/otlp-exporter-base` (90 passing). The three new tests fail on `main` and pass with the change.
- [x] `npm test` in the same package (151 passing), plus `test:browser` of `exporter-trace-otlp-http`, `exporter-logs-otlp-http` and `opentelemetry-exporter-metrics-otlp-http`.
- [x] `npm run lint` (no new findings).

New tests cover that the body is read to its end (and not cancelled) on a successful export, that it is read on a retryable one, and that a body which fails to read leaves the export result untouched.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated

<!-- oss-radar:idempotency=auto-20260815-101259.w2.open-telemetry_opentelemetry-js.7001 -->


