### PR TITLE
feat(sdk-node)!: remove deprecated NodeSDKConfiguration fields and namespace re-exports

### DIFF
--- a/doc/3.x/migration-guide.md
+++ b/doc/3.x/migration-guide.md
@@ -158,3 +158,81 @@ import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 // after
 import { AsynLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 ```
+
+---
+
+## `@opentelemetry/sdk-node`
+
+### Removed: `NodeSDKConfiguration.logRecordProcessor`
+
+The singular `logRecordProcessor` option on `NodeSDKConfiguration` has been removed. Use `logRecordProcessors` (array) instead.
+
+```ts
+// before
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { SimpleLogRecordProcessor } from '@opentelemetry/sdk-logs';
+
+const sdk = new NodeSDK({
+  logRecordProcessor: new SimpleLogRecordProcessor({ exporter }),
+});
+
+// after
+const sdk = new NodeSDK({
+  logRecordProcessors: [new SimpleLogRecordProcessor({ exporter })],
+});
+```
+
+### Removed: `NodeSDKConfiguration.metricReader`
+
+The singular `metricReader` option on `NodeSDKConfiguration` has been removed. Use `metricReaders` (array) instead.
+
+```ts
+// before
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+
+const sdk = new NodeSDK({
+  metricReader: new PeriodicExportingMetricReader({ exporter }),
+});
+
+// after
+const sdk = new NodeSDK({
+  metricReaders: [new PeriodicExportingMetricReader({ exporter })],
+});
+```
+
+### Removed: `NodeSDKConfiguration.spanProcessor`
+
+The singular `spanProcessor` option on `NodeSDKConfiguration` has been removed. Use `spanProcessors` (array) instead.
+
+```ts
+// before
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace';
+
+const sdk = new NodeSDK({
+  spanProcessor: new SimpleSpanProcessor(exporter),
+});
+
+// after
+const sdk = new NodeSDK({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+});
+```
+
+### Removed: `node` and `tracing` namespace re-exports
+
+The deprecated namespace re-exports `node` (re-exporting `@opentelemetry/sdk-trace-node`) and `tracing` (re-exporting `@opentelemetry/sdk-trace-base`) have been removed from `@opentelemetry/sdk-node`. Import directly from the originating packages instead.
+
+```ts
+// before
+import { node, tracing } from '@opentelemetry/sdk-node';
+const provider = new node.NodeTracerProvider();
+const exporter = new tracing.ConsoleSpanExporter();
+
+// after
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
+const provider = new NodeTracerProvider();
+const exporter = new ConsoleSpanExporter();
+```

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -9,6 +9,12 @@ For notes on migrating to 3.x see [the 3.x migration guide](doc/3.x/migration-gu
 
 ### :boom: Breaking Changes
 
+* feat(sdk-node)!: remove deprecated `NodeSDKConfiguration` fields `logRecordProcessor`, `metricReader`, `spanProcessor` and deprecated namespace re-exports `node`, `tracing`
+  * `NodeSDKConfiguration.logRecordProcessor` — use `logRecordProcessors` instead.
+  * `NodeSDKConfiguration.metricReader` — use `metricReaders` instead.
+  * `NodeSDKConfiguration.spanProcessor` — use `spanProcessors` instead.
+  * `export * as node from '@opentelemetry/sdk-node'` — import directly from `@opentelemetry/sdk-trace-node` instead.
+  * `export * as tracing from '@opentelemetry/sdk-node'` — import directly from `@opentelemetry/sdk-trace-base` instead.
 * feat(sdk-logs)!: remove deprecated `SdkLogRecord` type alias and `LoggerProviderConfig` type alias [#7062](https://github.com/open-telemetry/opentelemetry-js/pull/7062)
   * `SdkLogRecord` — use `ReadWriteLogRecord` instead.
   * `LoggerProviderConfig` — use `LoggerProviderOptions` instead.

--- a/experimental/packages/opentelemetry-sdk-node/src/index.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/index.ts
@@ -15,15 +15,6 @@ export * as core from '@opentelemetry/core';
 export * as logs from '@opentelemetry/sdk-logs';
 export * as metrics from '@opentelemetry/sdk-metrics';
 export * as resources from '@opentelemetry/resources';
-
-/**
- * @deprecated Import directly from `@opentelemetry/sdk-trace` instead.
- */
-export * as node from '@opentelemetry/sdk-trace-node';
-/**
- * @deprecated Import directly from `@opentelemetry/sdk-trace` instead.
- */
-export * as tracing from '@opentelemetry/sdk-trace-base';
 /* eslint-enable no-restricted-syntax */
 
 export { NodeSDK } from './sdk';

--- a/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/sdk.ts
@@ -198,23 +198,10 @@ export class NodeSDK {
 
     this._serviceName = configuration.serviceName;
 
-    if (configuration.spanProcessor) {
-      diag.warn(
-        "The 'spanProcessor' option is deprecated. Please use 'spanProcessors' instead."
-      );
-    }
-
     if (configuration.logRecordProcessors) {
       this._loggerProviderConfig = {
         logRecordProcessors: configuration.logRecordProcessors,
       };
-    } else if (configuration.logRecordProcessor) {
-      this._loggerProviderConfig = {
-        logRecordProcessors: [configuration.logRecordProcessor],
-      };
-      diag.warn(
-        "The 'logRecordProcessor' option is deprecated. Please use 'logRecordProcessors' instead."
-      );
     }
 
     if (configuration.metricReaders) {
@@ -222,14 +209,6 @@ export class NodeSDK {
         readers: configuration.metricReaders,
         views: configuration.views,
       };
-    } else if (configuration.metricReader) {
-      this._meterProviderConfig = {
-        readers: [configuration.metricReader],
-        views: configuration.views,
-      };
-      diag.warn(
-        "The 'metricReader' option is deprecated. Please use 'metricReaders' instead."
-      );
     } else {
       this._meterProviderConfig = {
         readers: getMetricReadersFromEnv(),
@@ -305,12 +284,10 @@ export class NodeSDK {
       }
     }
 
-    // Determine `spanProcessors` from multiple possible options.
+    // Determine `spanProcessors` from configuration options.
     let spanProcessors: SpanProcessor[];
     if (this._configuration?.spanProcessors) {
       spanProcessors = this._configuration.spanProcessors;
-    } else if (this._configuration?.spanProcessor) {
-      spanProcessors = [this._configuration.spanProcessor];
     } else if (this._configuration?.traceExporter) {
       spanProcessors = [
         createBatchSpanProcessorFromEnv(

--- a/experimental/packages/opentelemetry-sdk-node/src/types.ts
+++ b/experimental/packages/opentelemetry-sdk-node/src/types.ts
@@ -26,11 +26,7 @@ export interface NodeSDKConfiguration {
   autoDetectResources: boolean;
   contextManager: ContextManager;
   textMapPropagator: TextMapPropagator | null;
-  /** @deprecated use logRecordProcessors instead*/
-  logRecordProcessor: LogRecordProcessor;
   logRecordProcessors?: LogRecordProcessor[];
-  /** @deprecated use metricReaders instead*/
-  metricReader: IMetricReader;
   metricReaders?: IMetricReader[];
   views: ViewOptions[];
   instrumentations: (Instrumentation | Instrumentation[])[];
@@ -46,8 +42,6 @@ export interface NodeSDKConfiguration {
   resourceDetectors: Array<ResourceDetector>;
   sampler: Sampler;
   serviceName?: string;
-  /** @deprecated use spanProcessors instead*/
-  spanProcessor?: SpanProcessor;
   spanProcessors?: SpanProcessor[];
   traceExporter: SpanExporter;
   spanLimits: SpanLimits;

--- a/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
+++ b/experimental/packages/opentelemetry-sdk-node/test/sdk.test.ts
@@ -276,7 +276,7 @@ describe('NodeSDK', () => {
       });
 
       const sdk = new NodeSDK({
-        metricReader: metricReader,
+        metricReaders: [metricReader],
         autoDetectResources: false,
       });
 
@@ -332,62 +332,6 @@ describe('NodeSDK', () => {
       // Verify that both metric readers are registered
       const sharedState = (meterProvider as any)['_sharedState'];
       assert.strictEqual(sharedState.metricCollectors.length, 2);
-
-      await sdk.shutdown();
-    });
-
-    it('should show deprecation warning when using metricReader option', async () => {
-      const exporter = new ConsoleMetricExporter();
-      const metricReader = new PeriodicExportingMetricReader({
-        exporter: exporter,
-        exportIntervalMillis: 100,
-        exportTimeoutMillis: 100,
-      });
-
-      const warnSpy = Sinon.spy(diag, 'warn');
-
-      const sdk = new NodeSDK({
-        metricReader: metricReader,
-        autoDetectResources: false,
-      });
-
-      sdk.start();
-
-      // Verify deprecation warning was shown
-      Sinon.assert.calledWith(
-        warnSpy,
-        "The 'metricReader' option is deprecated. Please use 'metricReaders' instead."
-      );
-
-      assert.ok(metrics.getMeterProvider() instanceof MeterProvider);
-
-      await sdk.shutdown();
-    });
-
-    it('should not show deprecation warning when using metricReaders option', async () => {
-      const exporter = new ConsoleMetricExporter();
-      const metricReader = new PeriodicExportingMetricReader({
-        exporter: exporter,
-        exportIntervalMillis: 100,
-        exportTimeoutMillis: 100,
-      });
-
-      const warnSpy = Sinon.spy(diag, 'warn');
-
-      const sdk = new NodeSDK({
-        metricReaders: [metricReader],
-        autoDetectResources: false,
-      });
-
-      sdk.start();
-
-      // Verify no metricReader deprecation warning was shown
-      Sinon.assert.neverCalledWith(
-        warnSpy,
-        "The 'metricReader' option is deprecated. Please use 'metricReaders' instead."
-      );
-
-      assert.ok(metrics.getMeterProvider() instanceof MeterProvider);
 
       await sdk.shutdown();
     });
@@ -556,7 +500,7 @@ describe('NodeSDK', () => {
         exporter: logRecordExporter,
       });
       const sdk = new NodeSDK({
-        logRecordProcessor: logRecordProcessor,
+        logRecordProcessors: [logRecordProcessor],
         autoDetectResources: false,
       });
 
@@ -733,7 +677,7 @@ describe('NodeSDK', () => {
     });
 
     const sdk = new NodeSDK({
-      metricReader: metricReader,
+      metricReaders: [metricReader],
       views: [
         {
           name: 'test-view',
@@ -1192,7 +1136,7 @@ describe('NodeSDK', () => {
       });
 
       const sdk = new NodeSDK({
-        metricReader: metricReader,
+        metricReaders: [metricReader],
         autoDetectResources: false,
       });
       sdk.start();
@@ -1255,7 +1199,7 @@ describe('NodeSDK', () => {
       });
       const sdk = new NodeSDK({
         idGenerator,
-        spanProcessor,
+        spanProcessors: [spanProcessor],
       });
       sdk.start();
 
@@ -1843,7 +1787,7 @@ describe('NodeSDK', () => {
       const exporter = new ConsoleSpanExporter();
       const spanProcessor = new SimpleSpanProcessor({ exporter });
       const sdk = new NodeSDK({
-        spanProcessor,
+        spanProcessors: [spanProcessor],
       });
       sdk.start();
       const listOfProcessors = getSdkSpanProcessors(sdk);


### PR DESCRIPTION
## Which problem is this PR solving?

Remove deprecated `NodeSDKConfiguration` fields and namespace re-exports from `@opentelemetry/sdk-node` as part of the SDK v3 cleanup.

The deprecated configuration fields have newer plural alternatives, and the namespace re-exports should be imported directly from their respective packages.

ref https://github.com/open-telemetry/opentelemetry-js/issues/7052

## Short description of the changes

* Remove `NodeSDKConfiguration.logRecordProcessor` in favor of `logRecordProcessors`
* Remove `NodeSDKConfiguration.metricReader` in favor of `metricReaders`
* Remove `NodeSDKConfiguration.spanProcessor` in favor of `spanProcessors`
* Remove the deprecated `node` namespace re-export; import directly from `@opentelemetry/sdk-trace-node`
* Remove the deprecated `tracing` namespace re-export; import directly from `@opentelemetry/sdk-trace-base`
* Update affected tests to use the non-deprecated alternatives
* Add entries to the experimental CHANGELOG and 3.x migration guide

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

## Checklist:

* [x] Followed the style guidelines of this project
* [ ] Unit tests have been added
* [x] Documentation has been updated
