### PR TITLE
fix(configuration): preserve zero-valued limits

### DIFF
--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -12,6 +12,8 @@ For notes on migrating to 2.x / 0.200.x see [the upgrade guide](doc/upgrade-to-2
 
 ### :bug: Bug Fixes
 
+* fix(configuration): preserve zero-valued limits from environment variables [#7060](https://github.com/open-telemetry/opentelemetry-js/pull/7060) @DenisCDev
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/experimental/packages/configuration/src/EnvironmentConfigFactory.ts
+++ b/experimental/packages/configuration/src/EnvironmentConfigFactory.ts
@@ -183,7 +183,10 @@ export function setAttributeLimits(config: ConfigurationModel): void {
   const attributeValueLengthLimit = getNumberFromEnv(
     'OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT'
   );
-  if (attributeValueLengthLimit && attributeValueLengthLimit > 0) {
+  if (
+    attributeValueLengthLimit !== undefined &&
+    attributeValueLengthLimit >= 0
+  ) {
     if (config.attribute_limits == null) {
       config.attribute_limits = { attribute_count_limit: 128 };
     }
@@ -192,7 +195,7 @@ export function setAttributeLimits(config: ConfigurationModel): void {
   }
 
   const attributeCountLimit = getNumberFromEnv('OTEL_ATTRIBUTE_COUNT_LIMIT');
-  if (attributeCountLimit) {
+  if (attributeCountLimit !== undefined) {
     if (config.attribute_limits == null) {
       config.attribute_limits = { attribute_count_limit: attributeCountLimit };
     } else {
@@ -295,7 +298,7 @@ export function setTracerProvider(
   const attributeValueLengthLimit = getNumberFromEnv(
     'OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT'
   );
-  if (attributeValueLengthLimit) {
+  if (attributeValueLengthLimit !== undefined) {
     config.tracer_provider.limits!.attribute_value_length_limit =
       attributeValueLengthLimit;
   }
@@ -303,24 +306,24 @@ export function setTracerProvider(
   const attributeCountLimit = getNumberFromEnv(
     'OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT'
   );
-  if (attributeCountLimit) {
+  if (attributeCountLimit !== undefined) {
     config.tracer_provider.limits!.attribute_count_limit = attributeCountLimit;
   }
 
   const eventCountLimit = getNumberFromEnv('OTEL_SPAN_EVENT_COUNT_LIMIT');
-  if (eventCountLimit) {
+  if (eventCountLimit !== undefined) {
     config.tracer_provider.limits!.event_count_limit = eventCountLimit;
   }
 
   const linkCountLimit = getNumberFromEnv('OTEL_SPAN_LINK_COUNT_LIMIT');
-  if (linkCountLimit) {
+  if (linkCountLimit !== undefined) {
     config.tracer_provider.limits!.link_count_limit = linkCountLimit;
   }
 
   const eventAttributeCountLimit = getNumberFromEnv(
     'OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT'
   );
-  if (eventAttributeCountLimit) {
+  if (eventAttributeCountLimit !== undefined) {
     config.tracer_provider.limits!.event_attribute_count_limit =
       eventAttributeCountLimit;
   }
@@ -328,7 +331,7 @@ export function setTracerProvider(
   const linkAttributeCountLimit = getNumberFromEnv(
     'OTEL_LINK_ATTRIBUTE_COUNT_LIMIT'
   );
-  if (linkAttributeCountLimit) {
+  if (linkAttributeCountLimit !== undefined) {
     config.tracer_provider.limits!.link_attribute_count_limit =
       linkAttributeCountLimit;
   }
@@ -599,13 +602,16 @@ export function setLoggerProvider(config: ConfigurationModel): void {
   const attributeCountLimit = getNumberFromEnv(
     'OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT'
   );
-  if (attributeValueLengthLimit || attributeCountLimit) {
-    if (attributeValueLengthLimit) {
+  if (
+    attributeValueLengthLimit !== undefined ||
+    attributeCountLimit !== undefined
+  ) {
+    if (attributeValueLengthLimit !== undefined) {
       config.logger_provider.limits!.attribute_value_length_limit =
         attributeValueLengthLimit;
     }
 
-    if (attributeCountLimit) {
+    if (attributeCountLimit !== undefined) {
       config.logger_provider.limits!.attribute_count_limit =
         attributeCountLimit;
     }

--- a/experimental/packages/configuration/test/EnvironmentConfigFactory.test.ts
+++ b/experimental/packages/configuration/test/EnvironmentConfigFactory.test.ts
@@ -278,6 +278,40 @@ describe('EnvironmentConfigFactory', function () {
     assert.deepStrictEqual(configFactory.getConfigModel(), expectedConfig);
   });
 
+  it('should preserve zero-valued limits', function () {
+    process.env.OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT = '0';
+    process.env.OTEL_ATTRIBUTE_COUNT_LIMIT = '0';
+    process.env.OTEL_TRACES_EXPORTER = 'console';
+    process.env.OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT = '0';
+    process.env.OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT = '0';
+    process.env.OTEL_SPAN_EVENT_COUNT_LIMIT = '0';
+    process.env.OTEL_SPAN_LINK_COUNT_LIMIT = '0';
+    process.env.OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT = '0';
+    process.env.OTEL_LINK_ATTRIBUTE_COUNT_LIMIT = '0';
+    process.env.OTEL_LOGS_EXPORTER = 'console';
+    process.env.OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT = '0';
+    process.env.OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT = '0';
+
+    const config = createConfigFactory().getConfigModel();
+
+    assert.deepStrictEqual(config.attribute_limits, {
+      attribute_value_length_limit: 0,
+      attribute_count_limit: 0,
+    });
+    assert.deepStrictEqual(config.tracer_provider?.limits, {
+      attribute_value_length_limit: 0,
+      attribute_count_limit: 0,
+      event_count_limit: 0,
+      link_count_limit: 0,
+      event_attribute_count_limit: 0,
+      link_attribute_count_limit: 0,
+    });
+    assert.deepStrictEqual(config.logger_provider?.limits, {
+      attribute_value_length_limit: 0,
+      attribute_count_limit: 0,
+    });
+  });
+
   it('should not set propagators by default', function () {
     const configFactory = createConfigFactory();
     const config = configFactory.getConfigModel();


### PR DESCRIPTION
## Which problem is this PR solving?

`EnvironmentConfigFactory` uses truthiness checks for numeric limit environment variables. As a result, the valid value `0` is treated as absent and the generated `ConfigurationModel` silently retains its defaults or omits the override.

The OpenTelemetry SDK environment variable specification defines these ten attribute, span, event, link, and log record limits as non-negative integers. The declarative configuration schema also permits zero for the corresponding fields.

This is scoped to the environment-variable-to-`ConfigurationModel` mapping. It does not change how downstream SDK components interpret individual limits.

## Short description of the changes

Preserve `0` when mapping all ten limit environment variables, while retaining the existing behavior for absent and nonzero values. Add a regression test covering general attribute limits, all six span limits, and both log record limits in one generated model.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] The regression test fails on `main` with `attribute_count_limit: 128` instead of the configured zeros, then passes with this change.
- [x] `npm test --workspace @opentelemetry/configuration` — 139 passing
- [x] `npm run lint --workspace @opentelemetry/configuration`
- [x] `npm run compile --workspace @opentelemetry/configuration`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation is unchanged because the documented contract already accepts non-negative limits