### PR TITLE
feat(sdk-trace)!: remove deprecated TracerProviderOptions.forceFlushTimeoutMillis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ For notes on migrating to 3.x see [the 3.x migration guide](doc/3.x/migration-gu
 
 ### :boom: Breaking Changes
 
-* feat(core)!: remove deprecated `getTimeOrigin`, `otperformance`, `_globalThis`, and `unrefTimer` from `@opentelemetry/core` [#7048](https://github.com/open-telemetry/opentelemetry-js/pull/7048)
+* feat(core)!: remove deprecated `getTimeOrigin`, `otperformance`, `_globalThis`, and `unrefTimer` from `@opentelemetry/core` [#7053](https://github.com/open-telemetry/opentelemetry-js/pull/7053)
   * `getTimeOrigin()` — use `performance.timeOrigin` directly.
   * `otperformance` — use the global `performance` object directly.
   * `_globalThis` — use `globalThis` directly.
   * `unrefTimer(timer)` — call `timer.unref()` directly in your own code.
+* feat(sdk-trace)!: remove deprecated `TracerProviderOptions.forceFlushTimeoutMillis` [#7057](https://github.com/open-telemetry/opentelemetry-js/pull/7057)
+  * Pass `timeoutMillis` to `provider.forceFlush({ timeoutMillis })` instead. The default timeout is 30000ms.
 
 ### :rocket: Features
 

--- a/doc/3.x/migration-guide.md
+++ b/doc/3.x/migration-guide.md
@@ -66,3 +66,22 @@ if (typeof timer !== 'number') {
   timer.unref();
 }
 ```
+
+---
+
+## `@opentelemetry/sdk-trace`
+
+### Removed: `TracerProviderOptions.forceFlushTimeoutMillis`
+
+`forceFlushTimeoutMillis` on `TracerProviderOptions` has been removed. Pass
+instead. The default timeout is 30000ms.
+
+```ts
+// before
+const provider = new TracerProvider({ forceFlushTimeoutMillis: 5000 });
+await provider.forceFlush();
+
+// after
+const provider = new TracerProvider();
+await provider.forceFlush({ timeoutMillis: 5000 });
+```

--- a/packages/opentelemetry-sdk-trace-base/src/config.ts
+++ b/packages/opentelemetry-sdk-trace-base/src/config.ts
@@ -36,7 +36,6 @@ const DEFAULT_RATIO = 1;
 export function loadDefaultConfig() {
   return {
     sampler: buildSamplerFromEnv(),
-    forceFlushTimeoutMillis: 30000,
     generalLimits: {
       attributeValueLengthLimit:
         getNumberFromEnv('OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT') ?? Infinity,

--- a/packages/sdk-trace/src/TracerProvider.ts
+++ b/packages/sdk-trace/src/TracerProvider.ts
@@ -41,12 +41,10 @@ enum ForceFlushState {
 export class TracerProvider implements ApiTracerProvider {
   private readonly _resource: Resource;
   private readonly _activeSpanProcessor: MultiSpanProcessor;
-  private readonly _forceFlushTimeoutMillis: number;
   private readonly _tracerOptions: TracerOptions;
   private readonly _tracers: Map<string, Tracer> = new Map();
 
   constructor(options: TracerProviderOptions = {}) {
-    this._forceFlushTimeoutMillis = options.forceFlushTimeoutMillis ?? 30000;
     this._resource = options.resource ?? defaultResource();
     const spanProcessors = options.spanProcessors ?? [];
     this._activeSpanProcessor = new MultiSpanProcessor(spanProcessors);
@@ -99,7 +97,7 @@ export class TracerProvider implements ApiTracerProvider {
   }
 
   forceFlush(options?: ForceFlushOptions): Promise<void> {
-    const timeout = options?.timeoutMillis ?? this._forceFlushTimeoutMillis;
+    const timeout = options?.timeoutMillis ?? 30000;
     const promises = this._activeSpanProcessor['_spanProcessors'].map(
       (spanProcessor: SpanProcessor) => {
         return new Promise(resolve => {

--- a/packages/sdk-trace/src/types.ts
+++ b/packages/sdk-trace/src/types.ts
@@ -29,14 +29,6 @@ export interface TracerProviderOptions {
   idGenerator?: IdGenerator;
 
   /**
-   * How long the forceFlush can run before it is cancelled.
-   * The default value is 30000ms
-   *
-   * @deprecated Configure the timeout when calling `TracerProvider.forceFlush()` instead.
-   */
-  forceFlushTimeoutMillis?: number;
-
-  /**
    * List of SpanProcessor for the tracer
    */
   spanProcessors?: SpanProcessor[];
@@ -52,7 +44,7 @@ export interface TracerProviderOptions {
 export interface ForceFlushOptions {
   /**
    * How long the force flush can run before it is cancelled.
-   * Falls back to the timeout configured in `TracerProviderOptions`.
+   * Defaults to 30000ms.
    */
   timeoutMillis?: number;
 }

--- a/packages/sdk-trace/test/common/TracerProvider.test.ts
+++ b/packages/sdk-trace/test/common/TracerProvider.test.ts
@@ -369,7 +369,6 @@ describe('TracerProvider', () => {
       const spanProcessor = new NoopSpanProcessor();
       sinon.stub(spanProcessor, 'forceFlush').returns(new Promise(() => {}));
       const tracerProvider = new TracerProvider({
-        forceFlushTimeoutMillis: 100,
         spanProcessors: [spanProcessor],
       });
 
@@ -387,24 +386,23 @@ describe('TracerProvider', () => {
       );
     });
 
-    it('should fall back to the timeout passed to the constructor', async () => {
+    it('should use the default 30000ms timeout when none is passed to forceFlush', async () => {
       const clock = sinon.useFakeTimers();
       const spanProcessor = new NoopSpanProcessor();
       sinon.stub(spanProcessor, 'forceFlush').returns(new Promise(() => {}));
       const tracerProvider = new TracerProvider({
-        forceFlushTimeoutMillis: 20,
         spanProcessors: [spanProcessor],
       });
 
       const flush = tracerProvider.forceFlush().catch(error => error);
-      await clock.tickAsync(20);
+      await clock.tickAsync(30000);
 
       const rejection: unknown = await flush;
       assert.ok(Array.isArray(rejection));
       assert.ok(rejection[0] instanceof Error);
       assert.strictEqual(
         rejection[0].message,
-        'Span processor did not completed within timeout period of 20 ms'
+        'Span processor did not completed within timeout period of 30000 ms'
       );
     });
   });


### PR DESCRIPTION
### Which problem is this PR solving?

This PR removes the deprecated `TracerProviderOptions.forceFlushTimeoutMillis` option as part of the SDK 3.x cleanup.

ref #7052

### Short description of the changes

Removed the deprecated `forceFlushTimeoutMillis` option from `TracerProviderOptions`.

Users should now pass the timeout directly when calling `forceFlush()`:

* `forceFlushTimeoutMillis` → use `provider.forceFlush({ timeoutMillis })`

The default timeout remains `30000ms`.



### Type of change

* [ ] Bug fix (non-breaking change)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

### How Has This Been Tested?

Ran the relevant `@opentelemetry/sdk-trace` tests and affected package tests.

### Checklist:

* [x] Followed the style guidelines of this project
* [x] Unit tests have been added/updated
* [ ] Documentation has been updated
