### PR TITLE
feat(instrumentation-http)!: remove deprecated serverName option from HttpInstrumentationConfig

### DIFF
--- a/doc/3.x/migration-guide.md
+++ b/doc/3.x/migration-guide.md
@@ -36,6 +36,27 @@ propagation.setGlobalPropagator(new W3CTraceContextPropagator());
 
 ---
 
+## `@opentelemetry/instrumentation-http`
+
+### Removed: `HttpInstrumentationConfig.serverName`
+
+The `serverName` option on `HttpInstrumentationConfig` has been removed. It had no effect — stable HTTP semantic conventions do not include the `http.server_name` attribute. Remove the option from any `setConfig()` or constructor call.
+
+```ts
+// before
+instrumentation.setConfig({
+  serverName: 'my.server.name',
+  // ... other options
+});
+
+// after
+instrumentation.setConfig({
+  // ... other options (serverName removed)
+});
+```
+
+---
+
 ## `@opentelemetry/core`
 
 ### Removed: `getTimeOrigin()`

--- a/experimental/CHANGELOG.md
+++ b/experimental/CHANGELOG.md
@@ -9,6 +9,8 @@ For notes on migrating to 3.x see [the 3.x migration guide](../doc/3.x/migration
 
 ### :boom: Breaking Changes
 
+* feat(instrumentation-http)!: remove deprecated `serverName` field from `HttpInstrumentationConfig` [#7081](https://github.com/open-telemetry/opentelemetry-js/pull/7081)
+  * The `serverName` option had no effect; stable HTTP semantic conventions do not include `http.server_name`. Remove it from any `setConfig()` or constructor call.
 * feat(sdk-node)!: remove deprecated `NodeSDKConfiguration` fields `logRecordProcessor`, `metricReader`, `spanProcessor` and deprecated namespace re-exports `node`, `tracing`
   * `NodeSDKConfiguration.logRecordProcessor` — use `logRecordProcessors` instead.
   * `NodeSDKConfiguration.metricReader` — use `metricReaders` instead.

--- a/experimental/packages/opentelemetry-instrumentation-http/README.md
+++ b/experimental/packages/opentelemetry-instrumentation-http/README.md
@@ -61,7 +61,6 @@ Options                                 | Type                                  
 `ignoreOutgoingRequestHook`             | `IgnoreOutgoingRequestFunction`            | Function for filtering outgoing requests. HTTP instrumentation will not trace outgoing requests for which the function returns `true`.
 `disableOutgoingRequestInstrumentation` | `boolean`                                  | Set to true to avoid instrumenting outgoing requests at all. This can be helpful when another instrumentation handles outgoing requests.
 `disableIncomingRequestInstrumentation` | `boolean`                                  | Set to true to avoid instrumenting incoming requests at all. This can be helpful when another instrumentation handles incoming requests.
-`serverName`                            | `string`                                   | **Deprecated.** No longer used. Stable HTTP semantic conventions do not include the `http.server_name` attribute; this option has no effect.
 `requireParentforOutgoingSpans`         | Boolean                                    | Require that is a parent span to create new span for outgoing requests.
 `requireParentforIncomingSpans`         | Boolean                                    | Require that is a parent span to create new span for incoming requests.
 `redactedQueryParams`                   | `string[]`                                 | **Experimental.** Query parameter names whose values are redacted on outgoing (client) spans. Replaces the built-in list. See [Query parameter redaction](#query-parameter-redaction).
@@ -136,7 +135,6 @@ v1.23.0 semconv                     | Short Description
 (not included)                      | The size of the uncompressed response payload body after transport decoding. (In semconv v1.23.0 this is defined by `http.response.body.size`, which is experimental and opt-in.)
 no change                           | The matched route (path template).
 `url.scheme`                        | The URI scheme identifying the used protocol
-`server.address`                    | The primary server name of the matched virtual host
 `http.response.status_code`         | HTTP response status code
 `url.path` and `url.query`          | The URI path and query component
 `url.full`                          | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`

--- a/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/src/types.ts
@@ -87,12 +87,6 @@ export interface HttpInstrumentationConfig extends InstrumentationConfig {
   startIncomingSpanHook?: StartIncomingSpanCustomAttributeFunction;
   /** Function for adding custom attributes before a span is started in outgoingRequest */
   startOutgoingSpanHook?: StartOutgoingSpanCustomAttributeFunction;
-  /**
-   * The primary server name of the matched virtual host.
-   * @deprecated No longer used. Stable HTTP semantic conventions do not include
-   * the `http.server_name` attribute; this option has no effect.
-   */
-  serverName?: string;
   /** Require parent to create span for outgoing requests */
   requireParentforOutgoingSpans?: boolean;
   /** Require parent to create span for incoming requests */

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/http-enable.test.ts
@@ -68,7 +68,6 @@ const serverPort = 22346;
 const protocol = 'http';
 const hostname = 'localhost';
 const pathname = '/test';
-const serverName = 'my.server.name';
 const memoryExporter = new InMemorySpanExporter();
 const provider = new TracerProvider({
   spanProcessors: [new SimpleSpanProcessor({ exporter: memoryExporter })],
@@ -303,7 +302,6 @@ describe('HttpInstrumentation', () => {
           responseHook: responseHookFunction,
           startIncomingSpanHook: startIncomingSpanHookFunction,
           startOutgoingSpanHook: startOutgoingSpanHookFunction,
-          serverName,
         });
         instrumentation.enable();
         server = http.createServer((request, response) => {
@@ -379,7 +377,6 @@ describe('HttpInstrumentation', () => {
           resHeaders: result.resHeaders,
           reqHeaders: result.reqHeaders,
           component: 'http',
-          serverName,
         };
 
         assert.strictEqual(spans.length, 2);

--- a/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/functionals/https-enable.test.ts
@@ -49,7 +49,6 @@ let server: https.Server;
 const serverPort = 32345;
 const protocol = 'https';
 const hostname = 'localhost';
-const serverName = 'my.server.name';
 const pathname = '/test';
 const memoryExporter = new InMemorySpanExporter();
 const provider = new TracerProvider({
@@ -183,7 +182,6 @@ describe('HttpsInstrumentation', () => {
             return false;
           },
           applyCustomAttributesOnSpan: customAttributeFunction,
-          serverName,
         });
         instrumentation.enable();
         server = https.createServer(
@@ -231,7 +229,6 @@ describe('HttpsInstrumentation', () => {
           resHeaders: result.resHeaders,
           reqHeaders: result.reqHeaders,
           component: 'https',
-          serverName,
         };
 
         assert.strictEqual(spans.length, 2);

--- a/experimental/packages/opentelemetry-instrumentation-http/test/utils/assertSpan.ts
+++ b/experimental/packages/opentelemetry-instrumentation-http/test/utils/assertSpan.ts
@@ -34,7 +34,6 @@ export const assertSpan = (
     reqHeaders?: http.OutgoingHttpHeaders;
     path?: string | null;
     forceStatus?: SpanStatus;
-    serverName?: string;
     component: string;
     noNetPeer?: boolean; // we don't expect net peer info when request throw before being sent
     error?: Exception;
@@ -115,13 +114,6 @@ export const assertSpan = (
       validations.path || validations.pathname,
       'must have url.path'
     );
-    if (validations.serverName) {
-      assert.ok(span.attributes[ATTR_SERVER_PORT], 'must have server.port');
-      assert.ok(
-        span.attributes[ATTR_NETWORK_PEER_ADDRESS],
-        'must have network.peer.address'
-      );
-    }
     assert.strictEqual(
       span.attributes[ATTR_URL_SCHEME],
       validations.component,


### PR DESCRIPTION
## Which problem is this PR solving?

Remove the deprecated `serverName` option from `HttpInstrumentationConfig`.

The option had no effect because the stable HTTP semantic conventions do not define the `http.server_name` attribute.

## Short description of the changes

* Removed the deprecated `HttpInstrumentationConfig.serverName` option
* Removed`serverName` from affected `setConfig()` and constructor calls

ret #7052 
