### PR TITLE
docs(instrumentation): register ESM hooks via module.register() with --import

### DIFF
--- a/doc/esm-support.md
+++ b/doc/esm-support.md
@@ -30,8 +30,28 @@ The `NODE_OPTIONS` for the startup command should include `--import ./telemetry.
 ## Instrumentation Hook Required for ESM
 
 If your application is written in JavaScript as ESM, or compiled to ESM from TypeScript, then a loader hook is required to properly patch instrumentation.
-The custom hook for ESM instrumentation is `--experimental-loader=@opentelemetry/instrumentation/hook.mjs`.
-This flag must be passed to the `node` binary, which is often done as a startup command and/or in the `NODE_OPTIONS` environment variable.
+The custom hook for ESM instrumentation is `@opentelemetry/instrumentation/hook.mjs`.
+This must be registered with the `node` binary, which is often done as a startup command and/or in the `NODE_OPTIONS` environment variable.
+
+On Node.js versions that still use the experimental loader flag:
+
+```sh
+node --experimental-loader=@opentelemetry/instrumentation/hook.mjs --import ./telemetry.js app.js
+```
+
+`--import` does **not** register exported loader hooks by itself.
+`node --import @opentelemetry/instrumentation/hook.mjs` evaluates the file but does not install `load`/`resolve`/`initialize`, so ESM instrumentation is silently skipped.
+To register the hook with `--import`, use a small preload that calls `module.register()`:
+
+```javascript
+/*register-otel-hook.mjs*/
+import { register } from 'node:module';
+register('@opentelemetry/instrumentation/hook.mjs', import.meta.url);
+```
+
+```sh
+node --import ./register-otel-hook.mjs --import ./telemetry.js app.js
+```
 
 ### Additional Notes on Experimental Loaders
 
@@ -40,6 +60,7 @@ The only currently supported loader hook is `@opentelemetry/instrumentation/hook
 
 **Note:** Eventually the recommendation for how to setup OpenTelemetry for usage with ESM will change to no longer require `--experimental-loader=@opentelemetry/instrumentation/hook.mjs`.
 Instead the bootstrap code (in `./telemetry.js`) will use Node.js's newer `module.register(...)`.
