### PR TITLE
fix(instrumentation-fetch, instrumentation-xml-http-request)!: remove unreachable CORS Preflight span

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -19,6 +19,9 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
     Could not create OpenTelemetry SDK from configuration, SDK will not be setup: unknown ExperimentalResourceDetector name in configuration: "container"
     ```
 
+* fix(instrumentation-fetch, instrumentation-xml-http-request)!: remove the unreachable `CORS Preflight` span [#5122](https://github.com/open-telemetry/opentelemetry-js/issues/5122) @nabeelamjadsheikh
+  * Under Resource Timing Level 2, the preflight request is folded into the main request's `PerformanceResourceTiming` entry rather than reported as a separate one, so the branch that emitted the `CORS Preflight` child span could never be taken. No `CORS Preflight` span has been produced by either instrumentation in any browser that implements the current spec.
+
 ### :rocket: Features
 
 * feat(sdk-logs): deprecate `SdkLogRecord` in favor of `ReadWriteLogRecord` [#6939](https://github.com/open-telemetry/opentelemetry-js/pull/6939) @pichlermarc

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -110,34 +110,6 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
   init(): void {}
 
   /**
-   * Add cors pre flight child span
-   * @param span
-   * @param corsPreFlightRequest
-   */
-  private _addChildSpan(
-    span: Span,
-    corsPreFlightRequest: PerformanceResourceTiming
-  ): void {
-    const childSpan = this.tracer.startSpan(
-      'CORS Preflight',
-      {
-        startTime: corsPreFlightRequest[web.PerformanceTimingNames.FETCH_START],
-      },
-      trace.setSpan(context.active(), span)
-    );
-    web.addSpanNetworkEvents(
-      childSpan,
-      corsPreFlightRequest,
-      this.getConfig().ignoreNetworkEvents,
-      undefined,
-      true
-    );
-    childSpan.end(
-      corsPreFlightRequest[web.PerformanceTimingNames.RESPONSE_END]
-    );
-  }
-
-  /**
    * Adds more attributes to span just before ending it
    * @param span
    * @param response
@@ -272,11 +244,6 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
       const mainRequest = resource.mainRequest;
       this._markResourceAsUsed(mainRequest);
 
-      const corsPreFlightRequest = resource.corsPreFlightRequest;
-      if (corsPreFlightRequest) {
-        this._addChildSpan(span, corsPreFlightRequest);
-        this._markResourceAsUsed(corsPreFlightRequest);
-      }
       web.addSpanNetworkEvents(
         span,
         mainRequest,

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/src/xhr.ts
@@ -13,7 +13,6 @@ import { hrTime, isUrlIgnored, otperformance } from '@opentelemetry/core';
 import {
   addSpanNetworkEvents,
   getResource,
-  PerformanceTimingNames as PTN,
   shouldPropagateTraceHeaders,
   parseUrl,
 } from '@opentelemetry/sdk-trace-web';
@@ -133,31 +132,6 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
     api.propagation.inject(api.context.active(), headers);
     Object.keys(headers).forEach(key => {
       xhr.setRequestHeader(key, String(headers[key]));
-    });
-  }
-
-  /**
-   * Add cors pre flight child span
-   * @param span
-   * @param corsPreFlightRequest
-   * @private
-   */
-  private _addChildSpan(
-    span: api.Span,
-    corsPreFlightRequest: PerformanceResourceTiming
-  ): void {
-    api.context.with(api.trace.setSpan(api.context.active(), span), () => {
-      const childSpan = this.tracer.startSpan('CORS Preflight', {
-        startTime: corsPreFlightRequest[PTN.FETCH_START],
-      });
-      addSpanNetworkEvents(
-        childSpan,
-        corsPreFlightRequest,
-        this.getConfig().ignoreNetworkEvents,
-        undefined,
-        true
-      );
-      childSpan.end(corsPreFlightRequest[PTN.RESPONSE_END]);
     });
   }
 
@@ -286,11 +260,6 @@ export class XMLHttpRequestInstrumentation extends InstrumentationBase<XMLHttpRe
       const mainRequest = resource.mainRequest;
       this._markResourceAsUsed(mainRequest);
 
-      const corsPreFlightRequest = resource.corsPreFlightRequest;
-      if (corsPreFlightRequest) {
-        this._addChildSpan(span, corsPreFlightRequest);
-        this._markResourceAsUsed(corsPreFlightRequest);
-      }
       addSpanNetworkEvents(
         span,
         mainRequest,

--- a/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-xml-http-request/test/xhr.test.ts
@@ -451,7 +451,7 @@ describe('xhr', () => {
           });
 
           it('should create a span with correct root span', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             assert.strictEqual(
               span.parentSpanContext?.spanId,
               rootSpan.spanContext().spanId,
@@ -460,12 +460,12 @@ describe('xhr', () => {
           });
 
           it('span should have correct name', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             assert.strictEqual(span.name, 'GET', 'span has wrong name');
           });
 
           it('span should have correct kind', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             assert.strictEqual(
               span.kind,
               api.SpanKind.CLIENT,
@@ -474,7 +474,7 @@ describe('xhr', () => {
           });
 
           it('span should have correct attributes', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const attributes = span.attributes;
             let expectedNumAttrs = 0;
             expectedNumAttrs += 5;
@@ -499,7 +499,7 @@ describe('xhr', () => {
           });
 
           it('span should have correct events', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const events = span.events;
             testForCorrectEvents(events, [
               EventNames.METHOD_OPEN,
@@ -517,50 +517,6 @@ describe('xhr', () => {
             assert.strictEqual(events.length, 11, 'number of events is wrong');
           });
 
-          it('should create a span for preflight request', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-            const parentSpan: tracing.ReadableSpan = exportSpy.args[1][0][0];
-            assert.strictEqual(
-              span.parentSpanContext?.spanId,
-              parentSpan.spanContext().spanId,
-              'parent span is not root span'
-            );
-          });
-
-          it('preflight request span should have correct name', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-            assert.strictEqual(
-              span.name,
-              'CORS Preflight',
-              'preflight request span has wrong name'
-            );
-          });
-
-          it('preflight request span should have correct kind', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-            assert.strictEqual(
-              span.kind,
-              api.SpanKind.INTERNAL,
-              'span has wrong kind'
-            );
-          });
-
-          it('preflight request span should have correct events', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-            const events = span.events;
-            assert.strictEqual(events.length, 8, 'number of events is wrong');
-            testForCorrectEvents(events, [
-              PTN.FETCH_START,
-              PTN.DOMAIN_LOOKUP_START,
-              PTN.DOMAIN_LOOKUP_END,
-              PTN.CONNECT_START,
-              PTN.CONNECT_END,
-              PTN.REQUEST_START,
-              PTN.RESPONSE_START,
-              PTN.RESPONSE_END,
-            ]);
-          });
-
           it('should NOT clear the resources', () => {
             assert.ok(
               clearResourceTimingsSpy.notCalled,
@@ -572,7 +528,6 @@ describe('xhr', () => {
         describe('when making https requests', () => {
           beforeEach(done => {
             clearData();
-            // this won't generate a preflight span
             const propagateTraceHeaderCorsUrls = [secureUrl];
             prepareData(secureUrl, {
               propagateTraceHeaderCorsUrls,
@@ -581,7 +536,7 @@ describe('xhr', () => {
           });
 
           it('span should have correct events', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const events = span.events;
 
             testForCorrectEvents(events, [
@@ -600,29 +555,11 @@ describe('xhr', () => {
             ]);
             assert.strictEqual(events.length, 12, 'number of events is wrong');
           });
-
-          it('preflight request span should have correct events', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-            const events = span.events;
-            assert.strictEqual(events.length, 9, 'number of events is wrong');
-            testForCorrectEvents(events, [
-              PTN.FETCH_START,
-              PTN.DOMAIN_LOOKUP_START,
-              PTN.DOMAIN_LOOKUP_END,
-              PTN.CONNECT_START,
-              PTN.SECURE_CONNECTION_START,
-              PTN.CONNECT_END,
-              PTN.REQUEST_START,
-              PTN.RESPONSE_START,
-              PTN.RESPONSE_END,
-            ]);
-          });
         });
 
         describe('AND origin match with window.location', () => {
           beforeEach(done => {
             clearData();
-            // this won't generate a preflight span
             const propagateTraceHeaderCorsUrls = [url];
             prepareData(window.location.origin + '/xml-http-request.js', {
               propagateTraceHeaderCorsUrls,
@@ -665,8 +602,7 @@ describe('xhr', () => {
               successfulGetRequest(ghUrl, done);
             });
             it('should set trace headers', () => {
-              // span at exportSpy.args[0][0][0] is the preflight span
-              const span: api.Span = exportSpy.args[1][0][0];
+              const span: api.Span = exportSpy.args[0][0][0];
               assert.strictEqual(
                 requests[0].requestHeaders[X_B3_TRACE_ID],
                 span.spanContext().traceId,
@@ -796,7 +732,7 @@ describe('xhr', () => {
           });
 
           it('should clear previous span information', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[2][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
             const attributes = span.attributes;
             const keys = Object.keys(attributes);
 
@@ -826,7 +762,7 @@ describe('xhr', () => {
           });
 
           it('span should have custom attribute', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const attributes = span.attributes;
             assert.ok(attributes['xhr-custom-attribute'] === 'bar');
           });
@@ -882,7 +818,7 @@ describe('xhr', () => {
             successfulGetRequest(url, done);
           });
           it('should NOT add network events', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const events = span.events;
             assert.strictEqual(events.length, 3, 'number of events is wrong');
           });
@@ -986,7 +922,7 @@ describe('xhr', () => {
           });
 
           it('span should have correct attributes and status', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const attributes = span.attributes;
             let expectedNumAttrs = 0;
             assert.strictEqual(span.status.code, api.SpanStatusCode.ERROR);
@@ -1015,7 +951,7 @@ describe('xhr', () => {
           });
 
           it('span should have correct events', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const events = span.events;
 
             testForCorrectEvents(events, [
@@ -1213,7 +1149,7 @@ describe('xhr', () => {
             });
 
             it('span should have custom attribute', () => {
-              const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+              const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
               const attributes = span.attributes;
               assert.ok(attributes['xhr-custom-error-code'] === 400);
             });
@@ -1350,7 +1286,7 @@ describe('xhr', () => {
           });
 
           it('should create a span with correct root span', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             assert.strictEqual(
               span.parentSpanContext?.spanId,
               rootSpan.spanContext().spanId,
@@ -1359,12 +1295,12 @@ describe('xhr', () => {
           });
 
           it('span should have correct name', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             assert.strictEqual(span.name, 'POST', 'span has wrong name');
           });
 
           it('span should have correct kind', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             assert.strictEqual(
               span.kind,
               api.SpanKind.CLIENT,
@@ -1373,7 +1309,7 @@ describe('xhr', () => {
           });
 
           it('span should have correct attributes and status', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const attributes = span.attributes;
 
             let expectedNumAttrs = 0;
@@ -1403,7 +1339,7 @@ describe('xhr', () => {
           });
 
           it('span should have correct events', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const events = span.events;
             testForCorrectEvents(events, [
               EventNames.METHOD_OPEN,
@@ -1421,50 +1357,6 @@ describe('xhr', () => {
             assert.strictEqual(events.length, 11, 'number of events is wrong');
           });
 
-          it('should create a span for preflight request', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-            const parentSpan: tracing.ReadableSpan = exportSpy.args[1][0][0];
-            assert.strictEqual(
-              span.parentSpanContext?.spanId,
-              parentSpan.spanContext().spanId,
-              'parent span is not root span'
-            );
-          });
-
-          it('preflight request span should have correct name', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-            assert.strictEqual(
-              span.name,
-              'CORS Preflight',
-              'preflight request span has wrong name'
-            );
-          });
-
-          it('preflight request span should have correct kind', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-            assert.strictEqual(
-              span.kind,
-              api.SpanKind.INTERNAL,
-              'span has wrong kind'
-            );
-          });
-
-          it('preflight request span should have correct events', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-            const events = span.events;
-            assert.strictEqual(events.length, 8, 'number of events is wrong');
-            testForCorrectEvents(events, [
-              PTN.FETCH_START,
-              PTN.DOMAIN_LOOKUP_START,
-              PTN.DOMAIN_LOOKUP_END,
-              PTN.CONNECT_START,
-              PTN.CONNECT_END,
-              PTN.REQUEST_START,
-              PTN.RESPONSE_START,
-              PTN.RESPONSE_END,
-            ]);
-          });
-
           it('should NOT clear the resources', () => {
             assert.ok(
               clearResourceTimingsSpy.notCalled,
@@ -1476,7 +1368,6 @@ describe('xhr', () => {
         describe('When making https requests', () => {
           beforeEach(done => {
             clearData();
-            // this won't generate a preflight span
             const propagateTraceHeaderCorsUrls = [secureUrl];
             prepareData(secureUrl, {
               propagateTraceHeaderCorsUrls,
@@ -1485,7 +1376,7 @@ describe('xhr', () => {
           });
 
           it('span should have correct events', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const events = span.events;
             testForCorrectEvents(events, [
               EventNames.METHOD_OPEN,
@@ -1503,29 +1394,11 @@ describe('xhr', () => {
             ]);
             assert.strictEqual(events.length, 12, 'number of events is wrong');
           });
-
-          it('preflight request span should have correct events', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
-            const events = span.events;
-            assert.strictEqual(events.length, 9, 'number of events is wrong');
-            testForCorrectEvents(events, [
-              PTN.FETCH_START,
-              PTN.DOMAIN_LOOKUP_START,
-              PTN.DOMAIN_LOOKUP_END,
-              PTN.CONNECT_START,
-              PTN.SECURE_CONNECTION_START,
-              PTN.CONNECT_END,
-              PTN.REQUEST_START,
-              PTN.RESPONSE_START,
-              PTN.RESPONSE_END,
-            ]);
-          });
         });
 
         describe('AND origin match with window.location', () => {
           beforeEach(done => {
             clearData();
-            // this won't generate a preflight span
             const propagateTraceHeaderCorsUrls = [url];
             prepareData(window.location.origin + '/xml-http-request.js', {
               propagateTraceHeaderCorsUrls,
@@ -1570,8 +1443,7 @@ describe('xhr', () => {
               successfulPostRequest(ghUrl, done);
             });
             it('should set trace headers', () => {
-              // span at exportSpy.args[0][0][0] is the preflight span
-              const span: api.Span = exportSpy.args[1][0][0];
+              const span: api.Span = exportSpy.args[0][0][0];
               assert.strictEqual(
                 requests[0].requestHeaders[X_B3_TRACE_ID],
                 span.spanContext().traceId,
@@ -1690,8 +1562,7 @@ describe('xhr', () => {
           });
 
           it('should clear previous span information', () => {
-            // span at exportSpy.args[0][0][0] is the preflight span
-            const span: tracing.ReadableSpan = exportSpy.args[2][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
             const attributes = span.attributes;
             const keys = Object.keys(attributes);
 
@@ -1721,8 +1592,7 @@ describe('xhr', () => {
           });
 
           it('span should have custom attribute', () => {
-            // span at exportSpy.args[0][0][0] is the preflight span
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const attributes = span.attributes;
             assert.ok(attributes['xhr-custom-attribute'] === 'bar');
           });
@@ -1879,7 +1749,7 @@ describe('xhr', () => {
           });
 
           it('span should have correct attributes', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const attributes = span.attributes;
 
             let expectedNumAttrs = 0;
@@ -1909,7 +1779,7 @@ describe('xhr', () => {
           });
 
           it('span should have correct events', () => {
-            const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+            const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const events = span.events;
 
             testForCorrectEvents(events, [
@@ -1931,7 +1801,6 @@ describe('xhr', () => {
         });
 
         describe('when request encounters a network error', () => {
-          // this won't generate a preflight span
           beforeEach(done => {
             networkErrorRequest(done);
           });
@@ -1989,7 +1858,6 @@ describe('xhr', () => {
             }
           });
 
-          // this won't generate a preflight span
           beforeEach(done => {
             abortedRequest(done);
           });
@@ -2046,7 +1914,6 @@ describe('xhr', () => {
             }
           });
 
-          // this won't generate a preflight span
           beforeEach(done => {
             timedOutRequest(done);
           });
@@ -2110,7 +1977,7 @@ describe('xhr', () => {
             });
 
             it('span should have custom attribute', () => {
-              const span: tracing.ReadableSpan = exportSpy.args[1][0][0];
+              const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
               const attributes = span.attributes;
               assert.ok(attributes['xhr-custom-error-code'] === 400);
             });


### PR DESCRIPTION
Fixes #5122

## What

Removes the `CORS Preflight` span from `@opentelemetry/instrumentation-fetch` and `@opentelemetry/instrumentation-xml-http-request`.

Both instrumentations carried an `_addChildSpan` helper that started a `CORS Preflight` child span whenever `getResource()` came back with a `corsPreFlightRequest`:

```ts
const corsPreFlightRequest = resource.corsPreFlightRequest;
if (corsPreFlightRequest) {
  this._addChildSpan(span, corsPreFlightRequest);
  this._markResourceAsUsed(corsPreFlightRequest);
}
```

That branch cannot be taken. `getResource()` derives `corsPreFlightRequest` by splitting *two* `PerformanceResourceTiming` entries inside the span's time window, but under [Resource Timing Level 2](https://www.w3.org/TR/resource-timing-2/) a preflight is not reported as its own entry — it is folded into the main request's entry, alongside redirects and authentication challenges.

## Prior art

This is the follow-up @pichlermarc invited when closing #5130 ("please open a new PR if this is incorrect"). Context from that thread:

- @mariomc opened #5130 with the same diagnosis and later offered it up: *"If you want to pick this up before that, be my guest!"*
- @chancancode confirmed in [this comment](https://github.com/open-telemetry/opentelemetry-js/pull/5130#issuecomment-2624952240) that #5282 handled the **test** side but *"The refactor to remove the runtime code (that does nothing, as you pointed out), is still needed, as I didn't want to touch the implementation while doing a big test refactor."*
- @pichlermarc re-labelled the issue as an enhancement: *"there's nothing wrong with the existing telemetry but we just have extra code that needs to be removed"*

So the runtime removal was never actually landed — #5130 was closed on the understanding it had been, when only the fetch tests had.

## Verification

The premise was asserted from the spec in the original thread but never demonstrated, so I measured it. Two local origins, an endpoint that requires a preflight (custom request header), and both round trips deliberately delayed 300 ms so a separate entry would be trivially visible if one existed:

```
browser:               Chrome/151.0.7922.170
server saw methods:    ["OPTIONS","GET"]     <- preflight genuinely sent
getEntriesByName len:  1
resource entries len:  1
```

`fetch` initiator:

```json
{ "initiatorType": "fetch", "fetchStart": 43.7, "requestStart": 347.6,
  "responseStart": 649.6, "responseEnd": 649.9, "duration": 606.2 }
