### PR TITLE
chore: add @maryliag to maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ We have a weekly SIG meeting! See the [community page](https://github.com/open-t
 - [David Luna](https://github.com/david-luna), Elastic
 - [Jamie Danielson](https://github.com/JamieDanielson), Honeycomb
 - [Marc Pichler](https://github.com/pichlermarc), Dynatrace
+- [Marylia Gutierrez](https://github.com/maryliag), Grafana Labs
 - [Trent Mick](https://github.com/trentm), Elastic
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
@@ -259,7 +260,6 @@ For more information about the maintainer role, see the [community repository](h
 - [Hector Hernandez](https://github.com/hectorhdzg), Microsoft
 - [Jackson Weber](https://github.com/JacksonWeber), Microsoft
 - [Martin Kuba](https://github.com/martinkuba), Grafana Labs
-- [Marylia Gutierrez](https://github.com/maryliag), Grafana Labs
 - [Raphaël Thériault](https://github.com/raphael-theriault-swi), SolarWinds
 
 In addition, [Browser SIG Maintainers](https://github.com/orgs/open-telemetry/teams/browser-maintainers) are granted the


### PR DESCRIPTION
In recognition of her exceptional contributions to technical, security and governance initiatives, I propose adding @maryliag to the list of JS Maintainers.

cc @open-telemetry/javascript-maintainers 