+Until then, the `register-otel-hook.mjs` preload above is the supported `--import` replacement.
 Refer to this [issue](https://github.com/open-telemetry/opentelemetry-js/issues/4933) for details.
 
 Because of ongoing issues with loaders running TypeScript code as ESM in development environments, results may vary.
@@ -118,6 +139,12 @@ Startup command for compiled ESM:
 node --experimental-loader=@opentelemetry/instrumentation/hook.mjs --import ./telemetry.js app.js
 ```
 
+On Node.js 24+, register the hook with `--import` of a `module.register()` preload instead of `--experimental-loader`:
+
+```sh
+node --import ./register-otel-hook.mjs --import ./telemetry.js app.js
+```
+
 ### ESM Options for Different Versions of Node.js
 
 The entire startup command should include the following `NODE_OPTIONS`:
@@ -129,3 +156,4 @@ The entire startup command should include the following `NODE_OPTIONS`:
 | ^18.19.0          | `--import ./telemetry.mjs --experimental-loader=@opentelemetry/instrumentation/hook.mjs`  |
 | 20.x              | `--import ./telemetry.mjs --experimental-loader=@opentelemetry/instrumentation/hook.mjs`  |
 | 22.x              | `--import ./telemetry.mjs --experimental-loader=@opentelemetry/instrumentation/hook.mjs`  |
+| 24.x              | `--import ./register-otel-hook.mjs --import ./telemetry.mjs`                                   |

--- a/experimental/packages/opentelemetry-instrumentation/test/node/HookCliRegistration.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation/test/node/HookCliRegistration.test.ts
@@ -8,8 +8,12 @@ import { spawnSync } from 'child_process';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
 
-const hookPath = path.join(__dirname, '..', '..', 'hook.mjs');
-const registerHookPath = path.join(__dirname, 'register-otel-hook.mjs');
+const hookUrl = pathToFileURL(
+  path.join(__dirname, '..', '..', 'hook.mjs')
+).href;
+const registerHookUrl = pathToFileURL(
+  path.join(__dirname, 'register-otel-hook.mjs')
+).href;
 const probePath = path.join(__dirname, 'fixtures', 'esm-hook-cli-probe.mjs');
 
 function runProbe(nodeArgs: string[]): {
@@ -42,7 +46,7 @@ describe('ESM hook CLI registration', function () {
   this.timeout(10000);
 
   it('should patch ESM exports with --experimental-loader', function () {
-    const result = runProbe([`--experimental-loader=${hookPath}`]);
+    const result = runProbe([`--experimental-loader=${hookUrl}`]);
     assert.strictEqual(
       result.status,
       0,
@@ -52,7 +56,7 @@ describe('ESM hook CLI registration', function () {
   });
 
   it('should not patch ESM exports when --import loads hook.mjs directly', function () {
-    const result = runProbe([`--import=${pathToFileURL(hookPath).href}`]);
+    const result = runProbe([`--import=${hookUrl}`]);
     assert.strictEqual(
       result.status,
       0,
@@ -62,9 +66,7 @@ describe('ESM hook CLI registration', function () {
   });
 
   it('should patch ESM exports when --import registers hook.mjs via module.register()', function () {
-    const result = runProbe([
-      `--import=${pathToFileURL(registerHookPath).href}`,
-    ]);
+    const result = runProbe([`--import=${registerHookUrl}`]);
     assert.strictEqual(
       result.status,
       0,

--- a/experimental/packages/opentelemetry-instrumentation/test/node/HookCliRegistration.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation/test/node/HookCliRegistration.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import { spawnSync } from 'child_process';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+
+const hookPath = path.join(__dirname, '..', '..', 'hook.mjs');
+const registerHookPath = path.join(__dirname, 'register-otel-hook.mjs');
+const probePath = path.join(__dirname, 'fixtures', 'esm-hook-cli-probe.mjs');
+
+function runProbe(nodeArgs: string[]): {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+} {
+  const env = { ...process.env };
+  delete env.NODE_OPTIONS;
+
+  const result = spawnSync(process.execPath, [...nodeArgs, probePath], {
+    encoding: 'utf8',
+    env,
+    timeout: 10000,
+  });
+
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function probeResult(stdout: string): string | undefined {
+  const match = stdout.match(/^PROBE_RESULT=(.*)$/m);
+  return match?.[1];
+}
+
+describe('ESM hook CLI registration', function () {
+  this.timeout(10000);
+
+  it('should patch ESM exports with --experimental-loader', function () {
+    const result = runProbe([`--experimental-loader=${hookPath}`]);
+    assert.strictEqual(
+      result.status,
+      0,
+      `unexpected exit: ${result.stderr}\n${result.stdout}`
+    );
+    assert.strictEqual(probeResult(result.stdout), 'patched');
+  });
+
+  it('should not patch ESM exports when --import loads hook.mjs directly', function () {
+    const result = runProbe([`--import=${pathToFileURL(hookPath).href}`]);
+    assert.strictEqual(
+      result.status,
+      0,
+      `unexpected exit: ${result.stderr}\n${result.stdout}`
+    );
+    assert.strictEqual(probeResult(result.stdout), 'original');
+  });
+
+  it('should patch ESM exports when --import registers hook.mjs via module.register()', function () {
+    const result = runProbe([
+      `--import=${pathToFileURL(registerHookPath).href}`,
+    ]);
+    assert.strictEqual(
+      result.status,
+      0,
+      `unexpected exit: ${result.stderr}\n${result.stdout}`
+    );
+    assert.strictEqual(probeResult(result.stdout), 'patched');
+  });
+});

--- a/experimental/packages/opentelemetry-instrumentation/test/node/fixtures/esm-hook-cli-probe.mjs
+++ b/experimental/packages/opentelemetry-instrumentation/test/node/fixtures/esm-hook-cli-probe.mjs
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  InstrumentationBase,
+  InstrumentationNodeModuleDefinition,
+  InstrumentationNodeModuleFile,
+} from '../../../build/src/index.js';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const targetPath = path.join(dir, '../esm/test.mjs');
+
+class TestInstrumentation extends InstrumentationBase {
+  constructor() {
+    super('test-esm-hook-cli', '0.0.1', { enabled: false });
+  }
+  init() {
+    return new InstrumentationNodeModuleDefinition(
+      targetPath,
+      ['*'],
+      undefined,
+      undefined,
+      [
+        new InstrumentationNodeModuleFile(
+          'test',
+          ['*'],
+          moduleExports => {
+            this._wrap(moduleExports, 'testFunction', () => {
+              return function wrappedTestFunction() {
+                return 'patched';
+              };
+            });
+            return moduleExports;
+          },
+          moduleExports => {
+            this._unwrap(moduleExports, 'testFunction');
+            return moduleExports;
+          }
+        ),
+      ]
+    );
+  }
+}
+
+const instrumentation = new TestInstrumentation();
+instrumentation.enable();
+const { testFunction } = await import(pathToFileURL(targetPath).href);
+process.stdout.write(`PROBE_RESULT=${testFunction()}\n`);

--- a/experimental/packages/opentelemetry-instrumentation/test/node/register-otel-hook.mjs
+++ b/experimental/packages/opentelemetry-instrumentation/test/node/register-otel-hook.mjs
@@ -1,0 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { register } from 'node:module';
+
+register('../../hook.mjs', import.meta.url);


### PR DESCRIPTION
## Summary

- follow up from https://github.com/open-telemetry/opentelemetry-js/pull/6909

- `--import @opentelemetry/instrumentation/hook.mjs` does not register exported loader hooks, so ESM instrumentation is silently skipped.
- Document a user-owned `register-otel-hook.mjs` preload that calls `module.register('@opentelemetry/instrumentation/hook.mjs', import.meta.url)` and use that with `--import` on Node 24+.
- Add a child-process integration test covering `--experimental-loader` (patched), bare `--import hook.mjs` (unpatched), and `--import` of the `module.register()` preload (patched).

We verify's @JacksonWeber concern  that `--import` of `hook.mjs` may silently disable ESM instrumentation.

## Test plan
- [x] `npx mocha test/node/HookCliRegistration.test.ts` in `@opentelemetry/instrumentation`
- [x] `npm test` in `@opentelemetry/instrumentation`
- [x] `npm run lint` in `@opentelemetry/instrumentation`
- [ ] Confirm CI on Node 18/20/22/24/26