### PR TITLE
fix(api): preserve tracestate member order when truncating over 32 items

### DIFF
--- a/api/src/trace/internal/tracestate-impl.ts
+++ b/api/src/trace/internal/tracestate-impl.ts
@@ -88,6 +88,7 @@ export class TraceStateImpl implements TraceState {
         Array.from(this._internalState.entries())
           .reverse() // Use reverse same as original tracestate parse chain
           .slice(0, MAX_TRACE_STATE_ITEMS)
+          .reverse() // Restore the internal reverse-insertion-order convention after truncation
       );
     }
   }

--- a/api/test/common/trace/tracestate.test.ts
+++ b/api/test/common/trace/tracestate.test.ts
@@ -89,12 +89,10 @@ describe('TraceState', function () {
     });
 
     it('must truncate states with too many items', function () {
-      const state = createTraceState(
-        new Array(33)
-          .fill(0)
-          .map((_: null, num: number) => `a${num}=${num}`)
-          .join(',')
-      ) as TraceStateImpl;
+      const items = new Array(33)
+        .fill(0)
+        .map((_: null, num: number) => `a${num}=${num}`);
+      const state = createTraceState(items.join(',')) as TraceStateImpl;
       assert.deepStrictEqual(state['_keys']().length, 32);
       assert.deepStrictEqual(state.get('a0'), '0');
       assert.deepStrictEqual(state.get('a31'), '31');
@@ -102,6 +100,11 @@ describe('TraceState', function () {
         state.get('a32'),
         undefined,
         'should truncate from the tail'
+      );
+      assert.deepStrictEqual(
+        state.serialize(),
+        items.slice(0, 32).join(','),
+        'should preserve the original member order after truncation'
       );
     });
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

`TraceStateImpl` (in `@opentelemetry/api`, `api/src/trace/internal/tracestate-impl.ts`) truncates tracestate entries when there are more than 32 members. 
The truncation logic reversed the entry list to slice off the oldest members, but never reversed the result back before rebuilding the internal `Map`, breaking the map's reverse-insertion-order convention. 
As a result, `serialize()` on a truncated `TraceStateImpl` emitted members in reverse order, violating the W3C tracestate ordering requirement (most recently updated member first).

Fixes # (issue)

## Short description of the changes

- Added a `.reverse()` call after `slice()` in `_parse()` so the internal map's insertion order is restored after truncation.
- Extended the existing truncation test to assert `serialize()` preserves the original member order after truncating over-limit entries.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Ran `api/test/common/trace/tracestate.test.ts` (transpile-only mocha run) — all 12 tests pass, including the new order assertion.
- Manually reproduced the truncation logic in a standalone Node script with a 5-member tracestate truncated to 3 members, confirming the serialized order matches the expected "e=5,d=4,c=3" (previously produced "c=3,d=4,e=5").

- [x] Test A: `npx mocha 'test/common/trace/tracestate.test.ts` in `api/`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
