### PR TITLE
fix: parse Retry-After delay strictly

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -19,6 +19,7 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 ### :bug: Bug Fixes
 
 * fix(sdk-node): support `headers_list` when creating OTLP exporters from declarative configuration [#6953](https://github.com/open-telemetry/opentelemetry-js/issues/6953) @JacksonWeber
+* fix(otlp-exporter-base): parse the `Retry-After` delay strictly so a malformed value falls back to exponential backoff [#7010](https://github.com/open-telemetry/opentelemetry-js/pull/7010) @rajanpanth
 
 ### :books: Documentation
 

--- a/experimental/packages/otlp-exporter-base/src/is-export-retryable.ts
+++ b/experimental/packages/otlp-exporter-base/src/is-export-retryable.ts
@@ -27,8 +27,14 @@ export function parseRetryAfterToMills(
     return seconds > 0 ? seconds * 1000 : -1;
   }
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After#directives
-  const delay = new Date(retryAfter).getTime() - Date.now();
+  const delay = new Date(trimmedRetryAfter).getTime() - Date.now();
 
+  if (Number.isNaN(delay)) {
+    // Neither delay-seconds nor a parseable HTTP-date. Returning undefined
+    // lets the retrying transport fall back to its exponential backoff
+    // instead of retrying immediately.
+    return undefined;
+  }
   if (delay >= 0) {
     return delay;
   }

--- a/experimental/packages/otlp-exporter-base/src/is-export-retryable.ts
+++ b/experimental/packages/otlp-exporter-base/src/is-export-retryable.ts
@@ -19,7 +19,10 @@ export function parseRetryAfterToMills(
     return undefined;
   }
 
-  const seconds = Number.parseInt(retryAfter, 10);
+  const trimmedRetryAfter = retryAfter.trim();
+  const seconds = /^-?\d+$/.test(trimmedRetryAfter)
+    ? Number.parseInt(trimmedRetryAfter, 10)
+    : NaN;
   if (Number.isInteger(seconds)) {
     return seconds > 0 ? seconds * 1000 : -1;
   }

--- a/experimental/packages/otlp-exporter-base/test/common/is-export-retryable.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/common/is-export-retryable.test.ts
@@ -16,6 +16,8 @@ describe('parseRetryAfterToMills', function () {
     // duration
     ['-100', -1],
     ['1000', 1000 * 1000],
+    [' 5 ', 5 * 1000],
+    ['1000abc', 0],
     // future timestamp
     ['Fri, 20 Jan 2023 00:00:01 GMT', 1000],
     // Past timestamp

--- a/experimental/packages/otlp-exporter-base/test/common/is-export-retryable.test.ts
+++ b/experimental/packages/otlp-exporter-base/test/common/is-export-retryable.test.ts
@@ -17,12 +17,13 @@ describe('parseRetryAfterToMills', function () {
     ['-100', -1],
     ['1000', 1000 * 1000],
     [' 5 ', 5 * 1000],
-    ['1000abc', 0],
+    ['1000abc', undefined],
+    ['not-a-date', undefined],
     // future timestamp
     ['Fri, 20 Jan 2023 00:00:01 GMT', 1000],
     // Past timestamp
     ['Fri, 19 Jan 2023 23:59:59 GMT', 0],
-  ] as [string | null, number][];
+  ] as [string | null, number | undefined][];
 
   afterEach(() => {
     sinon.restore();


### PR DESCRIPTION
## Summary
- parse `Retry-After` delay-seconds only when the whole trimmed value is numeric
- avoid treating malformed values such as `1000abc` as valid retry delays
- add unit coverage for whitespace-trimmed delays and malformed numeric prefixes

## Testing
- `git diff --check`

Note: package tests were not run locally because this checkout does not have Node dependencies installed.