### PR TITLE
docs(otlp-transformer): mark log APIs experimental

### DIFF
--- a/experimental/packages/otlp-transformer/src/logs/index.ts
+++ b/experimental/packages/otlp-transformer/src/logs/index.ts
@@ -13,6 +13,9 @@ export type {
   IExportLogsPartialSuccess,
 } from './export-response';
 
+/**
+ * @experimental this helper may receive breaking changes in minor versions, pin this package's version when using this constant
+ */
 export const LogsExporterMetricsHelper: IExporterMetricsHelper<
   ReadableLogRecord[]
 > = {

--- a/experimental/packages/otlp-transformer/src/logs/json/logs.ts
+++ b/experimental/packages/otlp-transformer/src/logs/json/logs.ts
@@ -9,7 +9,7 @@ import type { IExportLogsServiceResponse } from '../export-response';
 import { JSON_ENCODER } from '../../common/utils';
 import { diag } from '@opentelemetry/api';
 
-/*
+/**
  * @experimental this serializer may receive breaking changes in minor versions, pin this package's version when using this constant
  */
 export const JsonLogsSerializer: ISerializer<

--- a/experimental/packages/otlp-transformer/src/logs/protobuf/logs.ts
+++ b/experimental/packages/otlp-transformer/src/logs/protobuf/logs.ts
@@ -9,7 +9,7 @@ import type { ISerializer } from '../../i-serializer';
 import { serializeLogsExportRequest } from './logs-serializer';
 import { deserializeExportLogsServiceResponse } from './response-deserializer';
 
-/*
+/**
  * @experimental this serializer may receive breaking changes in minor versions, pin this package's version when using this constant
  */
 export const ProtobufLogsSerializer: ISerializer<


### PR DESCRIPTION
## Summary

- mark `LogsExporterMetricsHelper` as experimental because it exposes `ReadableLogRecord[]`
- make the existing experimental annotations on `JsonLogsSerializer` and `ProtobufLogsSerializer` TypeDoc-compatible
- leave internal APIs and self-contained log export response interfaces unchanged, per the maintainer clarification

## Validation

- targeted ESLint on the three changed files
- targeted TypeScript no-emit check using repository compiler options
- TypeDoc conversion confirming exactly the three intended public exports are marked `@experimental`
- `git diff --check`

Closes #4584