### PR TITLE
docs: remove stale compatibility example links

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,6 @@ use the latest and greatest features, and best practices.
 | [https](https/)                           | HTTPS Instrumentation to automatically collect trace data and export them to the backend of choice                               | Intermediate     |
 | [grpc](grpc-js/)                          | gRPC Instrumentation to automatically collect trace data and export them to the backend of choice                                | Intermediate     |
 | [otlp-exporter-node](otlp-exporter-node/) | This example shows how to use `@opentelemetry/exporter-otlp-http` to instrument a simple Node.js application                     | Intermediate     |
-| [opentracing-shim](opentracing-shim/)     | This is a simple example that demonstrates how existing OpenTracing instrumentation can be integrated with OpenTelemetry         | Intermediate     |
 | [esm-http-ts](esm-http-ts/)               | This is a simple example that demonstrates tracing HTTP request, with an app written in TypeScript and transpiled to ES Modules. | Intermediate     |
 
 Examples of experimental packages can be found at [experimental/examples](../experimental/examples).

--- a/experimental/packages/shim-opencensus/README.md
+++ b/experimental/packages/shim-opencensus/README.md
@@ -97,10 +97,6 @@ new MeterProvider({
 });
 ```
 
-## Example
-
-See [examples/opencensus-shim](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/examples/opencensus-shim) for a short example.
-
 ## License
 
 Apache 2.0 - See [LICENSE][license-url] for more information.


### PR DESCRIPTION
## Summary
- remove the `opentracing-shim` row from the examples index because that example directory is no longer present
- remove the OpenCensus shim README link to the removed `experimental/examples/opencensus-shim` example

## Testing
- ran `git diff --check`
- verified the referenced example directories are absent locally