### PR TITLE
ci: roll prerelease changelog into one final release changelog

### DIFF
--- a/doc/contributing/releasing.md
+++ b/doc/contributing/releasing.md
@@ -89,6 +89,17 @@ So a full 3.0.0 cycle looks like:
   Experimental packages pin stable SDK packages exactly, so this would publish a stable
   version depending on a pre-release. Finalize the Stable SDK first.
 
+#### Changelogs across a cycle
+
+Each pre-release rotates the `## Unreleased` section into its own `## 3.0.0-development.3` heading,
+so its GitHub release notes describe what changed since the previous pre-release.
+
+Finalizing collapses those sections back together: the pre-release headings are removed and their
+entries are merged, per category, into the single `## 3.0.0` section. The changelog then reads as if
+there were never any pre-releases, and the release notes for `3.0.0` cover the whole cycle rather
+than just the entries that landed after the last release candidate. Nothing is lost - the
+per-pre-release notes stay in the git history and in the GitHub pre-releases published from them.
+
 > [!TIP]
 > If there was a commit to `main`, after PR creation simply run the workflow again before merging it.
 > Re-running it will update the PR with the contents from `main` and will update the PR body too.

--- a/scripts/lib/changelog-utils.mjs
+++ b/scripts/lib/changelog-utils.mjs
@@ -1,0 +1,181 @@
+/**
+ * Changelog rotation for the release scripts.
+ *
+ * Releasing turns the `## Unreleased` section into a `## <version>` section and starts a fresh,
+ * empty `## Unreleased`. With pre-releases in play that is not quite enough: every iteration of a
+ * cycle mints its own section, so `## 3.0.0` would end up holding nothing but the entries that
+ * landed after the last release candidate, and the changelog would carry a stack of
+ * `## 3.0.0-development.N` / `## 3.0.0-rc.N` sections nobody reads once 3.0.0 is out.
+ *
+ * Finalizing therefore *collapses* those sections into the release they were leading up to - see
+ * `rotateChangelog()`. Their per-pre-release notes are still in the git history and in the
+ * GitHub pre-releases that were published from them.
+ */
+
+import semver from 'semver';
+
+/**
+ * The subsections a release section is made of, in the order they are rendered. Also the skeleton
+ * of a freshly rotated `## Unreleased` - contributors fill in the one their change belongs to.
+ */
+export const CHANGELOG_SUBSECTIONS = [
+  ':boom: Breaking Changes',
+  ':rocket: Features',
+  ':bug: Bug Fixes',
+  ':books: Documentation',
+  ':house: Internal',
+];
+
+const EMPTY_UNRELEASED_SECTION =
+  '## Unreleased\n\n' +
+  CHANGELOG_SUBSECTIONS.map(heading => `### ${heading}\n\n`).join('');
+
+// The negative lookahead keeps the levels apart: without it `^## ` also matches the first three
+// characters of a `### ` heading, and `^### ` those of a `#### ` one.
+const H2 = /^##(?!#) (.*)$/gm;
+const H3 = /^###(?!#) (.*)$/gm;
+
+/**
+ * Split a document at headings of one level.
+ *
+ * `body` is the verbatim slice between two headings, so bullets, sub-bullets, links, HTML comments
+ * and blank lines all survive a split/render round-trip untouched.
+ *
+ * @param {string} text
+ * @param {RegExp} headingRe One of H2/H3 - must be sticky-free and `g`-flagged.
+ * @returns {{ preamble: string, sections: Array<{ heading: string, body: string }> }}
+ *   `preamble` is everything before the first heading (the whole text if there is none).
+ */
+function splitByHeading(text, headingRe) {
+  const matches = [...text.matchAll(headingRe)];
+
+  return {
+    preamble: matches.length > 0 ? text.slice(0, matches[0].index) : text,
+    sections: matches.map((match, i) => ({
+      heading: match[1].trim(),
+      body: text.slice(
+        match.index + match[0].length,
+        i + 1 < matches.length ? matches[i + 1].index : text.length
+      ),
+    })),
+  };
+}
+
+/** The `major.minor.patch` of a version, without any pre-release suffix. */
+function baseVersionOf(parsed) {
+  return `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+}
+
+/**
+ * Merge several release section bodies into one set of rendered subsections.
+ *
+ * Entries are concatenated in the order the bodies are passed in, which is why the caller passes
+ * them oldest-first: within `### :rocket: Features`, the reader then sees the same order in which
+ * the entries were written.
+ *
+ * @param {string[]} bodies
+ * @returns {string} Rendered subsections, each block terminated by a blank line, or '' if all
+ *   bodies were empty.
+ */
+function mergeBodies(bodies) {
+  const entriesByHeading = new Map();
+
+  for (const body of bodies) {
+    for (const { heading, body: entries } of splitByHeading(body, H3).sections) {
+      const trimmed = entries.trim();
+      // Subsections nobody filled in are dropped rather than carried over empty.
+      if (trimmed === '') continue;
+
+      if (!entriesByHeading.has(heading)) {
+        entriesByHeading.set(heading, []);
+      }
+      entriesByHeading.get(heading).push(trimmed);
+    }
+  }
+
+  // Known subsections in their canonical order, then anything hand-written, in the order it first
+  // appeared - an unrecognized heading is a maintainer's deliberate addition, not something to
+  // silently drop.
+  const headings = [
+    ...CHANGELOG_SUBSECTIONS.filter(heading => entriesByHeading.has(heading)),
+    ...[...entriesByHeading.keys()].filter(
+      heading => !CHANGELOG_SUBSECTIONS.includes(heading)
+    ),
+  ];
+
+  return headings
+    .map(heading => `### ${heading}\n\n${entriesByHeading.get(heading).join('\n')}\n\n`)
+    .join('');
+}
+
+/**
+ * Rotate `## Unreleased` into `## <version>` and start a fresh, empty `## Unreleased`.
+ *
+ * When `version` is a normal release, the pre-release sections of the same base version directly
+ * below `## Unreleased` are collapsed into the new section: their headings go away and their
+ * entries are merged per subsection, oldest pre-release first, `Unreleased` last. That makes
+ * `## 3.0.0` the changelog for the whole cycle, which is also what
+ * `scripts/extract-latest-release-notes.js` turns into the GitHub release notes.
+ *
+ * Pre-release versions absorb nothing: while a cycle is in flight, each iteration's section
+ * describes what changed since the previous one.
+ *
+ * @param {string} changelogText Contents of a CHANGELOG.md.
+ * @param {string} version The version being released, e.g. `3.0.0` or `3.0.0-rc.0`.
+ * @returns {{ changelog: string, absorbed: string[] }} `absorbed` lists the collapsed pre-release
+ *   versions in the order they appeared in the file (newest first), and is empty when nothing was
+ *   collapsed.
+ * @throws {Error} If `version` is not a valid version, or the changelog has no `## Unreleased`.
+ */
+export function rotateChangelog(changelogText, version) {
+  const parsedVersion = semver.parse(version);
+  if (parsedVersion == null) {
+    throw new Error(`Not a valid version: "${version}"`);
+  }
+
+  // Prune subsections that were left empty. Applied to the whole file, as it always has been.
+  const text = changelogText.replace(/^###.*\n*(?=^##)/gm, '');
+
+  const { preamble, sections } = splitByHeading(text, H2);
+  const unreleasedIndex = sections.findIndex(section => section.heading === 'Unreleased');
+  if (unreleasedIndex === -1) {
+    throw new Error('Could not find an "## Unreleased" section');
+  }
+
+  const absorbed = [];
+  if (parsedVersion.prerelease.length === 0) {
+    const base = baseVersionOf(parsedVersion);
+
+    for (const section of sections.slice(unreleasedIndex + 1)) {
+      const parsed = semver.parse(section.heading);
+      // Stop at the first section that is not a pre-release of the version being finalized: an
+      // earlier normal release, a pre-release of some other version, or a non-version heading.
+      if (parsed == null || parsed.prerelease.length === 0 || baseVersionOf(parsed) !== base) {
+        break;
+      }
+      absorbed.push(section);
+    }
+  }
+
+  // The file lists sections newest first, so reverse to get chronological order, and append the
+  // still-unreleased entries as the most recent ones.
+  const bodies = [...absorbed]
+    .reverse()
+    .map(section => section.body)
+    .concat(sections[unreleasedIndex].body);
+
+  const retained = sections.slice(unreleasedIndex + 1 + absorbed.length);
+
+  const changelog =
+    preamble +
+    EMPTY_UNRELEASED_SECTION +
+    `## ${version}\n\n` +
+    mergeBodies(bodies) +
+    // `body` already starts with the newline that ended the heading line.
+    retained.map(section => `## ${section.heading}${section.body}`).join('');
+
+  return {
+    changelog: retained.length > 0 ? changelog : changelog.replace(/\n+$/, '\n'),
+    absorbed: absorbed.map(section => section.heading),
+  };
+}

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -3,7 +3,8 @@
  * This script:
  * 1. Validates and resolves release configuration from environment variables
  * 2. Bumps package versions selectively based on configuration
- * 3. Updates changelogs for affected packages
+ * 3. Updates changelogs for affected packages, collapsing the pre-release sections of a
+ *    cycle into the release that finalizes it - see lib/changelog-utils.mjs
  * 4. Handles API version bumping when needed
  *
  * Environment Variables (Input):
@@ -29,6 +30,7 @@ import {
 } from './lib/package-utils.mjs';
 import { RELEASE_GROUPS } from './lib/release-groups.mjs';
 import { nextVersion } from './lib/bump-utils.mjs';
+import { rotateChangelog } from './lib/changelog-utils.mjs';
 
 function isLowerOrEqualReleaseType(expectedLower, expectedHigher) {
   const order = { 'patch': 1, 'minor': 2, 'major': 3 };
@@ -338,41 +340,33 @@ function bumpApiVersion(releaseType) {
 
 // Update changelogs
 function updateChangelogs(config) {
-  const EMPTY_UNRELEASED_SECTION = `## Unreleased
-
-### :boom: Breaking Changes
-
-### :rocket: Features
-
-### :bug: Bug Fixes
-
-### :books: Documentation
-
-### :house: Internal
-
-`;
-
-  const updateSingleChangelog = (changelogPath, packagePath) => {
-    const version = determineVersionFromPath(packagePath);
-
-    const changelog = fs.readFileSync(changelogPath, 'utf8').toString()
-      // replace all empty sections
-      .replace(new RegExp('^###.*\n*(?=^##)', 'gm'), '')
-      // replace unreleased header with new unreleased section and a version header for the former unreleased section
-      .replace(RegExp('## Unreleased'), EMPTY_UNRELEASED_SECTION + '## ' + version);
-
-    fs.writeFileSync(changelogPath, changelog);
-  };
-
   console.log('\nUpdating changelogs...');
 
-  // Update changelogs for each release group
   Object.entries(RELEASE_GROUPS).forEach(([groupName, groupConfig]) => {
-    const releaseType = config[groupConfig.configKey];
-    if (releaseType) {
-      console.log(`  Updating ${groupName} changelog...`);
-      updateSingleChangelog(groupConfig.changelogPath, groupConfig.packagePath);
+    if (!config[groupConfig.configKey]) return;
+
+    const version = determineVersionFromPath(groupConfig.packagePath);
+    console.log(`  Updating ${groupName} changelog (${version})...`);
+
+    let result;
+    try {
+      result = rotateChangelog(
+        fs.readFileSync(groupConfig.changelogPath, 'utf8'),
+        version
+      );
+    } catch (err) {
+      console.error(`Error updating ${groupConfig.changelogPath}: ${err.message}`);
+      process.exit(1);
     }
+
+    // Finalizing a pre-release cycle folds the pre-release sections into this release. Logged
+    // because it is the one case where the release notes cover more than the "## Unreleased"
+    // section did.
+    if (result.absorbed.length > 0) {
+      console.log(`    Collapsed ${result.absorbed.join(', ')} into ${version}`);
+    }
+
+    fs.writeFileSync(groupConfig.changelogPath, result.changelog);
   });
 
   console.log('Changelog updates complete.');

--- a/scripts/test/changelog-utils.test.mjs
+++ b/scripts/test/changelog-utils.test.mjs
@@ -1,0 +1,142 @@
+/**
+ * Tests for changelog rotation.
+ *
+ * The test data lives in `fixtures/changelog/`: `<name>.md` is a changelog before releasing, and
+ * `<name>.<version>.md` is what it has to look like after releasing `<version>`. Assertions
+ * compare whole files, so a stray blank line is a test failure - the rotation writes the changelog
+ * the whole project reads.
+ *
+ * Run with `npm run test:scripts`.
+ */
+
+import assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { rotateChangelog } from '../lib/changelog-utils.mjs';
+
+const FIXTURE_DIR = path.join(import.meta.dirname, 'fixtures', 'changelog');
+
+const fixture = name => fs.readFileSync(path.join(FIXTURE_DIR, `${name}.md`), 'utf8');
+
+describe('rotateChangelog', function () {
+  const cases = [
+    {
+      description: 'rotates "## Unreleased" into the new version and drops empty subsections',
+      name: 'no-prereleases',
+      version: '2.11.0',
+      absorbed: [],
+    },
+    {
+      description: 'merges every pre-release section into the final one, oldest entries first',
+      name: 'prerelease-cycle',
+      version: '3.0.0',
+      absorbed: ['3.0.0-rc.0', '3.0.0-development.1', '3.0.0-development.0'],
+    },
+    {
+      description: 'collapses nothing when the new version is itself a pre-release',
+      name: 'prerelease-cycle',
+      version: '3.0.0-rc.1',
+      absorbed: [],
+    },
+    {
+      description: 'keeps an unrecognized subsection, after the known ones',
+      name: 'custom-subsection',
+      version: '3.0.0',
+      absorbed: ['3.0.0-rc.0'],
+    },
+    {
+      description: 'drops an empty "## Unreleased" and empty pre-release sections',
+      name: 'empty-sections',
+      version: '3.0.0',
+      absorbed: ['3.0.0-rc.0', '3.0.0-development.0'],
+    },
+    {
+      description: 'writes an empty version section when there is nothing to release',
+      name: 'nothing-to-release',
+      version: '2.11.0',
+      absorbed: [],
+    },
+  ];
+
+  for (const { description, name, version, absorbed } of cases) {
+    it(description, function () {
+      const result = rotateChangelog(fixture(name), version);
+
+      assert.strictEqual(result.changelog, fixture(`${name}.${version}`));
+      assert.deepStrictEqual(result.absorbed, absorbed);
+    });
+  }
+
+  // The rotation is a no-op for every release that does not finalize a pre-release cycle, which is
+  // the vast majority of them - guard that it stays that way.
+  it('matches the pre-aggregation output byte for byte when there is nothing to collapse', function () {
+    const before = fixture('no-prereleases');
+    const legacy = before
+      .replace(new RegExp('^###.*\n*(?=^##)', 'gm'), '')
+      .replace(
+        RegExp('## Unreleased'),
+        '## Unreleased\n\n' +
+          '### :boom: Breaking Changes\n\n' +
+          '### :rocket: Features\n\n' +
+          '### :bug: Bug Fixes\n\n' +
+          '### :books: Documentation\n\n' +
+          '### :house: Internal\n\n' +
+          '## 2.11.0'
+      );
+
+    assert.strictEqual(rotateChangelog(before, '2.11.0').changelog, legacy);
+  });
+
+  describe('the collapse boundary', function () {
+    // Only the section headings matter here, so they are generated rather than fixtured: each
+    // changelog is `## Unreleased`, then the given headings, then `## 1.0.0`.
+    const changelogWith = (...headings) =>
+      '# CHANGELOG\n\n' +
+      '## Unreleased\n\n### :rocket: Features\n\n- feat: unreleased @someone\n\n' +
+      headings
+        .map(heading => `## ${heading}\n\n### :rocket: Features\n\n- feat: from ${heading} @someone\n\n`)
+        .join('') +
+      '## 1.0.0\n\n### :rocket: Features\n\n- feat: ancient @someone\n';
+
+    const cases = [
+      ['a normal release', ['2.11.0'], []],
+      ['a pre-release of another version', ['2.11.0-rc.0'], []],
+      ['a heading that is not a version', ['Some note'], []],
+      [
+        'a normal release below the pre-releases',
+        ['3.0.0-rc.0', '2.10.1', '3.0.0-development.0'],
+        ['3.0.0-rc.0'],
+      ],
+      [
+        'a differently-based pre-release below the pre-releases',
+        ['3.0.0-rc.0', '2.11.0-rc.0'],
+        ['3.0.0-rc.0'],
+      ],
+    ];
+
+    for (const [description, headings, absorbed] of cases) {
+      it(`stops at ${description}`, function () {
+        assert.deepStrictEqual(
+          rotateChangelog(changelogWith(...headings), '3.0.0').absorbed,
+          absorbed
+        );
+      });
+    }
+  });
+
+  describe('errors', function () {
+    it('rejects a changelog without an "## Unreleased" section', function () {
+      assert.throws(
+        () => rotateChangelog(fixture('no-unreleased'), '2.11.0'),
+        /Could not find an "## Unreleased" section/
+      );
+    });
+
+    it('rejects an invalid version', function () {
+      assert.throws(
+        () => rotateChangelog(fixture('no-prereleases'), 'not-a-version'),
+        /Not a valid version/
+      );
+    });
+  });
+});

--- a/scripts/test/fixtures/changelog/custom-subsection.3.0.0.md
+++ b/scripts/test/fixtures/changelog/custom-subsection.3.0.0.md
@@ -1,0 +1,32 @@
+<!-- markdownlint-disable MD004 -->
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### :boom: Breaking Changes
+
+### :rocket: Features
+
+### :bug: Bug Fixes
+
+### :books: Documentation
+
+### :house: Internal
+
+## 3.0.0
+
+### :rocket: Features
+
+* feat: a feature @someone
+
+### :house: Internal
+
+* chore: a chore @someone
+
+### Committers: 1
+
+* @someone
+
+## 2.10.0

--- a/scripts/test/fixtures/changelog/custom-subsection.md
+++ b/scripts/test/fixtures/changelog/custom-subsection.md
@@ -1,0 +1,22 @@
+<!-- markdownlint-disable MD004 -->
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### :house: Internal
+
+* chore: a chore @someone
+
+### Committers: 1
+
+* @someone
+
+## 3.0.0-rc.0
+
+### :rocket: Features
+
+* feat: a feature @someone
+
+## 2.10.0

--- a/scripts/test/fixtures/changelog/empty-sections.3.0.0.md
+++ b/scripts/test/fixtures/changelog/empty-sections.3.0.0.md
@@ -1,0 +1,24 @@
+<!-- markdownlint-disable MD004 -->
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### :boom: Breaking Changes
+
+### :rocket: Features
+
+### :bug: Bug Fixes
+
+### :books: Documentation
+
+### :house: Internal
+
+## 3.0.0
+
+### :rocket: Features
+
+* feat: a feature @someone
+
+## 2.10.0

--- a/scripts/test/fixtures/changelog/empty-sections.md
+++ b/scripts/test/fixtures/changelog/empty-sections.md
@@ -1,0 +1,20 @@
+<!-- markdownlint-disable MD004 -->
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### :rocket: Features
+
+## 3.0.0-rc.0
+
+### :rocket: Features
+
+* feat: a feature @someone
+
+## 3.0.0-development.0
+
+### :bug: Bug Fixes
+
+## 2.10.0

--- a/scripts/test/fixtures/changelog/no-prereleases.2.11.0.md
+++ b/scripts/test/fixtures/changelog/no-prereleases.2.11.0.md
@@ -1,0 +1,33 @@
+<!-- markdownlint-disable MD004 -->
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### :boom: Breaking Changes
+
+### :rocket: Features
+
+### :bug: Bug Fixes
+
+### :books: Documentation
+
+### :house: Internal
+
+## 2.11.0
+
+### :rocket: Features
+
+* feat(sdk-trace): a feature [#1](url) @someone
+  * a detail
+
+### :house: Internal
+
+* chore: some chore [#2](url) @someone
+
+## 2.10.0
+
+### :rocket: Features
+
+* feat: an older feature [#0](url) @someone

--- a/scripts/test/fixtures/changelog/no-prereleases.md
+++ b/scripts/test/fixtures/changelog/no-prereleases.md
@@ -1,0 +1,27 @@
+<!-- markdownlint-disable MD004 -->
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### :boom: Breaking Changes
+
+### :rocket: Features
+
+* feat(sdk-trace): a feature [#1](url) @someone
+  * a detail
+
+### :bug: Bug Fixes
+
+### :books: Documentation
+
+### :house: Internal
+
+* chore: some chore [#2](url) @someone
+
+## 2.10.0
+
+### :rocket: Features
+
+* feat: an older feature [#0](url) @someone

--- a/scripts/test/fixtures/changelog/no-unreleased.md
+++ b/scripts/test/fixtures/changelog/no-unreleased.md
@@ -1,0 +1,10 @@
+<!-- markdownlint-disable MD004 -->
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## 2.10.0
+
+### :rocket: Features
+
+* feat: an older feature @someone

--- a/scripts/test/fixtures/changelog/nothing-to-release.2.11.0.md
+++ b/scripts/test/fixtures/changelog/nothing-to-release.2.11.0.md
@@ -1,0 +1,20 @@
+<!-- markdownlint-disable MD004 -->
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### :boom: Breaking Changes
+
+### :rocket: Features
+
+### :bug: Bug Fixes
+
+### :books: Documentation
+
+### :house: Internal
+
+## 2.11.0
+
+## 2.10.0

--- a/scripts/test/fixtures/changelog/nothing-to-release.md
+++ b/scripts/test/fixtures/changelog/nothing-to-release.md
@@ -1,0 +1,10 @@
+<!-- markdownlint-disable MD004 -->
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### :rocket: Features
+
+## 2.10.0

--- a/scripts/test/fixtures/changelog/prerelease-cycle.3.0.0-rc.1.md
+++ b/scripts/test/fixtures/changelog/prerelease-cycle.3.0.0-rc.1.md
@@ -1,0 +1,55 @@
+<!-- markdownlint-disable MD004 -->
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### :boom: Breaking Changes
+
+### :rocket: Features
+
+### :bug: Bug Fixes
+
+### :books: Documentation
+
+### :house: Internal
+
+## 3.0.0-rc.1
+
+### :bug: Bug Fixes
+
+* fix: landed after rc.0 @someone
+
+## 3.0.0-rc.0
+
+### :boom: Breaking Changes
+
+* feat!: breaking from rc.0 @someone
+
+### :rocket: Features
+
+* feat: feature from rc.0 @someone
+
+## 3.0.0-development.1
+
+### :rocket: Features
+
+* feat: feature from development.1 @someone
+
+## 3.0.0-development.0
+
+### :boom: Breaking Changes
+
+* feat!: breaking from development.0 @someone
+
+### :rocket: Features
+
+* feat: feature from development.0 @someone
+  * a detail
+
+## 2.10.0
+
+### :rocket: Features
+
+* feat: an older feature @someone

--- a/scripts/test/fixtures/changelog/prerelease-cycle.3.0.0.md
+++ b/scripts/test/fixtures/changelog/prerelease-cycle.3.0.0.md
@@ -1,0 +1,40 @@
+<!-- markdownlint-disable MD004 -->
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### :boom: Breaking Changes
+
+### :rocket: Features
+
+### :bug: Bug Fixes
+
+### :books: Documentation
+
+### :house: Internal
+
+## 3.0.0
+
+### :boom: Breaking Changes
+
+* feat!: breaking from development.0 @someone
+* feat!: breaking from rc.0 @someone
+
+### :rocket: Features
+
+* feat: feature from development.0 @someone
+  * a detail
+* feat: feature from development.1 @someone
+* feat: feature from rc.0 @someone
+
+### :bug: Bug Fixes
+
+* fix: landed after rc.0 @someone
+
+## 2.10.0
+
+### :rocket: Features
+
+* feat: an older feature @someone

--- a/scripts/test/fixtures/changelog/prerelease-cycle.md
+++ b/scripts/test/fixtures/changelog/prerelease-cycle.md
@@ -1,0 +1,45 @@
+<!-- markdownlint-disable MD004 -->
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+### :bug: Bug Fixes
+
+* fix: landed after rc.0 @someone
+
+### :house: Internal
+
+## 3.0.0-rc.0
+
+### :boom: Breaking Changes
+
+* feat!: breaking from rc.0 @someone
+
+### :rocket: Features
+
+* feat: feature from rc.0 @someone
+
+## 3.0.0-development.1
+
+### :rocket: Features
+
+* feat: feature from development.1 @someone
+
+## 3.0.0-development.0
+
+### :boom: Breaking Changes
+
+* feat!: breaking from development.0 @someone
+
+### :rocket: Features
+
+* feat: feature from development.0 @someone
+  * a detail
+
+## 2.10.0
+
+### :rocket: Features
+
+* feat: an older feature @someone


### PR DESCRIPTION
## Which problem is this PR solving?

Rolls pre-release changelog entries into one final changelog entry once the actual release is happening.

Unblocks #7044

GenAI Disclosure: I used Claude Opus to align changelog handling to our requirements.