### PR TITLE
docs(api): complete `@since` annotations for the public API

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to this project will be documented in this file.
 
 ### :books: Documentation
 
+* docs(api): complete `@since` annotations for the public API [#7023](https://github.com/open-telemetry/opentelemetry-js/pull/7023) @nabeelamjadsheikh
+  * Adds the three missing exported-type annotations and the member-level annotations for methods and properties introduced after their enclosing type.
+  * Corrects `Attributes`, `AttributeValue` and `TracerOptions` from `1.3.0` to `1.1.0`; all three were already importable in 1.1.0 via wildcard re-export.
+
 ### :house: Internal
 
 * perf(api): add getGlobal fast-path [#6956](https://github.com/open-telemetry/opentelemetry-js/pull/6956) @legendecas

--- a/api/src/api/metrics.ts
+++ b/api/src/api/metrics.ts
@@ -17,6 +17,8 @@ const API_NAME = 'metrics';
 
 /**
  * Singleton object which represents the entry point to the OpenTelemetry Metrics API
+ *
+ * @since 1.4.1
  */
 export class MetricsAPI {
   private static _instance?: MetricsAPI;

--- a/api/src/api/propagation.ts
+++ b/api/src/api/propagation.ts
@@ -106,6 +106,7 @@ export class PropagationAPI {
 
   public getBaggage = getBaggage;
 
+  /** @since 1.4.0 */
   public getActiveBaggage = getActiveBaggage;
 
   public setBaggage = setBaggage;

--- a/api/src/api/trace.ts
+++ b/api/src/api/trace.ts
@@ -94,6 +94,7 @@ export class TraceAPI {
 
   public getSpan = getSpan;
 
+  /** @since 1.2.0 */
   public getActiveSpan = getActiveSpan;
 
   public getSpanContext = getSpanContext;

--- a/api/src/common/Attributes.ts
+++ b/api/src/common/Attributes.ts
@@ -8,7 +8,7 @@
  *
  * Note: only the own enumerable keys are counted as valid attribute keys.
  *
- * @since 1.3.0
+ * @since 1.1.0
  */
 export interface Attributes {
   [attributeKey: string]: AttributeValue | undefined;
@@ -19,7 +19,7 @@ export interface Attributes {
  *
  * null or undefined attribute values are invalid and will result in undefined behavior.
  *
- * @since 1.3.0
+ * @since 1.1.0
  */
 export type AttributeValue =
   | string

--- a/api/src/diag/types.ts
+++ b/api/src/diag/types.ts
@@ -57,6 +57,8 @@ export interface DiagLogger {
  * Defines the available internal logging levels for the diagnostic logger, the numeric values
  * of the levels are defined to match the original values from the initial LogLevel to avoid
  * compatibility/migration issues for any implementation that assume the numeric ordering.
+ *
+ * @since 1.0.0
  */
 export enum DiagLogLevel {
   /** Diagnostic Logging level setting to disable all logging (except and forced logs) */

--- a/api/src/metrics/Meter.ts
+++ b/api/src/metrics/Meter.ts
@@ -43,6 +43,8 @@ export interface Meter {
    * Creates and returns a new `Gauge`.
    * @param name the name of the metric.
    * @param [options] the metric options.
+   *
+   * @since 1.9.0
    */
   createGauge<AttributesTypes extends MetricAttributes = MetricAttributes>(
     name: string,

--- a/api/src/metrics/Metric.ts
+++ b/api/src/metrics/Metric.ts
@@ -161,6 +161,8 @@ export interface ObservableResult<
 
 /**
  * Interface that is being used in batch observable callback function.
+ *
+ * @since 1.3.0
  */
 export interface BatchObservableResult<
   AttributesTypes extends MetricAttributes = MetricAttributes,

--- a/api/src/trace/ProxyTracer.ts
+++ b/api/src/trace/ProxyTracer.ts
@@ -23,6 +23,7 @@ export class ProxyTracer implements Tracer {
   private _provider: TracerDelegator;
   public readonly name: string;
   public readonly version?: string;
+  /** @since 1.1.0 */
   public readonly options?: TracerOptions;
 
   constructor(

--- a/api/src/trace/SamplingResult.ts
+++ b/api/src/trace/SamplingResult.ts
@@ -54,6 +54,8 @@ export interface SamplingResult {
    * the new {@link SpanContext}. Samplers SHOULD return the TraceState from
    * the passed-in {@link Context} if they do not intend to change it. Leaving
    * the value undefined will also leave the TraceState unchanged.
+   *
+   * @since 1.4.1
    */
   traceState?: TraceState;
 }

--- a/api/src/trace/link.ts
+++ b/api/src/trace/link.ts
@@ -28,6 +28,10 @@ export interface Link {
   context: SpanContext;
   /** A set of {@link SpanAttributes} on the link. */
   attributes?: SpanAttributes;
-  /** Count of attributes of the link that were dropped due to collection limits */
+  /**
+   * Count of attributes of the link that were dropped due to collection limits
+   *
+   * @since 1.4.1
+   */
   droppedAttributesCount?: number;
 }

--- a/api/src/trace/span.ts
+++ b/api/src/trace/span.ts
@@ -75,6 +75,8 @@ export interface Span {
    * It is preferred span links be added at span creation.
    *
    * @param link the link to add.
+   *
+   * @since 1.9.0
    */
   addLink(link: Link): this;
 
@@ -85,6 +87,8 @@ export interface Span {
    * It is preferred span links be added at span creation.
    *
    * @param links the links to add.
+   *
+   * @since 1.9.0
    */
   addLinks(links: Link[]): this;
 

--- a/api/src/trace/tracer_options.ts
+++ b/api/src/trace/tracer_options.ts
@@ -6,7 +6,7 @@
 /**
  * An interface describes additional metadata of a tracer.
  *
- * @since 1.3.0
+ * @since 1.1.0
  */
 export interface TracerOptions {
   /**


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #4661.

#4661 asks for two things, and #4906 completed most of the first one:

- [x] add `@since` to the jsdoc of each exported public type — 80 of 83 were done by #4906; **3 were still missing**
- [ ] add `@since` to each method and property added after the enclosing type's `@since` — **not started** (exactly one member in `api/src` carried an annotation)

This PR finishes both.

## Short description of the changes

**Commit 1 — complete the annotations (additive, 11 annotations).**

The three exported types that had no `@since`:

| Symbol | `@since` |
| --- | --- |
| `BatchObservableResult` | 1.3.0 |
| `DiagLogLevel` | 1.0.0 |
| `MetricsAPI` | 1.4.1 |

The members introduced after their enclosing type, per the second task:

| Member | `@since` | Enclosing type `@since` |
| --- | --- | --- |
| `ProxyTracer.options` | 1.1.0 | 1.0.0 |
| `TraceAPI.getActiveSpan` | 1.2.0 | 1.0.0 |
| `PropagationAPI.getActiveBaggage` | 1.4.0 | 1.0.0 |
| `Link.droppedAttributesCount` | 1.4.1 | 1.0.0 |
| `SamplingResult.traceState` | 1.4.1 | 1.0.0 |
| `Span.addLink` | 1.9.0 | 1.0.0 |
| `Span.addLinks` | 1.9.0 | 1.0.0 |
| `Meter.createGauge` | 1.9.0 | 1.3.0 |

`MetricOptions.advice` (1.7.0) already had one and is unchanged.

**Commit 2 — correct three existing annotations. This is separable; drop the commit if you disagree.**

`Attributes`, `AttributeValue` and `TracerOptions` are annotated `@since 1.3.0`, but all three were importable from `@opentelemetry/api` in **1.1.0**, via wildcard re-export:

```ts
// @opentelemetry/api@1.1.0 → build/src/index.d.ts, lines 5 and 24
export * from './common/Attributes';
export * from './trace/tracer_options';
```

1.3.0 is only when `index.ts` switched from wildcard to explicit named re-exports, which does not change what a consumer could import. Since the stated purpose of these annotations is to let instrumentation authors choose a minimum API version, `1.3.0` makes them over-constrain their peer dependency by two minors.

## How were the versions determined?

Not by reading diffs. All 16 published `1.x` releases of `@opentelemetry/api` were fetched from npm, and the public export surface of each was extracted from its shipped `.d.ts` with the TypeScript compiler API (`checker.getExportsOfModule` on `build/src/index.d.ts`, so wildcard re-exports resolve correctly). Each symbol and each member was then mapped to the earliest release that exported it.

Run against the annotations already in `main`, that procedure reproduces **76 of 80** — the four it disagrees with are the three in commit 2 plus `ContextManagementToken`, which is annotated `@since 1.10.0` and is correctly absent from every published release.

## Type of change

- [x] This change requires a documentation update

Documentation only. No runtime code, type signatures, or exports were changed.

## How Has This Been Tested?

- [x] `nx run @opentelemetry/api:compile` — passes
- [x] `nx run @opentelemetry/api:lint` — passes, no circular dependencies
- [x] `nx run @opentelemetry/api:test` — 1134 passing, 0 failing
- [x] Re-ran the audit against the final tree: all 83 exported types now carry `@since`, and 82 of 83 match the npm-derived map (the exception being the unreleased `ContextManagementToken`)

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added — n/a, comments only
- [x] Documentation has been updated
