### PR TITLE
fix(exporter-prometheus): deduplicate metric metadata

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -37,6 +37,7 @@ For notes on migrating to 3.x see [the 3.x migration guide](../doc/3.x/migration
 ### :bug: Bug Fixes
 
 * fix(instrumentation-http): set `error.type` on spans whose status code makes them an error [#7061](https://github.com/open-telemetry/opentelemetry-js/pull/7061) @mwear
+* fix(exporter-prometheus): prevent duplicate metric metadata in Prometheus scrapes [#7047](https://github.com/open-telemetry/opentelemetry-js/pull/7047) @freben
 
 ### :books: Documentation
 

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -37,7 +37,7 @@ For notes on migrating to 3.x see [the 3.x migration guide](../doc/3.x/migration
 ### :bug: Bug Fixes
 
 * fix(instrumentation-http): set `error.type` on spans whose status code makes them an error [#7061](https://github.com/open-telemetry/opentelemetry-js/pull/7061) @mwear
-* fix(exporter-prometheus): prevent duplicate metric metadata in Prometheus scrapes [#7047](https://github.com/open-telemetry/opentelemetry-js/pull/7047) @freben
+* fix(exporter-prometheus): prevent duplicate metric metadata and keep metric families grouped across instrumentation scopes in Prometheus scrapes [#7047](https://github.com/open-telemetry/opentelemetry-js/pull/7047) @freben
 
 ### :books: Documentation
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/README.md
+++ b/experimental/packages/opentelemetry-exporter-prometheus/README.md
@@ -47,6 +47,8 @@ counter.add(10, { pid: process.pid });
 
 With the above you should now be able to navigate to the Prometheus UI at: <http://localhost:9464/metrics>
 
+Metrics from different instrumentation scopes that translate to the same Prometheus metric name are exported together, with one set of metadata. Scope labels distinguish their samples by default. If descriptions or units conflict, the exporter selects the first non-empty value and logs a warning. If metric types conflict, the entire family is omitted and a warning is logged.
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -31,6 +31,37 @@ type PrometheusDataTypeLiteral =
   | 'summary'
   | 'untyped';
 
+interface PrometheusMetadata {
+  help: string;
+  unit: string;
+  type: PrometheusDataTypeLiteral;
+  state: 'pending' | 'emitted' | 'dropped';
+  helpValues: Set<string>;
+  unitValues: Set<string>;
+  typeValues: Set<PrometheusDataTypeLiteral>;
+}
+
+interface PrometheusMetadataCollection {
+  metricNames: Map<MetricData, string>;
+  metadataByName: Map<string, PrometheusMetadata>;
+}
+
+function createPrometheusMetadata(
+  help: string,
+  unit: string,
+  type: PrometheusDataTypeLiteral
+): PrometheusMetadata {
+  return {
+    help,
+    unit,
+    type,
+    state: 'pending',
+    helpValues: new Set(help ? [help] : []),
+    unitValues: new Set(unit ? [unit] : []),
+    typeValues: new Set([type]),
+  };
+}
+
 function escapeString(str: string) {
   return str.replace(/\\/g, '\\\\').replace(/\n/g, '\\n');
 }
@@ -173,6 +204,7 @@ export class PrometheusSerializer {
   private _withResourceConstantLabels: RegExp | undefined;
   private _withoutScopeInfo: boolean | undefined;
   private _withoutTargetInfo: boolean | undefined;
+  private _activeMetadataConflicts = new Set<string>();
 
   constructor(
     prefix?: string,
@@ -192,21 +224,27 @@ export class PrometheusSerializer {
 
   serialize(resourceMetrics: ResourceMetrics): string {
     let str = '';
+    const metadata = this._collectMetadata(resourceMetrics);
 
     this._additionalAttributes = this._filterResourceConstantLabels(
       resourceMetrics.resource.attributes,
       this._withResourceConstantLabels
     );
 
+    const resource = this._serializeResource(
+      resourceMetrics.resource,
+      metadata.metadataByName
+    );
+
     for (const scopeMetrics of resourceMetrics.scopeMetrics) {
-      str += this._serializeScopeMetrics(scopeMetrics);
+      str += this._serializeScopeMetrics(scopeMetrics, metadata);
     }
 
     if (str === '') {
       str += NO_REGISTERED_METRICS;
     }
 
-    return this._serializeResource(resourceMetrics.resource) + str;
+    return resource + str;
   }
 
   private _filterResourceConstantLabels(
@@ -225,10 +263,21 @@ export class PrometheusSerializer {
     return;
   }
 
-  private _serializeScopeMetrics(scopeMetrics: ScopeMetrics) {
+  private _serializeScopeMetrics(
+    scopeMetrics: ScopeMetrics,
+    metadata?: PrometheusMetadataCollection
+  ) {
     let str = '';
     for (const metric of scopeMetrics.metrics) {
-      const metricStr = this._serializeMetricData(metric, scopeMetrics.scope);
+      if (metadata && !metadata.metricNames.has(metric)) {
+        continue;
+      }
+      const metricStr = this._serializeMetricData(
+        metric,
+        scopeMetrics.scope,
+        metadata?.metricNames.get(metric),
+        metadata?.metadataByName
+      );
 
       if (metricStr) {
         str += metricStr + '\n';
@@ -237,42 +286,148 @@ export class PrometheusSerializer {
     return str;
   }
 
+  private _collectMetadata(
+    resourceMetrics: ResourceMetrics
+  ): PrometheusMetadataCollection {
+    // A TYPE conflict requires dropping the entire family, so all metadata must
+    // be resolved before any samples are serialized.
+    const metricNames = new Map<MetricData, string>();
+    const metadataByName = new Map<string, PrometheusMetadata>();
+
+    if (!this._withoutTargetInfo) {
+      metadataByName.set(
+        'target_info',
+        createPrometheusMetadata('Target metadata', '', 'gauge')
+      );
+    }
+
+    for (const scope of resourceMetrics.scopeMetrics) {
+      for (const metric of scope.metrics) {
+        const name = this._getPrometheusMetricName(metric);
+        if (name === undefined) {
+          continue;
+        }
+
+        metricNames.set(metric, name);
+        const currentMetadata = createPrometheusMetadata(
+          metric.descriptor.description,
+          metric.descriptor.unit,
+          toPrometheusType(metric)
+        );
+        const previousMetadata = metadataByName.get(name);
+
+        if (previousMetadata === undefined) {
+          metadataByName.set(name, currentMetadata);
+          continue;
+        }
+
+        previousMetadata.typeValues.add(currentMetadata.type);
+        if (previousMetadata.typeValues.size > 1) {
+          previousMetadata.state = 'dropped';
+          continue;
+        }
+
+        if (currentMetadata.help) {
+          previousMetadata.helpValues.add(currentMetadata.help);
+          if (!previousMetadata.help) {
+            previousMetadata.help = currentMetadata.help;
+          }
+        }
+
+        if (currentMetadata.unit) {
+          previousMetadata.unitValues.add(currentMetadata.unit);
+          if (!previousMetadata.unit) {
+            previousMetadata.unit = currentMetadata.unit;
+          }
+        }
+      }
+    }
+
+    this._warnAboutMetadataConflicts(metadataByName);
+    return { metricNames, metadataByName };
+  }
+
+  private _warnAboutMetadataConflicts(
+    metadataByName: Map<string, PrometheusMetadata>
+  ) {
+    const activeConflicts = new Set<string>();
+    const warn = (
+      kind: 'HELP' | 'UNIT' | 'TYPE',
+      name: string,
+      values: Set<string>,
+      selected?: string
+    ) => {
+      const sortedValues = [...values].sort();
+      const key = JSON.stringify([kind, name, selected, sortedValues]);
+      activeConflicts.add(key);
+      if (this._activeMetadataConflicts.has(key)) {
+        return;
+      }
+
+      const formattedValues = sortedValues
+        .map(value => JSON.stringify(value))
+        .join(', ');
+      if (kind === 'TYPE') {
+        diag.warn(
+          `Conflicting ${kind} comments for metric "${name}": ${formattedValues}; dropping the metric.`
+        );
+      } else {
+        diag.warn(
+          `Conflicting ${kind} comments for metric "${name}": ${formattedValues}; exporting ${JSON.stringify(
+            selected
+          )}.`
+        );
+      }
+    };
+
+    for (const [name, metadata] of metadataByName) {
+      if (metadata.typeValues.size > 1) {
+        warn('TYPE', name, metadata.typeValues);
+        continue;
+      }
+      if (metadata.helpValues.size > 1) {
+        warn('HELP', name, metadata.helpValues, metadata.help);
+      }
+      if (metadata.unitValues.size > 1) {
+        warn('UNIT', name, metadata.unitValues, metadata.unit);
+      }
+    }
+
+    this._activeMetadataConflicts = activeConflicts;
+  }
+
   private _serializeMetricData(
     metricData: MetricData,
-    scope: InstrumentationScope
+    scope: InstrumentationScope,
+    normalizedName?: string,
+    metadataByName?: Map<string, PrometheusMetadata>
   ) {
-    let name = sanitizePrometheusMetricName(
-      escapeString(metricData.descriptor.name)
-    );
-    if (this._prefix) {
-      name = `${this._prefix}${name}`;
+    const name = normalizedName ?? this._getPrometheusMetricName(metricData);
+    if (name === undefined) {
+      return '';
     }
 
-    if (name === '') {
-      diag.error(
-        `Normalization for metric "${metricData.descriptor.name}" resulted in empty name`
+    const currentMetadata =
+      metadataByName?.get(name) ??
+      createPrometheusMetadata(
+        metricData.descriptor.description,
+        metricData.descriptor.unit,
+        toPrometheusType(metricData)
       );
+    if (currentMetadata.state === 'dropped') {
       return '';
-    } else if (name === '_') {
-      diag.error(
-        `Normalization for metric "${metricData.descriptor.name}" resulted in an invalid name: "_"`
-      );
-      return '';
-    } else if (name[0] >= '0' && name[0] <= '9') {
-      name = `_${name}`;
     }
-
-    const dataPointType = metricData.dataPointType;
-
-    name = enforcePrometheusNamingConvention(name, metricData);
+    const writeMetadata = currentMetadata.state === 'pending';
+    currentMetadata.state = 'emitted';
 
     const help = `# HELP ${name} ${escapeString(
-      metricData.descriptor.description || 'description missing'
+      currentMetadata.help || 'description missing'
     )}`;
-    const unit = metricData.descriptor.unit
-      ? `\n# UNIT ${name} ${escapeString(metricData.descriptor.unit)}`
+    const unit = currentMetadata.unit
+      ? `\n# UNIT ${name} ${escapeString(currentMetadata.unit)}`
       : '';
-    const type = `# TYPE ${name} ${toPrometheusType(metricData)}`;
+    const type = `# TYPE ${name} ${currentMetadata.type}`;
+    const dataPointType = metricData.dataPointType;
     let additionalAttributes: Attributes | undefined;
 
     if (this._withoutScopeInfo) {
@@ -330,7 +485,32 @@ export class PrometheusSerializer {
       }
     }
 
-    return `${help}${unit}\n${type}\n${results}`.trim();
+    return `${writeMetadata ? `${help}${unit}\n${type}\n` : ''}${results}`.trim();
+  }
+
+  private _getPrometheusMetricName(metricData: MetricData) {
+    let name = sanitizePrometheusMetricName(
+      escapeString(metricData.descriptor.name)
+    );
+    if (this._prefix) {
+      name = `${this._prefix}${name}`;
+    }
+
+    if (name === '') {
+      diag.error(
+        `Normalization for metric "${metricData.descriptor.name}" resulted in empty name`
+      );
+      return undefined;
+    } else if (name === '_') {
+      diag.error(
+        `Normalization for metric "${metricData.descriptor.name}" resulted in an invalid name: "_"`
+      );
+      return undefined;
+    } else if (name[0] >= '0' && name[0] <= '9') {
+      name = `_${name}`;
+    }
+
+    return enforcePrometheusNamingConvention(name, metricData);
   }
 
   private _serializeSingularDataPoint(
@@ -412,16 +592,31 @@ export class PrometheusSerializer {
     return results;
   }
 
-  protected _serializeResource(resource: Resource): string {
+  protected _serializeResource(
+    resource: Resource,
+    metadataByName?: Map<string, PrometheusMetadata>
+  ): string {
     if (this._withoutTargetInfo === true) {
       return '';
     }
 
     const name = 'target_info';
-    const help = `# HELP ${name} Target metadata`;
-    const type = `# TYPE ${name} gauge`;
+    const metadata =
+      metadataByName?.get(name) ??
+      createPrometheusMetadata('Target metadata', '', 'gauge');
+    if (metadata.state === 'dropped') {
+      return '';
+    }
+
+    const writeMetadata = metadata.state === 'pending';
+    metadata.state = 'emitted';
+    const help = `# HELP ${name} ${escapeString(metadata.help)}`;
+    const unit = metadata.unit
+      ? `\n# UNIT ${name} ${escapeString(metadata.unit)}`
+      : '';
+    const type = `# TYPE ${name} ${metadata.type}`;
 
     const results = stringify(name, resource.attributes, 1).trim();
-    return `${help}\n${type}\n${results}\n`;
+    return `${writeMetadata ? `${help}${unit}\n${type}\n` : ''}${results}\n`;
   }
 }

--- a/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/src/PrometheusSerializer.ts
@@ -7,7 +7,6 @@ import type { Attributes, AttributeValue } from '@opentelemetry/api';
 import { diag } from '@opentelemetry/api';
 import type {
   ResourceMetrics,
-  ScopeMetrics,
   MetricData,
   DataPoint,
   Histogram,
@@ -42,7 +41,10 @@ interface PrometheusMetadata {
 }
 
 interface PrometheusMetadataCollection {
-  metricNames: Map<MetricData, string>;
+  metricsByName: Map<
+    string,
+    { metric: MetricData; scope: InstrumentationScope }[]
+  >;
   metadataByName: Map<string, PrometheusMetadata>;
 }
 
@@ -236,8 +238,20 @@ export class PrometheusSerializer {
       metadata.metadataByName
     );
 
-    for (const scopeMetrics of resourceMetrics.scopeMetrics) {
-      str += this._serializeScopeMetrics(scopeMetrics, metadata);
+    // Preserve first-seen family order, with target_info first, and keep each
+    // family's samples together even when they originate from different scopes.
+    for (const name of metadata.metadataByName.keys()) {
+      for (const { metric, scope } of metadata.metricsByName.get(name) ?? []) {
+        const metricStr = this._serializeMetricData(
+          metric,
+          scope,
+          name,
+          metadata.metadataByName
+        );
+        if (metricStr) {
+          str += metricStr + '\n';
+        }
+      }
     }
 
     if (str === '') {
@@ -263,35 +277,13 @@ export class PrometheusSerializer {
     return;
   }
 
-  private _serializeScopeMetrics(
-    scopeMetrics: ScopeMetrics,
-    metadata?: PrometheusMetadataCollection
-  ) {
-    let str = '';
-    for (const metric of scopeMetrics.metrics) {
-      if (metadata && !metadata.metricNames.has(metric)) {
-        continue;
-      }
-      const metricStr = this._serializeMetricData(
-        metric,
-        scopeMetrics.scope,
-        metadata?.metricNames.get(metric),
-        metadata?.metadataByName
-      );
-
-      if (metricStr) {
-        str += metricStr + '\n';
-      }
-    }
-    return str;
-  }
-
   private _collectMetadata(
     resourceMetrics: ResourceMetrics
   ): PrometheusMetadataCollection {
     // A TYPE conflict requires dropping the entire family, so all metadata must
     // be resolved before any samples are serialized.
-    const metricNames = new Map<MetricData, string>();
+    const metricsByName: PrometheusMetadataCollection['metricsByName'] =
+      new Map();
     const metadataByName = new Map<string, PrometheusMetadata>();
 
     if (!this._withoutTargetInfo) {
@@ -308,7 +300,12 @@ export class PrometheusSerializer {
           continue;
         }
 
-        metricNames.set(metric, name);
+        const metrics = metricsByName.get(name);
+        if (metrics) {
+          metrics.push({ metric, scope: scope.scope });
+        } else {
+          metricsByName.set(name, [{ metric, scope: scope.scope }]);
+        }
         const currentMetadata = createPrometheusMetadata(
           metric.descriptor.description,
           metric.descriptor.unit,
@@ -344,7 +341,7 @@ export class PrometheusSerializer {
     }
 
     this._warnAboutMetadataConflicts(metadataByName);
-    return { metricNames, metadataByName };
+    return { metricsByName, metadataByName };
   }
 
   private _warnAboutMetadataConflicts(

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import { diag } from '@opentelemetry/api';
-import type { Attributes, UpDownCounter } from '@opentelemetry/api';
+import type { Attributes, Meter, UpDownCounter } from '@opentelemetry/api';
 import type { DataPoint, Histogram } from '@opentelemetry/sdk-metrics';
 import {
   AggregationTemporality,
@@ -565,6 +565,256 @@ describe('PrometheusSerializer', () => {
             'test_bucket{val="2",otel_scope_name="test",le="+Inf"} 1\n'
         );
       });
+    });
+  });
+
+  describe('metric metadata', () => {
+    async function serializeScopedMetrics(
+      createInstruments: (firstMeter: Meter, secondMeter: Meter) => void,
+      serializer = new PrometheusSerializer()
+    ) {
+      const reader = new TestMetricReader();
+      const meterProvider = new MeterProvider({ readers: [reader] });
+      const firstMeter = meterProvider.getMeter('first-scope');
+      const secondMeter = meterProvider.getMeter('second-scope');
+
+      createInstruments(firstMeter, secondMeter);
+
+      const { resourceMetrics, errors } = await reader.collect();
+      assert.strictEqual(errors.length, 0);
+
+      return serializer.serialize(resourceMetrics);
+    }
+
+    it('emits metadata once for the same family in different scopes', async () => {
+      const warn = sinon.stub(diag, 'warn');
+      const result = await serializeScopedMetrics((firstMeter, secondMeter) => {
+        firstMeter
+          .createCounter('requests', {
+            description: 'Number of requests',
+            unit: 'requests',
+          })
+          .add(1);
+        secondMeter
+          .createCounter('requests', {
+            description: 'Number of requests',
+            unit: 'requests',
+          })
+          .add(2);
+      });
+
+      assert.strictEqual(
+        result,
+        serializedDefaultResource +
+          '# HELP requests_total Number of requests\n' +
+          '# UNIT requests_total requests\n' +
+          '# TYPE requests_total counter\n' +
+          'requests_total{otel_scope_name="first-scope"} 1\n' +
+          'requests_total{otel_scope_name="second-scope"} 2\n'
+      );
+      sinon.assert.notCalled(warn);
+    });
+
+    it('keeps points and warns when HELP metadata conflicts', async () => {
+      const warn = sinon.stub(diag, 'warn');
+      const result = await serializeScopedMetrics((firstMeter, secondMeter) => {
+        firstMeter
+          .createUpDownCounter('jobs', { description: 'First description' })
+          .add(1);
+        secondMeter
+          .createUpDownCounter('jobs', { description: 'Second description' })
+          .add(2);
+      });
+
+      assert.strictEqual(
+        result,
+        serializedDefaultResource +
+          '# HELP jobs First description\n' +
+          '# TYPE jobs gauge\n' +
+          'jobs{otel_scope_name="first-scope"} 1\n' +
+          'jobs{otel_scope_name="second-scope"} 2\n'
+      );
+      sinon.assert.calledOnceWithExactly(
+        warn,
+        'Conflicting HELP comments for metric "jobs": "First description", "Second description"; exporting "First description".'
+      );
+    });
+
+    it('keeps points and warns when UNIT metadata conflicts', async () => {
+      const warn = sinon.stub(diag, 'warn');
+      const result = await serializeScopedMetrics((firstMeter, secondMeter) => {
+        firstMeter.createUpDownCounter('queue_size', { unit: 'jobs' }).add(1);
+        secondMeter
+          .createUpDownCounter('queue_size', { unit: 'requests' })
+          .add(2);
+      });
+
+      assert.strictEqual(
+        result,
+        serializedDefaultResource +
+          '# HELP queue_size description missing\n' +
+          '# UNIT queue_size jobs\n' +
+          '# TYPE queue_size gauge\n' +
+          'queue_size{otel_scope_name="first-scope"} 1\n' +
+          'queue_size{otel_scope_name="second-scope"} 2\n'
+      );
+      sinon.assert.calledOnceWithExactly(
+        warn,
+        'Conflicting UNIT comments for metric "queue_size": "jobs", "requests"; exporting "jobs".'
+      );
+    });
+
+    it('uses later non-empty HELP and UNIT metadata', async () => {
+      const warn = sinon.stub(diag, 'warn');
+      const result = await serializeScopedMetrics((firstMeter, secondMeter) => {
+        firstMeter.createUpDownCounter('active_jobs').add(1);
+        secondMeter
+          .createUpDownCounter('active_jobs', {
+            description: 'Number of active jobs',
+            unit: 'jobs',
+          })
+          .add(2);
+      });
+
+      assert.strictEqual(
+        result,
+        serializedDefaultResource +
+          '# HELP active_jobs Number of active jobs\n' +
+          '# UNIT active_jobs jobs\n' +
+          '# TYPE active_jobs gauge\n' +
+          'active_jobs{otel_scope_name="first-scope"} 1\n' +
+          'active_jobs{otel_scope_name="second-scope"} 2\n'
+      );
+      sinon.assert.notCalled(warn);
+    });
+
+    it('drops the family and warns when TYPE metadata conflicts', async () => {
+      const warn = sinon.stub(diag, 'warn');
+      const result = await serializeScopedMetrics((firstMeter, secondMeter) => {
+        firstMeter.createUpDownCounter('workers').add(1);
+        firstMeter.createUpDownCounter('healthy_workers').add(3);
+        secondMeter.createHistogram('workers').record(2);
+      });
+
+      assert.strictEqual(
+        result,
+        serializedDefaultResource +
+          '# HELP healthy_workers description missing\n' +
+          '# TYPE healthy_workers gauge\n' +
+          'healthy_workers{otel_scope_name="first-scope"} 3\n'
+      );
+      sinon.assert.calledOnceWithExactly(
+        warn,
+        'Conflicting TYPE comments for metric "workers": "gauge", "histogram"; dropping the metric.'
+      );
+    });
+
+    it('groups metadata by the normalized Prometheus family name', async () => {
+      const result = await serializeScopedMetrics((firstMeter, secondMeter) => {
+        firstMeter.createUpDownCounter('queue.depth').add(1);
+        secondMeter.createUpDownCounter('queue-depth').add(2);
+      });
+
+      assert.strictEqual(
+        result,
+        serializedDefaultResource +
+          '# HELP queue_depth description missing\n' +
+          '# TYPE queue_depth gauge\n' +
+          'queue_depth{otel_scope_name="first-scope"} 1\n' +
+          'queue_depth{otel_scope_name="second-scope"} 2\n'
+      );
+    });
+
+    it('detects TYPE conflicts after applying counter suffixes', async () => {
+      const warn = sinon.stub(diag, 'warn');
+      const result = await serializeScopedMetrics((firstMeter, secondMeter) => {
+        firstMeter.createCounter('requests').add(1);
+        secondMeter.createUpDownCounter('requests_total').add(2);
+      });
+
+      assert.strictEqual(
+        result,
+        serializedDefaultResource + '# no registered metrics'
+      );
+      sinon.assert.calledOnceWithExactly(
+        warn,
+        'Conflicting TYPE comments for metric "requests_total": "counter", "gauge"; dropping the metric.'
+      );
+    });
+
+    it('resolves metadata collisions with generated target_info', async () => {
+      const warn = sinon.stub(diag, 'warn');
+      const result = await serializeScopedMetrics(firstMeter => {
+        firstMeter
+          .createUpDownCounter('target_info', {
+            description: 'Application target metadata',
+            unit: 'items',
+          })
+          .add(2);
+      });
+
+      assert.strictEqual(
+        result,
+        '# HELP target_info Target metadata\n' +
+          '# UNIT target_info items\n' +
+          '# TYPE target_info gauge\n' +
+          `target_info{${resourceAttributes}} 1\n` +
+          'target_info{otel_scope_name="first-scope"} 2\n'
+      );
+      sinon.assert.calledOnceWithExactly(
+        warn,
+        'Conflicting HELP comments for metric "target_info": "Application target metadata", "Target metadata"; exporting "Target metadata".'
+      );
+    });
+
+    it('drops generated target_info when its TYPE conflicts', async () => {
+      const warn = sinon.stub(diag, 'warn');
+      const result = await serializeScopedMetrics(firstMeter => {
+        firstMeter.createHistogram('target_info').record(2);
+        firstMeter.createUpDownCounter('healthy_workers').add(3);
+      });
+
+      assert.strictEqual(
+        result,
+        '# HELP healthy_workers description missing\n' +
+          '# TYPE healthy_workers gauge\n' +
+          'healthy_workers{otel_scope_name="first-scope"} 3\n'
+      );
+      sinon.assert.calledOnceWithExactly(
+        warn,
+        'Conflicting TYPE comments for metric "target_info": "gauge", "histogram"; dropping the metric.'
+      );
+    });
+
+    it('warns once per active metadata conflict and again after recurrence', async () => {
+      const warn = sinon.stub(diag, 'warn');
+      const serializer = new PrometheusSerializer();
+      const conflictingInstruments = (
+        firstMeter: Meter,
+        secondMeter: Meter
+      ) => {
+        firstMeter
+          .createUpDownCounter('jobs', { description: 'First description' })
+          .add(1);
+        secondMeter
+          .createUpDownCounter('jobs', { description: 'Second description' })
+          .add(2);
+      };
+
+      await serializeScopedMetrics(conflictingInstruments, serializer);
+      await serializeScopedMetrics(conflictingInstruments, serializer);
+      await serializeScopedMetrics(firstMeter => {
+        firstMeter
+          .createUpDownCounter('jobs', { description: 'First description' })
+          .add(1);
+      }, serializer);
+      await serializeScopedMetrics(conflictingInstruments, serializer);
+
+      sinon.assert.calledTwice(warn);
+      assert.deepStrictEqual(warn.firstCall.args, [
+        'Conflicting HELP comments for metric "jobs": "First description", "Second description"; exporting "First description".',
+      ]);
+      assert.deepStrictEqual(warn.secondCall.args, warn.firstCall.args);
     });
   });
 

--- a/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
+++ b/experimental/packages/opentelemetry-exporter-prometheus/test/PrometheusSerializer.test.ts
@@ -244,7 +244,11 @@ describe('PrometheusSerializer', () => {
           '_filterResourceConstantLabels'
         ](resourceAttributes, serializer['_withResourceConstantLabels']);
 
-        const result = serializer['_serializeScopeMetrics'](scopeMetrics);
+        const result =
+          serializer['_serializeMetricData'](
+            scopeMetrics.metrics[0],
+            scopeMetrics.scope
+          ) + '\n';
         return result;
       }
 
@@ -315,7 +319,12 @@ describe('PrometheusSerializer', () => {
           '_filterResourceConstantLabels'
         ](resourceAttributes, serializer['_withResourceConstantLabels']);
 
-        return serializer['_serializeScopeMetrics'](scopeMetrics);
+        return (
+          serializer['_serializeMetricData'](
+            scopeMetrics.metrics[0],
+            scopeMetrics.scope
+          ) + '\n'
+        );
       }
 
       it('should serialize metric record', async () => {
@@ -388,7 +397,12 @@ describe('PrometheusSerializer', () => {
           '_filterResourceConstantLabels'
         ](resourceAttributes, serializer['_withResourceConstantLabels']);
 
-        return serializer['_serializeScopeMetrics'](scopeMetrics);
+        return (
+          serializer['_serializeMetricData'](
+            scopeMetrics.metrics[0],
+            scopeMetrics.scope
+          ) + '\n'
+        );
       }
 
       it('should serialize metric record', async () => {
@@ -464,7 +478,11 @@ describe('PrometheusSerializer', () => {
           '_filterResourceConstantLabels'
         ](resourceAttributes, serializer['_withResourceConstantLabels']);
 
-        const result = serializer['_serializeScopeMetrics'](scopeMetrics);
+        const result =
+          serializer['_serializeMetricData'](
+            scopeMetrics.metrics[0],
+            scopeMetrics.scope
+          ) + '\n';
         return result;
       }
 
@@ -548,7 +566,11 @@ describe('PrometheusSerializer', () => {
           '_filterResourceConstantLabels'
         ](resourceAttributes, serializer['_withResourceConstantLabels']);
 
-        const result = serializer['_serializeScopeMetrics'](scopeMetrics);
+        const result =
+          serializer['_serializeMetricData'](
+            scopeMetrics.metrics[0],
+            scopeMetrics.scope
+          ) + '\n';
         assert.strictEqual(
           result,
           '# HELP test foobar\n' +
@@ -578,13 +600,131 @@ describe('PrometheusSerializer', () => {
       const firstMeter = meterProvider.getMeter('first-scope');
       const secondMeter = meterProvider.getMeter('second-scope');
 
-      createInstruments(firstMeter, secondMeter);
+      try {
+        createInstruments(firstMeter, secondMeter);
 
-      const { resourceMetrics, errors } = await reader.collect();
-      assert.strictEqual(errors.length, 0);
+        const { resourceMetrics, errors } = await reader.collect();
+        assert.strictEqual(errors.length, 0);
 
-      return serializer.serialize(resourceMetrics);
+        const result = serializer.serialize(resourceMetrics);
+        assert.strictEqual(serializer.serialize(resourceMetrics), result);
+        return result;
+      } finally {
+        await meterProvider.shutdown();
+      }
     }
+
+    it('keeps interleaved families contiguous across scopes after name translation', async () => {
+      for (const withoutScopeInfo of [false, true]) {
+        const result = await serializeScopedMetrics(
+          (firstMeter, secondMeter) => {
+            firstMeter.createCounter('requests').add(1, { plugin: 'first' });
+            firstMeter
+              .createUpDownCounter('queue.depth')
+              .add(3, { plugin: 'first' });
+            secondMeter
+              .createUpDownCounter('queue-depth')
+              .add(4, { plugin: 'second' });
+            secondMeter
+              .createCounter('requests_total')
+              .add(2, { plugin: 'second' });
+          },
+          new PrometheusSerializer(
+            'app',
+            false,
+            undefined,
+            true,
+            withoutScopeInfo
+          )
+        );
+
+        const firstScope = withoutScopeInfo
+          ? ''
+          : ',otel_scope_name="first-scope"';
+        const secondScope = withoutScopeInfo
+          ? ''
+          : ',otel_scope_name="second-scope"';
+        assert.strictEqual(
+          result,
+          '# HELP app_requests_total description missing\n' +
+            '# TYPE app_requests_total counter\n' +
+            `app_requests_total{plugin="first"${firstScope}} 1\n` +
+            `app_requests_total{plugin="second"${secondScope}} 2\n` +
+            '# HELP app_queue_depth description missing\n' +
+            '# TYPE app_queue_depth gauge\n' +
+            `app_queue_depth{plugin="first"${firstScope}} 3\n` +
+            `app_queue_depth{plugin="second"${secondScope}} 4\n`
+        );
+      }
+    });
+
+    it('keeps all histogram samples together across interleaved scopes', async () => {
+      const result = await serializeScopedMetrics((firstMeter, secondMeter) => {
+        firstMeter.createHistogram('duration').record(2);
+        firstMeter.createUpDownCounter('workers').add(1);
+        secondMeter.createUpDownCounter('workers').add(2);
+        secondMeter.createHistogram('duration').record(7);
+      });
+      const lines = result.trim().split('\n');
+      const workersStart = lines.indexOf('# HELP workers description missing');
+      const histogramLines = lines.filter(line => line.startsWith('duration_'));
+      assert(
+        histogramLines.some(line =>
+          line.includes('otel_scope_name="first-scope"')
+        )
+      );
+      assert(
+        histogramLines.some(line =>
+          line.includes('otel_scope_name="second-scope"')
+        )
+      );
+      assert.strictEqual(
+        lines.filter(line => line === '# TYPE duration histogram').length,
+        1
+      );
+      assert(histogramLines.every(line => lines.indexOf(line) < workersStart));
+      for (const scope of ['first-scope', 'second-scope']) {
+        assert(lines.includes(`duration_count{otel_scope_name="${scope}"} 1`));
+        assert(
+          lines.includes(
+            `duration_bucket{otel_scope_name="${scope}",le="+Inf"} 1`
+          )
+        );
+      }
+      assert(lines.includes('duration_sum{otel_scope_name="first-scope"} 2'));
+      assert(lines.includes('duration_sum{otel_scope_name="second-scope"} 7'));
+      assert.deepStrictEqual(lines.slice(workersStart), [
+        '# HELP workers description missing',
+        '# TYPE workers gauge',
+        'workers{otel_scope_name="first-scope"} 1',
+        'workers{otel_scope_name="second-scope"} 2',
+      ]);
+    });
+
+    it('keeps application target_info samples adjacent to the generated resource sample', async () => {
+      const result = await serializeScopedMetrics((firstMeter, secondMeter) => {
+        firstMeter.createUpDownCounter('workers').add(3);
+        firstMeter
+          .createUpDownCounter('target_info', {
+            description: 'Target metadata',
+          })
+          .add(1);
+        secondMeter
+          .createUpDownCounter('target_info', {
+            description: 'Target metadata',
+          })
+          .add(2);
+      });
+      assert.strictEqual(
+        result,
+        serializedDefaultResource +
+          'target_info{otel_scope_name="first-scope"} 1\n' +
+          'target_info{otel_scope_name="second-scope"} 2\n' +
+          '# HELP workers description missing\n' +
+          '# TYPE workers gauge\n' +
+          'workers{otel_scope_name="first-scope"} 3\n'
+      );
+    });
 
     it('emits metadata once for the same family in different scopes', async () => {
       const warn = sinon.stub(diag, 'warn');


### PR DESCRIPTION
**Disclosure**: This PR was authored with the help of Codex on GPT-5.6 Sol, but I am fully part of the process and manually tracking both the original implementation and any feedback.

Hey, nice to meet you. This is my first otel contribution PR; let me know if anything seems amiss.

The trigger for making this, is that we are trying to properly (as far as we know) leverage dedicated meters named `backstage-plugin-${pluginId}` for plugins running side by side in a Backstage installation, and each of those may have colliding metric names. This works fine - except the we hit the quirk that the prom exporter may produce multiple HELP sections instead of collapsing them into one. This [upsets some readers](https://github.com/backstage/backstage/pull/35369), and indeed seems to be in violation of the spec if I read it right.

I did see https://github.com/open-telemetry/opentelemetry-js/issues/3467 and thought I would take a stab at moving that forward again. I hope this looks good.

There's interesting partial overlap with https://github.com/open-telemetry/opentelemetry-js/pull/6653 but that one has been around for quite some time and my uneducated take is that this PR helps things forward and then #6653 (which already has conflicts) can be rebased upon mine.

Original AI generated content follows:

## Which problem is this PR solving?

The Prometheus serializer currently writes `HELP`, `UNIT`, and `TYPE` metadata once per OpenTelemetry scope. Two valid meters from different instrumentation scopes can therefore produce duplicate metadata for the same final Prometheus metric name in one scrape. The scope labels keep their metric points distinct, but Prometheus metadata is keyed only by metric name.

This addresses the metadata-collision part of #3467. It is intentionally separate from the duplicate metric-storage bug fixed in #3488: this case starts with valid, distinct instrumentation scopes.

The [OpenTelemetry Prometheus compatibility specification](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#metric-metadata-1) requires pull exporters to emit at most one `HELP`, `UNIT`, and `TYPE` comment per metric name. It also requires the whole metric family to be dropped for conflicting types, while retaining points when only `HELP` or `UNIT` differs. The implementation follows the same precompute-and-group approach used by the [.NET Prometheus exporter](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.Prometheus.HttpListener/Internal/Shared/PrometheusCollectionManager.cs#L623-L721).

## Short description of the changes

- Resolve the final normalized Prometheus family name before serialization.
- Group metadata and samples across all instrumentation scopes by that final name, emitting each family contiguously with one set of metadata.
- For conflicting `HELP` or `UNIT`, keep all points, choose the first non-empty value, and emit a diagnostic warning.
- For conflicting `TYPE`, emit a diagnostic warning and drop the entire family before any samples are written.
- Cover identical and conflicting metadata, normalization and counter-suffix collisions, interleaved scopes, histograms, and generated `target_info` grouping with regression tests.

#6653 is adding configurable translation strategies. This PR does not depend on it, but the grouping invariant should continue to be applied after whichever final name translation is selected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] `npm test -w @opentelemetry/exporter-prometheus` (80 passing)
- [x] `npm run compile -w @opentelemetry/exporter-prometheus`
- [x] `npm run lint -w @opentelemetry/exporter-prometheus`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated

Generated with [Codex](https://openai.com/codex/).