```

`xmlhttprequest` initiator:

```json
{ "initiatorType": "xmlhttprequest", "fetchStart": 40.4, "requestStart": 345.1,
  "responseStart": 647.4, "responseEnd": 647.7, "duration": 607.3 }
```

One entry in both cases, and the ~304 ms gap between `fetchStart` and `requestStart` is the preflight — absorbed into the single entry rather than reported beside it, with `duration` spanning both round trips. There is no second entry for the split to find, and no way to recover the preflight's timing from what is exposed.

This also matches the note already sitting in the fetch test suite, which points at this same issue:

https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts#L951-L961

> since preflight requests are completely transparent, the instrumentation code could not detect that it happened, let alone report on its timing

## Changes

- `instrumentation-fetch`: drop `_addChildSpan` and its call site.
- `instrumentation-xml-http-request`: drop `_addChildSpan` and its call site, plus the now-unused `PerformanceTimingNames as PTN` import.
- `xhr.test.ts`: delete the 10 preflight assertions and re-index the `exportSpy.args[...]` lookups that were offset by the preflight span being exported first. (These tests fabricate two mock resource entries, which is why they exercised a shape browsers do not emit.) `fetch.test.ts` needs no changes — #5282 already removed its preflight assertions.
- Changelog entry under **Breaking Changes**.

Test results:

- `instrumentation-xml-http-request`: `Executed 124 of 136 (skipped 12) SUCCESS` — the 12 skips are the pre-existing sync-mode abort/timeout cases.
- `instrumentation-fetch`: `Executed 103 of 103 SUCCESS` — unchanged.
- `lint` and `prettier --check` clean for both packages.

## Scope — narrower than #5130, deliberately

#5130 also stripped `corsPreFlightRequest` and `findMainRequest()` out of `@opentelemetry/sdk-trace-web`. I've left that package untouched here, because `PerformanceResourceTimingInfo` is public API of a **stable** package and removing a field from it can't land outside a major. Keeping it also means the main-request selection behaviour is unchanged — the main span still takes its network events from `mainRequest` exactly as before, so this PR is purely a removal of spans that were never emitted.

Happy to follow up with a deprecation on `corsPreFlightRequest` to start that clock, if maintainers want it.

## One behavioural note for reviewers

Alongside the span, this also drops `this._markResourceAsUsed(corsPreFlightRequest)`. If a split ever did occur, the preflight entry would no longer be marked and could be matched against a later span. The measurement above says that can't happen, but I'd rather flag it than bury it — if you'd prefer the marking kept defensively, say the word and I'll restore it.
