### PR TITLE
docs: fix sdk-trace references

### DIFF
--- a/doc/contributing/benchmark-tests.md
+++ b/doc/contributing/benchmark-tests.md
@@ -16,7 +16,7 @@ Performance benchmark tests can be run from the root for all modules or from a s
 npm run test:bench
 
 # benchmark a single module
-cd packages/opentelemetry-sdk-trace
+cd packages/sdk-trace
 npm run test:bench
 ```
 

--- a/experimental/examples/prometheus/README.md
+++ b/experimental/examples/prometheus/README.md
@@ -66,7 +66,7 @@ If you are using the default configurations, the prometheus client will be avail
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
 - For more information on OpenTelemetry metrics, visit: <https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-metrics>
-- For more information on OpenTelemetry tracing, visit: <https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace>
+- For more information on OpenTelemetry tracing, visit: <https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/sdk-trace>
 
 ## LICENSE
 


### PR DESCRIPTION
## Summary
- update stale `packages/opentelemetry-sdk-trace` references to `packages/sdk-trace`
- fixes the benchmark guide command and Prometheus example tracing link

## Testing
- ran `git diff --check`
- verified `packages/sdk-trace` exists locally