### PR TITLE
chore(instrumentation-http): fix lint errors

### DIFF
--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/utils.test.ts
@@ -254,24 +254,28 @@ describe('Utility', () => {
   describe('redactQueryString()', () => {
     it('redacts a matching parameter', () => {
       assert.strictEqual(
-        utils.redactQueryString(new URLSearchParams('sig=secret&foo=bar'), ['sig']),
+        utils.redactQueryString(new URLSearchParams('sig=secret&foo=bar'), [
+          'sig',
+        ]),
         'sig=REDACTED&foo=bar'
       );
     });
 
     it('leaves non-matching parameters unchanged', () => {
       assert.strictEqual(
-        utils.redactQueryString(new URLSearchParams('foo=bar&baz=qux'), ['sig']),
+        utils.redactQueryString(new URLSearchParams('foo=bar&baz=qux'), [
+          'sig',
+        ]),
         'foo=bar&baz=qux'
       );
     });
 
     it('redacts multiple parameters', () => {
       assert.strictEqual(
-        utils.redactQueryString(new URLSearchParams('sig=a&AWSAccessKeyId=b&keep=c'), [
-          'sig',
-          'AWSAccessKeyId',
-        ]),
+        utils.redactQueryString(
+          new URLSearchParams('sig=a&AWSAccessKeyId=b&keep=c'),
+          ['sig', 'AWSAccessKeyId']
+        ),
         'sig=REDACTED&AWSAccessKeyId=REDACTED&keep=c'
       );
     });
@@ -292,7 +296,10 @@ describe('Utility', () => {
 
     it('redacts all occurrences of a duplicated parameter', () => {
       assert.strictEqual(
-        utils.redactQueryString(new URLSearchParams('sig=SECRET1&sig=SECRET2&foo=bar'), ['sig']),
+        utils.redactQueryString(
+          new URLSearchParams('sig=SECRET1&sig=SECRET2&foo=bar'),
+          ['sig']
+        ),
         'sig=REDACTED&foo=bar'
       );
     });


### PR DESCRIPTION
## Which problem is this PR solving?

Lint is currently failing on `main`: https://github.com/open-telemetry/opentelemetry-js/actions/runs/33154572622/job/98794175046

This PR fixes that (applies `npm run lint:fix`) 