### PR TITLE
fix(instrumentation-fetch): do not consume Request before ignoreUrls

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -342,16 +342,12 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
           args[0] instanceof Request ? args[0].url : String(args[0])
         ).href;
 
-        // `new Request(existing, init)` consumes the original body. Decide
-        // whether to create a span first so ignored/unsampled calls can
-        // forward the caller's args untouched (#7037).
-        const createdSpan = plugin._createSpan(
-          url,
-          args[0] instanceof Request
-            ? { method: args[1]?.method ?? args[0].method }
-            : args[1] || {}
-        );
-        if (!createdSpan) {
+        // `new Request(existing, init)` consumes the original body. Check
+        // ignoreUrls first so ignored calls forward the caller's args
+        // untouched (#7037). Keep _createSpan after the Request clone so a
+        // constructor throw cannot leave a span open.
+        if (core.isUrlIgnored(url, plugin.getConfig().ignoreUrls)) {
+          plugin._diag.debug('ignoring span as url matches ignored url');
           return original.apply(this, args);
         }
 
@@ -366,6 +362,19 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
           options = args[1] != null ? new Request(args[0], args[1]) : args[0];
         } else {
           options = args[1] || {};
+        }
+
+        const createdSpan = plugin._createSpan(
+          url,
+          args[0] instanceof Request
+            ? { method: args[1]?.method ?? args[0].method }
+            : args[1] || {}
+        );
+        if (!createdSpan) {
+          return original.apply(
+            this,
+            options instanceof Request && args[1] != null ? [options] : args
+          );
         }
         const spanData = plugin._prepareSpanData(url);
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/src/fetch.ts
@@ -342,6 +342,19 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
           args[0] instanceof Request ? args[0].url : String(args[0])
         ).href;
 
+        // `new Request(existing, init)` consumes the original body. Decide
+        // whether to create a span first so ignored/unsampled calls can
+        // forward the caller's args untouched (#7037).
+        const createdSpan = plugin._createSpan(
+          url,
+          args[0] instanceof Request
+            ? { method: args[1]?.method ?? args[0].method }
+            : args[1] || {}
+        );
+        if (!createdSpan) {
+          return original.apply(this, args);
+        }
+
         // Per the Fetch spec, when fetch() is called with a Request object
         // and a separate init object, the init properties override the
         // Request's properties. Merge them into a new Request so that
@@ -353,10 +366,6 @@ export class FetchInstrumentation extends InstrumentationBase<FetchInstrumentati
           options = args[1] != null ? new Request(args[0], args[1]) : args[0];
         } else {
           options = args[1] || {};
-        }
-        const createdSpan = plugin._createSpan(url, options);
-        if (!createdSpan) {
-          return original.apply(this, args);
         }
         const spanData = plugin._prepareSpanData(url);
 

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -1827,6 +1827,31 @@ describe('fetch', () => {
 
         assertDebugMessage();
       });
+
+      // fetch(Request, init) is spec-valid (used by clients such as ky).
+      // Merging init into a new Request consumes the original body; if that
+      // happens before the ignoreUrls check, the follow-up original.fetch()
+      // throws "Request object that has already been used".
+      it('should not throw when fetch(Request, init) is ignored', async () => {
+        await tracedFetch({
+          handlers: [
+            msw.http.post('/api/ignored.json', () => {
+              return msw.HttpResponse.json({ ok: true });
+            }),
+          ],
+          callback: () =>
+            fetch(
+              new Request('/api/ignored.json', {
+                method: 'POST',
+                body: JSON.stringify({ hello: 'world' }),
+              }),
+              { headers: { 'content-type': 'application/json' } }
+            ),
+          expectExport: false,
+        });
+
+        assertDebugMessage();
+      });
     });
 
     describe('unsuccessful request', () => {

--- a/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-fetch/test/fetch.test.ts
@@ -1852,6 +1852,34 @@ describe('fetch', () => {
 
         assertDebugMessage();
       });
+
+      it('should not leave a span open if Request constructor throws', async () => {
+        let threw: unknown;
+        try {
+          await tracedFetch({
+            handlers: [
+              msw.http.post('/api/not-ignored.json', () => {
+                return msw.HttpResponse.json({ ok: true });
+              }),
+            ],
+            callback: () =>
+              fetch(
+                new Request('/api/not-ignored.json', {
+                  method: 'POST',
+                  body: JSON.stringify({ hello: 'world' }),
+                }),
+                { method: 'GET' }
+              ),
+            expectExport: false,
+          });
+        } catch (err) {
+          threw = err;
+        }
+
+        assert.ok(threw instanceof TypeError);
+        assert.strictEqual(exportedSpans.length, 0);
+        assertNoDebugMessages();
+      });
     });
 
     describe('unsuccessful request', () => {

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -254,24 +254,28 @@ describe('Utility', () => {
   describe('redactQueryString()', () => {
     it('redacts a matching parameter', () => {
       assert.strictEqual(
-        utils.redactQueryString(new URLSearchParams('sig=secret&foo=bar'), ['sig']),
+        utils.redactQueryString(new URLSearchParams('sig=secret&foo=bar'), [
+          'sig',
+        ]),
         'sig=REDACTED&foo=bar'
       );
     });
 
     it('leaves non-matching parameters unchanged', () => {
       assert.strictEqual(
-        utils.redactQueryString(new URLSearchParams('foo=bar&baz=qux'), ['sig']),
+        utils.redactQueryString(new URLSearchParams('foo=bar&baz=qux'), [
+          'sig',
+        ]),
         'foo=bar&baz=qux'
       );
     });
 
     it('redacts multiple parameters', () => {
       assert.strictEqual(
-        utils.redactQueryString(new URLSearchParams('sig=a&AWSAccessKeyId=b&keep=c'), [
-          'sig',
-          'AWSAccessKeyId',
-        ]),
+        utils.redactQueryString(
+          new URLSearchParams('sig=a&AWSAccessKeyId=b&keep=c'),
+          ['sig', 'AWSAccessKeyId']
+        ),
         'sig=REDACTED&AWSAccessKeyId=REDACTED&keep=c'
       );
     });
@@ -285,14 +289,19 @@ describe('Utility', () => {
 
     it('redacts a param with an empty value', () => {
       assert.strictEqual(
-        utils.redactQueryString(new URLSearchParams('sig=&foo=bar'), ['sig']),
+        utils.redactQueryString(new URLSearchParams('sig=&foo=bar'), [
+          'sig',
+        ]),
         'sig=REDACTED&foo=bar'
       );
     });
 
     it('redacts all occurrences of a duplicated parameter', () => {
       assert.strictEqual(
-        utils.redactQueryString(new URLSearchParams('sig=SECRET1&sig=SECRET2&foo=bar'), ['sig']),
+        utils.redactQueryString(
+          new URLSearchParams('sig=SECRET1&sig=SECRET2&foo=bar'),
+          ['sig']
+        ),
         'sig=REDACTED&foo=bar'
       );
     });


### PR DESCRIPTION
Fixes #7037. Delay Request clone until after the ignoreUrls span check so fetch(Request, init) does not throw on ignored URLs.