### PR TITLE
fix(api): align tracestate length-truncation with `@opentelemetry/core`

### DIFF
--- a/api/src/trace/internal/tracestate-impl.ts
+++ b/api/src/trace/internal/tracestate-impl.ts
@@ -63,33 +63,46 @@ export class TraceStateImpl implements TraceState {
   }
 
   private _parse(rawTraceState: string) {
-    if (rawTraceState.length > MAX_TRACE_STATE_LEN) return;
-    this._internalState = rawTraceState
-      .split(LIST_MEMBERS_SEPARATOR)
-      // Use reduceRight() so new keys (.set(...)) will be placed at the beginning
-      .reduceRight((agg: Map<string, string>, part: string) => {
-        const listMember = part.trim(); // Optional Whitespace (OWS) handling
-        const i = listMember.indexOf(LIST_MEMBER_KEY_VALUE_SPLITTER);
-        if (i !== -1) {
-          const key = listMember.slice(0, i);
-          const value = listMember.slice(i + 1, part.length);
-          if (validateKey(key) && validateValue(value)) {
-            agg.set(key, value);
-          } else {
-            // TODO: Consider to add warning log
-          }
-        }
-        return agg;
-      }, new Map());
+    const vendorMembers = rawTraceState.split(LIST_MEMBERS_SEPARATOR);
+    // This Map will have the order reversed (most recent member first)
+    const vendorEntries = new Map<string, string>();
+    let currentLength = 0;
 
-    // Because of the reverse() requirement, trunc must be done after map is created
-    if (this._internalState.size > MAX_TRACE_STATE_ITEMS) {
-      this._internalState = new Map(
-        Array.from(this._internalState.entries())
-          .reverse() // Use reverse same as original tracestate parse chain
-          .slice(0, MAX_TRACE_STATE_ITEMS)
-      );
+    for (const member of vendorMembers) {
+      const listMember = member.trim(); // Optional Whitespace (OWS) handling
+      const i = listMember.indexOf(LIST_MEMBER_KEY_VALUE_SPLITTER);
+      if (i === -1) {
+        continue;
+      }
+
+      const key = listMember.slice(0, i);
+      const value = listMember.slice(i + 1);
+      if (!validateKey(key) || !validateValue(value)) {
+        // TODO: Consider to add warning log
+        continue;
+      }
+
+      // Skip the member if adding it would exceed the max tracestate
+      // length, but keep checking the remaining (older) members.
+      const futureLength =
+        currentLength + listMember.length + (vendorEntries.size > 0 ? 1 : 0);
+      if (futureLength > MAX_TRACE_STATE_LEN) {
+        continue;
+      }
+
+      vendorEntries.set(key, value);
+      currentLength = futureLength;
+
+      if (vendorEntries.size >= MAX_TRACE_STATE_ITEMS) {
+        break;
+      }
     }
+
+    // Reverse to match the internal reverse-insertion-order convention
+    // (oldest first) used by get()/serialize().
+    this._internalState = new Map(
+      Array.from(vendorEntries.entries()).reverse()
+    );
   }
 
   // @ts-expect-error TS6133 Accessed in tests only.

--- a/api/test/common/trace/tracestate.test.ts
+++ b/api/test/common/trace/tracestate.test.ts
@@ -61,6 +61,13 @@ describe('TraceState', function () {
       assert.deepStrictEqual(state.serialize(), '');
     });
 
+    it('must skip list-members when the value is too long, but keep the remaining ones', function () {
+      const state = createTraceState('a=' + 'b'.repeat(512) + ',c=d');
+      assert.deepStrictEqual(state.get('a'), undefined);
+      assert.deepStrictEqual(state.get('c'), 'd');
+      assert.deepStrictEqual(state.serialize(), 'c=d');
+    });
+
     it('must drop states which cannot be parsed', function () {
       const state = createTraceState('a=1,b,c=3');
       assert.deepStrictEqual(state.get('a'), '1');


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

~~Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.~~

`TraceStateImpl` (in `@opentelemetry/api`, `api/src/trace/internal/tracestate-impl.ts`) dropped the entire tracestate whenever the raw header string exceeded 512 characters (`if (rawTraceState.length > MAX_TRACE_STATE_LEN) return;`). This diverges from `@opentelemetry/core`'s `TraceState` (`packages/opentelemetry-core/src/trace/TraceState.ts`), which instead accumulates valid members from the front (most recently updated first) and only skips the individual member that would push the running length over 512, continuing to check the remaining, potentially shorter, members. 
Because `createTraceState` (api, deprecated) and `TraceState` (core, used in practice) are meant to have equivalent parsing semantics, so this inconsistency meant the same raw tracestate header could be parsed completely differently depending on which implementation handled it.

Fixes # (issue)

## Short description of the changes

- Rewrote `TraceStateImpl._parse()` to accumulate members left-to-right with a running length budget, matching `@opentelemetry/core`'s `TraceState._getState()` behavior: a member that would exceed the 512-character limit is skipped, but subsequent (shorter) members are still evaluated instead of discarding the whole state.
- Item-count truncation (max 32 members) is now handled in the same loop via early `break`, replacing the previous separate post-processing step.
- Added a test mirroring `@opentelemetry/core`'s equivalent case: a state with an oversized member followed by a short one keeps the short member instead of dropping everything.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

~~Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration~~

- Ran `api/test/common/trace/tracestate.test.ts` (transpile-only mocha run) — all 13 tests pass, including the new test.
- Ran `eslint` on the changed files — no issues.
- Ran `tsc --noEmit` — only pre-existing, unrelated errors from a missing generated `src/version.ts` file (not touched by this change).
- 
- [x] Test A: `npx mocha 'test/common/trace/tracestate.test.ts'` in `api/`

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated
