### PR TITLE
docs: fix stale example links

### DIFF
--- a/examples/opentelemetry-web/package.json
+++ b/examples/opentelemetry-web/package.json
@@ -59,5 +59,5 @@
     "@opentelemetry/sdk-trace-web": "2.10.0",
     "@opentelemetry/semantic-conventions": "^1.29.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/opentelemetry-web"
 }

--- a/experimental/packages/opentelemetry-instrumentation-fetch/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/README.md
@@ -60,7 +60,7 @@ fetch('http://localhost:8090/fetch.js');
 ![Screenshot of the running example](images/trace2.png)
 ![Screenshot of the running example](images/trace3.png)
 
-See [examples/tracer-web/fetch](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web) for a short example.
+See [examples/opentelemetry-web](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/opentelemetry-web) for a short example.
 
 ### Fetch Instrumentation options
 

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/README.md
@@ -95,7 +95,7 @@ The `instrumentation-xml-http-request` versions v0.220.0 and later emit the stab
 ![Screenshot of the running example](images/request.jpg)
 ![Screenshot of the running example](images/cors.jpg)
 
-See [examples/tracer-web](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web) for a short example.
+See [examples/opentelemetry-web](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/opentelemetry-web) for a short example.
 
 ## Useful links
 

--- a/packages/opentelemetry-sdk-trace-node/README.md
+++ b/packages/opentelemetry-sdk-trace-node/README.md
@@ -105,7 +105,7 @@ registerInstrumentations({
 
 ## Examples
 
-See how to automatically instrument [http](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/http) and [gRPC](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/grpc) / [grpc-js](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/grpc-js) using node-sdk.
+See how to automatically instrument [http](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/http) and [grpc-js](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/grpc-js) using node-sdk.
 
 ## Useful links
 

--- a/packages/opentelemetry-shim-opentracing/README.md
+++ b/packages/opentelemetry-shim-opentracing/README.md
@@ -47,8 +47,6 @@ new TracerShim(tracer, {
 
 If propagators are not specified, OpenTelemetry's global propagator will be used.
 
-See [examples/opentracing-shim](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/opentracing-shim) for a short example.
-
 ## License
 
 Apache 2.0 - See [LICENSE][license-url] for more information.


### PR DESCRIPTION
## Summary
- update stale example links from removed/renamed examples
- point web instrumentation docs and package metadata to `examples/opentelemetry-web`
- remove the broken OpenTracing shim example pointer because that example is no longer present

## Testing
- ran `git diff --check`
- verified `examples/grpc-js` and `examples/opentelemetry-web` exist locally