### PR TITLE
fix(core): enforce max TraceState items in set(), not just on parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ For notes on migrating to 3.x see [the 3.x migration guide](doc/3.x/migration-gu
 
 ### :bug: Bug Fixes
 
-* fix(core): enforce max number of `TraceState` entries in `set()`, not just on parse [#7091](https://github.com/open-telemetry/opentelemetry-js/pull/7091) @abhiyadav79
+* fix(core): enforce max number of `TraceState` entries in `set()`, not just on parse [#7080](https://github.com/open-telemetry/opentelemetry-js/pull/7080) @abhiyadav79
 
 ### :books: Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ For notes on migrating to 3.x see [the 3.x migration guide](doc/3.x/migration-gu
 
 ### :bug: Bug Fixes
 
+* fix(core): enforce max number of `TraceState` entries in `set()`, not just on parse [#7091](https://github.com/open-telemetry/opentelemetry-js/pull/7091) @abhiyadav79
+
 ### :books: Documentation
 
 ### :house: Internal

--- a/packages/opentelemetry-core/src/trace/TraceState.ts
+++ b/packages/opentelemetry-core/src/trace/TraceState.ts
@@ -56,6 +56,20 @@ export class TraceState implements TraceStateApi {
     const newState = new Map(currState);
     newState.delete(key);
     newState.set(key, value);
+
+    // Adding a new key can push the number of list-members over the max
+    // allowed by the spec. When that happens, drop the oldest entry (stored
+    // at the front of the map) to make room, same as the constructor does.
+    if (newState.size > MAX_TRACE_STATE_ITEMS) {
+      const oldestKey = newState.keys().next().value as string;
+      const oldestValue = newState.get(oldestKey) as string;
+      newState.delete(oldestKey);
+      newLength -= oldestKey.length + oldestValue.length + 1;
+      if (newState.size > 0) {
+        newLength -= 1;
+      }
+    }
+
     return this._fromState(newState, newLength);
   }
 

--- a/packages/opentelemetry-core/test/common/trace/tracestate.test.ts
+++ b/packages/opentelemetry-core/test/common/trace/tracestate.test.ts
@@ -62,6 +62,30 @@ describe('TraceState', () => {
         assert.strictEqual(orgState, state);
         assert.deepStrictEqual(orgState.serialize(), tracestate);
       });
+
+      it('must drop the oldest entry when exceeding the max number of items', () => {
+        // the first member in the list is the most recently updated one, so
+        // 'a31' (the last member) is the oldest entry.
+        const members = new Array(32)
+          .fill(0)
+          .map((_: null, num: number) => `a${num}=${num}`);
+        const orgState = new TraceState(members.join(','));
+
+        const state = orgState.set('new-key', 'new-value');
+
+        assert.deepStrictEqual(state.get('new-key'), 'new-value');
+        // oldest entry (a31) must be evicted to make room
+        assert.deepStrictEqual(state.get('a31'), undefined);
+        // the rest of the entries are preserved
+        for (let i = 0; i < 31; i++) {
+          assert.deepStrictEqual(state.get(`a${i}`), `${i}`);
+        }
+        assert.deepStrictEqual(
+          state.serialize().split(',').length,
+          32,
+          'must not exceed the max number of list-members'
+        );
+      });
     });
 
     describe('when updating a list member', () => {


### PR DESCRIPTION
## Summary
- `TraceState.set()` only checked the serialized-length limit (512 chars) and never re-applied the W3C tracestate 32-item cap, so repeated `.set()` calls on an already-full `TraceState` could produce more than 32 list-members.
- `set()` now evicts the oldest entry (mirroring the eviction the constructor already does when parsing) whenever adding a new key would push the count over 32.

Fixes #4979

## Test plan
- [x] Added a regression test in `packages/opentelemetry-core/test/common/trace/tracestate.test.ts` that fills a `TraceState` to 32 entries, calls `.set()` with a new key, and asserts the oldest entry was evicted and the item count stays at 32.
- [x] `npm test` in `packages/opentelemetry-core` passes (240+ tests).
- [x] `npm run lint` clean on changed files.
