### PR TITLE
fix: use new dist/ directory for benchmarking

### DIFF
--- a/api/test/performance/benchmark/api-accessors.js
+++ b/api/test/performance/benchmark/api-accessors.js
@@ -7,7 +7,7 @@
 // bottoms out in a getGlobal lookup against the global registry.
 
 const Benchmark = require('benchmark');
-const { context, trace } = require('../../../build/src');
+const { context, trace } = require('../../../dist/index.cjs');
 
 const ROOT_CONTEXT = {
   getValue() {},

--- a/api/test/performance/benchmark/get-global.js
+++ b/api/test/performance/benchmark/get-global.js
@@ -9,10 +9,10 @@
 // Each case batches the nanosecond-level calls and makes the result observable.
 
 const Benchmark = require('benchmark');
-const { getGlobal } = require('../../../build/src/internal/global-utils');
-const { isCompatible } = require('../../../build/src/internal/semver');
-const { VERSION } = require('../../../build/src/version');
-const { context, trace } = require('../../../build/src');
+const { getGlobal } = require('../../../dist/internal/global-utils.cjs');
+const { isCompatible } = require('../../../dist/internal/semver.cjs');
+const { VERSION } = require('../../../dist/version.cjs');
+const { context, trace } = require('../../../dist/index.cjs');
 
 // Register globals so getGlobal takes its steady-state path (the realistic
 // "SDK installed" case): version read + compatibility check + type read.

--- a/packages/opentelemetry-context-async-hooks/test/performance/benchmark/attach.js
+++ b/packages/opentelemetry-context-async-hooks/test/performance/benchmark/attach.js
@@ -8,7 +8,7 @@
 const Benchmark = require('benchmark');
 const {
   AsyncLocalStorageContextManager,
-} = require('../../../build/src');
+} = require('../../../dist/index.cjs');
 const { createContextKey, ROOT_CONTEXT } = require('@opentelemetry/api');
 
 const contextManager = new AsyncLocalStorageContextManager();


### PR DESCRIPTION
I missed the benchmark scripts over at #6293 when I merged `main`, this PR restores the remaining ones that are currently failing on `main`.
